### PR TITLE
fix: graph expand endpoint returning empty results

### DIFF
--- a/src/metatron/storage/graph_ops.py
+++ b/src/metatron/storage/graph_ops.py
@@ -551,19 +551,19 @@ def get_graph_overview(workspace_id: Optional[str] = None,
         q_edges = (
             f"MATCH (a:Entity)-[r]->(b:Entity) "
             f"WHERE {ws_filter} "
-            "RETURN r"
+            "RETURN a, r, b"
         )
         logger.debug("graph_overview.edges", query=q_edges)
         all_edges: list[Dict] = []
         node_map: dict[int, Dict] = {}  # id → node dict
         try:
             for rec in s.run(q_edges):
-                rel = rec[0]
-                src_node = rel.start_node
-                tgt_node = rel.end_node
+                src_node = rec[0]
+                rel = rec[1]
+                tgt_node = rec[2]
                 src_id = src_node.id
                 tgt_id = tgt_node.id
-                # Collect nodes from edges
+                # Collect nodes from edges (full properties via explicit RETURN)
                 if src_id not in node_map:
                     ws = src_node.get("workspace_id")
                     if ws is not None:
@@ -671,10 +671,17 @@ def get_graph_expand(entity_id: int,
         _ws = _esc(workspace_id)
 
         # 1. Fetch ALL edges for workspace in one query
+        if workspace_id == DEFAULT_WORKSPACE_ID:
+            ws_filter = (
+                f"(a.workspace_id = {_ws} "
+                "OR a.workspace_id IS NULL)"
+            )
+        else:
+            ws_filter = f"a.workspace_id = {_ws}"
         q_edges = (
             f"MATCH (a:Entity)-[r]->(b:Entity) "
-            f"WHERE a.workspace_id = {_ws} "
-            "RETURN r"
+            f"WHERE {ws_filter} "
+            "RETURN a, r, b"
         )
         logger.debug("graph_expand.edges", query=q_edges)
 
@@ -684,12 +691,12 @@ def get_graph_expand(entity_id: int,
         adj: dict[int, set[int]] = {}
         try:
             for rec in s.run(q_edges):
-                rel = rec[0]
-                src_node = rel.start_node
-                tgt_node = rel.end_node
+                src_node = rec[0]
+                rel = rec[1]
+                tgt_node = rec[2]
                 src_id = src_node.id
                 tgt_id = tgt_node.id
-                # Collect nodes
+                # Collect nodes (full properties from explicit RETURN)
                 for nd, nid in ((src_node, src_id), (tgt_node, tgt_id)):
                     if nid not in node_map:
                         ws = nd.get("workspace_id")

--- a/tests/unit/test_graph_api.py
+++ b/tests/unit/test_graph_api.py
@@ -77,7 +77,7 @@ def test_overview_limit_param(client):
         resp = client.get("/api/v1/graph/overview?workspace_id=ws_test&limit=50")
 
     assert resp.status_code == 200
-    m.assert_called_once_with("ws_test", 50)
+    m.assert_called_once_with("ws_test", 50, user_groups=None)
 
 
 def test_overview_limit_validation(client):
@@ -128,7 +128,7 @@ def test_expand_depth_and_limit(client):
         )
 
     assert resp.status_code == 200
-    m.assert_called_once_with(1, "ws_test", 3, 20)
+    m.assert_called_once_with(1, "ws_test", 3, 20, user_groups=None)
 
 
 def test_expand_depth_validation(client):


### PR DESCRIPTION
Memgraph's neo4j driver returns "thin" nodes (id only, no properties) when query uses RETURN r. Changed to RETURN a, r, b in both get_graph_overview and get_graph_expand so node properties (name, type, workspace_id) are populated. Also added OR workspace_id IS NULL filter for default workspace in expand to match overview behavior.