### PR TITLE
feat: query classifier for intent-based scoring weight profiles

### DIFF
--- a/docs/superpowers/plans/2026-03-26-query-classifier.md
+++ b/docs/superpowers/plans/2026-03-26-query-classifier.md
@@ -1,0 +1,1038 @@
+# Query Classifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Classify incoming queries into 6 intent profiles and dynamically adjust scoring weights so the most relevant recall channel and signal dominate the ranking.
+
+**Architecture:** Hybrid classifier — fast rule gate covers obvious cases (Jira keys, dates, keywords), LLM fallback for ambiguous queries. Each profile maps to a weight preset applied to `compute_signal_score()` and `compute_final_score()`. Graceful degradation: any failure → `mixed` profile (current defaults, zero behavior change).
+
+**Tech Stack:** Python 3.12, regex (rule gate), `chat_completion` from `metatron.llm` (LLM fallback), pydantic-settings (config)
+
+**Spec:** `docs/superpowers/specs/2026-03-26-query-classifier-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/metatron/core/config.py` | Modify | Add `query_classifier_enabled` field to Settings |
+| `src/metatron/retrieval/query_classifier.py` | Create | Rule gate, LLM fallback, `classify_query()`, `get_profile_weights()`, weight presets, `QueryClassification` TypedDict |
+| `src/metatron/retrieval/search.py` | Modify | Call `classify_query()`, pass profile weights to scoring loop, add trace fields |
+| `tests/unit/test_query_classifier.py` | Create | All tests for query classifier |
+| `tests/unit/test_search_trace_extended.py` | Modify | Add `classify_query` patch to `_patch_search_internals()`, verify new trace fields |
+
+---
+
+### Task 1: Add `query_classifier_enabled` config field
+
+**Files:**
+- Modify: `src/metatron/core/config.py:109` (after `reranker_enabled`)
+- Test: `tests/unit/test_query_classifier.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_query_classifier.py`:
+
+```python
+"""Tests for query classifier: config, rule gate, LLM fallback, integration."""
+
+from __future__ import annotations
+
+
+class TestQueryClassifierConfig:
+    def test_query_classifier_enabled_default_true(self) -> None:
+        from metatron.core.config import Settings
+
+        s = Settings()
+        assert s.query_classifier_enabled is True
+
+    def test_query_classifier_disabled_via_env(self, monkeypatch) -> None:
+        from metatron.core.config import Settings
+
+        monkeypatch.setenv("QUERY_CLASSIFIER_ENABLED", "false")
+        s = Settings()
+        assert s.query_classifier_enabled is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestQueryClassifierConfig -v`
+Expected: FAIL — `AttributeError: 'Settings' object has no attribute 'query_classifier_enabled'`
+
+- [ ] **Step 3: Add config field**
+
+In `src/metatron/core/config.py`, after line 109 (`reranker_enabled`), add:
+
+```python
+    query_classifier_enabled: bool = Field(True, alias="QUERY_CLASSIFIER_ENABLED")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestQueryClassifierConfig -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metatron/core/config.py tests/unit/test_query_classifier.py
+git commit -m "feat(classifier): add query_classifier_enabled config field"
+```
+
+---
+
+### Task 2: Weight presets and `get_profile_weights()`
+
+**Files:**
+- Create: `src/metatron/retrieval/query_classifier.py`
+- Test: `tests/unit/test_query_classifier.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_query_classifier.py`:
+
+```python
+import pytest
+
+
+class TestProfileWeights:
+    def test_all_profiles_exist(self) -> None:
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        expected = {"execution", "documentation", "user_file", "relationship", "temporal", "mixed"}
+        assert set(QUERY_PROFILE_WEIGHTS.keys()) == expected
+
+    @pytest.mark.parametrize("profile", [
+        "execution", "documentation", "user_file", "relationship", "temporal", "mixed",
+    ])
+    def test_signal_weights_sum_to_085(self, profile: str) -> None:
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        w = QUERY_PROFILE_WEIGHTS[profile]
+        signal_sum = (
+            w["dense_weight"] + w["sparse_weight"] + w["graph_weight"]
+            + w["metadata_weight"] + w["recency_weight"] + w["balance_weight"]
+        )
+        assert abs(signal_sum - 0.85) < 1e-9, f"{profile}: signal sum = {signal_sum}"
+
+    @pytest.mark.parametrize("profile", [
+        "execution", "documentation", "user_file", "relationship", "temporal", "mixed",
+    ])
+    def test_all_weight_keys_present(self, profile: str) -> None:
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        expected_keys = {
+            "dense_weight", "sparse_weight", "graph_weight",
+            "metadata_weight", "recency_weight", "balance_weight", "blend_weight",
+        }
+        assert set(QUERY_PROFILE_WEIGHTS[profile].keys()) == expected_keys
+
+    def test_mixed_matches_current_defaults(self) -> None:
+        """mixed profile must match compute_signal_score() defaults exactly."""
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        mixed = QUERY_PROFILE_WEIGHTS["mixed"]
+        assert mixed["dense_weight"] == 0.35
+        assert mixed["sparse_weight"] == 0.0
+        assert mixed["graph_weight"] == 0.15
+        assert mixed["metadata_weight"] == 0.20
+        assert mixed["recency_weight"] == 0.10
+        assert mixed["balance_weight"] == 0.05
+        assert mixed["blend_weight"] == 0.30
+
+    def test_get_profile_weights_valid(self) -> None:
+        from metatron.retrieval.query_classifier import get_profile_weights
+
+        w = get_profile_weights("execution")
+        assert w["dense_weight"] == 0.20
+        assert w["metadata_weight"] == 0.35
+
+    def test_get_profile_weights_unknown_falls_back_to_mixed(self) -> None:
+        from metatron.retrieval.query_classifier import get_profile_weights
+
+        w = get_profile_weights("nonexistent")
+        assert w == get_profile_weights("mixed")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestProfileWeights -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'metatron.retrieval.query_classifier'`
+
+- [ ] **Step 3: Create `query_classifier.py` with weight presets**
+
+Create `src/metatron/retrieval/query_classifier.py`:
+
+```python
+"""Query classifier for source-of-truth profiles.
+
+Classifies incoming queries into 6 intent profiles and returns weight
+presets for compute_signal_score() and compute_final_score().
+
+Hybrid approach: fast rule gate for obvious cases, LLM fallback for ambiguous.
+Any failure gracefully degrades to 'mixed' (current defaults).
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+class QueryClassification(TypedDict):
+    profile: str       # "execution" | "documentation" | "user_file" | "relationship" | "temporal" | "mixed"
+    confidence: float  # 0.0 - 1.0
+    method: str        # "rule" | "llm" | "default" | "disabled"
+
+
+QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
+    "execution":     {"dense_weight": 0.20, "sparse_weight": 0.0, "graph_weight": 0.10, "metadata_weight": 0.35, "recency_weight": 0.15, "balance_weight": 0.05, "blend_weight": 0.25},
+    "documentation": {"dense_weight": 0.45, "sparse_weight": 0.0, "graph_weight": 0.15, "metadata_weight": 0.15, "recency_weight": 0.05, "balance_weight": 0.05, "blend_weight": 0.35},
+    "user_file":     {"dense_weight": 0.45, "sparse_weight": 0.0, "graph_weight": 0.05, "metadata_weight": 0.20, "recency_weight": 0.05, "balance_weight": 0.10, "blend_weight": 0.35},
+    "relationship":  {"dense_weight": 0.25, "sparse_weight": 0.0, "graph_weight": 0.35, "metadata_weight": 0.15, "recency_weight": 0.05, "balance_weight": 0.05, "blend_weight": 0.25},
+    "temporal":      {"dense_weight": 0.25, "sparse_weight": 0.0, "graph_weight": 0.10, "metadata_weight": 0.15, "recency_weight": 0.30, "balance_weight": 0.05, "blend_weight": 0.30},
+    "mixed":         {"dense_weight": 0.35, "sparse_weight": 0.0, "graph_weight": 0.15, "metadata_weight": 0.20, "recency_weight": 0.10, "balance_weight": 0.05, "blend_weight": 0.30},
+}
+
+
+def get_profile_weights(profile: str) -> dict[str, float]:
+    """Return weight preset for the given profile. Falls back to 'mixed' if unknown."""
+    return QUERY_PROFILE_WEIGHTS.get(profile, QUERY_PROFILE_WEIGHTS["mixed"])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestProfileWeights -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metatron/retrieval/query_classifier.py tests/unit/test_query_classifier.py
+git commit -m "feat(classifier): add weight presets and get_profile_weights()"
+```
+
+---
+
+### Task 3: Rule gate
+
+**Files:**
+- Modify: `src/metatron/retrieval/query_classifier.py`
+- Test: `tests/unit/test_query_classifier.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_query_classifier.py`:
+
+```python
+class TestRuleGate:
+    """Rule gate classifies obvious cases without LLM."""
+
+    # -- execution profile --
+    def test_jira_key_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is the status of MTRNIX-104?") == "execution"
+
+    def test_jira_key_case_insensitive(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("mtrnix-104") == "execution"
+
+    def test_status_keyword_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What tasks are in progress?") == "execution"
+
+    def test_russian_status_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Что в работе?") == "execution"
+
+    def test_sprint_keyword_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is in the current sprint?") == "execution"
+
+    def test_backlog_keyword_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Show me the backlog") == "execution"
+
+    # -- temporal profile --
+    def test_date_expression_triggers_temporal(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What was done last week?") == "temporal"
+
+    def test_this_month_triggers_temporal(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Show changes this month") == "temporal"
+
+    def test_recently_triggers_temporal(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What was updated recently?") == "temporal"
+
+    def test_russian_temporal_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Что было на этой неделе?") == "temporal"
+
+    # -- user_file profile --
+    def test_uploaded_triggers_user_file(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What does the uploaded document say?") == "user_file"
+
+    def test_pdf_triggers_user_file(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Summarize the PDF report") == "user_file"
+
+    def test_10k_triggers_user_file(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What does the 10K say?") == "user_file"
+
+    def test_russian_file_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Что в загруженном файле?") == "user_file"
+
+    def test_russian_file_word_forms(self) -> None:
+        """файл prefix should match all word forms: файлы, файла, файле."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Покажи файлы") == "user_file"
+        assert _rule_gate("Содержание файла") == "user_file"
+
+    # -- relationship profile --
+    def test_relationship_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("How does RBAC relate to auth?") == "relationship"
+
+    def test_depends_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What depends on the auth module?") == "relationship"
+
+    def test_between_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is the link between RBAC and users?") == "relationship"
+
+    def test_russian_relationship_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Как связаны RBAC и пользователи?") == "relationship"
+
+    # -- no match / ambiguous --
+    def test_no_match_returns_none(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is Metatron?") is None
+
+    def test_multiple_profiles_returns_none(self) -> None:
+        """Query matching 2+ profiles should fall through to LLM."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        # "in progress" → execution, "last week" → temporal
+        assert _rule_gate("What was in progress last week?") is None
+
+    # -- word boundary safety --
+    def test_file_word_boundary(self) -> None:
+        """'profile' should NOT match \\bfile\\b."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        # Should not match user_file just because "profile" contains "file"
+        result = _rule_gate("Update the user profile settings")
+        assert result != "user_file"
+
+    def test_between_word_boundary(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        # "between" as standalone word triggers relationship
+        assert _rule_gate("difference between A and B") == "relationship"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestRuleGate -v`
+Expected: FAIL — `ImportError: cannot import name '_rule_gate'`
+
+- [ ] **Step 3: Implement rule gate**
+
+Add to `src/metatron/retrieval/query_classifier.py`, after the `get_profile_weights` function:
+
+```python
+import re
+
+from metatron.ingestion.processors.dates import extract_date_range
+
+# -- Rule gate patterns (per profile) --
+
+_JIRA_KEY_RE = re.compile(r'\b[A-Z]{2,}-\d+\b', re.IGNORECASE)
+
+_EXECUTION_KW = re.compile(
+    r'\bin progress\b|\bdone\b|\bsprint\b|\bbacklog\b'
+    r'|\bв работе\b|\bтекущий спринт\b',
+    re.IGNORECASE,
+)
+
+_TEMPORAL_KW = re.compile(
+    r'\bthis month\b|\blast week\b|\blast month\b|\brecently\b|\bthis week\b'
+    r'|\bна этой неделе\b|\bза последний месяц\b|\bна прошлой неделе\b|\bнедавно\b',
+    re.IGNORECASE,
+)
+
+_USER_FILE_KW = re.compile(
+    r'\bfile\b|\buploaded\b|\bpdf\b|\breport\b|\b10K\b'
+    r'|\bфайл|\bзагруженн|\bотчет\b',
+    re.IGNORECASE,
+)
+
+_RELATIONSHIP_KW = re.compile(
+    r'\brelat\w*\b|\bconnect\w*\b|\bdepend\w*\b|\bbetween\b|\blinked\b'
+    r'|\bсвязан\w*\b|\bзависи\w*\b|\bмежду\b',
+    re.IGNORECASE,
+)
+
+
+def _rule_gate(query: str) -> str | None:
+    """Fast deterministic classification via keyword/regex rules.
+
+    Returns a profile name if exactly one profile matches.
+    Returns None if 0 or 2+ profiles match (caller should use LLM fallback).
+    """
+    matched: set[str] = set()
+
+    # execution: Jira key or status keywords
+    if _JIRA_KEY_RE.search(query) or _EXECUTION_KW.search(query):
+        matched.add("execution")
+
+    # temporal: date expressions or time keywords
+    try:
+        date_range = extract_date_range(query)
+    except Exception:
+        date_range = None
+    if date_range or _TEMPORAL_KW.search(query):
+        matched.add("temporal")
+
+    # user_file: upload/file keywords
+    if _USER_FILE_KW.search(query):
+        matched.add("user_file")
+
+    # relationship: entity connection keywords
+    if _RELATIONSHIP_KW.search(query):
+        matched.add("relationship")
+
+    # documentation has no rule gate (too broad, handled by LLM)
+
+    if len(matched) == 1:
+        return matched.pop()
+    return None
+```
+
+Note: move `import re` to the top of the file (after `import structlog`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestRuleGate -v`
+Expected: PASS (18 tests)
+
+- [ ] **Step 5: Run all classifier tests so far**
+
+Run: `pytest tests/unit/test_query_classifier.py -v`
+Expected: PASS (all 27 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/metatron/retrieval/query_classifier.py tests/unit/test_query_classifier.py
+git commit -m "feat(classifier): add rule gate for keyword-based classification"
+```
+
+---
+
+### Task 4: LLM fallback
+
+**Files:**
+- Modify: `src/metatron/retrieval/query_classifier.py`
+- Test: `tests/unit/test_query_classifier.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_query_classifier.py`:
+
+```python
+from unittest.mock import patch
+
+
+class TestLLMFallback:
+    """LLM fallback for queries the rule gate can't classify."""
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_returns_llm_profile(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "documentation", "confidence": 0.9}'
+        result = _llm_classify("What is Metatron?")
+        assert result["profile"] == "documentation"
+        assert result["confidence"] == 0.9
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_low_confidence_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "documentation", "confidence": 0.3}'
+        result = _llm_classify("vague query")
+        assert result["profile"] == "mixed"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_invalid_json_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = "not json at all"
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_unknown_profile_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "nonexistent", "confidence": 0.95}'
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_timeout_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.side_effect = TimeoutError("LLM timeout")
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_exception_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.side_effect = RuntimeError("connection failed")
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_llm_called_with_correct_params(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "execution", "confidence": 0.8}'
+        _llm_classify("test query")
+
+        call_kwargs = mock_llm.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.0
+        assert call_kwargs["timeout"] == 10
+        messages = call_kwargs["messages"]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "test query"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_llm_prompt_mentions_all_profiles(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "mixed", "confidence": 0.5}'
+        _llm_classify("test query")
+
+        system_prompt = mock_llm.call_args.kwargs["messages"][0]["content"]
+        for profile in ("execution", "documentation", "user_file", "relationship", "temporal", "mixed"):
+            assert profile in system_prompt
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestLLMFallback -v`
+Expected: FAIL — `ImportError: cannot import name '_llm_classify'`
+
+- [ ] **Step 3: Implement LLM fallback**
+
+Add to `src/metatron/retrieval/query_classifier.py`, after `_rule_gate`:
+
+```python
+import json
+
+from metatron.llm import chat_completion
+
+_CLASSIFIER_SYSTEM_PROMPT = """\
+You are a query intent classifier. Given a search query, classify it into one of 6 profiles.
+
+Profiles:
+- "execution": Task status, Jira tickets, current work, sprint, who is doing what. \
+Examples: "What is the status of MTRNIX-104?", "What tasks are in progress?"
+- "documentation": Architecture, concepts, explanations, how things work. \
+Examples: "What is Metatron?", "How does RBAC work?"
+- "user_file": Questions about uploaded files, reports, PDFs. \
+Examples: "What does the 10K report say?", "Summarize the uploaded document"
+- "relationship": Connections between entities, dependencies, links. \
+Examples: "How does RBAC relate to user docs?", "What depends on the auth module?"
+- "temporal": Date-bound, recent activity, sprints, time ranges. \
+Examples: "What was done last week?", "Show documentation updated in 2026"
+- "mixed": Unclear intent or spans multiple categories. Use when unsure.
+
+Respond with JSON only: {"profile": "<name>", "confidence": <0.0-1.0>}"""
+
+_VALID_PROFILES = frozenset(QUERY_PROFILE_WEIGHTS.keys())
+
+
+def _llm_classify(query: str) -> QueryClassification:
+    """Classify query via LLM. Returns mixed on any failure."""
+    try:
+        raw = chat_completion(
+            messages=[
+                {"role": "system", "content": _CLASSIFIER_SYSTEM_PROMPT},
+                {"role": "user", "content": query},
+            ],
+            temperature=0.0,
+            max_tokens=60,
+            timeout=10,
+        )
+        parsed = json.loads(raw.strip())
+        profile = parsed.get("profile", "mixed")
+        confidence = float(parsed.get("confidence", 0.0))
+
+        if profile not in _VALID_PROFILES or confidence < 0.5:
+            return {"profile": "mixed", "confidence": confidence, "method": "default"}
+
+        return {"profile": profile, "confidence": confidence, "method": "llm"}
+    except Exception:
+        logger.warning("query_classifier.llm_failed", query=query[:100])
+        return {"profile": "mixed", "confidence": 0.0, "method": "default"}
+```
+
+Note: move `import json` to the top of the file. Add `from metatron.llm import chat_completion` to imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestLLMFallback -v`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metatron/retrieval/query_classifier.py tests/unit/test_query_classifier.py
+git commit -m "feat(classifier): add LLM fallback for ambiguous queries"
+```
+
+---
+
+### Task 5: `classify_query()` orchestrator
+
+**Files:**
+- Modify: `src/metatron/retrieval/query_classifier.py`
+- Test: `tests/unit/test_query_classifier.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_query_classifier.py`:
+
+```python
+class TestClassifyQuery:
+    """classify_query() orchestrates rule gate → LLM fallback."""
+
+    def test_rule_gate_match_skips_llm(self) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        with patch("metatron.retrieval.query_classifier._llm_classify") as mock_llm:
+            result = classify_query("What is MTRNIX-104?")
+            mock_llm.assert_not_called()
+        assert result["profile"] == "execution"
+        assert result["method"] == "rule"
+        assert result["confidence"] == 1.0
+
+    @patch("metatron.retrieval.query_classifier._llm_classify")
+    def test_no_rule_match_calls_llm(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        mock_llm.return_value = {"profile": "documentation", "confidence": 0.85, "method": "llm"}
+        result = classify_query("What is Metatron?")
+        mock_llm.assert_called_once()
+        assert result["profile"] == "documentation"
+
+    @patch("metatron.retrieval.query_classifier._llm_classify")
+    def test_ambiguous_query_calls_llm(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        mock_llm.return_value = {"profile": "temporal", "confidence": 0.7, "method": "llm"}
+        # Matches both execution ("in progress") and temporal ("last week")
+        result = classify_query("What was in progress last week?")
+        mock_llm.assert_called_once()
+        assert result["profile"] == "temporal"
+
+    def test_uses_original_query_not_translated(self) -> None:
+        """Classifier should run on original query (rq), not expanded."""
+        from metatron.retrieval.query_classifier import classify_query
+
+        # Russian query with Jira key — rule gate should catch it
+        result = classify_query("Статус MTRNIX-104?")
+        assert result["profile"] == "execution"
+        assert result["method"] == "rule"
+
+    def test_translated_query_checked_for_english_keywords(self) -> None:
+        """For Russian queries, translated_query is checked for English keywords too."""
+        from metatron.retrieval.query_classifier import classify_query
+
+        with patch("metatron.retrieval.query_classifier._llm_classify") as mock_llm:
+            mock_llm.return_value = {"profile": "user_file", "confidence": 0.8, "method": "llm"}
+            # translated_query contains "uploaded file" → user_file via rule gate
+            result = classify_query(
+                "Что в документе?",
+                translated_query="What is in the uploaded file?",
+            )
+            mock_llm.assert_not_called()
+        assert result["profile"] == "user_file"
+
+    def test_exception_in_classify_returns_mixed(self) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        with patch("metatron.retrieval.query_classifier._rule_gate", side_effect=RuntimeError("boom")):
+            result = classify_query("any query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestClassifyQuery -v`
+Expected: FAIL — `ImportError: cannot import name 'classify_query'`
+
+- [ ] **Step 3: Implement `classify_query()`**
+
+Add to `src/metatron/retrieval/query_classifier.py`, after `_llm_classify`:
+
+```python
+def classify_query(
+    query: str,
+    translated_query: str | None = None,
+) -> QueryClassification:
+    """Classify query intent into a profile for weight selection.
+
+    Uses rule gate first (fast, deterministic). Falls back to LLM for
+    ambiguous queries. Any exception returns 'mixed' (graceful degradation).
+
+    Args:
+        query: Original user query (rq).
+        translated_query: English translation of query (for Russian queries).
+            If None, only the original query is checked by the rule gate.
+    """
+    try:
+        # Rule gate: check original query
+        profile = _rule_gate(query)
+
+        # For Russian queries, also check translated version for English keywords
+        if profile is None and translated_query and translated_query != query:
+            profile = _rule_gate(translated_query)
+
+        if profile is not None:
+            logger.info("query_classifier.rule", profile=profile, query=query[:100])
+            return {"profile": profile, "confidence": 1.0, "method": "rule"}
+
+        # LLM fallback
+        result = _llm_classify(query)
+        logger.info(
+            "query_classifier.llm",
+            profile=result["profile"],
+            confidence=result["confidence"],
+            query=query[:100],
+        )
+        return result
+    except Exception:
+        logger.warning("query_classifier.failed", query=query[:100])
+        return {"profile": "mixed", "confidence": 0.0, "method": "default"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestClassifyQuery -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Run all classifier tests**
+
+Run: `pytest tests/unit/test_query_classifier.py -v`
+Expected: PASS (all 41 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/metatron/retrieval/query_classifier.py tests/unit/test_query_classifier.py
+git commit -m "feat(classifier): add classify_query() orchestrator with rule gate + LLM fallback"
+```
+
+---
+
+### Task 6: Pipeline integration in `search.py`
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py:417` (after query expansion, before recall), `search.py:469-479` (scoring loop), `search.py:494-498` (blend), `search.py:591-607` (trace)
+- Modify: `tests/unit/test_search_trace_extended.py` (add classify_query patch + verify new trace fields)
+- Test: `tests/unit/test_query_classifier.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/unit/test_query_classifier.py`:
+
+```python
+class TestSearchIntegration:
+    """Verify classify_query is called in the search pipeline."""
+
+    def test_classifier_called_in_search(self) -> None:
+        """When enabled, classify_query is called with original query."""
+        from tests.unit.test_search_trace_extended import _patch_search_internals
+
+        patches = _patch_search_internals()
+        for p in patches.values():
+            p.start()
+
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
+
+            with patch("metatron.retrieval.search.classify_query") as mock_cls:
+                mock_cls.return_value = {"profile": "mixed", "confidence": 1.0, "method": "rule"}
+                hybrid_search_and_answer(
+                    query="What is Metatron?",
+                    return_trace=True,
+                    workspace_id="ws_test",
+                )
+                mock_cls.assert_called_once()
+                # First arg is the original query (rq)
+                assert mock_cls.call_args.args[0] == "What is Metatron?"
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_classifier_disabled_uses_mixed(self) -> None:
+        from tests.unit.test_search_trace_extended import _patch_search_internals
+
+        patches = _patch_search_internals()
+        for p in patches.values():
+            p.start()
+
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
+
+            with patch("metatron.retrieval.search.classify_query") as mock_cls, \
+                 patch("metatron.core.config.Settings.query_classifier_enabled", False):
+                hybrid_search_and_answer(
+                    query="What is Metatron?",
+                    return_trace=True,
+                    workspace_id="ws_test",
+                )
+                mock_cls.assert_not_called()
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_trace_includes_classifier_fields(self) -> None:
+        from tests.unit.test_search_trace_extended import _patch_search_internals
+
+        patches = _patch_search_internals()
+        for p in patches.values():
+            p.start()
+
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
+
+            with patch("metatron.retrieval.search.classify_query") as mock_cls:
+                mock_cls.return_value = {"profile": "documentation", "confidence": 0.9, "method": "llm"}
+                result = hybrid_search_and_answer(
+                    query="What is Metatron?",
+                    return_trace=True,
+                    workspace_id="ws_test",
+                )
+                stages = result["pipeline_stages"]
+                assert stages["query_profile"] == "documentation"
+                assert stages["query_profile_method"] == "llm"
+                assert stages["query_profile_confidence"] == 0.9
+        finally:
+            for p in patches.values():
+                p.stop()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestSearchIntegration -v`
+Expected: FAIL — `ImportError: cannot import name 'classify_query' from 'metatron.retrieval.search'`
+
+- [ ] **Step 3: Add classifier call to search.py**
+
+In `src/metatron/retrieval/search.py`, add import at line ~29 (with other retrieval imports):
+
+```python
+from metatron.retrieval.query_classifier import classify_query, get_profile_weights
+```
+
+After line 417 (`sq = translate_query_to_english(eq) if _has_cyrillic(eq) else eq`), add:
+
+```python
+    # -- Classify query intent --
+    if _s.query_classifier_enabled:
+        _translated_for_classifier = (
+            translate_query_to_english(rq) if _has_cyrillic(rq) else rq
+        )
+        classification = classify_query(rq, translated_query=_translated_for_classifier)
+    else:
+        classification = {"profile": "mixed", "confidence": 1.0, "method": "disabled"}
+
+    _profile_weights = get_profile_weights(classification["profile"])
+```
+
+- [ ] **Step 4: Replace Settings weights with profile weights in scoring loop**
+
+In the scoring loop (lines ~469-479), replace:
+
+```python
+        mr["signal_score"] = compute_signal_score(
+            channel_scores=mr["channel_scores"],
+            recency=rec,
+            balance=bal,
+            dense_weight=_s.dense_weight,
+            sparse_weight=_s.sparse_weight,
+            graph_weight=_s.graph_weight,
+            metadata_weight=_s.metadata_weight,
+            recency_weight=_s.recency_weight,
+            balance_weight=_s.balance_weight,
+        )
+```
+
+with (placed before the `for mr in merged:` loop, since it's constant per query):
+
+```python
+    _scoring_weights = {k: v for k, v in _profile_weights.items() if k != "blend_weight"}
+```
+
+And inside the loop, replace the `compute_signal_score` call with:
+
+```python
+        mr["signal_score"] = compute_signal_score(
+            channel_scores=mr["channel_scores"],
+            recency=rec,
+            balance=bal,
+            **_scoring_weights,
+        )
+```
+
+- [ ] **Step 5: Replace blend_weight in compute_final_score**
+
+In the reranker block (line ~497), replace:
+
+```python
+                blend_weight=_s.blend_weight,
+```
+
+with:
+
+```python
+                blend_weight=_profile_weights["blend_weight"],
+```
+
+- [ ] **Step 6: Add trace fields to pipeline_stages**
+
+In the `pipeline_stages` dict (line ~591-607), add these three fields after existing fields:
+
+```python
+                "query_profile": classification["profile"],
+                "query_profile_method": classification["method"],
+                "query_profile_confidence": classification["confidence"],
+```
+
+- [ ] **Step 7: Run integration tests to verify they pass**
+
+Run: `pytest tests/unit/test_query_classifier.py::TestSearchIntegration -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 8: Update `_patch_search_internals()` in trace test**
+
+In `tests/unit/test_search_trace_extended.py`, add a `classify_query` patch to `_patch_search_internals()`:
+
+```python
+        "classify_query": patch(
+            f"{_SEARCH_MODULE}.classify_query",
+            return_value={"profile": "mixed", "confidence": 1.0, "method": "rule"},
+        ),
+```
+
+- [ ] **Step 9: Update expected trace subkeys in trace test**
+
+In `tests/unit/test_search_trace_extended.py`, `test_pipeline_stages_has_all_subkeys`, add to `expected_subkeys`:
+
+```python
+                "query_profile",
+                "query_profile_method",
+                "query_profile_confidence",
+```
+
+- [ ] **Step 10: Run all existing tests to verify no regressions**
+
+Run: `pytest tests/unit/test_search_trace_extended.py tests/unit/test_diversify_results.py tests/unit/test_name_aliases.py -v`
+Expected: PASS (all existing tests still pass)
+
+- [ ] **Step 11: Run full classifier test suite**
+
+Run: `pytest tests/unit/test_query_classifier.py -v`
+Expected: PASS (all ~44 tests)
+
+- [ ] **Step 12: Run full unit test suite**
+
+Run: `make test`
+Expected: All unit tests pass (existing 915+ plus new ~44)
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/metatron/retrieval/search.py src/metatron/retrieval/query_classifier.py \
+  tests/unit/test_query_classifier.py tests/unit/test_search_trace_extended.py
+git commit -m "feat(classifier): integrate query classifier into search pipeline"
+```
+
+---
+
+### Task 7: Final verification and eval
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+Expected: All tests pass, zero regressions.
+
+- [ ] **Step 2: Run lint and typecheck**
+
+Run: `make lint && make typecheck`
+Expected: No new errors.
+
+- [ ] **Step 3: Manual smoke test — verify disabled mode**
+
+Run:
+```bash
+QUERY_CLASSIFIER_ENABLED=false python -c "
+from metatron.core.config import Settings
+s = Settings()
+assert s.query_classifier_enabled is False
+print('OK: classifier disabled')
+"
+```
+Expected: prints "OK: classifier disabled"
+
+- [ ] **Step 4: Commit any final fixes**
+
+If lint/typecheck required fixes:
+```bash
+git add -u
+git commit -m "fix(classifier): lint and type fixes"
+```

--- a/docs/superpowers/search-quality-backlog.md
+++ b/docs/superpowers/search-quality-backlog.md
@@ -75,3 +75,30 @@
 **Проблема:** Спека говорит "normalized by sum of active weights", код делит на сумму всех весов. Код правильнее — штрафует single-channel results.
 **Решение:** Обновить формулировку в спеке.
 **Источник:** PR #43 code review, issue #2.
+
+---
+
+## Query Classifier — Eval Results & Known Issues
+
+### Eval baseline (2026-03-26, classifier ON vs OFF)
+
+| Metric | Classifier OFF | Classifier ON | Delta |
+|--------|---------------|---------------|-------|
+| P@10 | baseline | +0.0014 | ~flat |
+| MRR | baseline | -0.0345 | regression |
+| NDCG@10 | baseline | -0.0453 | regression |
+
+**Вывод:** Классификатор в текущем виде не улучшает метрики. Нужна тонкая настройка весов профилей или grid search (см. Q1). Классификатор оставлен включённым (`QUERY_CLASSIFIER_ENABLED=True`) как инфраструктура для дальнейшей оптимизации.
+
+### Known Issue: ru-01 false positive (relationship)
+**Проблема:** Запрос «Что такое Метатрон?» классифицируется как `relationship` вместо `documentation`. Причина: перевод через LLM содержит слово "relat*", которое матчится в rule gate (`_RELATIONSHIP_KW`).
+**Влияние:** Русские запросы с переводом, содержащим relationship-слова, получают неверный профиль.
+**Приоритет:** Низкий — фокус пока не на русском языке.
+**Возможные фиксы:** (a) ужесточить regex для relationship, (b) не применять rule gate к переведённым запросам, только LLM fallback.
+
+### Performance: Ollama model swapping
+**Проблема:** Eval 44 запросов занял 112 мин (vs 17 мин без классификатора). Причина — каскадный эффект:
+1. Классификатор добавляет 1-2 вызова DeepSeek API на запрос (перевод для classifier + LLM fallback)
+2. Увеличенные паузы между embedding-вызовами к Ollama → Ollama выгружает `nomic-embed-text` по idle timeout → каждый последующий embedding-вызов ждёт reload модели (~30-60 сек)
+**Фикс:** `OLLAMA_KEEP_ALIVE=-1` (не выгружать модель) или `curl /api/embeddings -d '{"model":"nomic-embed-text","keep_alive":-1}'` перед eval.
+**Рекомендация:** Добавить `OLLAMA_KEEP_ALIVE=-1` в docker-compose и документацию по развёртыванию.

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -107,6 +107,7 @@ class Settings(BaseSettings):
     bm25_vocab_size: int = Field(30000, alias="BM25_VOCAB_SIZE")
     query_expansion_enabled: bool = Field(True, alias="QUERY_EXPANSION_ENABLED")
     reranker_enabled: bool = Field(True, alias="RERANKER_ENABLED")
+    query_classifier_enabled: bool = Field(True, alias="QUERY_CLASSIFIER_ENABLED")
 
     # Per-channel recall limits
     recall_top_n_dense: int = Field(30, alias="RECALL_TOP_N_DENSE")

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -1,0 +1,37 @@
+"""Query classifier for source-of-truth profiles.
+
+Classifies incoming queries into 6 intent profiles and returns weight
+presets for compute_signal_score() and compute_final_score().
+
+Hybrid approach: fast rule gate for obvious cases, LLM fallback for ambiguous.
+Any failure gracefully degrades to 'mixed' (current defaults).
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+class QueryClassification(TypedDict):
+    profile: str       # "execution" | "documentation" | "user_file" | "relationship" | "temporal" | "mixed"
+    confidence: float  # 0.0 - 1.0
+    method: str        # "rule" | "llm" | "default" | "disabled"
+
+
+QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
+    "execution":     {"dense_weight": 0.20, "sparse_weight": 0.0, "graph_weight": 0.10, "metadata_weight": 0.35, "recency_weight": 0.15, "balance_weight": 0.05, "blend_weight": 0.25},
+    "documentation": {"dense_weight": 0.45, "sparse_weight": 0.0, "graph_weight": 0.15, "metadata_weight": 0.15, "recency_weight": 0.05, "balance_weight": 0.05, "blend_weight": 0.35},
+    "user_file":     {"dense_weight": 0.45, "sparse_weight": 0.0, "graph_weight": 0.05, "metadata_weight": 0.20, "recency_weight": 0.05, "balance_weight": 0.10, "blend_weight": 0.35},
+    "relationship":  {"dense_weight": 0.25, "sparse_weight": 0.0, "graph_weight": 0.35, "metadata_weight": 0.15, "recency_weight": 0.05, "balance_weight": 0.05, "blend_weight": 0.25},
+    "temporal":      {"dense_weight": 0.25, "sparse_weight": 0.0, "graph_weight": 0.10, "metadata_weight": 0.15, "recency_weight": 0.30, "balance_weight": 0.05, "blend_weight": 0.30},
+    "mixed":         {"dense_weight": 0.35, "sparse_weight": 0.0, "graph_weight": 0.15, "metadata_weight": 0.20, "recency_weight": 0.10, "balance_weight": 0.05, "blend_weight": 0.30},
+}
+
+
+def get_profile_weights(profile: str) -> dict[str, float]:
+    """Return weight preset for the given profile. Falls back to 'mixed' if unknown."""
+    return QUERY_PROFILE_WEIGHTS.get(profile, QUERY_PROFILE_WEIGHTS["mixed"])

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -9,6 +9,7 @@ Any failure gracefully degrades to 'mixed' (current defaults).
 
 from __future__ import annotations
 
+import re
 from typing import TypedDict
 
 import structlog
@@ -35,3 +36,69 @@ QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
 def get_profile_weights(profile: str) -> dict[str, float]:
     """Return weight preset for the given profile. Falls back to 'mixed' if unknown."""
     return QUERY_PROFILE_WEIGHTS.get(profile, QUERY_PROFILE_WEIGHTS["mixed"])
+
+
+from metatron.ingestion.processors.dates import extract_date_range  # noqa: E402
+
+# -- Rule gate patterns (per profile) --
+
+_JIRA_KEY_RE = re.compile(r'\b[A-Z]{2,}-\d+\b', re.IGNORECASE)
+
+_EXECUTION_KW = re.compile(
+    r'\bin progress\b|\bsprint\b|\bbacklog\b'
+    r'|\bв работе\b|\bтекущий спринт\b',
+    re.IGNORECASE,
+)
+
+_TEMPORAL_KW = re.compile(
+    r'\bthis month\b|\blast week\b|\blast month\b|\brecently\b|\bthis week\b'
+    r'|\bна этой неделе\b|\bза последний месяц\b|\bна прошлой неделе\b|\bнедавно\b',
+    re.IGNORECASE,
+)
+
+_USER_FILE_KW = re.compile(
+    r'\bfile\b|\buploaded\b|\bpdf\b|\breport\b|\b10K\b'
+    r'|\bфайл|\bзагруженн|\bотчет\b',
+    re.IGNORECASE,
+)
+
+_RELATIONSHIP_KW = re.compile(
+    r'\brelat\w*\b|\bconnect\w*\b|\bdepend\w*\b|\bbetween\b|\blinked\b'
+    r'|\bсвязан\w*\b|\bзависи\w*\b|\bмежду\b',
+    re.IGNORECASE,
+)
+
+
+def _rule_gate(query: str) -> str | None:
+    """Fast deterministic classification via keyword/regex rules.
+
+    Returns a profile name if exactly one profile matches.
+    Returns None if 0 or 2+ profiles match (caller should use LLM fallback).
+    """
+    matched: set[str] = set()
+
+    # execution: Jira key or status keywords
+    if _JIRA_KEY_RE.search(query) or _EXECUTION_KW.search(query):
+        matched.add("execution")
+
+    # temporal: date expressions or time keywords
+    try:
+        date_range = extract_date_range(query)
+    except Exception:
+        date_range = None
+    if date_range or _TEMPORAL_KW.search(query):
+        matched.add("temporal")
+
+    # user_file: upload/file keywords
+    if _USER_FILE_KW.search(query):
+        matched.add("user_file")
+
+    # relationship: entity connection keywords
+    if _RELATIONSHIP_KW.search(query):
+        matched.add("relationship")
+
+    # documentation has no rule gate (too broad, handled by LLM)
+
+    if len(matched) == 1:
+        return matched.pop()
+    return None

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -28,6 +28,10 @@ class QueryClassification(TypedDict):
     method: str        # "rule" | "llm" | "default" | "disabled"
 
 
+# NOTE: When the classifier is enabled, these weights OVERRIDE the per-signal
+# weights from Settings (dense_weight, graph_weight, etc.). Env var tuning of
+# individual weights has no effect while the classifier is active.
+# Disable the classifier (QUERY_CLASSIFIER_ENABLED=False) to use Settings weights.
 QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
     "execution": {
         "dense_weight": 0.20,
@@ -108,13 +112,14 @@ _TEMPORAL_KW = re.compile(
 )
 
 _USER_FILE_KW = re.compile(
-    r'\bfile\b|\buploaded\b|\bpdf\b|\breport\b|\b10K\b'
+    r'\bfile\b|\buploaded\b|\bpdf\b|\b10K\b'
     r'|\bфайл|\bзагруженн|\bотчет\b',
     re.IGNORECASE,
 )
 
 _RELATIONSHIP_KW = re.compile(
-    r'\brelat\w*\b|\bconnect\w*\b|\bdepend\w*\b|\bbetween\b|\blinked\b'
+    r'\brelationship\w*\b|\brelate[ds]?\b|\bconnect\w*\b|\bdepend\w*\b'
+    r'|\bbetween\b|\blinked\b'
     r'|\bсвязан\w*\b|\bзависи\w*\b|\bмежду\b',
     re.IGNORECASE,
 )
@@ -227,8 +232,9 @@ def classify_query(
             logger.info("query_classifier.rule", profile=profile, query=query[:100])
             return {"profile": profile, "confidence": 1.0, "method": "rule"}
 
-        # LLM fallback
-        result = _llm_classify(query)
+        # LLM fallback — use translated query for better classification if available
+        llm_input = translated_query if translated_query and translated_query != query else query
+        result = _llm_classify(llm_input)
         logger.info(
             "query_classifier.llm",
             profile=result["profile"],

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -9,6 +9,7 @@ Any failure gracefully degrades to 'mixed' (current defaults).
 
 from __future__ import annotations
 
+import json
 import re
 from typing import TypedDict
 
@@ -39,6 +40,7 @@ def get_profile_weights(profile: str) -> dict[str, float]:
 
 
 from metatron.ingestion.processors.dates import extract_date_range  # noqa: E402
+from metatron.llm import chat_completion  # noqa: E402
 
 # -- Rule gate patterns (per profile) --
 
@@ -102,3 +104,49 @@ def _rule_gate(query: str) -> str | None:
     if len(matched) == 1:
         return matched.pop()
     return None
+
+
+_CLASSIFIER_SYSTEM_PROMPT = """\
+You are a query intent classifier. Given a search query, classify it into one of 6 profiles.
+
+Profiles:
+- "execution": Task status, Jira tickets, current work, sprint, who is doing what. \
+Examples: "What is the status of MTRNIX-104?", "What tasks are in progress?"
+- "documentation": Architecture, concepts, explanations, how things work. \
+Examples: "What is Metatron?", "How does RBAC work?"
+- "user_file": Questions about uploaded files, reports, PDFs. \
+Examples: "What does the 10K report say?", "Summarize the uploaded document"
+- "relationship": Connections between entities, dependencies, links. \
+Examples: "How does RBAC relate to user docs?", "What depends on the auth module?"
+- "temporal": Date-bound, recent activity, sprints, time ranges. \
+Examples: "What was done last week?", "Show documentation updated in 2026"
+- "mixed": Unclear intent or spans multiple categories. Use when unsure.
+
+Respond with JSON only: {"profile": "<name>", "confidence": <0.0-1.0>}"""
+
+_VALID_PROFILES = frozenset(QUERY_PROFILE_WEIGHTS.keys())
+
+
+def _llm_classify(query: str) -> QueryClassification:
+    """Classify query via LLM. Returns mixed on any failure."""
+    try:
+        raw = chat_completion(
+            messages=[
+                {"role": "system", "content": _CLASSIFIER_SYSTEM_PROMPT},
+                {"role": "user", "content": query},
+            ],
+            temperature=0.0,
+            max_tokens=60,
+            timeout=10,
+        )
+        parsed = json.loads(raw.strip())
+        profile = parsed.get("profile", "mixed")
+        confidence = float(parsed.get("confidence", 0.0))
+
+        if profile not in _VALID_PROFILES or confidence < 0.5:
+            return {"profile": "mixed", "confidence": confidence, "method": "default"}
+
+        return {"profile": profile, "confidence": confidence, "method": "llm"}
+    except Exception:
+        logger.warning("query_classifier.llm_failed", query=query[:100])
+        return {"profile": "mixed", "confidence": 0.0, "method": "default"}

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -15,22 +15,74 @@ from typing import TypedDict
 
 import structlog
 
+from metatron.ingestion.processors.dates import extract_date_range
+from metatron.llm import chat_completion
+
 logger = structlog.get_logger()
 
 
 class QueryClassification(TypedDict):
-    profile: str       # "execution" | "documentation" | "user_file" | "relationship" | "temporal" | "mixed"
+    # "execution" | "documentation" | "user_file" | "relationship" | "temporal" | "mixed"
+    profile: str
     confidence: float  # 0.0 - 1.0
     method: str        # "rule" | "llm" | "default" | "disabled"
 
 
 QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
-    "execution":     {"dense_weight": 0.20, "sparse_weight": 0.0, "graph_weight": 0.10, "metadata_weight": 0.35, "recency_weight": 0.15, "balance_weight": 0.05, "blend_weight": 0.25},
-    "documentation": {"dense_weight": 0.45, "sparse_weight": 0.0, "graph_weight": 0.15, "metadata_weight": 0.15, "recency_weight": 0.05, "balance_weight": 0.05, "blend_weight": 0.35},
-    "user_file":     {"dense_weight": 0.45, "sparse_weight": 0.0, "graph_weight": 0.05, "metadata_weight": 0.20, "recency_weight": 0.05, "balance_weight": 0.10, "blend_weight": 0.35},
-    "relationship":  {"dense_weight": 0.25, "sparse_weight": 0.0, "graph_weight": 0.35, "metadata_weight": 0.15, "recency_weight": 0.05, "balance_weight": 0.05, "blend_weight": 0.25},
-    "temporal":      {"dense_weight": 0.25, "sparse_weight": 0.0, "graph_weight": 0.10, "metadata_weight": 0.15, "recency_weight": 0.30, "balance_weight": 0.05, "blend_weight": 0.30},
-    "mixed":         {"dense_weight": 0.35, "sparse_weight": 0.0, "graph_weight": 0.15, "metadata_weight": 0.20, "recency_weight": 0.10, "balance_weight": 0.05, "blend_weight": 0.30},
+    "execution": {
+        "dense_weight": 0.20,
+        "sparse_weight": 0.0,
+        "graph_weight": 0.10,
+        "metadata_weight": 0.35,
+        "recency_weight": 0.15,
+        "balance_weight": 0.05,
+        "blend_weight": 0.25,
+    },
+    "documentation": {
+        "dense_weight": 0.45,
+        "sparse_weight": 0.0,
+        "graph_weight": 0.15,
+        "metadata_weight": 0.15,
+        "recency_weight": 0.05,
+        "balance_weight": 0.05,
+        "blend_weight": 0.35,
+    },
+    "user_file": {
+        "dense_weight": 0.45,
+        "sparse_weight": 0.0,
+        "graph_weight": 0.05,
+        "metadata_weight": 0.20,
+        "recency_weight": 0.05,
+        "balance_weight": 0.10,
+        "blend_weight": 0.35,
+    },
+    "relationship": {
+        "dense_weight": 0.25,
+        "sparse_weight": 0.0,
+        "graph_weight": 0.35,
+        "metadata_weight": 0.15,
+        "recency_weight": 0.05,
+        "balance_weight": 0.05,
+        "blend_weight": 0.25,
+    },
+    "temporal": {
+        "dense_weight": 0.25,
+        "sparse_weight": 0.0,
+        "graph_weight": 0.10,
+        "metadata_weight": 0.15,
+        "recency_weight": 0.30,
+        "balance_weight": 0.05,
+        "blend_weight": 0.30,
+    },
+    "mixed": {
+        "dense_weight": 0.35,
+        "sparse_weight": 0.0,
+        "graph_weight": 0.15,
+        "metadata_weight": 0.20,
+        "recency_weight": 0.10,
+        "balance_weight": 0.05,
+        "blend_weight": 0.30,
+    },
 }
 
 
@@ -38,9 +90,6 @@ def get_profile_weights(profile: str) -> dict[str, float]:
     """Return weight preset for the given profile. Falls back to 'mixed' if unknown."""
     return QUERY_PROFILE_WEIGHTS.get(profile, QUERY_PROFILE_WEIGHTS["mixed"])
 
-
-from metatron.ingestion.processors.dates import extract_date_range  # noqa: E402
-from metatron.llm import chat_completion  # noqa: E402
 
 # -- Rule gate patterns (per profile) --
 

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -150,3 +150,43 @@ def _llm_classify(query: str) -> QueryClassification:
     except Exception:
         logger.warning("query_classifier.llm_failed", query=query[:100])
         return {"profile": "mixed", "confidence": 0.0, "method": "default"}
+
+
+def classify_query(
+    query: str,
+    translated_query: str | None = None,
+) -> QueryClassification:
+    """Classify query intent into a profile for weight selection.
+
+    Uses rule gate first (fast, deterministic). Falls back to LLM for
+    ambiguous queries. Any exception returns 'mixed' (graceful degradation).
+
+    Args:
+        query: Original user query (rq).
+        translated_query: English translation of query (for Russian queries).
+            If None, only the original query is checked by the rule gate.
+    """
+    try:
+        # Rule gate: check original query
+        profile = _rule_gate(query)
+
+        # For Russian queries, also check translated version for English keywords
+        if profile is None and translated_query and translated_query != query:
+            profile = _rule_gate(translated_query)
+
+        if profile is not None:
+            logger.info("query_classifier.rule", profile=profile, query=query[:100])
+            return {"profile": profile, "confidence": 1.0, "method": "rule"}
+
+        # LLM fallback
+        result = _llm_classify(query)
+        logger.info(
+            "query_classifier.llm",
+            profile=result["profile"],
+            confidence=result["confidence"],
+            query=query[:100],
+        )
+        return result
+    except Exception:
+        logger.warning("query_classifier.failed", query=query[:100])
+        return {"profile": "mixed", "confidence": 0.0, "method": "default"}

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -419,9 +419,11 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
 
     # -- Classify query intent --
     if _s.query_classifier_enabled:
-        _translated_for_classifier = (
-            translate_query_to_english(rq) if _has_cyrillic(rq) else rq
-        )
+        # Reuse sq when original == expanded (avoids duplicate LLM translation)
+        if _has_cyrillic(rq):
+            _translated_for_classifier = sq if rq == eq else translate_query_to_english(rq)
+        else:
+            _translated_for_classifier = rq
         classification = classify_query(rq, translated_query=_translated_for_classifier)
     else:
         classification = {"profile": "mixed", "confidence": 1.0, "method": "disabled"}

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -25,6 +25,7 @@ from metatron.retrieval.channels import (
     RecallContext, merge_channels,
     recall_dense, recall_exact, recall_metadata, recall_graph,
 )
+from metatron.retrieval.query_classifier import classify_query, get_profile_weights
 from metatron.retrieval.query_expansion import expand_query
 from metatron.retrieval.scoring import (
     compute_signal_score,
@@ -416,6 +417,17 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     # Translate expanded query for vector/BM25 search if it has Cyrillic
     sq = translate_query_to_english(eq) if _has_cyrillic(eq) else eq
 
+    # -- Classify query intent --
+    if _s.query_classifier_enabled:
+        _translated_for_classifier = (
+            translate_query_to_english(rq) if _has_cyrillic(rq) else rq
+        )
+        classification = classify_query(rq, translated_query=_translated_for_classifier)
+    else:
+        classification = {"profile": "mixed", "confidence": 1.0, "method": "disabled"}
+
+    _profile_weights = get_profile_weights(classification["profile"])
+
     # -- ACL pre-filter: restrict search to user's groups --
     access_filter = None
     if plugin_manager:
@@ -455,6 +467,8 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     )
     total_merged = len(merged)
 
+    _scoring_weights = {k: v for k, v in _profile_weights.items() if k != "blend_weight"}
+
     for mr in merged:
         mem = mr["memory"]
         date_str = mem.get("date") or (mem.get("payload") or {}).get("date")
@@ -470,12 +484,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             channel_scores=mr["channel_scores"],
             recency=rec,
             balance=bal,
-            dense_weight=_s.dense_weight,
-            sparse_weight=_s.sparse_weight,
-            graph_weight=_s.graph_weight,
-            metadata_weight=_s.metadata_weight,
-            recency_weight=_s.recency_weight,
-            balance_weight=_s.balance_weight,
+            **_scoring_weights,
         )
 
     merged.sort(key=lambda x: x.get("signal_score", 0), reverse=True)
@@ -494,7 +503,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             r["_final_score"] = compute_final_score(
                 signal_score=r.get("_signal_score", 0),
                 rerank_score=r.get("rerank_score", 0),
-                blend_weight=_s.blend_weight,
+                blend_weight=_profile_weights["blend_weight"],
             )
         base.sort(key=lambda x: x.get("_final_score", 0), reverse=True)
     base = base[:k]
@@ -604,6 +613,9 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
                 "rerank_pool_count": pool_size,
                 "fragment_count": len(frags),
                 "token_budget_used": _token_budget_used,
+                "query_profile": classification["profile"],
+                "query_profile_method": classification["method"],
+                "query_profile_confidence": classification["confidence"],
             },
             "retrieved_doc_labels": [
                 r.get("doc_label", "") for r in base if r.get("doc_label")

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -359,3 +359,80 @@ class TestClassifyQuery:
             result = classify_query("any query")
         assert result["profile"] == "mixed"
         assert result["method"] == "default"
+
+
+class TestSearchIntegration:
+    """Verify classify_query is called in the search pipeline."""
+
+    def test_classifier_called_in_search(self) -> None:
+        """When enabled, classify_query is called with original query."""
+        from tests.unit.test_search_trace_extended import _patch_search_internals
+
+        patches = _patch_search_internals()
+        for p in patches.values():
+            p.start()
+
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
+
+            with patch("metatron.retrieval.search.classify_query") as mock_cls:
+                mock_cls.return_value = {"profile": "mixed", "confidence": 1.0, "method": "rule"}
+                hybrid_search_and_answer(
+                    query="What is Metatron?",
+                    return_trace=True,
+                    workspace_id="ws_test",
+                )
+                mock_cls.assert_called_once()
+                # First arg is the original query (rq)
+                assert mock_cls.call_args.args[0] == "What is Metatron?"
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_classifier_disabled_uses_mixed(self) -> None:
+        from tests.unit.test_search_trace_extended import _patch_search_internals
+
+        patches = _patch_search_internals()
+        for p in patches.values():
+            p.start()
+
+        try:
+            from metatron.retrieval import search as _search_mod
+            from metatron.retrieval.search import hybrid_search_and_answer
+
+            with patch("metatron.retrieval.search.classify_query") as mock_cls, \
+                 patch.object(_search_mod._s, "query_classifier_enabled", False):
+                hybrid_search_and_answer(
+                    query="What is Metatron?",
+                    return_trace=True,
+                    workspace_id="ws_test",
+                )
+                mock_cls.assert_not_called()
+        finally:
+            for p in patches.values():
+                p.stop()
+
+    def test_trace_includes_classifier_fields(self) -> None:
+        from tests.unit.test_search_trace_extended import _patch_search_internals
+
+        patches = _patch_search_internals()
+        for p in patches.values():
+            p.start()
+
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
+
+            with patch("metatron.retrieval.search.classify_query") as mock_cls:
+                mock_cls.return_value = {"profile": "documentation", "confidence": 0.9, "method": "llm"}
+                result = hybrid_search_and_answer(
+                    query="What is Metatron?",
+                    return_trace=True,
+                    workspace_id="ws_test",
+                )
+                stages = result["pipeline_stages"]
+                assert stages["query_profile"] == "documentation"
+                assert stages["query_profile_method"] == "llm"
+                assert stages["query_profile_confidence"] == 0.9
+        finally:
+            for p in patches.values():
+                p.stop()

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -1,0 +1,18 @@
+"""Tests for query classifier: config, rule gate, LLM fallback, integration."""
+
+from __future__ import annotations
+
+
+class TestQueryClassifierConfig:
+    def test_query_classifier_enabled_default_true(self) -> None:
+        from metatron.core.config import Settings
+
+        s = Settings()
+        assert s.query_classifier_enabled is True
+
+    def test_query_classifier_disabled_via_env(self, monkeypatch) -> None:
+        from metatron.core.config import Settings
+
+        monkeypatch.setenv("QUERY_CLASSIFIER_ENABLED", "false")
+        s = Settings()
+        assert s.query_classifier_enabled is False

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -295,3 +295,67 @@ class TestLLMFallback:
         system_prompt = mock_llm.call_args.kwargs["messages"][0]["content"]
         for profile in ("execution", "documentation", "user_file", "relationship", "temporal", "mixed"):
             assert profile in system_prompt
+
+
+class TestClassifyQuery:
+    """classify_query() orchestrates rule gate → LLM fallback."""
+
+    def test_rule_gate_match_skips_llm(self) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        with patch("metatron.retrieval.query_classifier._llm_classify") as mock_llm:
+            result = classify_query("What is MTRNIX-104?")
+            mock_llm.assert_not_called()
+        assert result["profile"] == "execution"
+        assert result["method"] == "rule"
+        assert result["confidence"] == 1.0
+
+    @patch("metatron.retrieval.query_classifier._llm_classify")
+    def test_no_rule_match_calls_llm(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        mock_llm.return_value = {"profile": "documentation", "confidence": 0.85, "method": "llm"}
+        result = classify_query("What is Metatron?")
+        mock_llm.assert_called_once()
+        assert result["profile"] == "documentation"
+
+    @patch("metatron.retrieval.query_classifier._llm_classify")
+    def test_ambiguous_query_calls_llm(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        mock_llm.return_value = {"profile": "temporal", "confidence": 0.7, "method": "llm"}
+        # Matches both execution ("in progress") and temporal ("last week")
+        result = classify_query("What was in progress last week?")
+        mock_llm.assert_called_once()
+        assert result["profile"] == "temporal"
+
+    def test_uses_original_query_not_translated(self) -> None:
+        """Classifier should run on original query (rq), not expanded."""
+        from metatron.retrieval.query_classifier import classify_query
+
+        # Russian query with Jira key — rule gate should catch it
+        result = classify_query("Статус MTRNIX-104?")
+        assert result["profile"] == "execution"
+        assert result["method"] == "rule"
+
+    def test_translated_query_checked_for_english_keywords(self) -> None:
+        """For Russian queries, translated_query is checked for English keywords too."""
+        from metatron.retrieval.query_classifier import classify_query
+
+        with patch("metatron.retrieval.query_classifier._llm_classify") as mock_llm:
+            mock_llm.return_value = {"profile": "user_file", "confidence": 0.8, "method": "llm"}
+            # translated_query contains "uploaded file" → user_file via rule gate
+            result = classify_query(
+                "Что в документе?",
+                translated_query="What is in the uploaded file?",
+            )
+            mock_llm.assert_not_called()
+        assert result["profile"] == "user_file"
+
+    def test_exception_in_classify_returns_mixed(self) -> None:
+        from metatron.retrieval.query_classifier import classify_query
+
+        with patch("metatron.retrieval.query_classifier._rule_gate", side_effect=RuntimeError("boom")):
+            result = classify_query("any query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -185,6 +185,26 @@ class TestRuleGate:
 
         assert _rule_gate("Как связаны RBAC и пользователи?") == "relationship"
 
+    def test_relatively_does_not_trigger_relationship(self) -> None:
+        """'relatively' should NOT match relationship profile."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is relatively new?") is None
+
+    def test_related_triggers_relationship(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("How are these related?") == "relationship"
+
+    def test_report_does_not_trigger_user_file(self) -> None:
+        """'report' alone should not trigger user_file — too ambiguous."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        # "sprint" matches execution, but "report" should NOT add user_file
+        assert _rule_gate("Show me the sprint report") == "execution"
+        # plain "report" with no other signals → no match (goes to LLM)
+        assert _rule_gate("Where is the quarterly report?") is None
+
     # -- no match / ambiguous --
     def test_no_match_returns_none(self) -> None:
         from metatron.retrieval.query_classifier import _rule_gate
@@ -316,8 +336,17 @@ class TestClassifyQuery:
 
         mock_llm.return_value = {"profile": "documentation", "confidence": 0.85, "method": "llm"}
         result = classify_query("What is Metatron?")
-        mock_llm.assert_called_once()
+        mock_llm.assert_called_once_with("What is Metatron?")
         assert result["profile"] == "documentation"
+
+    @patch("metatron.retrieval.query_classifier._llm_classify")
+    def test_llm_receives_translated_query_when_available(self, mock_llm) -> None:
+        """When translated_query is provided and differs, LLM gets translated version."""
+        from metatron.retrieval.query_classifier import classify_query
+
+        mock_llm.return_value = {"profile": "documentation", "confidence": 0.85, "method": "llm"}
+        classify_query("Что такое Метатрон?", translated_query="What is Metatron?")
+        mock_llm.assert_called_once_with("What is Metatron?")
 
     @patch("metatron.retrieval.query_classifier._llm_classify")
     def test_ambiguous_query_calls_llm(self, mock_llm) -> None:

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -209,3 +209,89 @@ class TestRuleGate:
         from metatron.retrieval.query_classifier import _rule_gate
 
         assert _rule_gate("difference between A and B") == "relationship"
+
+
+from unittest.mock import patch
+
+
+class TestLLMFallback:
+    """LLM fallback for queries the rule gate can't classify."""
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_returns_llm_profile(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "documentation", "confidence": 0.9}'
+        result = _llm_classify("What is Metatron?")
+        assert result["profile"] == "documentation"
+        assert result["confidence"] == 0.9
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_low_confidence_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "documentation", "confidence": 0.3}'
+        result = _llm_classify("vague query")
+        assert result["profile"] == "mixed"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_invalid_json_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = "not json at all"
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_unknown_profile_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "nonexistent", "confidence": 0.95}'
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_timeout_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.side_effect = TimeoutError("LLM timeout")
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_exception_returns_mixed(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.side_effect = RuntimeError("connection failed")
+        result = _llm_classify("some query")
+        assert result["profile"] == "mixed"
+        assert result["method"] == "default"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_llm_called_with_correct_params(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "execution", "confidence": 0.8}'
+        _llm_classify("test query")
+
+        call_kwargs = mock_llm.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.0
+        assert call_kwargs["timeout"] == 10
+        messages = call_kwargs["messages"]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "test query"
+
+    @patch("metatron.retrieval.query_classifier.chat_completion")
+    def test_llm_prompt_mentions_all_profiles(self, mock_llm) -> None:
+        from metatron.retrieval.query_classifier import _llm_classify
+
+        mock_llm.return_value = '{"profile": "mixed", "confidence": 0.5}'
+        _llm_classify("test query")
+
+        system_prompt = mock_llm.call_args.kwargs["messages"][0]["content"]
+        for profile in ("execution", "documentation", "user_file", "relationship", "temporal", "mixed"):
+            assert profile in system_prompt

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -16,3 +16,65 @@ class TestQueryClassifierConfig:
         monkeypatch.setenv("QUERY_CLASSIFIER_ENABLED", "false")
         s = Settings()
         assert s.query_classifier_enabled is False
+
+
+import pytest
+
+
+class TestProfileWeights:
+    def test_all_profiles_exist(self) -> None:
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        expected = {"execution", "documentation", "user_file", "relationship", "temporal", "mixed"}
+        assert set(QUERY_PROFILE_WEIGHTS.keys()) == expected
+
+    @pytest.mark.parametrize("profile", [
+        "execution", "documentation", "user_file", "relationship", "temporal", "mixed",
+    ])
+    def test_signal_weights_sum_to_085(self, profile: str) -> None:
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        w = QUERY_PROFILE_WEIGHTS[profile]
+        signal_sum = (
+            w["dense_weight"] + w["sparse_weight"] + w["graph_weight"]
+            + w["metadata_weight"] + w["recency_weight"] + w["balance_weight"]
+        )
+        assert abs(signal_sum - 0.85) < 1e-9, f"{profile}: signal sum = {signal_sum}"
+
+    @pytest.mark.parametrize("profile", [
+        "execution", "documentation", "user_file", "relationship", "temporal", "mixed",
+    ])
+    def test_all_weight_keys_present(self, profile: str) -> None:
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        expected_keys = {
+            "dense_weight", "sparse_weight", "graph_weight",
+            "metadata_weight", "recency_weight", "balance_weight", "blend_weight",
+        }
+        assert set(QUERY_PROFILE_WEIGHTS[profile].keys()) == expected_keys
+
+    def test_mixed_matches_current_defaults(self) -> None:
+        """mixed profile must match compute_signal_score() defaults exactly."""
+        from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+        mixed = QUERY_PROFILE_WEIGHTS["mixed"]
+        assert mixed["dense_weight"] == 0.35
+        assert mixed["sparse_weight"] == 0.0
+        assert mixed["graph_weight"] == 0.15
+        assert mixed["metadata_weight"] == 0.20
+        assert mixed["recency_weight"] == 0.10
+        assert mixed["balance_weight"] == 0.05
+        assert mixed["blend_weight"] == 0.30
+
+    def test_get_profile_weights_valid(self) -> None:
+        from metatron.retrieval.query_classifier import get_profile_weights
+
+        w = get_profile_weights("execution")
+        assert w["dense_weight"] == 0.20
+        assert w["metadata_weight"] == 0.35
+
+    def test_get_profile_weights_unknown_falls_back_to_mixed(self) -> None:
+        from metatron.retrieval.query_classifier import get_profile_weights
+
+        w = get_profile_weights("nonexistent")
+        assert w == get_profile_weights("mixed")

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -78,3 +78,134 @@ class TestProfileWeights:
 
         w = get_profile_weights("nonexistent")
         assert w == get_profile_weights("mixed")
+
+
+class TestRuleGate:
+    """Rule gate classifies obvious cases without LLM."""
+
+    # -- execution profile --
+    def test_jira_key_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is the status of MTRNIX-104?") == "execution"
+
+    def test_jira_key_case_insensitive(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("mtrnix-104") == "execution"
+
+    def test_status_keyword_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What tasks are in progress?") == "execution"
+
+    def test_russian_status_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Что в работе?") == "execution"
+
+    def test_sprint_keyword_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is in the current sprint?") == "execution"
+
+    def test_backlog_keyword_triggers_execution(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Show me the backlog") == "execution"
+
+    # -- temporal profile --
+    def test_date_expression_triggers_temporal(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What was done last week?") == "temporal"
+
+    def test_this_month_triggers_temporal(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Show changes this month") == "temporal"
+
+    def test_recently_triggers_temporal(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What was updated recently?") == "temporal"
+
+    def test_russian_temporal_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Что было на этой неделе?") == "temporal"
+
+    # -- user_file profile --
+    def test_uploaded_triggers_user_file(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What does the uploaded document say?") == "user_file"
+
+    def test_pdf_triggers_user_file(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Summarize the PDF report") == "user_file"
+
+    def test_10k_triggers_user_file(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What does the 10K say?") == "user_file"
+
+    def test_russian_file_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Что в загруженном файле?") == "user_file"
+
+    def test_russian_file_word_forms(self) -> None:
+        """файл prefix should match all word forms: файлы, файла, файле."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Покажи файлы") == "user_file"
+        assert _rule_gate("Содержание файла") == "user_file"
+
+    # -- relationship profile --
+    def test_relationship_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("How does RBAC relate to auth?") == "relationship"
+
+    def test_depends_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What depends on the auth module?") == "relationship"
+
+    def test_between_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is the link between RBAC and users?") == "relationship"
+
+    def test_russian_relationship_keyword(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("Как связаны RBAC и пользователи?") == "relationship"
+
+    # -- no match / ambiguous --
+    def test_no_match_returns_none(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("What is Metatron?") is None
+
+    def test_multiple_profiles_returns_none(self) -> None:
+        """Query matching 2+ profiles should fall through to LLM."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        # "in progress" → execution, "last week" → temporal
+        assert _rule_gate("What was in progress last week?") is None
+
+    # -- word boundary safety --
+    def test_file_word_boundary(self) -> None:
+        """'profile' should NOT match \\bfile\\b."""
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        result = _rule_gate("Update the user profile settings")
+        assert result != "user_file"
+
+    def test_between_word_boundary(self) -> None:
+        from metatron.retrieval.query_classifier import _rule_gate
+
+        assert _rule_gate("difference between A and B") == "relationship"

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
+
 
 class TestQueryClassifierConfig:
     def test_query_classifier_enabled_default_true(self) -> None:
@@ -16,9 +20,6 @@ class TestQueryClassifierConfig:
         monkeypatch.setenv("QUERY_CLASSIFIER_ENABLED", "false")
         s = Settings()
         assert s.query_classifier_enabled is False
-
-
-import pytest
 
 
 class TestProfileWeights:
@@ -211,9 +212,6 @@ class TestRuleGate:
         assert _rule_gate("difference between A and B") == "relationship"
 
 
-from unittest.mock import patch
-
-
 class TestLLMFallback:
     """LLM fallback for queries the rule gate can't classify."""
 
@@ -293,7 +291,9 @@ class TestLLMFallback:
         _llm_classify("test query")
 
         system_prompt = mock_llm.call_args.kwargs["messages"][0]["content"]
-        for profile in ("execution", "documentation", "user_file", "relationship", "temporal", "mixed"):
+        for profile in (
+            "execution", "documentation", "user_file", "relationship", "temporal", "mixed"
+        ):
             assert profile in system_prompt
 
 
@@ -355,7 +355,10 @@ class TestClassifyQuery:
     def test_exception_in_classify_returns_mixed(self) -> None:
         from metatron.retrieval.query_classifier import classify_query
 
-        with patch("metatron.retrieval.query_classifier._rule_gate", side_effect=RuntimeError("boom")):
+        with patch(
+            "metatron.retrieval.query_classifier._rule_gate",
+            side_effect=RuntimeError("boom"),
+        ):
             result = classify_query("any query")
         assert result["profile"] == "mixed"
         assert result["method"] == "default"
@@ -423,7 +426,9 @@ class TestSearchIntegration:
             from metatron.retrieval.search import hybrid_search_and_answer
 
             with patch("metatron.retrieval.search.classify_query") as mock_cls:
-                mock_cls.return_value = {"profile": "documentation", "confidence": 0.9, "method": "llm"}
+                mock_cls.return_value = {
+                    "profile": "documentation", "confidence": 0.9, "method": "llm"
+                }
                 result = hybrid_search_and_answer(
                     query="What is Metatron?",
                     return_trace=True,

--- a/tests/unit/test_search_trace_extended.py
+++ b/tests/unit/test_search_trace_extended.py
@@ -65,6 +65,10 @@ def _patch_search_internals():
             f"{_SEARCH_MODULE}.should_use_team_workflow_schema",
             return_value=False,
         ),
+        "classify_query": patch(
+            f"{_SEARCH_MODULE}.classify_query",
+            return_value={"profile": "mixed", "confidence": 1.0, "method": "rule"},
+        ),
     }
     return patches
 
@@ -123,6 +127,9 @@ class TestPipelineStagesInTrace:
                 "rerank_pool_count",
                 "fragment_count",
                 "token_budget_used",
+                "query_profile",
+                "query_profile_method",
+                "query_profile_confidence",
             }
             assert set(stages.keys()) == expected_subkeys
         finally:


### PR DESCRIPTION
## Summary

- **New module** `retrieval/query_classifier.py` — hybrid rule gate + LLM fallback classifier that categorizes queries into 6 intent profiles (execution, documentation, user_file, relationship, temporal, mixed)
- Each profile applies its own scoring weight preset to `compute_signal_score()` and `compute_final_score()`, dynamically adjusting which signals (dense, graph, metadata, recency) dominate ranking
- Rule gate handles obvious cases (Jira keys, date expressions, file/relationship keywords) without LLM cost; LLM fallback for ambiguous queries with confidence threshold
- New config: `QUERY_CLASSIFIER_ENABLED=True` (disable for zero-cost passthrough to `mixed` profile)
- Trace logging includes `query_profile`, `query_profile_method`, `query_profile_confidence`
- 58 new tests, all passing

## Eval Results

| Metric | Delta |
|--------|-------|
| P@10 | +0.0014 (flat) |
| MRR | -0.0345 |
| NDCG@10 | -0.0453 |

Classifier provides infrastructure for per-profile weight tuning. Current weight presets are expert-set and need grid search optimization (tracked in backlog Q1).

## Known Issues

- **ru-01 false positive**: Russian query "Что такое Метатрон?" classified as `relationship` due to translated query containing "relat*" matching rule gate. Low priority — Russian not primary focus yet.
- **Eval performance**: Extra DeepSeek API calls + Ollama model swapping caused 112 min eval time. Fix: `OLLAMA_KEEP_ALIVE=-1`.

## Files Changed

| File | Change |
|------|--------|
| `src/metatron/retrieval/query_classifier.py` | New: rule gate, LLM fallback, weight presets, classify_query() |
| `src/metatron/retrieval/search.py` | Integration: classify → weights → scoring loop + trace fields |
| `src/metatron/core/config.py` | New field: query_classifier_enabled |
| `tests/unit/test_query_classifier.py` | 58 new tests |
| `tests/unit/test_search_trace_extended.py` | Updated: classify_query mock + new trace fields |
| `docs/superpowers/search-quality-backlog.md` | Eval results, known issues, performance notes |

## Test plan

- [x] 58 unit tests for classifier (rule gate, LLM fallback, orchestrator, weights, integration)
- [x] Pre-existing search tests pass (155 tests)
- [x] Re-run eval with OLLAMA_KEEP_ALIVE=-1 to get clean performance numbers
- [x] Manual validation on eval set queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)