### PR TITLE
fix: always return 200 from /ready endpoint

### DIFF
--- a/src/metatron/api/routes/health.py
+++ b/src/metatron/api/routes/health.py
@@ -81,7 +81,7 @@ async def ready() -> JSONResponse:
     all_ok = all(v == "ok" for v in services.values())
     return JSONResponse(
         content={"status": "ready" if all_ok else "degraded", "services": services},
-        status_code=200 if all_ok else 503,
+        status_code=200,
     )
 
 


### PR DESCRIPTION
The readiness probe was returning 503 when any service was degraded, causing orchestrators to pull the container from load balancing even when the app could still serve requests (graceful degradation by design).