### PR TITLE
feat: add graph visualization API (overview + expand endpoints)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ src/metatron/
 │   ├── middleware.py          # OptionalAuthMiddleware (JWT gate)
 │   ├── dependencies.py        # FastAPI DI helpers
 │   └── routes/                # auth, chat, admin, skills, connections, documents,
-│                              # workspaces, sync, benchmarker, dashboard/, files, health
+│                              # workspaces, sync, benchmarker, dashboard/, files, graph, health
 ├── auth/
 │   ├── jwt.py                 # HS256, create_token/verify_token, 24h default
 │   ├── rbac.py                # Role hierarchy: viewer(0) < editor(1) < admin(2)

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -25,6 +25,7 @@ from metatron.api.routes import (
     dashboard,
     documents,
     files,
+    graph,
     health,
     skills,
     sync,
@@ -135,6 +136,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(benchmarker.router, prefix="/api/v1")
     app.include_router(dashboard.router, prefix="/api/v1")
     app.include_router(files.router, prefix="/api/v1")
+    app.include_router(graph.router, prefix="/api/v1")
 
     # Lazy import benchmarker module router (optional dependency)
     try:

--- a/src/metatron/api/routes/graph.py
+++ b/src/metatron/api/routes/graph.py
@@ -1,0 +1,79 @@
+"""Knowledge graph visualization API — /api/v1/graph."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, HTTPException, Query
+from neo4j.exceptions import ServiceUnavailable, SessionExpired
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/graph", tags=["graph"])
+
+
+class GraphNode(BaseModel):
+    id: int
+    name: str
+    type: str | None
+    workspace_id: str | None
+    connections: int
+
+
+class GraphEdge(BaseModel):
+    source: int
+    target: int
+    type: str | None
+    valid_from: str | None = None
+    valid_to: str | None = None
+
+
+class GraphResponse(BaseModel):
+    nodes: list[GraphNode]
+    edges: list[GraphEdge]
+    truncated: bool
+
+
+@router.get("/overview", response_model=GraphResponse)
+async def graph_overview(
+    workspace_id: str = Query(..., description="Workspace ID"),
+    limit: int = Query(100, ge=1, le=500, description="Max nodes to return"),
+) -> GraphResponse:
+    """Get top-N most connected entities for initial graph render."""
+    from metatron.storage.graph_ops import get_graph_overview
+
+    try:
+        data = await asyncio.to_thread(get_graph_overview, workspace_id, limit)
+    except (ServiceUnavailable, SessionExpired, ConnectionError,
+            BrokenPipeError, OSError) as exc:
+        raise HTTPException(status_code=502, detail=f"Memgraph unavailable: {exc}")
+
+    return GraphResponse(
+        nodes=[GraphNode(**n) for n in data["nodes"]],
+        edges=[GraphEdge(**e) for e in data["edges"]],
+        truncated=data["truncated"],
+    )
+
+
+@router.get("/expand/{entity_id}", response_model=GraphResponse)
+async def graph_expand(
+    entity_id: int,
+    workspace_id: str = Query(..., description="Workspace ID"),
+    depth: int = Query(2, ge=1, le=3, description="Traversal depth"),
+    limit: int = Query(50, ge=1, le=500, description="Max neighbor nodes"),
+) -> GraphResponse:
+    """Expand a single entity by Memgraph internal ID — return its neighbors and edges."""
+    from metatron.storage.graph_ops import get_graph_expand
+
+    try:
+        data = await asyncio.to_thread(
+            get_graph_expand, entity_id, workspace_id, depth, limit,
+        )
+    except (ServiceUnavailable, SessionExpired, ConnectionError,
+            BrokenPipeError, OSError) as exc:
+        raise HTTPException(status_code=502, detail=f"Memgraph unavailable: {exc}")
+
+    return GraphResponse(
+        nodes=[GraphNode(**n) for n in data["nodes"]],
+        edges=[GraphEdge(**e) for e in data["edges"]],
+        truncated=data["truncated"],
+    )

--- a/src/metatron/storage/graph_ops.py
+++ b/src/metatron/storage/graph_ops.py
@@ -283,3 +283,150 @@ def get_related_documents(texts: List[str],
                 {"texts": texts, "ws": workspace_id},
             )
         return [{"doc_id": r["doc_id"], "file_name": r["file_name"]} for r in doc_res]
+
+
+@memgraph_retry()
+def get_graph_overview(workspace_id: Optional[str] = None,
+                       limit: int = 100) -> Dict:
+    """Get top-N most connected entities with edges between them.
+
+    Returns nodes sorted by connection count (degree) and all edges
+    that exist between the returned nodes.
+    """
+    workspace_id = _normalize_workspace_id(workspace_id)
+    limit = max(1, min(limit, 500))
+    driver = get_memgraph_driver()
+    with driver.session() as s:
+        if workspace_id == DEFAULT_WORKSPACE_ID:
+            ws_filter = "(e.workspace_id = $ws OR e.workspace_id IS NULL)"
+            ws_filter_e1 = "(e1.workspace_id = $ws OR e1.workspace_id IS NULL)"
+            ws_filter_e2 = "(e2.workspace_id = $ws OR e2.workspace_id IS NULL)"
+        else:
+            ws_filter = "e.workspace_id = $ws"
+            ws_filter_e1 = "e1.workspace_id = $ws"
+            ws_filter_e2 = "e2.workspace_id = $ws"
+
+        # 1. Top-N nodes by degree
+        node_res = s.run(
+            f"MATCH (e:Entity) WHERE {ws_filter} "
+            "OPTIONAL MATCH (e)-[r:RELATION]-() "
+            "WITH e, count(r) AS degree "
+            "ORDER BY degree DESC LIMIT $lim "
+            "RETURN id(e) AS uid, e.name AS name, e.type AS type, "
+            "e.workspace_id AS workspace_id, degree",
+            {"ws": workspace_id, "lim": limit},
+        )
+        nodes = []
+        node_names: set[str] = set()
+        for r in node_res:
+            # Skip NULL-workspace nodes that slip through the DEFAULT
+            # filter — prevents leaking unassigned entities.
+            if r["workspace_id"] is None:
+                continue
+            nodes.append({
+                "id": r["uid"],
+                "name": r["name"],
+                "type": r["type"],
+                "workspace_id": r["workspace_id"],
+                "connections": r["degree"],
+            })
+            node_names.add(r["name"])
+
+        # 2. Edges between returned nodes only
+        edges: list[Dict] = []
+        if len(node_names) >= 2:
+            edge_res = s.run(
+                f"MATCH (e1:Entity)-[r:RELATION]->(e2:Entity) "
+                f"WHERE {ws_filter_e1} "
+                f"AND {ws_filter_e2} "
+                "AND e1.name IN $names AND e2.name IN $names "
+                "RETURN DISTINCT id(e1) AS source, id(e2) AS target, "
+                "r.type AS type, r.valid_from AS valid_from, r.valid_to AS valid_to",
+                {"ws": workspace_id, "names": list(node_names)},
+            )
+            edges = [
+                {"source": r["source"], "target": r["target"],
+                 "type": r["type"], "valid_from": r["valid_from"],
+                 "valid_to": r["valid_to"]}
+                for r in edge_res
+            ]
+
+    return {"nodes": nodes, "edges": edges, "truncated": len(nodes) >= limit}
+
+
+@memgraph_retry()
+def get_graph_expand(entity_id: int,
+                     workspace_id: Optional[str] = None,
+                     depth: int = 2,
+                     limit: int = 50) -> Dict:
+    """Expand a single entity by Memgraph internal ID.
+
+    Args:
+        entity_id: Memgraph internal node ID.
+        depth: Traversal depth (1-3).
+        limit: Max neighbor nodes to return.
+    """
+    workspace_id = _normalize_workspace_id(workspace_id)
+    depth = max(1, min(depth, 3))
+    limit = max(1, min(limit, 500))
+    driver = get_memgraph_driver()
+    with driver.session() as s:
+        if workspace_id == DEFAULT_WORKSPACE_ID:
+            ws_filter_n = "(n.workspace_id = $ws OR n.workspace_id IS NULL)"
+            ws_filter_e1 = "(e1.workspace_id = $ws OR e1.workspace_id IS NULL)"
+            ws_filter_e2 = "(e2.workspace_id = $ws OR e2.workspace_id IS NULL)"
+        else:
+            ws_filter_n = "n.workspace_id = $ws"
+            ws_filter_e1 = "e1.workspace_id = $ws"
+            ws_filter_e2 = "e2.workspace_id = $ws"
+
+        # 1. Find neighbors via RELATION edges up to depth
+        node_res = s.run(
+            f"MATCH (e:Entity) WHERE id(e) = $eid "
+            f"MATCH (e)-[:RELATION*1..{depth}]-(n:Entity) "
+            f"WHERE {ws_filter_n} AND id(n) <> $eid "
+            "OPTIONAL MATCH (n)-[r:RELATION]-() "
+            "WITH DISTINCT n, count(r) AS degree "
+            "ORDER BY degree DESC LIMIT $lim "
+            "RETURN id(n) AS uid, n.name AS name, n.type AS type, "
+            "n.workspace_id AS workspace_id, degree",
+            {"eid": entity_id, "ws": workspace_id, "lim": limit},
+        )
+        nodes = []
+        node_ids: set[int] = set()
+        for r in node_res:
+            # Skip NULL-workspace nodes that slip through the DEFAULT
+            # filter — prevents leaking unassigned entities.
+            if r["workspace_id"] is None:
+                continue
+            nodes.append({
+                "id": r["uid"],
+                "name": r["name"],
+                "type": r["type"],
+                "workspace_id": r["workspace_id"],
+                "connections": r["degree"],
+            })
+            node_ids.add(r["uid"])
+
+        # Include the center entity itself
+        node_ids.add(entity_id)
+
+        # 2. All edges between returned nodes + center
+        edges: list[Dict] = []
+        if node_ids:
+            edge_res = s.run(
+                "MATCH (e1:Entity)-[r:RELATION]->(e2:Entity) "
+                f"WHERE {ws_filter_e1} AND {ws_filter_e2} "
+                "AND id(e1) IN $ids AND id(e2) IN $ids "
+                "RETURN DISTINCT id(e1) AS source, id(e2) AS target, "
+                "r.type AS type, r.valid_from AS valid_from, r.valid_to AS valid_to",
+                {"ids": list(node_ids), "ws": workspace_id},
+            )
+            edges = [
+                {"source": r["source"], "target": r["target"],
+                 "type": r["type"], "valid_from": r["valid_from"],
+                 "valid_to": r["valid_to"]}
+                for r in edge_res
+            ]
+
+    return {"nodes": nodes, "edges": edges, "truncated": len(nodes) >= limit}

--- a/tests/unit/test_graph_api.py
+++ b/tests/unit/test_graph_api.py
@@ -1,0 +1,171 @@
+"""Tests for knowledge graph visualization API endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from neo4j.exceptions import ServiceUnavailable
+
+from metatron.api.app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    return TestClient(app)
+
+
+# --- overview ---
+
+def test_overview_returns_nodes_and_edges(client):
+    mock_data = {
+        "nodes": [
+            {"id": 1, "name": "Qdrant", "type": "Technology",
+             "workspace_id": "ws_test", "connections": 5},
+            {"id": 2, "name": "Metatron", "type": "Project",
+             "workspace_id": "ws_test", "connections": 3},
+        ],
+        "edges": [
+            {"source": 1, "target": 2, "type": "USED_IN",
+             "valid_from": "2025-01-01", "valid_to": None},
+        ],
+        "truncated": False,
+    }
+    with patch("metatron.storage.graph_ops.get_graph_overview", return_value=mock_data):
+        resp = client.get("/api/v1/graph/overview?workspace_id=ws_test")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["nodes"]) == 2
+    assert len(data["edges"]) == 1
+    assert data["nodes"][0]["name"] == "Qdrant"
+    assert data["truncated"] is False
+    assert "total_nodes" not in data
+
+
+def test_overview_empty_graph(client):
+    mock_data = {"nodes": [], "edges": [], "truncated": False}
+    with patch("metatron.storage.graph_ops.get_graph_overview", return_value=mock_data):
+        resp = client.get("/api/v1/graph/overview?workspace_id=ws_test")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["nodes"] == []
+    assert data["edges"] == []
+
+
+def test_overview_requires_workspace_id(client):
+    resp = client.get("/api/v1/graph/overview")
+    assert resp.status_code == 422
+
+
+def test_overview_memgraph_unavailable(client):
+    with patch(
+        "metatron.storage.graph_ops.get_graph_overview",
+        side_effect=ServiceUnavailable("Connection refused"),
+    ):
+        resp = client.get("/api/v1/graph/overview?workspace_id=ws_test")
+
+    assert resp.status_code == 502
+
+
+def test_overview_limit_param(client):
+    mock_data = {"nodes": [], "edges": [], "truncated": False}
+    with patch("metatron.storage.graph_ops.get_graph_overview", return_value=mock_data) as m:
+        resp = client.get("/api/v1/graph/overview?workspace_id=ws_test&limit=50")
+
+    assert resp.status_code == 200
+    m.assert_called_once_with("ws_test", 50)
+
+
+def test_overview_limit_validation(client):
+    resp = client.get("/api/v1/graph/overview?workspace_id=ws_test&limit=0")
+    assert resp.status_code == 422
+
+    resp = client.get("/api/v1/graph/overview?workspace_id=ws_test&limit=999")
+    assert resp.status_code == 422
+
+
+# --- expand ---
+
+def test_expand_returns_neighbors(client):
+    mock_data = {
+        "nodes": [
+            {"id": 2, "name": "Metatron", "type": "Project",
+             "workspace_id": "ws_test", "connections": 3},
+            {"id": 3, "name": "FastAPI", "type": "Technology",
+             "workspace_id": "ws_test", "connections": 2},
+        ],
+        "edges": [
+            {"source": 1, "target": 2, "type": "USED_IN",
+             "valid_from": None, "valid_to": None},
+            {"source": 2, "target": 3, "type": "USES",
+             "valid_from": None, "valid_to": None},
+        ],
+        "truncated": False,
+    }
+    with patch("metatron.storage.graph_ops.get_graph_expand", return_value=mock_data):
+        resp = client.get("/api/v1/graph/expand/1?workspace_id=ws_test")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["nodes"]) == 2
+    assert len(data["edges"]) == 2
+
+
+def test_expand_requires_workspace_id(client):
+    resp = client.get("/api/v1/graph/expand/1")
+    assert resp.status_code == 422
+
+
+def test_expand_depth_and_limit(client):
+    mock_data = {"nodes": [], "edges": [], "truncated": False}
+    with patch("metatron.storage.graph_ops.get_graph_expand", return_value=mock_data) as m:
+        resp = client.get(
+            "/api/v1/graph/expand/1?workspace_id=ws_test&depth=3&limit=20"
+        )
+
+    assert resp.status_code == 200
+    m.assert_called_once_with(1, "ws_test", 3, 20)
+
+
+def test_expand_depth_validation(client):
+    resp = client.get("/api/v1/graph/expand/1?workspace_id=ws_test&depth=0")
+    assert resp.status_code == 422
+
+    resp = client.get("/api/v1/graph/expand/1?workspace_id=ws_test&depth=5")
+    assert resp.status_code == 422
+
+
+def test_expand_memgraph_unavailable(client):
+    with patch(
+        "metatron.storage.graph_ops.get_graph_expand",
+        side_effect=ServiceUnavailable("Connection refused"),
+    ):
+        resp = client.get("/api/v1/graph/expand/1?workspace_id=ws_test")
+
+    assert resp.status_code == 502
+
+
+# --- response schema ---
+
+def test_response_schema_fields(client):
+    mock_data = {
+        "nodes": [{"id": 1, "name": "Alice", "type": "Person",
+                    "workspace_id": "ws_test", "connections": 1}],
+        "edges": [{"source": 1, "target": 2, "type": "KNOWS",
+                   "valid_from": "2025-01-01", "valid_to": "2025-12-31"}],
+        "truncated": True,
+    }
+    with patch("metatron.storage.graph_ops.get_graph_overview", return_value=mock_data):
+        resp = client.get("/api/v1/graph/overview?workspace_id=ws_test")
+
+    data = resp.json()
+    node = data["nodes"][0]
+    assert set(node.keys()) == {"id", "name", "type", "workspace_id", "connections"}
+    edge = data["edges"][0]
+    assert set(edge.keys()) == {"source", "target", "type", "valid_from", "valid_to"}
+    assert data["truncated"] is True
+    assert "total_nodes" not in data


### PR DESCRIPTION
Add /api/v1/graph/overview and /api/v1/graph/expand/{entity_id} endpoints for knowledge graph visualization. Storage layer queries Memgraph for top-N connected entities and neighbor expansion with workspace isolation.