### PR TITLE
fix: implement .docx parsing in upload endpoint

### DIFF
--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -271,6 +271,9 @@ async def upload_file(
         if file_name.lower().endswith(".pdf"):
             from metatron.ingestion.processors.pdf import extract_text_from_pdf
             text = extract_text_from_pdf(raw_bytes, file_name)
+        elif file_name.lower().endswith(".docx"):
+            from metatron.ingestion.processors.office import extract_text_from_docx
+            text = extract_text_from_docx(raw_bytes)
         elif is_tabular_file(file_name):
             text, _meta = process_tabular_file(raw_bytes, file_name)
         elif file_name.lower().endswith((".html", ".htm")):

--- a/src/metatron/ingestion/processors/__init__.py
+++ b/src/metatron/ingestion/processors/__init__.py
@@ -7,7 +7,7 @@ from metatron.ingestion.processors.titles import extract_title_from_body, extrac
 from metatron.ingestion.processors.translation import (
     is_russian, is_english, translate_to_english, translate_to_russian,
 )
-from metatron.ingestion.processors.office import OfficeProcessor
+from metatron.ingestion.processors.office import OfficeProcessor, extract_text_from_docx
 from metatron.ingestion.processors.pdf import PdfProcessor, extract_text_from_pdf
 from metatron.ingestion.processors.text import TextProcessor
 
@@ -27,4 +27,5 @@ __all__ = [
     "PdfProcessor",
     "extract_text_from_pdf",
     "OfficeProcessor",
+    "extract_text_from_docx",
 ]

--- a/src/metatron/ingestion/processors/office.py
+++ b/src/metatron/ingestion/processors/office.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import io
+
+import docx
 import structlog
 
 from metatron.core.interfaces import ProcessorInterface
 
 logger = structlog.get_logger()
+
+
+def extract_text_from_docx(content: bytes) -> str:
+    """Extract plain text from a .docx file."""
+    doc = docx.Document(io.BytesIO(content))
+    return "\n".join(p.text for p in doc.paragraphs if p.text.strip())
 
 
 class OfficeProcessor(ProcessorInterface):
@@ -45,15 +54,8 @@ class OfficeProcessor(ProcessorInterface):
             raise ValueError(msg)
 
     async def _extract_docx(self, content: bytes) -> str:
-        """Extract text from a .docx file.
-
-        Uses python-docx to iterate paragraphs.
-        """
-        # TODO: implement .docx extraction
-        # 1. io.BytesIO(content) → docx.Document()
-        # 2. Iterate doc.paragraphs → paragraph.text
-        # 3. Join with newlines
-        raise NotImplementedError("DOCX extraction not yet implemented")
+        """Extract text from a .docx file."""
+        return extract_text_from_docx(content)
 
     async def _extract_xlsx(self, content: bytes) -> str:
         """Extract text from a .xlsx file.


### PR DESCRIPTION
.docx files were falling through to the UTF-8 text decode fallback, sending raw ZIP binary to embeddings and Memgraph (causing Invalid query errors). Implement extract_text_from_docx() using python-docx and wire it into the upload route.