### PR TITLE
feat: OpenAI-compatible API for Open WebUI integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,10 @@ CUSTOM_LLM_MODEL=default
 # --- Benchmarker ---
 BENCHMARKER_EMBEDDING_PROXY_URL=http://localhost:8001  # Embedding proxy for benchmarker metrics
 
+# --- OpenAI-Compatible API (Open WebUI) ---
+METATRON_OPENAI_COMPAT_ENABLED=true      # enable /v1/models and /v1/chat/completions
+METATRON_OPENAI_COMPAT_KEY=              # static API key (empty = endpoints disabled)
+
 # --- Search ---
 QUERY_EXPANSION_ENABLED=true     # LLM-based query expansion for better recall
 SEARCH_MAX_TOTAL_CHARS=40000     # max context chars sent to LLM

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ env/
 
 # Project planning (GSD workflow artifacts)
 .planning/
+docs/superpowers/
 
 # IDE
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,23 @@ Frontend splits on `" — "` to extract URL; no URL → title only.
 - RERANKER_ENABLED (true) — bge-reranker-v2-m3
 - QUERY_EXPANSION_ENABLED (true) — LLM query expansion
 - GRAPH_EXTRACTION_ENABLED (true) — NER → Memgraph
+- METATRON_OPENAI_COMPAT_ENABLED (true) — OpenAI-compatible API for Open WebUI
+- METATRON_OPENAI_COMPAT_KEY ("") — static API key for OpenAI-compat endpoints (empty = disabled)
 - See core/config.py for full list
+
+## Open WebUI Integration
+Metatron exposes OpenAI-compatible API at `/v1/` for use with Open WebUI or any OpenAI-compatible client.
+
+Endpoints:
+- `GET /v1/models` — list models (one per workspace, format: `metatron-rag-{workspace_id}`)
+- `POST /v1/chat/completions` — chat completions (streaming + non-streaming)
+- `GET /v1/openapi.json` — stub for connection verification
+
+Auth: `Authorization: Bearer <METATRON_OPENAI_COMPAT_KEY>`
+
+Setup in Open WebUI: Settings → Connections → OpenAI API → Add URL `http://metatron:8000/v1` + key.
+
+Docker: Open WebUI available in `docker-compose.full.yml` with profile `openwebui` on port 3080.
 
 ## Testing
 - 915+ tests, `make test` runs unit only

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -154,12 +154,38 @@ services:
   #     retries: 3
   #   restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Open WebUI — user-facing chat interface (OpenAI-compat connection to Metatron)
+  # Usage: docker compose -f docker-compose.full.yml --profile openwebui up
+  # Access: http://localhost:3080
+  # Metatron connection is pre-configured via OPENAI_API_BASE_URL.
+  # ---------------------------------------------------------------------------
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: metatron-full-openwebui
+    ports:
+      - "${OPENWEBUI_PORT:-3080}:8080"
+    volumes:
+      - full_openwebui_data:/app/backend/data
+    environment:
+      WEBUI_AUTH: "false"
+      OPENAI_API_BASE_URL: "http://metatron-core:8000/v1"
+      OPENAI_API_KEY: "${METATRON_OPENAI_COMPAT_KEY:-metatron}"
+    depends_on:
+      metatron-core:
+        condition: service_healthy
+    networks:
+      - metatron_full
+    profiles: ["openwebui"]
+    restart: unless-stopped
+
 volumes:
   full_pg_data:
   full_qdrant_data:
   full_memgraph_data:
   full_ollama_data:
   full_file_data:
+  full_openwebui_data:
 
 networks:
   metatron_full:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1288,6 +1288,104 @@ Delete a test run and all its results.
 
 - `workspace_id` (required): Workspace ID
 
+## OpenAI-Compatible API (Open WebUI Integration)
+
+OpenAI-compatible endpoints for connecting Open WebUI or any OpenAI-compatible client to Metatron.
+
+**Authentication:** `Authorization: Bearer <METATRON_OPENAI_COMPAT_KEY>`
+
+**Error format:** `{"error": {"message": "...", "type": "invalid_request_error"}}`
+
+### GET /v1/models
+
+List available models. Each workspace is exposed as a separate model.
+
+**Response:**
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "metatron-rag-MTRNIX",
+      "object": "model",
+      "created": 1710000000,
+      "owned_by": "metatron"
+    }
+  ]
+}
+```
+
+**Example:**
+
+```bash
+curl -H "Authorization: Bearer YOUR_KEY" http://localhost:8000/v1/models
+```
+
+### POST /v1/chat/completions
+
+Chat completions in OpenAI format. Calls the Metatron hybrid search pipeline internally.
+
+**Request Body:**
+
+```json
+{
+  "model": "metatron-rag-MTRNIX",
+  "messages": [
+    {"role": "user", "content": "What tasks are in backlog?"}
+  ],
+  "stream": true,
+  "user": "optional-user-id"
+}
+```
+
+Fields `temperature`, `max_tokens`, `top_p` etc. are accepted but ignored — LLM parameters are controlled by the search pipeline.
+
+**Streaming Response (SSE):**
+
+```
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","choices":[{"delta":{"role":"assistant"},"finish_reason":null}]}
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","choices":[{"delta":{"content":"The backlog contains..."},"finish_reason":null}]}
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","choices":[{"delta":{},"finish_reason":"stop"}]}
+data: [DONE]
+```
+
+**Non-Streaming Response:**
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "model": "metatron-rag-MTRNIX",
+  "choices": [
+    {
+      "index": 0,
+      "message": {"role": "assistant", "content": "Answer with sources..."},
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+}
+```
+
+**Example:**
+
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "metatron-rag-MTRNIX", "messages": [{"role": "user", "content": "Hello"}], "stream": false}'
+```
+
+### Open WebUI Setup
+
+1. Add Open WebUI to docker-compose: `docker compose -f docker-compose.full.yml --profile openwebui up`
+2. Open `http://localhost:3080`
+3. Settings → Connections → OpenAI API → Add
+4. URL: `http://metatron-core:8000/v1` (docker) or `http://host.docker.internal:8000/v1` (local dev)
+5. Auth: Bearer, Key: `<METATRON_OPENAI_COMPAT_KEY>`
+6. New Chat → select `metatron-rag-MTRNIX`
+
 ## Error Responses
 
 All endpoints may return error responses in the following format:

