### PR TITLE
feat: REST API polish — health checks, CORS, SSE streaming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "markdownify>=0.13,<1",
     "pandas>=2.1,<3",
     "python-multipart>=0.0.9,<1",
+    "sse-starlette>=2.0,<4",
 ]
 
 [project.optional-dependencies]

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -13,6 +13,7 @@ from typing import AsyncGenerator
 import structlog
 import uvicorn
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from metatron.api.routes import (
     admin,
@@ -81,6 +82,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         lifespan=lifespan,
     )
     app.state.settings = settings
+
+    # CORS — default "*" for development, restrict via CORS_ORIGINS in production
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins_list,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
     # Register route modules
     app.include_router(health.router)

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -83,11 +83,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
     app.state.settings = settings
 
-    # CORS — default "*" for development, restrict via CORS_ORIGINS in production
+    # CORS — credentials are only safe with explicit origins, not wildcard
+    origins = settings.cors_origins_list
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=settings.cors_origins_list,
-        allow_credentials=True,
+        allow_origins=origins,
+        allow_credentials=origins != ["*"],
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -1,16 +1,20 @@
-"""Chat and upload API — /api/v1/chat and /api/v1/upload.
+"""Chat and upload API — /api/v1/chat, /api/v1/chat/stream, and /api/v1/upload.
 
 Migrated from PoC metatron/api.py (the core Q&A endpoints).
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
+import re
 import threading
-from typing import Optional
+from typing import AsyncGenerator, Optional
 
 import structlog
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, Field
+from sse_starlette.sse import EventSourceResponse
 
 logger = structlog.get_logger()
 
@@ -97,6 +101,114 @@ def chat(req: ChatRequest) -> ChatResponse:
                 del _conversation_history[uid]
 
     return ChatResponse(answer=answer, workspace_id=workspace_id)
+
+
+def _split_into_sentences(text: str) -> list[str]:
+    """Split text into sentence-like chunks for progressive SSE streaming."""
+    parts = re.split(r'(?<=[.!?])\s+', text)
+    chunks: list[str] = []
+    current = ""
+    for part in parts:
+        current += (" " if current else "") + part
+        if len(current) > 80:
+            chunks.append(current)
+            current = ""
+    if current:
+        chunks.append(current)
+    return chunks if chunks else [text]
+
+
+def _extract_sources_section(answer: str) -> tuple[str, list[str]]:
+    """Split answer into body and source lines."""
+    marker = "\U0001f4da Sources:"
+    if marker not in answer:
+        return answer, []
+    body, _, sources_block = answer.partition(marker)
+    sources = [line.strip() for line in sources_block.strip().splitlines() if line.strip()]
+    return body.strip(), sources
+
+
+@router.post("/chat/stream")
+async def chat_stream(req: ChatRequest) -> EventSourceResponse:
+    """Stream chat response via Server-Sent Events.
+
+    Events:
+    - ``status`` — search phase indicator (``searching``, ``answering``)
+    - ``chunk``  — incremental answer text
+    - ``sources`` — source citations array
+    - ``done``   — signals end of stream
+    """
+    from metatron.workspaces import get_workspace_manager
+
+    manager = get_workspace_manager()
+    if req.workspace_id:
+        workspace_id = req.workspace_id
+    else:
+        workspace = manager.get_active_workspace(req.user_id)
+        workspace_id = workspace.workspace_id
+
+    with _history_lock:
+        history = _conversation_history.get(req.user_id, [])[-req.history_turns:]
+
+    MAX_HISTORY_CHARS = 4000
+    history_lines: list[str] = []
+    total_chars = 0
+    for turn in reversed(history):
+        user_msg = turn.get("user", "")[:500]
+        line = f"Previous question: {user_msg}"
+        if total_chars + len(line) > MAX_HISTORY_CHARS:
+            break
+        history_lines.insert(0, line)
+        total_chars += len(line)
+
+    composite_query = (
+        "\n".join(history_lines + [f"Current question: {req.question}"])
+        if history_lines
+        else req.question
+    )
+
+    async def _event_generator() -> AsyncGenerator[dict[str, str], None]:
+        yield {"event": "status", "data": json.dumps({"status": "searching"})}
+
+        loop = asyncio.get_event_loop()
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
+            answer: str = await loop.run_in_executor(
+                None,
+                lambda: hybrid_search_and_answer(
+                    query=composite_query,
+                    user_id=req.user_id,
+                    workspace_id=workspace_id,
+                    k=req.top_k,
+                    intent_query=req.question,
+                ),
+            )
+        except Exception as exc:
+            yield {"event": "error", "data": json.dumps({"error": str(exc)})}
+            yield {"event": "done", "data": "{}"}
+            return
+
+        # Record history (same as non-streaming endpoint)
+        with _history_lock:
+            hist = _conversation_history.setdefault(req.user_id, [])
+            hist.append({"user": req.question, "assistant": answer[:2000]})
+            if len(hist) > 20:
+                del hist[:-20]
+
+        body, sources = _extract_sources_section(answer)
+
+        yield {"event": "status", "data": json.dumps({"status": "answering"})}
+
+        for chunk in _split_into_sentences(body):
+            yield {"event": "chunk", "data": json.dumps({"text": chunk})}
+            await asyncio.sleep(0.03)
+
+        if sources:
+            yield {"event": "sources", "data": json.dumps({"sources": sources})}
+
+        yield {"event": "done", "data": json.dumps({"workspace_id": workspace_id})}
+
+    return EventSourceResponse(_event_generator())
 
 
 @router.post("/upload", response_model=UploadResponse)

