### PR TITLE
fix: workspace is_active flag and PostgreSQL sync

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -123,6 +123,7 @@ Replace per-source hardcoded metadata with universal LLM-based extraction at ing
 - [ ] Connection credentials in PostgreSQL (encrypted), not just .env
 - [ ] Docker Compose production hardening (limits, healthchecks, restart)
 - [ ] Centralized structured logging
+- [ ] **Workspace storage consolidation** — currently workspaces are duplicated in Memgraph (source of truth) and PostgreSQL (for foreign keys). Consider: (1) moving to PostgreSQL-only with optional Memgraph sync for graph queries, or (2) removing foreign key constraints and using workspace_id as plain string
 
 ### Auth
 - [ ] Telegram user → internal role mapping

--- a/src/metatron/api/routes/workspaces.py
+++ b/src/metatron/api/routes/workspaces.py
@@ -58,12 +58,24 @@ class ActivateResponse(BaseModel):
 
 
 @router.get("/", response_model=WorkspaceListResponse)
-def list_workspaces(user_id: Optional[str] = Query(None)) -> WorkspaceListResponse:
+def list_workspaces(user_id: Optional[str] = Query("user")) -> WorkspaceListResponse:
     """List all workspaces."""
     manager = get_workspace_manager()
     workspaces = manager.list_workspaces(user_id=user_id)
+    
+    # Get active workspace for this user
+    active_workspace = manager.get_active_workspace(user_id or "user")
+    active_workspace_id = active_workspace.workspace_id
+    
+    # Mark only the active workspace as is_active=True
+    workspace_responses = []
+    for ws in workspaces:
+        ws_dict = ws.to_dict()
+        ws_dict["is_active"] = (ws.workspace_id == active_workspace_id)
+        workspace_responses.append(WorkspaceResponse(**ws_dict))
+    
     return WorkspaceListResponse(
-        workspaces=[WorkspaceResponse(**ws.to_dict()) for ws in workspaces],
+        workspaces=workspace_responses,
         count=len(workspaces),
     )
 

--- a/src/metatron/workspaces/manager.py
+++ b/src/metatron/workspaces/manager.py
@@ -55,6 +55,8 @@ class WorkspaceManager:
             workspaces = self._persistence.load_all_workspaces()
             for ws in workspaces:
                 self._workspaces[ws.workspace_id] = ws
+                # Sync each workspace to PostgreSQL
+                self._sync_workspace_to_postgres(ws)
             logger.info("workspace.loaded", count=len(workspaces))
         except Exception as e:
             logger.error("workspace.load.failed", error=str(e))
@@ -62,6 +64,48 @@ class WorkspaceManager:
             self._stats = self._persistence.load_all_workspace_stats()
         except Exception as e:
             logger.error("workspace.stats.load.failed", error=str(e))
+
+    def _sync_workspace_to_postgres(self, workspace: Workspace) -> None:
+        """Sync workspace to PostgreSQL for foreign key integrity (minimal fields only)."""
+        try:
+            from metatron.storage.pg_connection import get_session
+            from sqlalchemy import text
+            
+            with get_session() as session:
+                # Check if workspace exists
+                result = session.execute(
+                    text("SELECT id FROM workspaces WHERE id = :id"),
+                    {"id": workspace.workspace_id}
+                ).fetchone()
+                
+                if result:
+                    # Update existing
+                    session.execute(
+                        text("UPDATE workspaces SET name = :name, slug = :slug WHERE id = :id"),
+                        {
+                            "id": workspace.workspace_id,
+                            "name": workspace.name,
+                            "slug": workspace.workspace_id.lower(),
+                        }
+                    )
+                else:
+                    # Create new (only fields that exist in migration 001)
+                    session.execute(
+                        text("""
+                            INSERT INTO workspaces (id, name, slug, created_at)
+                            VALUES (:id, :name, :slug, NOW())
+                        """),
+                        {
+                            "id": workspace.workspace_id,
+                            "name": workspace.name,
+                            "slug": workspace.workspace_id.lower(),
+                        }
+                    )
+                
+                session.commit()
+                logger.info("workspace.postgres.synced", workspace_id=workspace.workspace_id)
+        except Exception as e:
+            logger.warning("workspace.postgres.sync.failed", workspace_id=workspace.workspace_id, error=str(e))
 
     def _ensure_default_workspace(self) -> None:
         from metatron.core.config import Settings
@@ -82,6 +126,8 @@ class WorkspaceManager:
                     self._persistence.save_workspace(default)
                 except Exception as e:
                     logger.warning("workspace.persist.default.failed", error=str(e))
+            # Sync to PostgreSQL
+            self._sync_workspace_to_postgres(default)
             logger.info("workspace.default.created", workspace_id=default_id)
 
     def create_workspace(
@@ -109,6 +155,8 @@ class WorkspaceManager:
                     self._persistence.save_workspace(workspace)
                 except Exception as e:
                     logger.warning("workspace.persist.failed", error=str(e))
+            # Sync to PostgreSQL
+            self._sync_workspace_to_postgres(workspace)
             return workspace
 
     def get_workspace(self, workspace_id: str) -> Workspace | None:


### PR DESCRIPTION
- Fix is_active in workspace list to show only active workspace per user
- Add workspace sync to PostgreSQL for foreign key integrity
- Workspaces now stored in both Memgraph (source of truth) and PostgreSQL
- Auto-sync on workspace creation and manager initialization
- Add TODO note about workspace storage consolidation