--- a/docs/OPENAI_COMPAT_ROADMAP.md
+++ b/docs/OPENAI_COMPAT_ROADMAP.md
@@ -1,0 +1,126 @@
+# Tech Debt: Unify API to OpenAI Standard and Integrate RBAC with Open WebUI
+
+## Context
+
+An OpenAI-compatible API (`/v1/models`, `/v1/chat/completions`) has been implemented for Open WebUI integration. In parallel, RBAC with per-user authorization has been merged. Currently there are two parallel chat interfaces and a static API key with no user binding.
+
+Goal — eliminate duplication, make the OpenAI format the sole chat interface, and link Open WebUI users with Metatron RBAC.
+
+---
+
+## Block 1: Migrate Admin UI to OpenAI-Compatible API
+
+### Current State
+- Admin UI uses `/api/v1/chat` (sync) and `/api/v1/chat/stream` (SSE with custom events: `status`, `chunk`, `sources`, `done`)
+- OpenAI-compat: `/v1/chat/completions` (SSE with `delta` chunks in OpenAI format)
+- Two different request/response formats, two separate history stores
+
+### Action Items
+
+1. **Switch admin frontend to `/v1/chat/completions`**
+   - Replace SSE client: instead of custom events (`chunk`, `sources`, `done`), parse OpenAI delta format
+   - Request: instead of `{question, workspace_id, user_id}`, send `{model: "metatron-rag-{ws}", messages: [{role: "user", content: "..."}]}`
+   - Sources: currently arrive as a separate SSE event `sources` — in OpenAI format they are embedded in the response text as markdown. The frontend already parses `[$[title]$]` markers — ensure markdown links also render correctly
+
+2. **File upload**
+   - `/api/v1/upload` stays as-is (OpenAI format does not cover file ingestion)
+   - Consider a `/v1/files` endpoint analogous to the OpenAI Files API — for the future
+
+3. **Remove legacy endpoints**
+   - Remove `/api/v1/chat` and `/api/v1/chat/stream`
+   - Remove duplicate in-memory history from `chat.py`
+   - Keep one history store in `openai_compat.py` (or extract to a shared module)
+
+4. **Update channels (Telegram, Discord, Slack)**
+   - Bots currently call `hybrid_search_and_answer()` directly — this is fine, they don't go through HTTP
+   - But their in-memory history in `chat.py` is tied to the same dict — decide whether to migrate channels to a shared history store or leave as-is
+
+### Migration Order
+1. Frontend switches to `/v1/chat/completions` (both endpoints live in parallel)
+2. Verify everything works
+3. Remove legacy endpoints
+
+---
+
+## Block 2: Open WebUI User Mapping → Metatron RBAC
+
+### Current State
+- Open WebUI: own user database (email + password, or OAuth/LDAP)
+- Metatron: own user database after RBAC (`UserStore`, bcrypt, roles viewer/editor/admin)
+- OpenAI-compat API: static `METATRON_OPENAI_COMPAT_KEY`, all requests come from one "user"
+- The `user` field in OpenAI requests is currently only logged
+
+### Target Architecture
+
+Both services maintain their own user databases. Mapping between them is by email or external identifier.
+
+```
+Open WebUI (user: john@company.com)
+  → POST /v1/chat/completions { user: "john@company.com" }
+  → Metatron resolves john@company.com → Metatron User (role, workspace_ids)
+  → Filters response by permissions
+```
+
+### Action Items
+
+1. **Replace static API key with per-user tokens**
+   - Option A: Open WebUI sends a Metatron JWT in the `Authorization: Bearer <metatron-jwt>` header — requires Open WebUI to obtain a JWT for each user
+   - Option B: Open WebUI sends a service key + `user` field with identifier — Metatron resolves the user by the `user` field. Simpler to implement
+   - Option C: Shared OAuth/OIDC provider (Keycloak, etc.) — both services validate the same token. Most correct for enterprise
+   - **Recommendation**: start with Option B (service key + user field), then migrate to C for enterprise
+
+2. **Implement user → Metatron User resolution in OpenAI-compat**
+   - In `verify_openai_compat_key` or a separate dependency — look up the user from the `user` field in `UserStore`
+   - If not found — either 403, or auto-provision (create with viewer role)
+   - Place the resolved user into `request.state.user` — standard RBAC from there
+
+3. **Filter workspaces by permissions**
+   - `GET /v1/models` — return only workspaces accessible to the user
+   - Current: all workspaces without filtering
+   - After: `workspace_ids` from JWT/user profile → filter
+
+4. **User synchronization**
+   - With Option B: need a mechanism to create users in Metatron on first request from Open WebUI (auto-provision)
+   - Mapping: `Open WebUI email` → `Metatron user_id` (or by email directly)
+   - Roles: default role for auto-provisioned users (viewer), admin assigns roles manually
+
+5. **Audit and history**
+   - Bind OpenAI-compat requests to a specific user (not `"openai-default"`)
+   - Query traces in PostgreSQL — record real user_id
+   - Conversation history — keyed by real user_id
+
+### Open Questions
+
+- Is auto-provisioning users needed, or only manual creation via admin panel?
+- How to handle deleted/blocked users — Open WebUI doesn't know a user is deactivated in Metatron
+- Is bidirectional sync (Metatron → Open WebUI) needed, or only one-way?
+
+---
+
+## Block 3: Consolidate Conversation History
+
+### Current State
+- `chat.py`: in-memory dict, used by legacy endpoints and channels
+- `openai_compat.py`: separate in-memory dict, used by OpenAI-compat
+- Both are volatile (lost on restart)
+
+### Action Items
+
+1. **Extract history into a shared module** (`api/history.py` or `storage/conversation.py`)
+2. **Single store for all channels** — HTTP, OpenAI-compat, Telegram, Discord, Slack
+3. **Persistence** — migrate from in-memory to PostgreSQL (`conversations` table)
+4. **Per-user scoping** — history bound to user_id from RBAC, not an arbitrary string
+
+---
+
+## Priorities
+
+| # | Task | Dependencies | Priority |
+|---|------|-------------|----------|
+| 1 | Migrate frontend to `/v1/chat/completions` | None | High |
+| 2 | Remove legacy chat endpoints | Block 1 complete | Medium |
+| 3 | User field → Metatron RBAC mapping (Option B) | RBAC stable | High |
+| 4 | Filter `/v1/models` by permissions | Block 3 | High |
+| 5 | Consolidate history into shared module | Block 2 | Medium |
+| 6 | Persistent history in PostgreSQL | Block 5 | Low |
+| 7 | OAuth/OIDC integration (Option C) | Enterprise roadmap | Low |

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -213,6 +213,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     from metatron.api.routes.finops import router as finops_router
     app.include_router(finops_router, prefix="/api/v1")
 
