### PR TITLE
fix: return all sources so inline reference markers can resolve URLs

### DIFF
--- a/src/metatron/api/routes/openai_compat.py
+++ b/src/metatron/api/routes/openai_compat.py
@@ -212,12 +212,20 @@ def _resolve_reference_markers(text: str, sources: list[str]) -> str:
     return _INLINE_REF_RE.sub(_replace, text)
 
 
-def _sources_to_markdown(sources: list[str]) -> str:
-    """Convert source lines from 'icon Title — URL' to markdown links."""
+_DISPLAY_SOURCES_LIMIT = 5
+
+
+def _sources_to_markdown(sources: list[str], limit: int = _DISPLAY_SOURCES_LIMIT) -> str:
+    """Convert source lines from 'icon Title — URL' to markdown links.
+
+    Only the first *limit* sources are rendered in the footer block shown to
+    the user.  The full list is still used by ``_resolve_reference_markers``
+    so that every ``[$[title]$]`` inline reference can be resolved to a URL.
+    """
     if not sources:
         return ""
     md_lines: list[str] = []
-    for source in sources:
+    for source in sources[:limit]:
         if " \u2014 " in source:
             label, _, url = source.partition(" \u2014 ")
             md_lines.append(f"- [{label.strip()}]({url.strip()})")

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -528,11 +528,15 @@ def _collect_frags(base, seen, total):
 
 
 _SOURCE_ICONS = {"confluence": "\U0001f4c4", "jira": "\U0001f4cb", "upload": "\U0001f4ce", "notion": "\U0001f4d3"}
-_MAX_SOURCES = 5
 
 
 def _append_sources(answer: str, results: list) -> str:
-    """Append a sources section to the answer with document titles and types."""
+    """Append a sources section to the answer with document titles and types.
+
+    All unique sources are included so that every ``[$[title]$]`` reference
+    marker in the LLM answer can be resolved to a URL by downstream consumers
+    (frontend / OpenAI-compat layer).
+    """
     seen_titles: set[str] = set()
     sources: list[str] = []
     for mem in results:
@@ -555,8 +559,6 @@ def _append_sources(answer: str, results: list) -> str:
             sources.append(f"{icon} {title} \u2014 {url}")
         else:
             sources.append(f"{icon} {title}")
-        if len(sources) >= _MAX_SOURCES:
-            break
     if sources:
         return answer + "\n\n\U0001f4da Sources:\n" + "\n".join(sources)
     return answer

--- a/tests/unit/test_diversify_results.py
+++ b/tests/unit/test_diversify_results.py
@@ -155,11 +155,11 @@ class TestAppendSources:
         assert out.count("Same Page") == 1
         assert "Other Page" in out
 
-    def test_max_five_sources(self) -> None:
+    def test_all_unique_sources_included(self) -> None:
         results = [{"title": f"Page {i}", "type": "confluence"} for i in range(10)]
         out = _append_sources("Answer.", results)
         lines = out.split("\U0001f4da Sources:\n")[1].strip().split("\n")
-        assert len(lines) == 5
+        assert len(lines) == 10
 
     def test_title_from_payload(self) -> None:
         results = [{"payload": {"title": "From Payload", "type": "jira"}}]
@@ -405,3 +405,26 @@ class TestSearchByTitle:
         mock_get_store.side_effect = RuntimeError("Qdrant down")
         results = _search_by_title("What is Project Aurora?", workspace_id=None)
         assert results == []
+
+
+class TestSourcesToMarkdown:
+    def test_limits_displayed_sources(self) -> None:
+        from metatron.api.routes.openai_compat import _sources_to_markdown
+
+        sources = [f"\U0001f4c4 Page {i} \u2014 https://example.com/{i}" for i in range(10)]
+        md = _sources_to_markdown(sources)
+        lines = [l for l in md.strip().splitlines() if l.startswith("- ")]
+        assert len(lines) == 5
+
+    def test_custom_limit(self) -> None:
+        from metatron.api.routes.openai_compat import _sources_to_markdown
+
+        sources = [f"\U0001f4c4 Page {i} \u2014 https://example.com/{i}" for i in range(10)]
+        md = _sources_to_markdown(sources, limit=3)
+        lines = [l for l in md.strip().splitlines() if l.startswith("- ")]
+        assert len(lines) == 3
+
+    def test_empty_sources(self) -> None:
+        from metatron.api.routes.openai_compat import _sources_to_markdown
+
+        assert _sources_to_markdown([]) == ""


### PR DESCRIPTION
LLM answers may reference documents via [$[title]$] markers beyond the previous top-5 sources limit. This caused unresolvable references in both the chat/stream frontend and the OpenAI-compat layer.

- Remove _MAX_SOURCES cap in _append_sources(); all unique sources are now included in the Sources block
- Add _DISPLAY_SOURCES_LIMIT to openai_compat._sources_to_markdown() so the rendered footer still shows 5 while _resolve_reference_markers() can match against the full list
- Update and add tests for the new behaviour