### PR TITLE
feat: add GET /connections/{id}/reveal-secrets/ endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -532,6 +532,50 @@ Trigger a sync for a specific connection.
 curl -X POST http://localhost:8000/api/v1/connections/660e8400-e29b-41d4-a716-446655440001/sync
 ```
 
+### GET /api/v1/connections/{id}/reveal-secrets
+
+Get a single connection with decrypted secret values. Requires editor role or higher.
+
+**Query Parameters:**
+
+- `workspace_id` (optional): Workspace ID
+
+**Response:**
+
+```json
+{
+  "id": "660e8400-e29b-41d4-a716-446655440001",
+  "workspace_id": "550e8400-e29b-41d4-a716-446655440000",
+  "connector_type": "jira",
+  "name": "My Jira Connection",
+  "config": {
+    "url": "https://acme.atlassian.net/",
+    "username": "bot@acme.com",
+    "api_token": "ATATT3xFfGF0...",
+    "project_key": "PROJ"
+  },
+  "status": "active",
+  "enabled": true,
+  "error_message": null,
+  "last_synced_at": "2026-02-11T11:00:00Z",
+  "created_at": "2026-02-11T10:30:00Z",
+  "updated_at": null
+}
+```
+
+**Status Codes:**
+
+- `200 OK` — Success
+- `403 Forbidden` — Viewer role (requires editor or admin)
+- `404 Not Found` — Connection not found or workspace mismatch
+
+**Example:**
+
+```bash
+curl "http://localhost:8000/api/v1/connections/660e8400-e29b-41d4-a716-446655440001/reveal-secrets?workspace_id=550e8400-e29b-41d4-a716-446655440000" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
 ### DELETE /api/v1/connections/{id}
 
 Delete a connection and all associated data.

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -325,6 +325,43 @@ async def get_connection(
     return ConnectionResponse(**conn)
 
 
+@router.get(
+    "/{connection_id}/reveal-secrets/",
+    response_model=ConnectionResponse,
+)
+async def reveal_connection_secrets(
+    connection_id: str,
+    request: Request,
+    workspace_id: str | None = Query(None),
+) -> ConnectionResponse:
+    """Get a single connection with decrypted secret values.
+
+    Requires editor role or higher.  Returns the same shape as
+    ``get_connection`` but with real secret values instead of ``***``.
+    """
+    settings: Settings = request.app.state.settings
+    if settings.auth_enabled:
+        user = getattr(request.state, "user", {})
+        if user.get("role") not in ("editor", "admin"):
+            raise HTTPException(status_code=403, detail="Editor access required")
+
+    fernet_key = _get_fernet_key(request)
+    store = _get_store(request)
+    ws_id = _get_workspace_id(request, workspace_id)
+
+    conn = await store.get_connection_decrypted(connection_id, fernet_key)
+    if conn is None or conn["workspace_id"] != ws_id:
+        raise HTTPException(status_code=404, detail="Connection not found")
+
+    logger.info(
+        "api.connections.reveal_secrets",
+        connection_id=connection_id,
+        workspace_id=ws_id,
+    )
+
+    return ConnectionResponse(**conn)
+
+
 @router.put(
     "/{connection_id}/",
     response_model=ConnectionResponse,

--- a/tests/unit/test_connections_reveal.py
+++ b/tests/unit/test_connections_reveal.py
@@ -1,0 +1,184 @@
+"""Tests for GET /api/v1/connections/{id}/reveal-secrets/ endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from metatron.api.app import create_app
+from metatron.core.config import Settings
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_FERNET_KEY = "dGVzdC1mZXJuZXQta2V5LTMyLWJ5dGVzLWxvbmc="  # 32-byte base64
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=True,
+        AUTH_PASSWORD="testpass",
+        METATRON_SECRET_KEY="test-secret",
+        FERNET_KEY=_FERNET_KEY,
+        DEFAULT_WORKSPACE_ID="ws_test",
+    )
+
+
+@pytest.fixture
+def app(settings: Settings):
+    return create_app(settings)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_token(
+    role: str = "admin",
+    workspace_ids: list[str] | None = None,
+    secret: str = "test-secret",
+) -> str:
+    from metatron.auth.jwt import create_token
+
+    return create_token(
+        user_id="testuser",
+        role=role,
+        workspace_ids=workspace_ids or ["ws_test"],
+        secret_key=secret,
+    )
+
+
+_DECRYPTED_CONN = {
+    "id": "conn_001",
+    "workspace_id": "ws_test",
+    "connector_type": "jira",
+    "name": "Jira",
+    "config": {
+        "url": "https://acme.atlassian.net/",
+        "username": "bot@acme.com",
+        "api_token": "super-secret-token-123",
+        "project_key": "PROJ",
+    },
+    "status": "active",
+    "enabled": True,
+    "error_message": None,
+    "last_synced_at": None,
+    "created_at": "2026-01-01T00:00:00",
+    "updated_at": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRevealSecrets:
+    """GET /api/v1/connections/{id}/reveal-secrets/."""
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_admin_can_reveal(self, mock_store, client: TestClient) -> None:
+        store = mock_store.return_value
+        store.get_connection_decrypted = AsyncMock(return_value=_DECRYPTED_CONN)
+
+        token = _make_token(role="admin")
+        r = client.get(
+            "/api/v1/connections/conn_001/reveal-secrets/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["config"]["api_token"] == "super-secret-token-123"
+        assert body["id"] == "conn_001"
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_editor_can_reveal(self, mock_store, client: TestClient) -> None:
+        store = mock_store.return_value
+        store.get_connection_decrypted = AsyncMock(return_value=_DECRYPTED_CONN)
+
+        token = _make_token(role="editor")
+        r = client.get(
+            "/api/v1/connections/conn_001/reveal-secrets/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert r.status_code == 200
+        assert r.json()["config"]["api_token"] == "super-secret-token-123"
+
+    def test_viewer_gets_403(self, client: TestClient) -> None:
+        token = _make_token(role="viewer")
+        r = client.get(
+            "/api/v1/connections/conn_001/reveal-secrets/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert r.status_code == 403
+        assert "Editor access required" in r.json()["detail"]
+
+    def test_no_auth_gets_401(self, client: TestClient) -> None:
+        r = client.get(
+            "/api/v1/connections/conn_001/reveal-secrets/?workspace_id=ws_test",
+        )
+
+        assert r.status_code == 401
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_not_found_returns_404(self, mock_store, client: TestClient) -> None:
+        store = mock_store.return_value
+        store.get_connection_decrypted = AsyncMock(return_value=None)
+
+        token = _make_token(role="admin")
+        r = client.get(
+            "/api/v1/connections/nonexistent/reveal-secrets/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert r.status_code == 404
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_wrong_workspace_returns_404(self, mock_store, client: TestClient) -> None:
+        conn = {**_DECRYPTED_CONN, "workspace_id": "other_ws"}
+        store = mock_store.return_value
+        store.get_connection_decrypted = AsyncMock(return_value=conn)
+
+        token = _make_token(role="admin")
+        r = client.get(
+            "/api/v1/connections/conn_001/reveal-secrets/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert r.status_code == 404
+
+
+class TestRevealSecretsAuthDisabled:
+    """reveal-secrets when AUTH_ENABLED=false (no role in request.state.user)."""
+
+    @pytest.fixture
+    def client_no_auth(self) -> TestClient:
+        settings = Settings(
+            METATRON_ENV="development",
+            AUTH_ENABLED=False,
+            FERNET_KEY=_FERNET_KEY,
+            DEFAULT_WORKSPACE_ID="ws_test",
+        )
+        app = create_app(settings)
+        return TestClient(app, raise_server_exceptions=False)
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_reveal_works_without_auth(self, mock_store, client_no_auth: TestClient) -> None:
+        store = mock_store.return_value
+        store.get_connection_decrypted = AsyncMock(return_value=_DECRYPTED_CONN)
+
+        r = client_no_auth.get(
+            "/api/v1/connections/conn_001/reveal-secrets/?workspace_id=ws_test",
+        )
+
+        assert r.status_code == 200
+        assert r.json()["config"]["api_token"] == "super-secret-token-123"


### PR DESCRIPTION
Allows editor+ to retrieve decrypted API tokens for connections. Skips role check when AUTH_ENABLED=false. Includes 7 unit tests.