### PR TITLE
refactor: replace source/source_info with connection_id in benchmarker

### DIFF
--- a/migrations/versions/008_benchmarks_connection_id.py
+++ b/migrations/versions/008_benchmarks_connection_id.py
@@ -1,0 +1,43 @@
+"""Replace source/source_info with connection_id in benchmark_sets.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-03-19
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "008"
+down_revision: Union[str, None] = "007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Drop source/source_info, add connection_id to benchmark_sets."""
+    # Remove old columns
+    op.drop_column("benchmark_sets", "source")
+    op.drop_column("benchmark_sets", "source_info")
+
+    # Add connection_id (NOT NULL)
+    op.add_column(
+        "benchmark_sets",
+        sa.Column("connection_id", sa.String(64), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Revert: drop connection_id, restore source/source_info."""
+    op.drop_column("benchmark_sets", "connection_id")
+    op.add_column(
+        "benchmark_sets",
+        sa.Column("source", sa.String(50), nullable=False, server_default="unknown"),
+    )
+    op.add_column(
+        "benchmark_sets",
+        sa.Column("source_info", sa.JSON, nullable=True),
+    )

--- a/src/metatron/benchmarker/api/benchmarks.py
+++ b/src/metatron/benchmarker/api/benchmarks.py
@@ -30,10 +30,9 @@ def list_benchmarks(workspace_id: str = Query(..., description="Workspace ID")) 
                     {
                         "id": b.id,
                         "workspace_id": b.workspace_id,
+                        "connection_id": b.connection_id,
                         "name": b.name,
                         "description": b.description,
-                        "source": b.source,
-                        "source_info": b.source_info,
                         "question_count": b.question_count,
                         "tokens_used": b.tokens_used,
                         "created_at": b.created_at.isoformat(),
@@ -68,10 +67,9 @@ def get_benchmark(
                 "benchmark": {
                     "id": benchmark.id,
                     "workspace_id": benchmark.workspace_id,
+                    "connection_id": benchmark.connection_id,
                     "name": benchmark.name,
                     "description": benchmark.description,
-                    "source": benchmark.source,
-                    "source_info": benchmark.source_info,
                     "tokens_used": benchmark.tokens_used,
                     "question_count": benchmark.question_count,
                     "created_at": benchmark.created_at.isoformat(),
@@ -108,12 +106,11 @@ def create_benchmark(
             benchmark = crud.upsert_benchmark_set(
                 session,
                 workspace_id=workspace_id,
+                connection_id=request.connection_id,
                 questions=request.questions,
                 benchmark_id=request.id,
                 name=request.name,
-                source=request.source,
                 description=request.description,
-                source_info=request.source_info,
                 tokens_used=request.tokens_used,
             )
             session.commit()
@@ -124,8 +121,8 @@ def create_benchmark(
                 "benchmark_id": benchmark.id,
                 "id": benchmark.id,
                 "workspace_id": benchmark.workspace_id,
+                "connection_id": benchmark.connection_id,
                 "name": benchmark.name,
-                "source": benchmark.source,
                 "question_count": benchmark.question_count,
                 "created_at": benchmark.created_at.isoformat(),
             }
@@ -175,6 +172,7 @@ def clone_benchmark(
             return {
                 "id": clone.id,
                 "workspace_id": clone.workspace_id,
+                "connection_id": clone.connection_id,
                 "name": clone.name,
                 "question_count": clone.question_count,
                 "created_at": clone.created_at.isoformat(),

--- a/src/metatron/benchmarker/api/generation.py
+++ b/src/metatron/benchmarker/api/generation.py
@@ -121,8 +121,8 @@ async def generate_benchmark(request: GenerateRequest) -> dict:
             benchmark_set = crud.create_benchmark_set(
                 session,
                 workspace_id=request.workspace_id,
+                connection_id=request.connection_id,
                 name=f"Generated ({connector_type})",
-                source=connector_type,
                 description=(
                     f"Auto-generated from {connector_type} documents"
                 ),
@@ -147,8 +147,8 @@ async def generate_benchmark(request: GenerateRequest) -> dict:
             result = {
                 "id": benchmark_set.id,
                 "workspace_id": benchmark_set.workspace_id,
+                "connection_id": benchmark_set.connection_id,
                 "name": benchmark_set.name,
-                "source": benchmark_set.source,
                 "description": benchmark_set.description,
                 "tokens_used": benchmark_set.tokens_used,
                 "question_count": benchmark_set.question_count,

--- a/src/metatron/benchmarker/db/crud.py
+++ b/src/metatron/benchmarker/db/crud.py
@@ -65,12 +65,11 @@ def compute_avg_metrics(results: list[TestResultRow]) -> dict:
 def upsert_benchmark_set(
     session: Session,
     workspace_id: str,
+    connection_id: str,
     questions: list[dict],
     benchmark_id: Optional[str] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
-    source: Optional[str] = None,
-    source_info: Optional[dict] = None,
     tokens_used: int = 0,
 ) -> BenchmarkSetRow:
     """Create or update a benchmark set (upsert).
@@ -81,7 +80,10 @@ def upsert_benchmark_set(
     if benchmark_id:
         existing = (
             session.query(BenchmarkSetRow)
-            .filter(BenchmarkSetRow.id == benchmark_id)
+            .filter(
+                BenchmarkSetRow.id == benchmark_id,
+                BenchmarkSetRow.workspace_id == workspace_id,
+            )
             .first()
         )
         if existing:
@@ -90,10 +92,7 @@ def upsert_benchmark_set(
                 existing.name = name
             if description is not None:
                 existing.description = description
-            if source:
-                existing.source = source
-            if source_info is not None:
-                existing.source_info = source_info
+            existing.connection_id = connection_id
             existing.tokens_used = tokens_used
             existing.question_count = len(questions)
 
@@ -137,10 +136,9 @@ def upsert_benchmark_set(
     benchmark = BenchmarkSetRow(
         id=bid,
         workspace_id=workspace_id,
+        connection_id=connection_id,
         name=name or f"Benchmark {bid[:8]}",
-        source=source or "unknown",
         description=description,
-        source_info=source_info,
         tokens_used=tokens_used,
         question_count=len(questions),
         created_at=datetime.utcnow(),
@@ -164,10 +162,9 @@ def upsert_benchmark_set(
 def create_benchmark_set(
     session: Session,
     workspace_id: str,
+    connection_id: str,
     name: str,
-    source: str,
     description: Optional[str] = None,
-    source_info: Optional[dict] = None,
     tokens_used: int = 0,
     question_count: int = 0,
 ) -> BenchmarkSetRow:
@@ -175,10 +172,9 @@ def create_benchmark_set(
     benchmark = BenchmarkSetRow(
         id=str(uuid4()),
         workspace_id=workspace_id,
+        connection_id=connection_id,
         name=name,
-        source=source,
         description=description,
-        source_info=source_info,
         tokens_used=tokens_used,
         question_count=question_count,
         created_at=datetime.utcnow(),
@@ -283,8 +279,7 @@ def clone_benchmark_set(
         workspace_id=workspace_id,
         name=f"{original.name} copy",
         description=original.description,
-        source=original.source,
-        source_info=original.source_info,
+        connection_id=original.connection_id,
         tokens_used=original.tokens_used,
         question_count=original.question_count,
         created_at=datetime.utcnow(),

--- a/src/metatron/benchmarker/db/models.py
+++ b/src/metatron/benchmarker/db/models.py
@@ -33,8 +33,7 @@ class BenchmarkSetRow(Base):  # type: ignore[misc]
     workspace_id = Column(String(64), nullable=False)
     name = Column(String(255), nullable=False)
     description = Column(Text, nullable=True)
-    source = Column(String(50), nullable=False)  # jira / confluence
-    source_info = Column(JSON, nullable=True)
+    connection_id = Column(String(64), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     tokens_used = Column(Integer, default=0)
     question_count = Column(Integer, default=0)

--- a/src/metatron/benchmarker/schemas/benchmark.py
+++ b/src/metatron/benchmarker/schemas/benchmark.py
@@ -123,8 +123,7 @@ class SaveBenchmarkRequest(BaseModel):
 
     id: Optional[str] = Field(None, description="Benchmark ID (if provided, upsert)")
     name: str = Field(..., min_length=1, description="Benchmark set name")
-    source: str = Field(..., description="Document source (jira / confluence)")
+    connection_id: str = Field(..., description="Connection ID this benchmark belongs to")
     description: Optional[str] = Field(None, description="Optional description")
-    source_info: Optional[dict] = Field(None, description="Optional source metadata")
     questions: List[dict] = Field(..., description="List of question dicts")
     tokens_used: int = Field(default=0, ge=0, description="Tokens used during generation")

--- a/tests/unit/test_benchmarker_api.py
+++ b/tests/unit/test_benchmarker_api.py
@@ -101,7 +101,7 @@ def _create_benchmark(client: TestClient, workspace_id: str = "ws1") -> dict:
         params={"workspace_id": workspace_id},
         json={
             "name": "Test Benchmark",
-            "source": "jira",
+            "connection_id": "conn-1",
             "questions": [
                 {
                     "text": "What is X?",
@@ -184,7 +184,7 @@ class TestCreateBenchmark:
             params={"workspace_id": "ws1"},
             json={
                 "name": "Empty",
-                "source": "jira",
+                "connection_id": "conn-1",
                 "questions": [],
             },
         )
@@ -195,7 +195,7 @@ class TestCreateBenchmark:
             "/api/v1/benchmarker/benchmarks/",
             params={"workspace_id": "ws1"},
             json={
-                "source": "jira",
+                "connection_id": "conn-1",
                 "questions": [{"text": "Q?", "question_type": "data_local", "attributes": {}}],
             },
         )

--- a/tests/unit/test_benchmarker_crud.py
+++ b/tests/unit/test_benchmarker_crud.py
@@ -80,28 +80,26 @@ def _make_result_dict(
 class TestCreateBenchmarkSet:
     def test_create_returns_row(self, db_session):
         bs = crud.create_benchmark_set(
-            db_session, workspace_id="ws1", name="Test", source="jira",
+            db_session, workspace_id="ws1", connection_id="conn-1", name="Test",
         )
         assert bs.id is not None
         assert bs.workspace_id == "ws1"
         assert bs.name == "Test"
-        assert bs.source == "jira"
+        assert bs.connection_id == "conn-1"
 
     def test_create_with_all_fields(self, db_session):
         bs = crud.create_benchmark_set(
-            db_session, workspace_id="ws1", name="Full",
-            source="confluence", description="desc",
-            source_info={"key": "val"}, tokens_used=100, question_count=5,
+            db_session, workspace_id="ws1", connection_id="conn-1", name="Full",
+            description="desc", tokens_used=100, question_count=5,
         )
         assert bs.description == "desc"
-        assert bs.source_info == {"key": "val"}
         assert bs.tokens_used == 100
         assert bs.question_count == 5
 
 
 class TestReadBenchmarkSet:
     def test_get_by_id_and_workspace(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Test", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Test")
         db_session.flush()
 
         found = crud.get_benchmark_set(db_session, bs.id, "ws1")
@@ -109,16 +107,16 @@ class TestReadBenchmarkSet:
         assert found.id == bs.id
 
     def test_get_returns_none_for_wrong_workspace(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Test", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Test")
         db_session.flush()
 
         found = crud.get_benchmark_set(db_session, bs.id, "ws_other")
         assert found is None
 
     def test_list_returns_all_for_workspace(self, db_session):
-        crud.create_benchmark_set(db_session, "ws1", "A", "jira")
-        crud.create_benchmark_set(db_session, "ws1", "B", "confluence")
-        crud.create_benchmark_set(db_session, "ws2", "C", "jira")
+        crud.create_benchmark_set(db_session, "ws1", "conn-1", "A")
+        crud.create_benchmark_set(db_session, "ws1", "conn-2", "B")
+        crud.create_benchmark_set(db_session, "ws2", "conn-3", "C")
         db_session.flush()
 
         results = crud.get_benchmark_sets(db_session, "ws1")
@@ -127,7 +125,7 @@ class TestReadBenchmarkSet:
 
 class TestUpdateBenchmarkSet:
     def test_update_name(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Old", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Old")
         db_session.flush()
 
         updated = crud.update_benchmark_set(db_session, bs.id, "ws1", name="New")
@@ -141,7 +139,7 @@ class TestUpdateBenchmarkSet:
 
 class TestDeleteBenchmarkSet:
     def test_delete_existing(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Del", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Del")
         db_session.flush()
 
         deleted = crud.delete_benchmark_set(db_session, bs.id, "ws1")
@@ -154,7 +152,7 @@ class TestDeleteBenchmarkSet:
         assert crud.delete_benchmark_set(db_session, "fake", "ws1") is False
 
     def test_delete_wrong_workspace_returns_false(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "X", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "X")
         db_session.flush()
 
         assert crud.delete_benchmark_set(db_session, bs.id, "ws_other") is False
@@ -167,7 +165,7 @@ class TestDeleteBenchmarkSet:
 
 class TestCloneBenchmarkSet:
     def test_clone_creates_new_id(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Original", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Original")
         crud.create_benchmark_questions(db_session, bs.id, [_make_question_dict()])
         db_session.flush()
 
@@ -176,7 +174,7 @@ class TestCloneBenchmarkSet:
         assert clone.id != bs.id
 
     def test_clone_preserves_question_count(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Original", "jira",
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Original",
                                         question_count=2)
         crud.create_benchmark_questions(db_session, bs.id, [
             _make_question_dict("Q1"), _make_question_dict("Q2"),
@@ -190,7 +188,7 @@ class TestCloneBenchmarkSet:
         assert len(clone_qs) == len(original_qs)
 
     def test_clone_question_texts_match(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Original", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Original")
         crud.create_benchmark_questions(db_session, bs.id, [
             _make_question_dict("Alpha?"), _make_question_dict("Beta?"),
         ])
@@ -205,7 +203,7 @@ class TestCloneBenchmarkSet:
         assert orig_texts == clone_texts
 
     def test_clone_question_ids_differ(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "Original", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "Original")
         crud.create_benchmark_questions(db_session, bs.id, [_make_question_dict()])
         db_session.flush()
 
@@ -228,7 +226,7 @@ class TestCloneBenchmarkSet:
 
 class TestCreateTestRun:
     def test_create_test_run(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "BS", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "BS")
         db_session.flush()
 
         run = crud.create_test_run(
@@ -243,7 +241,7 @@ class TestCreateTestRun:
 
 class TestReadTestRun:
     def test_get_test_run_with_results(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "BS", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "BS")
         run = crud.create_test_run(db_session, bs.id, name="Run 1")
         crud.create_test_results(db_session, run.id, [_make_result_dict()])
         db_session.flush()
@@ -253,8 +251,8 @@ class TestReadTestRun:
         assert len(found.test_results) == 1
 
     def test_list_test_runs_by_workspace(self, db_session):
-        bs1 = crud.create_benchmark_set(db_session, "ws1", "BS1", "jira")
-        bs2 = crud.create_benchmark_set(db_session, "ws2", "BS2", "jira")
+        bs1 = crud.create_benchmark_set(db_session, "ws1", "conn-1", "BS1")
+        bs2 = crud.create_benchmark_set(db_session, "ws2", "conn-2", "BS2")
         crud.create_test_run(db_session, bs1.id, name="Run A")
         crud.create_test_run(db_session, bs2.id, name="Run B")
         db_session.flush()
@@ -266,7 +264,7 @@ class TestReadTestRun:
 
 class TestDeleteTestRun:
     def test_delete_existing(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "BS", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "BS")
         run = crud.create_test_run(db_session, bs.id, name="Run")
         db_session.flush()
 
@@ -274,7 +272,7 @@ class TestDeleteTestRun:
         assert crud.get_test_run(db_session, run.id, "ws1") is None
 
     def test_delete_wrong_workspace(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "BS", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "BS")
         run = crud.create_test_run(db_session, bs.id, name="Run")
         db_session.flush()
 
@@ -288,7 +286,7 @@ class TestDeleteTestRun:
 
 class TestRoundTripTestResult:
     def test_all_fields_preserved(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws1", "BS", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws1", "conn-1", "BS")
         run = crud.create_test_run(db_session, bs.id, name="Run")
 
         original = _make_result_dict(
@@ -370,8 +368,8 @@ class TestAverageMetrics:
 
 class TestWorkspaceIsolation:
     def test_benchmark_sets_isolated(self, db_session):
-        crud.create_benchmark_set(db_session, "ws_a", "Set A", "jira")
-        crud.create_benchmark_set(db_session, "ws_b", "Set B", "jira")
+        crud.create_benchmark_set(db_session, "ws_a", "conn-a", "Set A")
+        crud.create_benchmark_set(db_session, "ws_b", "conn-b", "Set B")
         db_session.flush()
 
         sets_a = crud.get_benchmark_sets(db_session, "ws_a")
@@ -383,14 +381,14 @@ class TestWorkspaceIsolation:
         assert sets_b[0].name == "Set B"
 
     def test_get_benchmark_set_wrong_workspace(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws_a", "Set A", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws_a", "conn-a", "Set A")
         db_session.flush()
 
         assert crud.get_benchmark_set(db_session, bs.id, "ws_b") is None
 
     def test_test_runs_isolated(self, db_session):
-        bs_a = crud.create_benchmark_set(db_session, "ws_a", "A", "jira")
-        bs_b = crud.create_benchmark_set(db_session, "ws_b", "B", "jira")
+        bs_a = crud.create_benchmark_set(db_session, "ws_a", "conn-a", "A")
+        bs_b = crud.create_benchmark_set(db_session, "ws_b", "conn-b", "B")
         crud.create_test_run(db_session, bs_a.id, name="Run A")
         crud.create_test_run(db_session, bs_b.id, name="Run B")
         db_session.flush()
@@ -404,7 +402,7 @@ class TestWorkspaceIsolation:
         assert runs_b[0].name == "Run B"
 
     def test_delete_benchmark_wrong_workspace_fails(self, db_session):
-        bs = crud.create_benchmark_set(db_session, "ws_a", "A", "jira")
+        bs = crud.create_benchmark_set(db_session, "ws_a", "conn-a", "A")
         db_session.flush()
 
         assert crud.delete_benchmark_set(db_session, bs.id, "ws_b") is False

--- a/tests/unit/test_benchmarker_endpoints.py
+++ b/tests/unit/test_benchmarker_endpoints.py
@@ -35,7 +35,7 @@ def mock_benchmark_set():
     benchmark.id = "bench1"
     benchmark.workspace_id = "ws1"
     benchmark.name = "Test Benchmark"
-    benchmark.source = "confluence"
+    benchmark.connection_id = "conn-1"
     return benchmark
 
 
@@ -237,7 +237,7 @@ class TestGenerateEndpoint:
         mock_benchmark.id = "bench1"
         mock_benchmark.workspace_id = "ws1"
         mock_benchmark.name = "Generated (confluence)"
-        mock_benchmark.source = "confluence"
+        mock_benchmark.connection_id = "conn1"
         mock_benchmark.description = "Auto-generated from confluence documents"
         mock_benchmark.tokens_used = 1000
         mock_benchmark.question_count = 5
@@ -312,7 +312,7 @@ class TestGenerateEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["id"] == "bench1"
-        assert data["source"] == "confluence"
+        assert data["connection_id"] == "conn1"
         assert data["question_count"] == 5
         assert data["tokens_used"] == 1000
 
@@ -332,8 +332,7 @@ class TestGenerateEndpoint:
                 json=request_data,
             )
 
-        assert response.status_code == 400
-        assert "connection_id" in response.json()["detail"]
+        assert response.status_code == 422
 
     def test_generate_connection_not_found(self, client):
         """Test with non-existent connection."""


### PR DESCRIPTION
Benchmarks now reference connections by connection_id instead of storing a redundant source type string — single source of truth for connector info.

- Add connection_id (NOT NULL) to benchmark_sets, drop source/source_info
- Update CRUD, API responses, and schemas across the benchmarker module
- Fix tenant isolation bug in upsert_benchmark_set (missing workspace_id filter)
- Add connection_id to clone response for API consistency
- Migration 008: drop source/source_info, add connection_id