### PR TITLE
fix: use CPU-only PyTorch in Docker to reduce image size from 9.4GB t…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY pyproject.toml README.md ./
 COPY src/ src/
 
-RUN pip install --no-cache-dir --prefix=/install ".[connectors,channels,benchmarker]"
+RUN pip install --no-cache-dir --prefix=/install \
+    --extra-index-url https://download.pytorch.org/whl/cpu \
+    ".[connectors,channels,benchmarker]"
 
 # Stage 2: Runtime
 FROM python:3.12-slim AS runtime


### PR DESCRIPTION
…o 2.9GB

sentence-transformers (used only for reranker) was pulling full CUDA torch stack (nvidia-cublas, nvidia-cudnn, triton, etc.) — ~4.5GB of unused libraries since the container runs on CPU.