+    # OpenAI-compatible API (for Open WebUI integration)
+    if settings.openai_compat_enabled:
+        from metatron.api.routes.openai_compat import router as openai_compat_router
+        app.include_router(openai_compat_router)
+
     # Lazy import benchmarker module router (optional dependency)
     try:
         from metatron.benchmarker.api import router as benchmarker_module_router

--- a/src/metatron/api/middleware.py
+++ b/src/metatron/api/middleware.py
@@ -13,6 +13,7 @@ PUBLIC_PATHS = {
     "/health", "/ready", "/metrics", "/metrics/reset",
     "/api/v1/auth/login",
     "/api/v1/config",
+    "/v1/models", "/v1/chat/completions", "/v1/openapi.json",
 }
 
 

--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -111,7 +111,7 @@ def chat(req: ChatRequest, request: Request) -> ChatResponse:
     return ChatResponse(answer=answer, workspace_id=workspace_id)
 
 
-def _split_into_sentences(text: str) -> list[str]:
+def split_into_sentences(text: str) -> list[str]:
     """Split text into sentence-like chunks for progressive SSE streaming."""
     parts = re.split(r'(?<=[.!?])\s+', text)
     chunks: list[str] = []
@@ -126,7 +126,7 @@ def _split_into_sentences(text: str) -> list[str]:
     return chunks if chunks else [text]
 
 
-def _extract_sources_section(answer: str) -> tuple[str, list[str]]:
+def extract_sources_section(answer: str) -> tuple[str, list[str]]:
     """Split answer into body and source lines."""
     marker = "\U0001f4da Sources:"
     if marker not in answer:
@@ -216,11 +216,11 @@ async def chat_stream(req: ChatRequest, request: Request) -> EventSourceResponse
             if len(hist) > 20:
                 del hist[:-20]
 
-        body, sources = _extract_sources_section(answer)
+        body, sources = extract_sources_section(answer)
 
         yield {"event": "status", "data": json.dumps({"status": "answering"})}
 
-        for chunk in _split_into_sentences(body):
+        for chunk in split_into_sentences(body):
             yield {"event": "chunk", "data": json.dumps({"text": chunk})}
             await asyncio.sleep(0.03)
 