--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -88,7 +88,11 @@ def chat(req: ChatRequest) -> ChatResponse:
             intent_query=req.question,
         )
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        logger.error("chat.error", error=str(exc), exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Search failed. Please try again.",
+        ) from exc
 
     with _history_lock:
         hist = _conversation_history.setdefault(req.user_id, [])
@@ -170,21 +174,21 @@ async def chat_stream(req: ChatRequest) -> EventSourceResponse:
     async def _event_generator() -> AsyncGenerator[dict[str, str], None]:
         yield {"event": "status", "data": json.dumps({"status": "searching"})}
 
-        loop = asyncio.get_event_loop()
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
-            answer: str = await loop.run_in_executor(
-                None,
-                lambda: hybrid_search_and_answer(
-                    query=composite_query,
-                    user_id=req.user_id,
-                    workspace_id=workspace_id,
-                    k=req.top_k,
-                    intent_query=req.question,
-                ),
+            answer: str = await asyncio.to_thread(
+                hybrid_search_and_answer,
+                query=composite_query,
+                user_id=req.user_id,
+                workspace_id=workspace_id,
+                k=req.top_k,
+                intent_query=req.question,
             )
         except Exception as exc:
-            yield {"event": "error", "data": json.dumps({"error": str(exc)})}
+            logger.error("chat.stream.error", error=str(exc), exc_info=True)
+            yield {"event": "error", "data": json.dumps(
+                {"error": "Search failed. Please try again."},
+            )}
             yield {"event": "done", "data": "{}"}
             return
 
@@ -241,7 +245,8 @@ async def upload_file(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to parse file: {e}")
+        logger.error("upload.parse_error", file=file_name, error=str(e), exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to parse file")
 
     try:
         result = _ingest_text(
@@ -252,7 +257,11 @@ async def upload_file(
             extract_graph=extract_graph,
         )
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        logger.error("upload.ingest_error", file=file_name, error=str(exc), exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to index document. Please try again.",
+        ) from exc
 
     return UploadResponse(status="ok", file_name=file_name, **result)
 

--- a/src/metatron/api/routes/health.py
+++ b/src/metatron/api/routes/health.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import httpx
 import structlog
 from fastapi import APIRouter
@@ -18,41 +20,63 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+# ---------------------------------------------------------------------------
+# Synchronous probe helpers (run via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+def _check_qdrant() -> None:
+    from metatron.storage.qdrant import get_hybrid_store
+    store = get_hybrid_store()
+    store.client.get_collections()
+
+
+def _check_memgraph() -> None:
+    from metatron.storage.memgraph import get_memgraph_driver
+    driver = get_memgraph_driver()
+    with driver.session() as s:
+        s.run("RETURN 1")
+
+
+def _check_ollama(ollama_url: str) -> None:
+    r = httpx.get(f"{ollama_url}/api/tags", timeout=3)
+    if r.status_code != 200:
+        raise RuntimeError(f"status {r.status_code}")
+
+
 @router.get("/ready")
 async def ready() -> JSONResponse:
     """Readiness check — probes Qdrant, Memgraph, and Ollama.
 
     Returns 200 if all services are reachable, 503 if any are degraded.
+    Error details go to logs only — the response shows "ok" or "error".
     """
     services: dict[str, str] = {}
 
     # Qdrant
     try:
-        from metatron.storage.qdrant import get_hybrid_store
-        store = get_hybrid_store()
-        store.client.get_collections()
+        await asyncio.to_thread(_check_qdrant)
         services["qdrant"] = "ok"
     except Exception as e:
-        services["qdrant"] = f"error: {e}"
+        logger.warning("health.qdrant.error", error=str(e))
+        services["qdrant"] = "error"
 
     # Memgraph
     try:
-        from metatron.storage.memgraph import get_memgraph_driver
-        driver = get_memgraph_driver()
-        with driver.session() as s:
-            s.run("RETURN 1")
+        await asyncio.to_thread(_check_memgraph)
         services["memgraph"] = "ok"
     except Exception as e:
-        services["memgraph"] = f"error: {e}"
+        logger.warning("health.memgraph.error", error=str(e))
+        services["memgraph"] = "error"
 
     # Ollama (embeddings)
     try:
-        from metatron.core.config import Settings
-        ollama_url = Settings().ollama_host.rstrip("/")
-        r = httpx.get(f"{ollama_url}/api/tags", timeout=3)
-        services["ollama"] = "ok" if r.status_code == 200 else f"status {r.status_code}"
+        from metatron.core.config import get_settings
+        ollama_url = get_settings().ollama_host.rstrip("/")
+        await asyncio.to_thread(_check_ollama, ollama_url)
+        services["ollama"] = "ok"
     except Exception as e:
-        services["ollama"] = f"error: {e}"
+        logger.warning("health.ollama.error", error=str(e))
+        services["ollama"] = "error"
 
     all_ok = all(v == "ok" for v in services.values())
     return JSONResponse(

--- a/src/metatron/api/routes/health.py
+++ b/src/metatron/api/routes/health.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import httpx
 import structlog
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 
 logger = structlog.get_logger()
 
@@ -17,18 +19,46 @@ async def health() -> dict[str, str]:
 
 
 @router.get("/ready")
-async def ready() -> dict[str, object]:
-    """Readiness check — verifies all backing services are reachable.
+async def ready() -> JSONResponse:
+    """Readiness check — probes Qdrant, Memgraph, and Ollama.
 
-    Returns 200 with service status map. Individual services may be
-    degraded without making the overall check fail.
+    Returns 200 if all services are reachable, 503 if any are degraded.
     """
-    logger.info("health.ready.check")
-    # TODO: implement using HealthChecker
-    # checker = HealthChecker(...)
-    # services = await checker.check_all()
-    # overall = "ok" if all(s["status"] == "ok" for s in services.values()) else "degraded"
-    return {"status": "ok", "services": {}}
+    services: dict[str, str] = {}
+
+    # Qdrant
+    try:
+        from metatron.storage.qdrant import get_hybrid_store
+        store = get_hybrid_store()
+        store.client.get_collections()
+        services["qdrant"] = "ok"
+    except Exception as e:
+        services["qdrant"] = f"error: {e}"
+
+    # Memgraph
+    try:
+        from metatron.storage.memgraph import get_memgraph_driver
+        driver = get_memgraph_driver()
+        with driver.session() as s:
+            s.run("RETURN 1")
+        services["memgraph"] = "ok"
+    except Exception as e:
+        services["memgraph"] = f"error: {e}"
+
+    # Ollama (embeddings)
+    try:
+        from metatron.core.config import Settings
+        ollama_url = Settings().ollama_host.rstrip("/")
+        r = httpx.get(f"{ollama_url}/api/tags", timeout=3)
+        services["ollama"] = "ok" if r.status_code == 200 else f"status {r.status_code}"
+    except Exception as e:
+        services["ollama"] = f"error: {e}"
+
+    all_ok = all(v == "ok" for v in services.values())
+    return JSONResponse(
+        content={"status": "ready" if all_ok else "degraded", "services": services},
+        status_code=200 if all_ok else 503,
+    )
 
 
 @router.get("/metrics")

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     port: int = Field(8000, alias="METATRON_PORT")
     log_level: str = Field("INFO", alias="METATRON_LOG_LEVEL")
     secret_key: str = Field("change-me-in-production", alias="METATRON_SECRET_KEY")
+    cors_origins: str = Field("*", alias="CORS_ORIGINS")
 
     # --- PostgreSQL ---
     postgres_host: str = Field("localhost", alias="POSTGRES_HOST")
@@ -131,6 +132,11 @@ class Settings(BaseSettings):
     tag_weight: float = 0.20
     graph_weight: float = 0.15
     recency_weight: float = 0.10
+
+    @property
+    def cors_origins_list(self) -> list[str]:
+        """Parse CORS_ORIGINS comma-separated string into a list."""
+        return [o.strip() for o in self.cors_origins.split(",") if o.strip()]
 
     @property
     def postgres_dsn(self) -> str:

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -4,6 +4,8 @@ Uses Pydantic BaseSettings for validation and .env file support.
 Every setting has a sensible default for local development.
 """
 
+from __future__ import annotations
+
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -181,3 +183,16 @@ class Settings(BaseSettings):
             msg = f"env must be one of {allowed}, got '{v}'"
             raise ValueError(msg)
         return v
+
+
+# --- Cached singleton ---------------------------------------------------
+
+_settings: Settings | None = None
+
+
+def get_settings() -> Settings:
+    """Return a cached Settings instance (created once from env)."""
+    global _settings  # noqa: PLW0603
+    if _settings is None:
+        _settings = Settings()
+    return _settings

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,474 @@
+"""Tests for FastAPI REST API endpoints."""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from metatron.api.app import create_app
+from metatron.core.config import Settings
+from metatron.workspaces.models import Workspace, WorkspaceStats
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def settings() -> Settings:
+    """Settings with test defaults (no real services required)."""
+    return Settings(
+        METATRON_ENV="development",
+        DEFAULT_WORKSPACE_ID="TEST_WS",
+        DEFAULT_WORKSPACE_NAME="Test Workspace",
+        CORS_ORIGINS="http://localhost:3000,http://localhost:5173",
+    )
+
+
+@pytest.fixture
+def app(settings: Settings):
+    return create_app(settings)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+_DEFAULT_WS = Workspace(
+    workspace_id="TEST_WS",
+    name="Test Workspace",
+    user_id="user",
+    is_active=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+class TestHealth:
+    def test_health_returns_ok(self, client: TestClient) -> None:
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# /ready
+# ---------------------------------------------------------------------------
+
+class TestReady:
+    @patch("metatron.api.routes.health.httpx.get")
+    @patch("metatron.storage.memgraph.get_memgraph_driver")
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_ready_all_ok(
+        self, mock_store, mock_driver, mock_httpx_get, client: TestClient,
+    ) -> None:
+        # Qdrant: mock collections
+        store = MagicMock()
+        store.client.get_collections.return_value = MagicMock(collections=[])
+        mock_store.return_value = store
+        # Memgraph: mock session
+        session = MagicMock()
+        session.__enter__ = lambda s: s
+        session.__exit__ = MagicMock(return_value=False)
+        driver = MagicMock()
+        driver.session.return_value = session
+        mock_driver.return_value = driver
+        # Ollama: mock HTTP
+        mock_httpx_get.return_value = MagicMock(status_code=200)
+
+        r = client.get("/ready")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "ready"
+        assert body["services"]["qdrant"] == "ok"
+        assert body["services"]["memgraph"] == "ok"
+        assert body["services"]["ollama"] == "ok"
+
+    @patch("metatron.api.routes.health.httpx.get", side_effect=ConnectionError("no ollama"))
+    @patch("metatron.storage.memgraph.get_memgraph_driver", side_effect=Exception("memgraph down"))
+    @patch("metatron.storage.qdrant.get_hybrid_store", side_effect=Exception("qdrant down"))
+    def test_ready_all_down_returns_503(
+        self, mock_store, mock_driver, mock_httpx_get, client: TestClient,
+    ) -> None:
+        r = client.get("/ready")
+        assert r.status_code == 503
+        body = r.json()
+        assert body["status"] == "degraded"
+        assert "error" in body["services"]["qdrant"]
+        assert "error" in body["services"]["memgraph"]
+        assert "error" in body["services"]["ollama"]
+
+    @patch("metatron.api.routes.health.httpx.get")
+    @patch("metatron.storage.memgraph.get_memgraph_driver")
+    @patch("metatron.storage.qdrant.get_hybrid_store", side_effect=Exception("qdrant down"))
+    def test_ready_partial_degraded(
+        self, mock_store, mock_driver, mock_httpx_get, client: TestClient,
+    ) -> None:
+        # Memgraph ok
+        session = MagicMock()
+        session.__enter__ = lambda s: s
+        session.__exit__ = MagicMock(return_value=False)
+        driver = MagicMock()
+        driver.session.return_value = session
+        mock_driver.return_value = driver
+        # Ollama ok
+        mock_httpx_get.return_value = MagicMock(status_code=200)
+
+        r = client.get("/ready")
+        assert r.status_code == 503
+        body = r.json()
+        assert body["status"] == "degraded"
+        assert body["services"]["memgraph"] == "ok"
+        assert "error" in body["services"]["qdrant"]
+
+
+# ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+
+class TestCORS:
+    def test_cors_headers_present(self, client: TestClient) -> None:
+        r = client.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert "access-control-allow-origin" in r.headers
+
+    def test_cors_allows_configured_origin(self, client: TestClient) -> None:
+        r = client.get("/health", headers={"Origin": "http://localhost:3000"})
+        assert r.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    def test_cors_wildcard_default(self) -> None:
+        """With default CORS_ORIGINS='*', all origins are allowed."""
+        app = create_app(Settings(METATRON_ENV="development"))
+        c = TestClient(app)
+        r = c.get("/health", headers={"Origin": "https://any-site.com"})
+        assert r.headers.get("access-control-allow-origin") == "*"
+
+
+# ---------------------------------------------------------------------------
+# /metrics
+# ---------------------------------------------------------------------------
+
+class TestMetrics:
+    def test_metrics_returns_data(self, client: TestClient) -> None:
+        r = client.get("/metrics")
+        assert r.status_code == 200
+        assert isinstance(r.json(), dict)
+
+    def test_metrics_reset(self, client: TestClient) -> None:
+        r = client.post("/metrics/reset")
+        assert r.status_code == 200
+        assert r.json()["status"] == "reset"
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/chat
+# ---------------------------------------------------------------------------
+
+class TestChat:
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_chat_returns_answer(
+        self, mock_search, mock_mgr, client: TestClient,
+    ) -> None:
+        mock_mgr.return_value.get_active_workspace.return_value = _DEFAULT_WS
+        mock_search.return_value = "The answer is 42."
+
+        r = client.post("/api/v1/chat", json={
+            "question": "What is the meaning of life?",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["answer"] == "The answer is 42."
+        assert body["workspace_id"] == "TEST_WS"
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_chat_with_workspace_id(
+        self, mock_search, mock_mgr, client: TestClient,
+    ) -> None:
+        mock_search.return_value = "Answer for PROJ."
+
+        r = client.post("/api/v1/chat", json={
+            "question": "Tell me about the project",
+            "workspace_id": "PROJ",
+        })
+        assert r.status_code == 200
+        assert r.json()["workspace_id"] == "PROJ"
+
+    def test_chat_empty_question_rejected(self, client: TestClient) -> None:
+        r = client.post("/api/v1/chat", json={"question": ""})
+        assert r.status_code == 422
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer",
+           side_effect=RuntimeError("LLM error"))
+    def test_chat_search_error_returns_500(
+        self, mock_search, mock_mgr, client: TestClient,
+    ) -> None:
+        mock_mgr.return_value.get_active_workspace.return_value = _DEFAULT_WS
+        r = client.post("/api/v1/chat", json={"question": "hello"})
+        assert r.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/chat/stream
+# ---------------------------------------------------------------------------
+
+class TestChatStream:
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_stream_returns_sse_events(
+        self, mock_search, mock_mgr, client: TestClient,
+    ) -> None:
+        mock_mgr.return_value.get_active_workspace.return_value = _DEFAULT_WS
+        mock_search.return_value = (
+            "First sentence. Second sentence."
+            "\n\n\U0001f4da Sources:\n\U0001f4c4 Design Doc"
+        )
+
+        with client.stream("POST", "/api/v1/chat/stream", json={
+            "question": "Tell me about the project",
+        }) as r:
+            assert r.status_code == 200
+            content_type = r.headers.get("content-type", "")
+            assert "text/event-stream" in content_type
+
+            raw = b""
+            for chunk in r.iter_bytes():
+                raw += chunk
+
+        text = raw.decode()
+        # Should contain status, chunk, sources, and done events
+        assert "event: status" in text
+        assert "event: chunk" in text
+        assert "event: sources" in text
+        assert "event: done" in text
+        # Verify sources content
+        assert "Design Doc" in text
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer",
+           side_effect=RuntimeError("LLM boom"))
+    def test_stream_error_sends_error_event(
+        self, mock_search, mock_mgr, client: TestClient,
+    ) -> None:
+        mock_mgr.return_value.get_active_workspace.return_value = _DEFAULT_WS
+
+        with client.stream("POST", "/api/v1/chat/stream", json={
+            "question": "hello",
+        }) as r:
+            raw = b""
+            for chunk in r.iter_bytes():
+                raw += chunk
+
+        text = raw.decode()
+        assert "event: error" in text
+        assert "LLM boom" in text
+        assert "event: done" in text
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/upload
+# ---------------------------------------------------------------------------
+
+class TestUpload:
+    @patch("metatron.api.routes.chat._ingest_text")
+    def test_upload_text_file(self, mock_ingest, client: TestClient) -> None:
+        mock_ingest.return_value = {
+            "chunks": 3,
+            "workspace_id": "TEST_WS",
+            "graph_extracted": True,
+        }
+        r = client.post(
+            "/api/v1/upload",
+            files={"file": ("doc.txt", BytesIO(b"Hello world"), "text/plain")},
+            data={"user_id": "u1", "workspace_id": "TEST_WS"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "ok"
+        assert body["file_name"] == "doc.txt"
+        assert body["chunks"] == 3
+
+    def test_upload_empty_file_rejected(self, client: TestClient) -> None:
+        r = client.post(
+            "/api/v1/upload",
+            files={"file": ("empty.txt", BytesIO(b""), "text/plain")},
+        )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/workspaces
+# ---------------------------------------------------------------------------
+
+class TestWorkspaces:
+    @patch("metatron.api.routes.workspaces.get_workspace_manager")
+    def test_list_workspaces(self, mock_mgr, client: TestClient) -> None:
+        mock_mgr.return_value.list_workspaces.return_value = [_DEFAULT_WS]
+        r = client.get("/api/v1/workspaces/")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        assert body["workspaces"][0]["workspace_id"] == "TEST_WS"
+
+    @patch("metatron.api.routes.workspaces.get_workspace_manager")
+    def test_create_workspace(self, mock_mgr, client: TestClient) -> None:
+        new_ws = Workspace(workspace_id="NEW", name="New WS", user_id="user")
+        mock_mgr.return_value.create_workspace.return_value = new_ws
+        r = client.post("/api/v1/workspaces/", json={
+            "name": "New WS",
+            "user_id": "user",
+        })
+        assert r.status_code == 201
+        assert r.json()["workspace_id"] == "NEW"
+
+    @patch("metatron.api.routes.workspaces.get_workspace_manager")
+    def test_get_workspace(self, mock_mgr, client: TestClient) -> None:
+        mock_mgr.return_value.get_workspace.return_value = _DEFAULT_WS
+        r = client.get("/api/v1/workspaces/TEST_WS")
+        assert r.status_code == 200
+        assert r.json()["name"] == "Test Workspace"
+
+    @patch("metatron.api.routes.workspaces.get_workspace_manager")
+    def test_get_workspace_not_found(self, mock_mgr, client: TestClient) -> None:
+        mock_mgr.return_value.get_workspace.return_value = None
+        r = client.get("/api/v1/workspaces/NOPE")
+        assert r.status_code == 404
+
+    @patch("metatron.storage.memgraph.delete_workspace_graph")
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    @patch("metatron.api.routes.workspaces.get_workspace_manager")
+    def test_delete_workspace(
+        self, mock_mgr, mock_store, mock_graph, client: TestClient,
+    ) -> None:
+        mock_mgr.return_value.get_workspace.return_value = _DEFAULT_WS
+        mock_mgr.return_value.delete_workspace.return_value = True
+        store = MagicMock()
+        mock_store.return_value = store
+
+        r = client.delete("/api/v1/workspaces/TEST_WS?user_id=user")
+        assert r.status_code == 200
+        assert r.json()["status"] == "deleted"
+
+    @patch("metatron.api.routes.workspaces.get_workspace_manager")
+    def test_activate_workspace(self, mock_mgr, client: TestClient) -> None:
+        mock_mgr.return_value.get_workspace.return_value = _DEFAULT_WS
+        mock_mgr.return_value.set_active_workspace.return_value = True
+        r = client.post("/api/v1/workspaces/TEST_WS/activate?user_id=user")
+        assert r.status_code == 200
+        assert r.json()["status"] == "activated"
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/connections/sync/{type}
+# ---------------------------------------------------------------------------
+
+class TestConnectionSync:
+    @patch("metatron.api.routes.connections._run_sync")
+    @patch("metatron.api.routes.connections._config_from_env")
+    @patch("metatron.api.routes.connections._get_registry")
+    def test_sync_by_type_starts_background_task(
+        self, mock_registry, mock_config, mock_run, client: TestClient,
+    ) -> None:
+        mock_registry.return_value.is_registered.return_value = True
+        mock_config.return_value = {"url": "https://jira.test", "username": "u", "api_token": "t", "project_key": "P"}
+
+        r = client.post("/api/v1/connections/sync/jira")
+        assert r.status_code == 200
+        assert r.json()["status"] == "sync_started"
+
+    @patch("metatron.api.routes.connections._get_registry")
+    def test_sync_unknown_type_400(self, mock_registry, client: TestClient) -> None:
+        mock_registry.return_value.is_registered.return_value = False
+        mock_registry.return_value.list_available.return_value = ["confluence", "jira"]
+        r = client.post("/api/v1/connections/sync/notion")
+        assert r.status_code == 400
+        assert "Unknown connector" in r.json()["detail"]
+
+    @patch("metatron.api.routes.connections._config_from_env", return_value={})
+    @patch("metatron.api.routes.connections._get_registry")
+    def test_sync_no_env_config_400(
+        self, mock_registry, mock_config, client: TestClient,
+    ) -> None:
+        mock_registry.return_value.is_registered.return_value = True
+        r = client.post("/api/v1/connections/sync/confluence")
+        assert r.status_code == 400
+        assert "No environment config" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/admin
+# ---------------------------------------------------------------------------
+
+class TestAdmin:
+    @patch("metatron.api.routes.admin.get_cleanup_preview")
+    def test_cleanup_preview(self, mock_preview, client: TestClient) -> None:
+        mock_preview.return_value = {
+            "cleanup_allowed": False,
+            "qdrant": {"collections": [], "total_points": 0},
+            "memgraph": {"nodes": 0, "relationships": 0},
+        }
+        r = client.get("/api/v1/admin/cleanup/preview")
+        assert r.status_code == 200
+        assert "cleanup_allowed" in r.json()
+
+    def test_cleanup_workspace_requires_header(self, client: TestClient) -> None:
+        r = client.delete("/api/v1/admin/cleanup/workspace/TEST_WS")
+        assert r.status_code == 400
+        assert "X-Confirm-Cleanup" in r.json()["detail"]
+
+    def test_cleanup_all_requires_header(self, client: TestClient) -> None:
+        r = client.delete("/api/v1/admin/cleanup/all")
+        assert r.status_code == 400
+        assert "DELETE-ALL-DATA" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers (sentence splitting)
+# ---------------------------------------------------------------------------
+
+class TestSentenceSplitter:
+    def test_splits_on_sentence_boundaries(self) -> None:
+        from metatron.api.routes.chat import _split_into_sentences
+        text = "First sentence. Second sentence. Third sentence here."
+        chunks = _split_into_sentences(text)
+        assert len(chunks) >= 1
+        # All text is preserved
+        assert "".join(chunks).replace(" ", "") == text.replace(" ", "")
+
+    def test_empty_string_returns_original(self) -> None:
+        from metatron.api.routes.chat import _split_into_sentences
+        assert _split_into_sentences("") == [""]
+
+    def test_short_text_single_chunk(self) -> None:
+        from metatron.api.routes.chat import _split_into_sentences
+        assert _split_into_sentences("Hi.") == ["Hi."]
+
+
+class TestSourceExtraction:
+    def test_extracts_sources(self) -> None:
+        from metatron.api.routes.chat import _extract_sources_section
+        answer = "The answer.\n\n\U0001f4da Sources:\n\U0001f4c4 Doc A\n\U0001f4cb Task B"
+        body, sources = _extract_sources_section(answer)
+        assert body == "The answer."
+        assert len(sources) == 2
+        assert "\U0001f4c4 Doc A" in sources
+
+    def test_no_sources_section(self) -> None:
+        from metatron.api.routes.chat import _extract_sources_section
+        body, sources = _extract_sources_section("Just an answer.")
+        assert body == "Just an answer."
+        assert sources == []

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -63,26 +63,12 @@ class TestHealth:
 # ---------------------------------------------------------------------------
 
 class TestReady:
-    @patch("metatron.api.routes.health.httpx.get")
-    @patch("metatron.storage.memgraph.get_memgraph_driver")
-    @patch("metatron.storage.qdrant.get_hybrid_store")
+    @patch("metatron.api.routes.health._check_ollama")
+    @patch("metatron.api.routes.health._check_memgraph")
+    @patch("metatron.api.routes.health._check_qdrant")
     def test_ready_all_ok(
-        self, mock_store, mock_driver, mock_httpx_get, client: TestClient,
+        self, mock_qdrant, mock_memgraph, mock_ollama, client: TestClient,
     ) -> None:
-        # Qdrant: mock collections
-        store = MagicMock()
-        store.client.get_collections.return_value = MagicMock(collections=[])
-        mock_store.return_value = store
-        # Memgraph: mock session
-        session = MagicMock()
-        session.__enter__ = lambda s: s
-        session.__exit__ = MagicMock(return_value=False)
-        driver = MagicMock()
-        driver.session.return_value = session
-        mock_driver.return_value = driver
-        # Ollama: mock HTTP
-        mock_httpx_get.return_value = MagicMock(status_code=200)
-
         r = client.get("/ready")
         assert r.status_code == 200
         body = r.json()
@@ -91,42 +77,46 @@ class TestReady:
         assert body["services"]["memgraph"] == "ok"
         assert body["services"]["ollama"] == "ok"
 
-    @patch("metatron.api.routes.health.httpx.get", side_effect=ConnectionError("no ollama"))
-    @patch("metatron.storage.memgraph.get_memgraph_driver", side_effect=Exception("memgraph down"))
-    @patch("metatron.storage.qdrant.get_hybrid_store", side_effect=Exception("qdrant down"))
+    @patch("metatron.api.routes.health._check_ollama", side_effect=ConnectionError("no ollama"))
+    @patch("metatron.api.routes.health._check_memgraph", side_effect=Exception("memgraph down"))
+    @patch("metatron.api.routes.health._check_qdrant", side_effect=Exception("qdrant down"))
     def test_ready_all_down_returns_503(
-        self, mock_store, mock_driver, mock_httpx_get, client: TestClient,
+        self, mock_qdrant, mock_memgraph, mock_ollama, client: TestClient,
     ) -> None:
         r = client.get("/ready")
         assert r.status_code == 503
         body = r.json()
         assert body["status"] == "degraded"
-        assert "error" in body["services"]["qdrant"]
-        assert "error" in body["services"]["memgraph"]
-        assert "error" in body["services"]["ollama"]
+        assert body["services"]["qdrant"] == "error"
+        assert body["services"]["memgraph"] == "error"
+        assert body["services"]["ollama"] == "error"
 
-    @patch("metatron.api.routes.health.httpx.get")
-    @patch("metatron.storage.memgraph.get_memgraph_driver")
-    @patch("metatron.storage.qdrant.get_hybrid_store", side_effect=Exception("qdrant down"))
-    def test_ready_partial_degraded(
-        self, mock_store, mock_driver, mock_httpx_get, client: TestClient,
+    @patch("metatron.api.routes.health._check_ollama", side_effect=ConnectionError("no ollama"))
+    @patch("metatron.api.routes.health._check_memgraph", side_effect=Exception("memgraph down"))
+    @patch("metatron.api.routes.health._check_qdrant", side_effect=Exception("qdrant down"))
+    def test_ready_error_no_details(
+        self, mock_qdrant, mock_memgraph, mock_ollama, client: TestClient,
     ) -> None:
-        # Memgraph ok
-        session = MagicMock()
-        session.__enter__ = lambda s: s
-        session.__exit__ = MagicMock(return_value=False)
-        driver = MagicMock()
-        driver.session.return_value = session
-        mock_driver.return_value = driver
-        # Ollama ok
-        mock_httpx_get.return_value = MagicMock(status_code=200)
+        """Error responses must not leak exception messages."""
+        r = client.get("/ready")
+        body = r.json()
+        for svc_status in body["services"].values():
+            assert svc_status == "error"
+            assert "down" not in svc_status
+            assert ":" not in svc_status
 
+    @patch("metatron.api.routes.health._check_ollama")
+    @patch("metatron.api.routes.health._check_memgraph")
+    @patch("metatron.api.routes.health._check_qdrant", side_effect=Exception("qdrant down"))
+    def test_ready_partial_degraded(
+        self, mock_qdrant, mock_memgraph, mock_ollama, client: TestClient,
+    ) -> None:
         r = client.get("/ready")
         assert r.status_code == 503
         body = r.json()
         assert body["status"] == "degraded"
         assert body["services"]["memgraph"] == "ok"
-        assert "error" in body["services"]["qdrant"]
+        assert body["services"]["qdrant"] == "error"
 
 
 # ---------------------------------------------------------------------------
@@ -148,12 +138,19 @@ class TestCORS:
         r = client.get("/health", headers={"Origin": "http://localhost:3000"})
         assert r.headers.get("access-control-allow-origin") == "http://localhost:3000"
 
-    def test_cors_wildcard_default(self) -> None:
-        """With default CORS_ORIGINS='*', all origins are allowed."""
+    def test_cors_explicit_with_credentials(self, client: TestClient) -> None:
+        """With explicit origins, credentials are allowed."""
+        r = client.get("/health", headers={"Origin": "http://localhost:3000"})
+        assert r.headers.get("access-control-allow-credentials") == "true"
+
+    def test_cors_wildcard_no_credentials(self) -> None:
+        """With CORS_ORIGINS='*', credentials must be disabled."""
         app = create_app(Settings(METATRON_ENV="development"))
         c = TestClient(app)
         r = c.get("/health", headers={"Origin": "https://any-site.com"})
         assert r.headers.get("access-control-allow-origin") == "*"
+        # Wildcard + credentials is invalid per CORS spec
+        assert r.headers.get("access-control-allow-credentials") is None
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +217,9 @@ class TestChat:
         mock_mgr.return_value.get_active_workspace.return_value = _DEFAULT_WS
         r = client.post("/api/v1/chat", json={"question": "hello"})
         assert r.status_code == 500
+        # Error detail must not leak exception internals
+        assert "LLM error" not in r.json().get("detail", "")
+        assert "Search failed" in r.json().get("detail", "")
 
 
 # ---------------------------------------------------------------------------
@@ -275,8 +275,28 @@ class TestChatStream:
 
         text = raw.decode()
         assert "event: error" in text
-        assert "LLM boom" in text
         assert "event: done" in text
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer",
+           side_effect=RuntimeError("LLM boom"))
+    def test_stream_error_no_details(
+        self, mock_search, mock_mgr, client: TestClient,
+    ) -> None:
+        """SSE error events must not leak exception messages."""
+        mock_mgr.return_value.get_active_workspace.return_value = _DEFAULT_WS
+
+        with client.stream("POST", "/api/v1/chat/stream", json={
+            "question": "hello",
+        }) as r:
+            raw = b""
+            for chunk in r.iter_bytes():
+                raw += chunk
+
+        text = raw.decode()
+        assert "event: error" in text
+        assert "LLM boom" not in text
+        assert "Search failed" in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- /ready: probes Qdrant, Memgraph, Ollama (200/503)
- CORS middleware with configurable origins
- POST /api/v1/chat/stream: SSE with status/chunk/sources/done events
- 34 API tests