--- a/src/metatron/api/routes/openai_compat.py
+++ b/src/metatron/api/routes/openai_compat.py
@@ -1,0 +1,466 @@
+"""OpenAI-compatible API — /v1/models and /v1/chat/completions.
+
+Allows Open WebUI (and any OpenAI-compatible client) to use Metatron
+as an LLM backend. Wraps the existing hybrid search pipeline into
+the OpenAI Chat Completions format.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from metatron.core.config import Settings
+
+logger = structlog.get_logger()
+
+router = APIRouter(prefix="/v1", tags=["openai-compat"])
+
+MODEL_PREFIX = "metatron-rag-"
+
+
+# ---------------------------------------------------------------------------
+# Auth dependency
+# ---------------------------------------------------------------------------
+
+
+async def verify_openai_compat_key(request: Request) -> None:
+    """Validate static API key for OpenAI-compat endpoints."""
+    import hmac
+
+    settings: Settings = request.app.state.settings
+    expected = settings.openai_compat_key
+    if not expected:
+        raise HTTPException(status_code=404, detail="OpenAI-compatible API is not configured")
+    auth = request.headers.get("authorization", "")
+    if not auth.startswith("Bearer ") or not hmac.compare_digest(auth[7:], expected):
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str = ""
+
+
+class ChatCompletionRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    model: str
+    messages: list[ChatMessage]
+    stream: bool = False
+    user: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Conversation history (own store, independent from chat.py)
+# ---------------------------------------------------------------------------
+
+_conversation_history: dict[str, list[dict[str, str]]] = {}
+_history_lock = threading.Lock()
+_MAX_HISTORY_TURNS = 20
+_MAX_HISTORY_USERS = 100
+_MAX_HISTORY_CHARS = 4000
+
+
+def _record_history(user_id: str, question: str, answer: str) -> None:
+    with _history_lock:
+        hist = _conversation_history.setdefault(user_id, [])
+        hist.append({"user": question, "assistant": answer[:2000]})
+        if len(hist) > _MAX_HISTORY_TURNS:
+            del hist[:-_MAX_HISTORY_TURNS]
+        if len(_conversation_history) > _MAX_HISTORY_USERS:
+            oldest = list(_conversation_history.keys())[: _MAX_HISTORY_USERS // 2]
+            for uid in oldest:
+                del _conversation_history[uid]
+
+
+def _build_composite_query(
+    user_id: str,
+    question: str,
+    history_turns: int = 6,
+) -> str:
+    """Build composite query with history context (same logic as chat.py)."""
+    with _history_lock:
+        history = _conversation_history.get(user_id, [])[-history_turns:]
+
+    history_lines: list[str] = []
+    total_chars = 0
+    for turn in reversed(history):
+        user_msg = turn.get("user", "")[:500]
+        line = f"Previous question: {user_msg}"
+        if total_chars + len(line) > _MAX_HISTORY_CHARS:
+            break
+        history_lines.insert(0, line)
+        total_chars += len(line)
+
+    if history_lines:
+        return "\n".join(history_lines + [f"Current question: {question}"])
+    return question
+
+
+# ---------------------------------------------------------------------------
+# Source formatting
+# ---------------------------------------------------------------------------
+
+_INLINE_REF_RE = re.compile(r"\[\$\[(.+?)\]\$\]")
+_KNOWN_EXT_RE = re.compile(
+    r"\.(pdf|txt|md|docx?|xlsx?|csv|json|html|xml|yml|yaml|pptx?|rtf)$",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class _ParsedSource:
+    title: str
+    url: str | None
+
+
+def _parse_source(raw: str) -> _ParsedSource:
+    """Parse raw source line like '📄 Title — URL' into title + url."""
+    # Skip leading emoji (first codepoint + whitespace)
+    chars = list(raw)
+    rest = raw[len(chars[0]) :].strip() if chars else raw
+    dash_idx = rest.rfind(" \u2014 ")
+    if dash_idx >= 0:
+        return _ParsedSource(
+            title=rest[:dash_idx].strip(),
+            url=rest[dash_idx + 3 :].strip(),
+        )
+    return _ParsedSource(title=rest, url=None)
+
+
+def _strip_ext(s: str) -> str:
+    return _KNOWN_EXT_RE.sub("", s).strip()
+
+
+def _match_inline_source(
+    ref_text: str,
+    sources: list[_ParsedSource],
+) -> _ParsedSource | None:
+    """Match reference marker text to a source using 4-level matching.
+
+    Mirrors frontend matchInlineSource() logic:
+    1. Exact match (case-insensitive)
+    2. Substring match (with 40% length threshold)
+    3. Exact match without file extensions
+    4. Substring match without file extensions (with 40% threshold)
+    """
+    norm = ref_text.lower().strip()
+    norm_no_ext = _strip_ext(norm)
+
+    def _substr(a: str, b: str) -> bool:
+        """Check if a contains b or b contains a (with 40% length ratio)."""
+        if len(a) < 3 or len(b) < 3:
+            return False
+        if a in b:
+            return True
+        return b in a and len(a) / len(b) >= 0.4
+
+    # Level 1: exact
+    for s in sources:
+        if s.title.lower() == norm:
+            return s
+    # Level 2: substring
+    for s in sources:
+        if _substr(s.title.lower(), norm):
+            return s
+    # Level 3: exact without extensions
+    for s in sources:
+        if _strip_ext(s.title.lower()) == norm_no_ext:
+            return s
+    # Level 4: substring without extensions
+    for s in sources:
+        if _substr(_strip_ext(s.title.lower()), norm_no_ext):
+            return s
+    return None
+
+
+def _resolve_reference_markers(text: str, sources: list[str]) -> str:
+    """Replace [$[title]$] markers with [title](url) markdown links.
+
+    Uses the same 4-level matching algorithm as the admin frontend.
+    """
+    parsed = [_parse_source(s) for s in sources]
+
+    def _replace(m: re.Match) -> str:
+        ref_text = m.group(1)
+        source = _match_inline_source(ref_text, parsed)
+        if not source:
+            return ref_text
+        if source.url:
+            return f"[{source.title}]({source.url})"
+        return source.title
+
+    return _INLINE_REF_RE.sub(_replace, text)
+
+
+def _sources_to_markdown(sources: list[str]) -> str:
+    """Convert source lines from 'icon Title — URL' to markdown links."""
+    if not sources:
+        return ""
+    md_lines: list[str] = []
+    for source in sources:
+        if " \u2014 " in source:
+            label, _, url = source.partition(" \u2014 ")
+            md_lines.append(f"- [{label.strip()}]({url.strip()})")
+        else:
+            md_lines.append(f"- {source}")
+    return "\n\n---\n**Sources:**\n" + "\n".join(md_lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_workspace_id(model: str) -> str | None:
+    """Extract workspace_id from model id like 'metatron-rag-MTRNIX'."""
+    if model.startswith(MODEL_PREFIX):
+        return model[len(MODEL_PREFIX) :]
+    return None
+
+
+def _openai_error(
+    status: int,
+    message: str,
+    error_type: str = "invalid_request_error",
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status,
+        content={"error": {"message": message, "type": error_type}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/openapi.json — stub for Open WebUI connection verification
+# ---------------------------------------------------------------------------
+
+
+@router.get("/openapi.json")
+async def openapi_stub() -> dict:
+    """Minimal OpenAPI spec stub so Open WebUI accepts the connection."""
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Metatron OpenAI-compatible API", "version": "0.1.0"},
+        "paths": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/models
+# ---------------------------------------------------------------------------
+
+
+@router.get("/models", dependencies=[Depends(verify_openai_compat_key)])
+async def list_models(request: Request) -> dict:
+    """List available models (one per workspace)."""
+    from metatron.workspaces import get_workspace_manager
+
+    manager = get_workspace_manager()
+    workspaces = manager.list_workspaces()
+    now = int(time.time())
+
+    models = []
+    for ws in workspaces:
+        created = now
+        if ws.created_at:
+            try:
+                from datetime import datetime
+
+                dt = datetime.fromisoformat(ws.created_at)
+                created = int(dt.timestamp())
+            except (ValueError, TypeError):
+                pass
+        models.append(
+            {
+                "id": f"{MODEL_PREFIX}{ws.workspace_id}",
+                "name": ws.name or ws.workspace_id,
+                "object": "model",
+                "created": created,
+                "owned_by": "metatron",
+            }
+        )
+
+    return {"object": "list", "data": models}
+
+
+# ---------------------------------------------------------------------------
+# Streaming generator
+# ---------------------------------------------------------------------------
+
+
+async def _stream_response(
+    composite_query: str,
+    user_message: str,
+    workspace_id: str,
+    user_id: str,
+    model: str,
+    completion_id: str,
+    created: int,
+) -> AsyncGenerator[str, None]:
+    """Generate OpenAI-format SSE stream from search pipeline."""
+    import asyncio
+
+    from metatron.api.routes.chat import extract_sources_section, split_into_sentences
+
+    def _chunk(delta: dict, finish_reason: str | None = None) -> str:
+        data = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+        return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+    # Role chunk
+    yield _chunk({"role": "assistant"})
+
+    # Run search pipeline
+    try:
+        from metatron.retrieval.search import hybrid_search_and_answer
+
+        answer = await asyncio.to_thread(
+            hybrid_search_and_answer,
+            query=composite_query,
+            user_id=user_id,
+            workspace_id=workspace_id,
+            intent_query=user_message,
+        )
+    except Exception as exc:
+        logger.error("openai_compat.stream.error", error=str(exc), exc_info=True)
+        yield _chunk({"content": "An error occurred while processing your request."})
+        yield _chunk({}, "stop")
+        yield "data: [DONE]\n\n"
+        return
+
+    # Record history
+    _record_history(user_id, user_message, answer)
+
+    # Parse sources and convert to markdown
+    body, sources = extract_sources_section(answer)
+    body = _resolve_reference_markers(body, sources)
+    final_content = body + _sources_to_markdown(sources)
+
+    # Stream answer in sentence chunks
+    for sentence in split_into_sentences(final_content):
+        yield _chunk({"content": sentence})
+        await asyncio.sleep(0.03)
+
+    # Finish
+    yield _chunk({}, "stop")
+    yield "data: [DONE]\n\n"
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+
+@router.post("/chat/completions", dependencies=[Depends(verify_openai_compat_key)])
+async def chat_completions(req: ChatCompletionRequest, request: Request):
+    """OpenAI-compatible chat completions endpoint."""
+    from metatron.workspaces import get_workspace_manager
+
+    # Validate messages
+    if not req.messages:
+        return _openai_error(400, "Messages required")
+
+    # Find last user message
+    user_message = None
+    for msg in reversed(req.messages):
+        if msg.role == "user":
+            user_message = msg.content
+            break
+    if not user_message:
+        return _openai_error(400, "No user message found")
+
+    # Parse workspace from model id
+    workspace_id = _parse_workspace_id(req.model)
+    if not workspace_id:
+        return _openai_error(404, f"Model not found: {req.model}")
+
+    manager = get_workspace_manager()
+    if not manager.get_workspace(workspace_id):
+        return _openai_error(404, f"Model not found: {req.model}")
+
+    user_id = req.user or "openai-default"
+    completion_id = f"chatcmpl-{uuid4().hex[:24]}"
+    created = int(time.time())
+
+    # Build composite query with our history
+    composite_query = _build_composite_query(user_id, user_message)
+
+    if req.stream:
+        return StreamingResponse(
+            _stream_response(
+                composite_query,
+                user_message,
+                workspace_id,
+                user_id,
+                req.model,
+                completion_id,
+                created,
+            ),
+            media_type="text/event-stream",
+        )
+
+    # Non-streaming path
+    import asyncio
+
+    try:
+        from metatron.retrieval.search import hybrid_search_and_answer
+
+        answer = await asyncio.to_thread(
+            hybrid_search_and_answer,
+            query=composite_query,
+            user_id=user_id,
+            workspace_id=workspace_id,
+            intent_query=user_message,
+        )
+    except Exception as exc:
+        logger.error("openai_compat.search_error", error=str(exc), exc_info=True)
+        return _openai_error(500, "Internal error", "server_error")
+
+    # Record history
+    _record_history(user_id, user_message, answer)
+
+    # Convert sources to markdown
+    from metatron.api.routes.chat import extract_sources_section
+
+    body, sources = extract_sources_section(answer)
+    body = _resolve_reference_markers(body, sources)
+    final_content = body + _sources_to_markdown(sources)
+
+    return {
+        "id": completion_id,
+        "object": "chat.completion",
+        "created": created,
+        "model": req.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": final_content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }

--- a/src/metatron/api/routes/openai_compat.py
+++ b/src/metatron/api/routes/openai_compat.py
@@ -315,6 +315,7 @@ async def _stream_response(
     model: str,
     completion_id: str,
     created: int,
+    plugin_manager: object | None = None,
 ) -> AsyncGenerator[str, None]:
     """Generate OpenAI-format SSE stream from search pipeline."""
     import asyncio
@@ -344,6 +345,7 @@ async def _stream_response(
             user_id=user_id,
             workspace_id=workspace_id,
             intent_query=user_message,
+            plugin_manager=plugin_manager,
         )
     except Exception as exc:
         logger.error("openai_compat.stream.error", error=str(exc), exc_info=True)
@@ -405,6 +407,7 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
     user_id = req.user or "openai-default"
     completion_id = f"chatcmpl-{uuid4().hex[:24]}"
     created = int(time.time())
+    plugin_manager = getattr(request.app.state, "plugin_manager", None)
 
     # Build composite query with our history
     composite_query = _build_composite_query(user_id, user_message)
@@ -419,6 +422,7 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
                 req.model,
                 completion_id,
                 created,
+                plugin_manager,
             ),
             media_type="text/event-stream",
         )
@@ -435,6 +439,7 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
             user_id=user_id,
             workspace_id=workspace_id,
             intent_query=user_message,
+            plugin_manager=plugin_manager,
         )
     except Exception as exc:
         logger.error("openai_compat.search_error", error=str(exc), exc_info=True)

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -31,6 +31,10 @@ class Settings(BaseSettings):
     auth_enabled: bool = Field(default=False, alias="AUTH_ENABLED")
     auth_password: str = Field(default="metatron", alias="AUTH_PASSWORD")
 
+    # --- OpenAI-compatible API (for Open WebUI integration) ---
+    openai_compat_enabled: bool = Field(True, alias="METATRON_OPENAI_COMPAT_ENABLED")
+    openai_compat_key: str = Field("", alias="METATRON_OPENAI_COMPAT_KEY")
+
     # --- PostgreSQL ---
     postgres_host: str = Field("localhost", alias="POSTGRES_HOST")
     postgres_port: int = Field(5432, alias="POSTGRES_PORT")

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -425,33 +425,33 @@ class TestAdmin:
 
 class TestSentenceSplitter:
     def test_splits_on_sentence_boundaries(self) -> None:
-        from metatron.api.routes.chat import _split_into_sentences
+        from metatron.api.routes.chat import split_into_sentences
         text = "First sentence. Second sentence. Third sentence here."
-        chunks = _split_into_sentences(text)
+        chunks = split_into_sentences(text)
         assert len(chunks) >= 1
         # All text is preserved
         assert "".join(chunks).replace(" ", "") == text.replace(" ", "")
 
     def test_empty_string_returns_original(self) -> None:
-        from metatron.api.routes.chat import _split_into_sentences
-        assert _split_into_sentences("") == [""]
+        from metatron.api.routes.chat import split_into_sentences
+        assert split_into_sentences("") == [""]
 
     def test_short_text_single_chunk(self) -> None:
-        from metatron.api.routes.chat import _split_into_sentences
-        assert _split_into_sentences("Hi.") == ["Hi."]
+        from metatron.api.routes.chat import split_into_sentences
+        assert split_into_sentences("Hi.") == ["Hi."]
 
 
 class TestSourceExtraction:
     def test_extracts_sources(self) -> None:
-        from metatron.api.routes.chat import _extract_sources_section
+        from metatron.api.routes.chat import extract_sources_section
         answer = "The answer.\n\n\U0001f4da Sources:\n\U0001f4c4 Doc A\n\U0001f4cb Task B"
-        body, sources = _extract_sources_section(answer)
+        body, sources = extract_sources_section(answer)
         assert body == "The answer."
         assert len(sources) == 2
         assert "\U0001f4c4 Doc A" in sources
 
     def test_no_sources_section(self) -> None:
-        from metatron.api.routes.chat import _extract_sources_section
-        body, sources = _extract_sources_section("Just an answer.")
+        from metatron.api.routes.chat import extract_sources_section
+        body, sources = extract_sources_section("Just an answer.")
         assert body == "Just an answer."
         assert sources == []

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -1,0 +1,270 @@
+"""Tests for OpenAI-compatible API endpoints."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from metatron.api.app import create_app
+from metatron.core.config import Settings
+from metatron.workspaces.models import Workspace
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        METATRON_ENV="development",
+        DEFAULT_WORKSPACE_ID="TEST_WS",
+        DEFAULT_WORKSPACE_NAME="Test Workspace",
+        METATRON_OPENAI_COMPAT_ENABLED=True,
+        METATRON_OPENAI_COMPAT_KEY="test-key-123",
+    )
+
+
+@pytest.fixture
+def app(settings):
+    return create_app(settings)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+_TEST_WS = Workspace(
+    workspace_id="TEST_WS",
+    name="Test Workspace",
+    user_id="system",
+    is_active=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/models
+# ---------------------------------------------------------------------------
+
+
+class TestModelsEndpoint:
+    """GET /v1/models"""
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    def test_list_models_returns_workspaces(self, mock_mgr, client):
+        mock_mgr.return_value.list_workspaces.return_value = [_TEST_WS]
+        r = client.get("/v1/models", headers={"Authorization": "Bearer test-key-123"})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["object"] == "list"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["id"] == "metatron-rag-TEST_WS"
+        assert data["data"][0]["owned_by"] == "metatron"
+
+    def test_list_models_no_auth_returns_401(self, client):
+        r = client.get("/v1/models")
+        assert r.status_code == 401
+
+    def test_list_models_wrong_key_returns_401(self, client):
+        r = client.get("/v1/models", headers={"Authorization": "Bearer wrong-key"})
+        assert r.status_code == 401
+
+    def test_list_models_disabled_returns_404(self):
+        settings = Settings(
+            METATRON_ENV="development",
+            METATRON_OPENAI_COMPAT_KEY="test-key",
+            METATRON_OPENAI_COMPAT_ENABLED=False,
+        )
+        app = create_app(settings)
+        client = TestClient(app, raise_server_exceptions=False)
+        r = client.get("/v1/models", headers={"Authorization": "Bearer test-key"})
+        assert r.status_code == 404
+
+    def test_list_models_no_key_configured_returns_404(self):
+        """When METATRON_OPENAI_COMPAT_KEY is empty, feature is disabled."""
+        settings = Settings(
+            METATRON_ENV="development",
+            METATRON_OPENAI_COMPAT_KEY="",
+            METATRON_OPENAI_COMPAT_ENABLED=True,
+        )
+        app = create_app(settings)
+        client = TestClient(app, raise_server_exceptions=False)
+        r = client.get("/v1/models", headers={"Authorization": "Bearer anything"})
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/chat/completions (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletions:
+    """POST /v1/chat/completions"""
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_non_streaming_returns_openai_format(self, mock_search, mock_mgr, client):
+        mock_mgr.return_value.get_workspace.return_value = _TEST_WS
+        mock_search.return_value = "The answer is 42."
+
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "metatron-rag-TEST_WS",
+                "messages": [{"role": "user", "content": "What is the answer?"}],
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["object"] == "chat.completion"
+        assert data["model"] == "metatron-rag-TEST_WS"
+        assert len(data["choices"]) == 1
+        assert data["choices"][0]["message"]["role"] == "assistant"
+        assert "42" in data["choices"][0]["message"]["content"]
+        assert data["choices"][0]["finish_reason"] == "stop"
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    def test_unknown_model_returns_404(self, mock_mgr, client):
+        mock_mgr.return_value.get_workspace.return_value = None
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "metatron-rag-NONEXISTENT",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        assert r.status_code == 404
+        assert "error" in r.json()
+
+    def test_empty_messages_returns_400(self, client):
+        r = client.post(
+            "/v1/chat/completions",
+            json={"model": "metatron-rag-TEST_WS", "messages": []},
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        assert r.status_code == 400
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    def test_no_user_message_returns_400(self, mock_mgr, client):
+        mock_mgr.return_value.get_workspace.return_value = _TEST_WS
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "metatron-rag-TEST_WS",
+                "messages": [{"role": "system", "content": "You are a bot"}],
+            },
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        assert r.status_code == 400
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_sources_converted_to_markdown_links(self, mock_search, mock_mgr, client):
+        mock_mgr.return_value.get_workspace.return_value = _TEST_WS
+        mock_search.return_value = (
+            "Answer here.\n\n\U0001f4da Sources:\n"
+            "\U0001f4c4 Doc Title \u2014 https://example.com/doc\n"
+            "\U0001f4cb JIRA-123 \u2014 https://jira.example.com/JIRA-123"
+        )
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "metatron-rag-TEST_WS",
+                "messages": [{"role": "user", "content": "test"}],
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        content = r.json()["choices"][0]["message"]["content"]
+        assert "[\U0001f4c4 Doc Title](https://example.com/doc)" in content
+        assert "[\U0001f4cb JIRA-123](https://jira.example.com/JIRA-123)" in content
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_extra_openai_params_ignored(self, mock_search, mock_mgr, client):
+        """temperature, max_tokens etc. are accepted but ignored."""
+        mock_mgr.return_value.get_workspace.return_value = _TEST_WS
+        mock_search.return_value = "OK"
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "metatron-rag-TEST_WS",
+                "messages": [{"role": "user", "content": "test"}],
+                "temperature": 0.5,
+                "max_tokens": 100,
+                "top_p": 0.9,
+                "frequency_penalty": 0.1,
+                "stream": False,
+            },
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/chat/completions (streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsStreaming:
+    """POST /v1/chat/completions with stream=true"""
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_streaming_returns_sse_chunks(self, mock_search, mock_mgr, client):
+        mock_mgr.return_value.get_workspace.return_value = _TEST_WS
+        mock_search.return_value = "The answer is 42."
+
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "metatron-rag-TEST_WS",
+                "messages": [{"role": "user", "content": "test"}],
+                "stream": True,
+            },
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        assert r.status_code == 200
+        assert "text/event-stream" in r.headers.get("content-type", "")
+
+        # Parse SSE events
+        lines = r.text.strip().split("\n")
+        data_lines = [line for line in lines if line.startswith("data: ")]
+        assert len(data_lines) >= 2  # at least one content chunk + [DONE]
+        assert data_lines[-1] == "data: [DONE]"
+
+        # First data chunk should have role
+        first = json.loads(data_lines[0][6:])
+        assert first["choices"][0]["delta"]["role"] == "assistant"
+
+        # Last data chunk before [DONE] should have finish_reason=stop
+        last_chunk = json.loads(data_lines[-2][6:])
+        assert last_chunk["choices"][0]["finish_reason"] == "stop"
+
+    @patch("metatron.workspaces.get_workspace_manager")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    def test_streaming_includes_sources_as_markdown(self, mock_search, mock_mgr, client):
+        mock_mgr.return_value.get_workspace.return_value = _TEST_WS
+        mock_search.return_value = (
+            "Answer.\n\n\U0001f4da Sources:\n\U0001f4c4 Doc \u2014 https://example.com"
+        )
+        r = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "metatron-rag-TEST_WS",
+                "messages": [{"role": "user", "content": "test"}],
+                "stream": True,
+            },
+            headers={"Authorization": "Bearer test-key-123"},
+        )
+        # Collect all content from delta chunks
+        full_text = ""
+        for line in r.text.strip().split("\n"):
+            if line.startswith("data: ") and line != "data: [DONE]":
+                chunk = json.loads(line[6:])
+                content = chunk["choices"][0]["delta"].get("content", "")
+                full_text += content
+        assert "[\U0001f4c4 Doc](https://example.com)" in full_text


### PR DESCRIPTION
Add /v1/models and /v1/chat/completions endpoints implementing the OpenAI Chat Completions spec. Enables Open WebUI (or any OpenAI-compatible client) to use Metatron as an LLM backend.

- GET /v1/models — list workspaces as selectable models
- POST /v1/chat/completions — streaming + non-streaming chat
- GET /v1/openapi.json — stub for connection verification
- Static API key auth (METATRON_OPENAI_COMPAT_KEY)
- Source reference markers resolved to markdown links
- Open WebUI added to docker-compose.full.yml (profile: openwebui)
- 13 unit tests, docs updated