### PR TITLE
feat: structured evidence packs for better answer grounding

### DIFF
--- a/docs/superpowers/plans/2026-03-26-evidence-packs.md
+++ b/docs/superpowers/plans/2026-03-26-evidence-packs.md
@@ -1,0 +1,1405 @@
+# Structured Evidence Packs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace flat fragment list with structured evidence packs grouped by source role, with explicit PRIMARY/SUPPORTING markers for better-grounded LLM answers.
+
+**Architecture:** Connectors declare `source_role` (class attribute), which flows through `Document` → ingestion pipeline → Qdrant payload → recall → `_collect_frags()` (now returns `list[dict]`) → `_mark_evidence_role()` → `_build_ctx()` (grouped markdown). System prompt gets atomic evidence rules.
+
+**Tech Stack:** Python 3.12+, FastAPI, Qdrant, pytest
+
+**Spec:** `docs/superpowers/specs/2026-03-26-evidence-packs-design.md`
+
+---
+
+### Task 1: Add `source_role` to ConnectorInterface and connector classes
+
+**Files:**
+- Modify: `src/metatron/core/interfaces.py:26-33` — add class attribute
+- Modify: `src/metatron/connectors/jira.py:24` — `source_role = "task_tracker"`
+- Modify: `src/metatron/connectors/github.py:19` — `source_role = "task_tracker"`
+- Modify: `src/metatron/connectors/slack_history.py:19` — `source_role = "communication"`
+- Modify: `src/metatron/connectors/files.py:20` — `source_role = "user_upload"`
+- Modify: `src/metatron/connectors/confluence.py:21` — keep default (no change needed)
+- Modify: `src/metatron/connectors/notion.py:26` — keep default (no change needed)
+- Modify: `src/metatron/connectors/gdrive.py:19` — keep default (no change needed)
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing tests for connector source_role**
+
+```python
+# tests/unit/test_evidence_packs.py
+"""Tests for structured evidence packs — source roles, marking, grouping, context assembly."""
+
+from __future__ import annotations
+
+
+class TestConnectorSourceRoles:
+    """Verify each connector declares the correct source_role."""
+
+    def test_connector_interface_default(self) -> None:
+        from metatron.core.interfaces import ConnectorInterface
+        assert ConnectorInterface.source_role == "knowledge_base"
+
+    def test_jira_connector_role(self) -> None:
+        from metatron.connectors.jira import JiraConnector
+        assert JiraConnector.source_role == "task_tracker"
+
+    def test_github_connector_role(self) -> None:
+        from metatron.connectors.github import GitHubConnector
+        assert GitHubConnector.source_role == "task_tracker"
+
+    def test_slack_history_connector_role(self) -> None:
+        from metatron.connectors.slack_history import SlackHistoryConnector
+        assert SlackHistoryConnector.source_role == "communication"
+
+    def test_files_connector_role(self) -> None:
+        from metatron.connectors.files import FilesConnector
+        assert FilesConnector.source_role == "user_upload"
+
+    def test_confluence_connector_role(self) -> None:
+        from metatron.connectors.confluence import ConfluenceConnector
+        assert ConfluenceConnector.source_role == "knowledge_base"
+
+    def test_notion_connector_role(self) -> None:
+        from metatron.connectors.notion import NotionConnector
+        assert NotionConnector.source_role == "knowledge_base"
+
+    def test_gdrive_connector_role(self) -> None:
+        from metatron.connectors.gdrive import GDriveConnector
+        assert GDriveConnector.source_role == "knowledge_base"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestConnectorSourceRoles -v`
+Expected: FAIL — `ConnectorInterface` has no attribute `source_role`
+
+- [ ] **Step 3: Add `source_role` to ConnectorInterface**
+
+In `src/metatron/core/interfaces.py`, add class attribute inside `ConnectorInterface` (after line 33, before the first `@abstractmethod`):
+
+```python
+class ConnectorInterface(ABC):
+    """Fetches documents from an external data source.
+
+    Each connector handles one source type (Confluence, Jira, etc.).
+    Connectors are stateless — configuration comes from Connection objects.
+
+    Lifecycle: configure(connection) → fetch(workspace_id) → documents
+    """
+
+    source_role: str = "knowledge_base"
+```
+
+- [ ] **Step 4: Set source_role on connector classes**
+
+In `src/metatron/connectors/jira.py`, add after `class JiraConnector(ConnectorInterface):` line:
+
+```python
+class JiraConnector(ConnectorInterface):
+    source_role = "task_tracker"
+```
+
+In `src/metatron/connectors/github.py`:
+
+```python
+class GitHubConnector(ConnectorInterface):
+    source_role = "task_tracker"
+```
+
+In `src/metatron/connectors/slack_history.py`:
+
+```python
+class SlackHistoryConnector(ConnectorInterface):
+    source_role = "communication"
+```
+
+In `src/metatron/connectors/files.py`:
+
+```python
+class FilesConnector(ConnectorInterface):
+    source_role = "user_upload"
+```
+
+Confluence, Notion, GDrive — no change (inherit `"knowledge_base"` default).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestConnectorSourceRoles -v`
+Expected: PASS (8/8)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/metatron/core/interfaces.py src/metatron/connectors/jira.py src/metatron/connectors/github.py src/metatron/connectors/slack_history.py src/metatron/connectors/files.py tests/unit/test_evidence_packs.py
+git commit -m "feat: add source_role class attribute to ConnectorInterface and connectors"
+```
+
+---
+
+### Task 2: Add `source_role` to Document model, ingestion pipeline, and Qdrant _format_result
+
+**Files:**
+- Modify: `src/metatron/core/models.py:46-61` — add `source_role` field to Document
+- Modify: `src/metatron/ingestion/pipeline.py:128-134` — add `source_role` param to `ingest_documents()`
+- Modify: `src/metatron/ingestion/pipeline.py:208-218` — write `source_role` into chunk metadata
+- Modify: `src/metatron/storage/qdrant.py:89-99` — extract `source_role` in `_format_result()`
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestSourceRoleDataFlow:
+    """Verify source_role flows through Document → pipeline → Qdrant payload."""
+
+    def test_document_has_source_role_field(self) -> None:
+        from metatron.core.models import Document
+        doc = Document(title="test", source_role="task_tracker")
+        assert doc.source_role == "task_tracker"
+
+    def test_document_source_role_default_empty(self) -> None:
+        from metatron.core.models import Document
+        doc = Document(title="test")
+        assert doc.source_role == ""
+
+    def test_format_result_includes_source_role(self) -> None:
+        """_format_result extracts source_role from Qdrant payload."""
+        from unittest.mock import MagicMock
+        from metatron.storage.qdrant import QdrantVectorStore
+
+        store = QdrantVectorStore.__new__(QdrantVectorStore)
+        point = MagicMock()
+        point.payload = {
+            "data": "some text",
+            "title": "Test",
+            "type": "jira",
+            "source_role": "task_tracker",
+            "url": "",
+            "date": "",
+            "doc_label": "jira:123",
+            "workspace_id": "ws1",
+        }
+        point.id = "abc123"
+        result = store._format_result(point, 0.95)
+        assert result["source_role"] == "task_tracker"
+
+    def test_format_result_source_role_defaults_to_knowledge_base(self) -> None:
+        """Chunks indexed before reindex get default source_role."""
+        from unittest.mock import MagicMock
+        from metatron.storage.qdrant import QdrantVectorStore
+
+        store = QdrantVectorStore.__new__(QdrantVectorStore)
+        point = MagicMock()
+        point.payload = {"data": "some text", "title": "Old"}
+        point.id = "old123"
+        result = store._format_result(point, 0.8)
+        assert result["source_role"] == "knowledge_base"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestSourceRoleDataFlow -v`
+Expected: FAIL — `Document` has no `source_role` parameter, `_format_result` doesn't return `source_role`
+
+- [ ] **Step 3: Add `source_role` to Document dataclass**
+
+In `src/metatron/core/models.py`, add field to `Document` dataclass (after `metadata` field, line 58):
+
+```python
+@dataclass
+class Document:
+    """A document fetched from a connector, before chunking."""
+
+    id: str = field(default_factory=lambda: uuid4().hex)
+    workspace_id: str = ""
+    source_type: str = ""          # e.g. "confluence", "jira", "github"
+    source_id: str = ""            # connector-specific unique ID
+    title: str = ""
+    content: str = ""
+    url: str = ""
+    author: str = ""
+    tags: list[str] = field(default_factory=list)
+    metadata: dict[str, str] = field(default_factory=dict)
+    source_role: str = ""          # e.g. "task_tracker", "knowledge_base", "user_upload", "communication"
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+```
+
+Note: `source_role` must come before `created_at`/`updated_at` since those have `field(default_factory=...)` and all fields with defaults must come after positional fields. Since all fields already have defaults, ordering is flexible — place it logically after `metadata`.
+
+- [ ] **Step 4: Add `source_role` param to `ingest_documents()` and write to metadata**
+
+In `src/metatron/ingestion/pipeline.py`, update function signature (line 128-134):
+
+```python
+def ingest_documents(
+    documents: list[Document],
+    workspace_id: str,
+    connector_type: str = "",
+    incremental: bool = False,
+    plugin_manager=None,
+    source_role: str = "knowledge_base",
+) -> SyncResult:
+```
+
+In the metadata dict (line 208-218), add `source_role`:
+
+```python
+                metadata = {
+                    "title": doc.title,
+                    "type": doc.source_type or connector_type,
+                    "source_id": doc.source_id,
+                    "doc_label": doc.source_id,
+                    "workspace_id": workspace_id,
+                    "author": doc.author,
+                    "date": doc_date,
+                    "simhash": chunk_hash,
+                    "source_role": source_role,
+                    **(doc.metadata or {}),
+                    "url": doc.url,  # after spread so doc.url takes precedence
+                }
+```
+
+- [ ] **Step 5: Add `source_role` to `_format_result()` in qdrant.py**
+
+In `src/metatron/storage/qdrant.py`, update `_format_result()` (line 89-99):
+
+```python
+    def _format_result(self, point: Any, score: float) -> Dict:
+        """Format a Qdrant point into a standardized result dict."""
+        payload = point.payload or {}
+        data = payload.get("data") or payload.get("memory") or ""
+        return {
+            "id": str(point.id), "score": score, "memory": data, "data": data,
+            "title": payload.get("title", ""), "type": payload.get("type", ""),
+            "url": payload.get("url", ""),
+            "date": payload.get("date", ""), "doc_label": payload.get("doc_label", ""),
+            "workspace_id": payload.get("workspace_id", ""),
+            "source_role": payload.get("source_role", "knowledge_base"),
+            "payload": payload,
+        }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestSourceRoleDataFlow -v`
+Expected: PASS (4/4)
+
+- [ ] **Step 7: Run full test suite to verify no regressions**
+
+Run: `pytest tests/unit/ -v --tb=short`
+Expected: All 915+ tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/metatron/core/models.py src/metatron/ingestion/pipeline.py src/metatron/storage/qdrant.py tests/unit/test_evidence_packs.py
+git commit -m "feat: source_role flows through Document → pipeline → Qdrant payload"
+```
+
+---
+
+### Task 3: Pass `source_role` from callers (sync + chat upload)
+
+Two callers write chunks to Qdrant: `_run_connection_sync()` in `connections.py` (uses `ingest_documents()`) and `_ingest_text()` in `chat.py` (calls `store.add_document()` directly with a metadata dict). Both need `source_role`.
+
+**Files:**
+- Modify: `src/metatron/api/routes/connections.py:666-670` — pass `source_role` to `ingest_documents()`
+- Modify: `src/metatron/api/routes/chat.py:344-351` — add `source_role` to upload metadata dict
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing test for chat upload metadata**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestSourceRoleInCallers:
+    """Verify source_role is passed from both sync and upload callers."""
+
+    def test_ingest_documents_accepts_source_role_param(self) -> None:
+        """ingest_documents signature includes source_role."""
+        import inspect
+        from metatron.ingestion.pipeline import ingest_documents
+        sig = inspect.signature(ingest_documents)
+        assert "source_role" in sig.parameters
+        assert sig.parameters["source_role"].default == "knowledge_base"
+
+    def test_chat_upload_metadata_has_source_role(self) -> None:
+        """_ingest_text metadata dict includes source_role for uploads."""
+        # We verify by reading the source — the metadata dict in _ingest_text
+        # must contain "source_role": "user_upload".
+        import ast
+        import inspect
+        from metatron.api.routes import chat
+        source = inspect.getsource(chat._ingest_text)
+        assert "source_role" in source
+        assert "user_upload" in source
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestSourceRoleInCallers -v`
+Expected: First test PASS (param added in Task 2), second FAIL — `_ingest_text` has no `source_role`
+
+- [ ] **Step 3: Update `_run_connection_sync` to pass `source_role`**
+
+In `src/metatron/api/routes/connections.py`, update lines 666-670. After `connector = registry.create(connector_type)` (line 647), the connector instance has `source_role`. Pass it to `ingest_documents`:
+
+```python
+        if documents:
+            # ingest_documents is sync — run in thread pool
+            result = await asyncio.to_thread(
+                ingest_documents, documents, workspace_id, connector_type,
+                source_role=connector.source_role,
+            )
+```
+
+- [ ] **Step 4: Add `source_role` to chat upload metadata**
+
+In `src/metatron/api/routes/chat.py`, update the metadata dict in `_ingest_text()` (line 344-351):
+
+```python
+    metadata = {
+        "title": file_name,
+        "type": "upload",
+        "workspace_id": workspace_id,
+        "user_id": user_id,
+        "doc_label": doc_label,
+        "source_role": "user_upload",
+        "url": f"/api/v1/files/{file_id}/download?workspace_id={workspace_id}" if file_id and workspace_id else "",
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestSourceRoleInCallers -v`
+Expected: PASS (2/2)
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pytest tests/unit/ -v --tb=short`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/metatron/api/routes/connections.py src/metatron/api/routes/chat.py tests/unit/test_evidence_packs.py
+git commit -m "feat: pass source_role from both sync and upload callers"
+```
+
+---
+
+### Task 4: Refactor `_collect_frags()` to return `list[dict]`
+
+This is the core refactor. Currently `_collect_frags()` returns `list[str]`. It needs to return `list[dict]` with metadata for evidence marking and grouped context assembly.
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py:239-279` — `_collect_frags()` returns `list[dict]`
+- Modify: `src/metatron/retrieval/search.py:521` — callers updated
+- Modify: `src/metatron/retrieval/search.py:529` — `get_graph_entities` call updated (takes texts from dicts)
+- Modify: `src/metatron/retrieval/search.py:561-566` — `select_fragments_within_budget` call updated
+- Modify: `src/metatron/retrieval/search.py:570` — `_build_ctx` call updated
+- Modify: `src/metatron/retrieval/search.py:594-635` — trace logging updated
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing tests for dict-based _collect_frags**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestCollectFragsDicts:
+    """_collect_frags returns list[dict] with metadata."""
+
+    def test_returns_list_of_dicts(self) -> None:
+        from metatron.retrieval.search import _collect_frags
+
+        base = [
+            {
+                "memory": "Some text about architecture",
+                "data": "Some text about architecture",
+                "title": "Architecture Overview",
+                "type": "confluence",
+                "source_role": "knowledge_base",
+                "doc_label": "confluence:123",
+                "date": "2026-03-20",
+                "payload": {},
+            },
+        ]
+        frags, seen, total, doc_stats = _collect_frags(base, set(), 0)
+        assert len(frags) == 1
+        assert isinstance(frags[0], dict)
+        assert frags[0]["text"] == "[CONFLUENCE] Architecture Overview\nSome text about architecture"
+        assert frags[0]["source_type"] == "confluence"
+        assert frags[0]["source_role"] == "knowledge_base"
+        assert frags[0]["title"] == "Architecture Overview"
+        assert frags[0]["date"] == "2026-03-20"
+        assert frags[0]["doc_label"] == "confluence:123"
+
+    def test_default_source_role_knowledge_base(self) -> None:
+        """Fragments without source_role get default 'knowledge_base'."""
+        from metatron.retrieval.search import _collect_frags
+
+        base = [
+            {
+                "memory": "Old chunk without source_role",
+                "data": "Old chunk without source_role",
+                "title": "Old Doc",
+                "type": "confluence",
+                "doc_label": "c:1",
+                "payload": {},
+            },
+        ]
+        frags, _, _, _ = _collect_frags(base, set(), 0)
+        assert frags[0]["source_role"] == "knowledge_base"
+
+    def test_dedup_by_text_hash(self) -> None:
+        """Duplicate fragments are deduplicated by hash of first 200 chars."""
+        from metatron.retrieval.search import _collect_frags
+
+        item = {
+            "memory": "Same text",
+            "data": "Same text",
+            "title": "Doc",
+            "type": "confluence",
+            "source_role": "knowledge_base",
+            "doc_label": "c:1",
+            "payload": {},
+        }
+        frags, _, _, _ = _collect_frags([item, item], set(), 0)
+        assert len(frags) == 1
+
+    def test_doc_stats_still_tracked(self) -> None:
+        """FinOps doc_stats tracking works with dict fragments."""
+        from metatron.retrieval.search import _collect_frags
+
+        base = [
+            {
+                "memory": "Task implementation details",
+                "data": "Task implementation details",
+                "title": "MTRNIX-104",
+                "type": "jira",
+                "source_role": "task_tracker",
+                "doc_label": "jira:104",
+                "payload": {},
+            },
+        ]
+        frags, _, _, doc_stats = _collect_frags(base, set(), 0)
+        assert "jira:104" in doc_stats
+        assert doc_stats["jira:104"]["title"] == "MTRNIX-104"
+        assert doc_stats["jira:104"]["fetch_count"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestCollectFragsDicts -v`
+Expected: FAIL — `_collect_frags` returns `list[str]`, not `list[dict]`
+
+- [ ] **Step 3: Refactor `_collect_frags()` to return `list[dict]`**
+
+In `src/metatron/retrieval/search.py`, replace `_collect_frags` function (lines 239-279):
+
+```python
+def _collect_frags(
+    base: list[dict], seen: set[int], total: int,
+) -> tuple[list[dict], set[int], int, dict[str, dict]]:
+    frags: list[dict] = []
+    doc_stats: dict[str, dict] = {}  # {doc_label: {title, word_count, fetch_count}}
+    for mem in base:
+        text = mem.get("memory") or mem.get("data") or ""
+        if len(text) > _MAX_FRAG:
+            text = text[:_MAX_FRAG] + "..."
+
+        # Prefix with source label so the LLM knows the origin
+        source_type = _result_type(mem)
+        title = (mem.get("title")
+                 or (mem.get("payload") or {}).get("title")
+                 or "")
+        if source_type != "unknown" or title:
+            parts = []
+            if source_type != "unknown":
+                parts.append(f"[{source_type.upper()}]")
+            if title:
+                parts.append(title)
+            text = " ".join(parts) + "\n" + text
+
+        th = hash(text[:200])
+        if th in seen:
+            continue
+        if total + len(text) > _MAX_TOTAL:
+            break
+        seen.add(th); total += len(text)
+
+        source_role = (mem.get("source_role")
+                       or (mem.get("payload") or {}).get("source_role")
+                       or "knowledge_base")
+        date = (mem.get("date")
+                or (mem.get("payload") or {}).get("date")
+                or "")
+        dl = mem.get("doc_label") or (mem.get("payload") or {}).get("doc_label") or ""
+
+        frags.append({
+            "text": text,
+            "source_type": source_type,
+            "source_role": source_role,
+            "title": title,
+            "date": date,
+            "doc_label": dl,
+            "evidence_marker": "",  # set later by _mark_evidence_role
+        })
+
+        # Track per-document stats for FinOps cost savings
+        if dl:
+            words = len(text.split())
+            if dl not in doc_stats:
+                doc_stats[dl] = {"title": title, "word_count": 0, "fetch_count": 0}
+            doc_stats[dl]["word_count"] += words
+            doc_stats[dl]["fetch_count"] += 1
+            if title:
+                doc_stats[dl]["title"] = title
+    return frags, seen, total, doc_stats
+```
+
+- [ ] **Step 4: Update all downstream consumers of `frags` in `hybrid_search_and_answer()`**
+
+Several places in `search.py` treat `frags` as `list[str]`. Update each:
+
+**Line 529** — `get_graph_entities` needs text strings:
+```python
+        frag_texts = [f["text"] for f in frags]
+        g_ents = get_entities_by_doc_labels(dl, workspace_id) if dl else get_graph_entities(frag_texts, workspace_id)
+```
+
+**Line 561-566** — `select_fragments_within_budget` (will be adapted in Task 5, for now extract texts):
+```python
+    frag_texts_for_budget = [f["text"] for f in frags]
+    selected_texts = select_fragments_within_budget(
+        frag_texts_for_budget,
+        max_tokens=_s.llm_context_max_tokens,
+        answer_reserve_tokens=_s.llm_answer_reserve_tokens,
+        graph_tokens=g_tokens,
+    )
+    # Filter frags to only those whose text was selected
+    selected_text_set = set(selected_texts)
+    frags = [f for f in frags if f["text"] in selected_text_set]
+```
+
+**Line 570** — `_build_ctx` needs text list (will be refactored in Task 7, for now extract texts):
+```python
+    ctx = _build_ctx(rq if use_schema else query, lang, [f["text"] for f in frags], g_ents, g_rels, g_docs)
+```
+
+**Line 594** — trace logging:
+```python
+        _token_budget_used = sum(len(f["text"]) for f in frags) // 4 if frags else 0
+```
+
+**Line 598** — fragments field in trace:
+```python
+            "fragments": frags,
+```
+(Already dicts — trace consumers handle this.)
+
+**Line 635** — `source_word_count`:
+```python
+            source_word_count = sum(len(f["text"].split()) for f in frags) if frags else 0
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestCollectFragsDicts -v`
+Expected: PASS (4/4)
+
+- [ ] **Step 6: Run full test suite to check for regressions**
+
+Run: `pytest tests/unit/ -v --tb=short`
+Expected: All tests pass. If any test breaks because it expected `frags` to be `list[str]`, update those tests to handle `list[dict]`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/metatron/retrieval/search.py tests/unit/test_evidence_packs.py
+git commit -m "refactor: _collect_frags returns list[dict] with source metadata"
+```
+
+---
+
+### Task 5: Adapt `select_fragments_within_budget()` for `list[dict]`
+
+**Files:**
+- Modify: `src/metatron/retrieval/token_budget.py:103-147` — accept/return `list[dict]`
+- Modify: `src/metatron/retrieval/search.py:561-566` — simplify caller (remove text extraction workaround from Task 4)
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestTokenBudgetWithDicts:
+    """select_fragments_within_budget works with list[dict] fragments."""
+
+    def test_accepts_dict_fragments(self) -> None:
+        from metatron.retrieval.token_budget import select_fragments_within_budget
+
+        frags = [
+            {"text": "Short fragment one.", "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "Short fragment two.", "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+        ]
+        result = select_fragments_within_budget(frags, max_tokens=10000)
+        assert len(result) == 2
+        assert all(isinstance(f, dict) for f in result)
+        assert result[0]["source_role"] == "task_tracker"
+
+    def test_budget_truncation_preserves_metadata(self) -> None:
+        from metatron.retrieval.token_budget import select_fragments_within_budget
+
+        frags = [
+            {"text": "A" * 4000, "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "B" * 4000, "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+            {"text": "C" * 4000, "source_role": "communication", "evidence_marker": "SUPPORTING"},
+        ]
+        # Budget of 2500 tokens ~ 10000 chars, should fit first 2 but not 3rd
+        result = select_fragments_within_budget(frags, max_tokens=2500)
+        assert len(result) <= 2
+        assert all("source_role" in f for f in result)
+
+    def test_backwards_compat_with_str_fragments(self) -> None:
+        """Still works with list[str] for backward compatibility during migration."""
+        from metatron.retrieval.token_budget import select_fragments_within_budget
+
+        frags = ["Fragment one text.", "Fragment two text."]
+        result = select_fragments_within_budget(frags, max_tokens=10000)
+        assert len(result) == 2
+        assert all(isinstance(f, str) for f in result)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestTokenBudgetWithDicts -v`
+Expected: FAIL — `select_fragments_within_budget` doesn't handle dicts
+
+- [ ] **Step 3: Update `select_fragments_within_budget()` to handle both str and dict**
+
+In `src/metatron/retrieval/token_budget.py`, replace `select_fragments_within_budget`:
+
+```python
+def select_fragments_within_budget(
+    fragments: list[str] | list[dict],
+    max_tokens: int = 10000,
+    system_prompt_tokens: int = 500,
+    answer_reserve_tokens: int = 1500,
+    graph_tokens: int = 0,
+) -> list[str] | list[dict]:
+    """Select as many fragments as fit within the token budget.
+
+    Budget = max_tokens - system_prompt - answer_reserve - graph_context,
+    but never less than MIN_FRAGMENT_TOKENS.
+    Fragments are already ranked by relevance (best first).
+    Greedily adds fragments until the budget is exhausted.
+
+    Accepts both list[str] (legacy) and list[dict] (evidence packs)
+    where dict has a "text" key.
+
+    Args:
+        fragments: Relevance-ranked fragments (str or dict with "text" key).
+        max_tokens: Total token budget for the LLM context window.
+        system_prompt_tokens: Estimated tokens for the system prompt.
+        answer_reserve_tokens: Tokens reserved for LLM answer generation.
+        graph_tokens: Tokens already allocated to graph context.
+
+    Returns:
+        List of fragments (same type as input) that fit within the budget.
+    """
+    computed = max_tokens - system_prompt_tokens - answer_reserve_tokens - graph_tokens
+    available = max(computed, MIN_FRAGMENT_TOKENS)
+
+    selected: list = []
+    used = 0
+
+    for frag in fragments:
+        frag_text = frag["text"] if isinstance(frag, dict) else frag
+        frag_tokens = estimate_tokens(frag_text)
+        if used + frag_tokens > available:
+            if not selected:
+                ratio = available / max(frag_tokens, 1)
+                if isinstance(frag, dict):
+                    truncated = {**frag, "text": frag_text[: int(len(frag_text) * ratio)]}
+                else:
+                    truncated = frag_text[: int(len(frag_text) * ratio)]
+                selected.append(truncated)
+            break
+        selected.append(frag)
+        used += frag_tokens
+
+    logger.info("token_budget.selected",
+                available=len(fragments), selected=len(selected),
+                tokens_used=used, tokens_budget=available)
+    return selected
+```
+
+- [ ] **Step 4: Simplify the caller in search.py**
+
+In `src/metatron/retrieval/search.py`, replace the workaround from Task 4 (lines 561-566):
+
+```python
+    frags = select_fragments_within_budget(
+        frags,
+        max_tokens=_s.llm_context_max_tokens,
+        answer_reserve_tokens=_s.llm_answer_reserve_tokens,
+        graph_tokens=g_tokens,
+    )
+```
+
+Remove the `frag_texts_for_budget`, `selected_texts`, `selected_text_set` lines from Task 4.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestTokenBudgetWithDicts -v`
+Expected: PASS (3/3)
+
+- [ ] **Step 6: Run full test suite + typecheck**
+
+Run: `pytest tests/unit/ -v --tb=short && make typecheck`
+Expected: All tests pass. If mypy flags the `list[str] | list[dict]` return type, add `from __future__ import annotations` and use `Union` type or adjust callers.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/metatron/retrieval/token_budget.py src/metatron/retrieval/search.py tests/unit/test_evidence_packs.py
+git commit -m "feat: select_fragments_within_budget handles dict fragments"
+```
+
+---
+
+### Task 6: Implement `_mark_evidence_role()` with PROFILE_PRIMARY_ROLE mapping
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py` — add `PROFILE_PRIMARY_ROLE` dict and `_mark_evidence_role()` function
+- Modify: `src/metatron/retrieval/search.py:521` — call `_mark_evidence_role` after `_collect_frags`
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestMarkEvidenceRole:
+    """_mark_evidence_role labels fragments PRIMARY/SUPPORTING based on query profile."""
+
+    def _make_frag(self, source_role: str) -> dict:
+        return {
+            "text": f"Fragment from {source_role}",
+            "source_type": "test",
+            "source_role": source_role,
+            "title": "Test",
+            "date": "",
+            "doc_label": "t:1",
+            "evidence_marker": "",
+        }
+
+    def test_execution_profile_primary_is_task_tracker(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "execution")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_documentation_profile_primary_is_knowledge_base(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "documentation")
+        assert frags[0]["evidence_marker"] == "SUPPORTING"
+        assert frags[1]["evidence_marker"] == "PRIMARY"
+
+    def test_user_file_profile_primary_is_user_upload(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("user_upload"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "user_file")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_mixed_profile_all_supporting(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "mixed")
+        assert all(f["evidence_marker"] == "SUPPORTING" for f in frags)
+
+    def test_relationship_profile_primary_is_knowledge_base(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("knowledge_base"), self._make_frag("task_tracker")]
+        _mark_evidence_role(frags, "relationship")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_temporal_profile_primary_is_task_tracker(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("communication")]
+        _mark_evidence_role(frags, "temporal")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_unknown_profile_all_supporting(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker")]
+        _mark_evidence_role(frags, "unknown_profile")
+        assert frags[0]["evidence_marker"] == "SUPPORTING"
+
+    def test_unknown_source_role_gets_supporting(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("some_new_connector")]
+        _mark_evidence_role(frags, "execution")
+        assert frags[0]["evidence_marker"] == "SUPPORTING"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestMarkEvidenceRole -v`
+Expected: FAIL — `_mark_evidence_role` doesn't exist
+
+- [ ] **Step 3: Implement PROFILE_PRIMARY_ROLE and _mark_evidence_role**
+
+In `src/metatron/retrieval/search.py`, add after the `_SOURCE_ICONS` dict (around line 282):
+
+```python
+# Maps query classifier profile → which source_role gets PRIMARY evidence marker.
+# None means all fragments get SUPPORTING (zero behavior change for mixed/unknown).
+PROFILE_PRIMARY_ROLE: dict[str, str | None] = {
+    "execution":     "task_tracker",
+    "documentation": "knowledge_base",
+    "user_file":     "user_upload",
+    "relationship":  "knowledge_base",
+    "temporal":      "task_tracker",
+    "mixed":         None,
+}
+
+
+def _mark_evidence_role(frags: list[dict], query_profile: str) -> None:
+    """Label each fragment as PRIMARY or SUPPORTING based on query profile.
+
+    Mutates frags in place. PRIMARY = source_role matches the expected
+    primary source for this query profile. Everything else is SUPPORTING.
+    """
+    primary_role = PROFILE_PRIMARY_ROLE.get(query_profile)
+    for frag in frags:
+        if primary_role and frag["source_role"] == primary_role:
+            frag["evidence_marker"] = "PRIMARY"
+        else:
+            frag["evidence_marker"] = "SUPPORTING"
+```
+
+- [ ] **Step 4: Wire _mark_evidence_role into hybrid_search_and_answer**
+
+In `src/metatron/retrieval/search.py`, after line 521 (`_collect_frags` call):
+
+```python
+    frags, seen_h, total_c, doc_stats = _collect_frags(base, set(), 0)
+    _mark_evidence_role(frags, classification["profile"])
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestMarkEvidenceRole -v`
+Expected: PASS (8/8)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/metatron/retrieval/search.py tests/unit/test_evidence_packs.py
+git commit -m "feat: _mark_evidence_role labels PRIMARY/SUPPORTING by query profile"
+```
+
+---
+
+### Task 7: Refactor `_build_ctx()` for grouped markdown format
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py:319-329` — `_build_ctx` groups frags by source_role
+- Modify: `src/metatron/retrieval/search.py:570` — update caller to pass dict frags
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestBuildCtxGrouped:
+    """_build_ctx groups fragments by source_role with markdown sections."""
+
+    def _make_frag(self, source_role: str, marker: str, source_type: str = "jira",
+                   title: str = "Doc", date: str = "2026-03-25") -> dict:
+        return {
+            "text": f"[{source_type.upper()}] {title}\nContent from {source_role}",
+            "source_type": source_type,
+            "source_role": source_role,
+            "title": title,
+            "date": date,
+            "doc_label": f"{source_type}:1",
+            "evidence_marker": marker,
+        }
+
+    def test_primary_group_appears_first(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [
+            self._make_frag("knowledge_base", "SUPPORTING", "confluence", "Arch Overview"),
+            self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104"),
+        ]
+        ctx = _build_ctx("What is the team doing?", "en", frags, [], [], [])
+        # Task tracker section (has PRIMARY) should appear before knowledge base
+        tt_pos = ctx.find("## Task tracker sources")
+        kb_pos = ctx.find("## Knowledge base sources")
+        assert tt_pos < kb_pos
+        assert "[PRIMARY]" in ctx
+        assert "[SUPPORTING]" in ctx
+
+    def test_empty_groups_skipped(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [
+            self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104"),
+        ]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        assert "## Task tracker sources" in ctx
+        assert "## Knowledge base sources" not in ctx
+        assert "## Communication sources" not in ctx
+
+    def test_all_supporting_no_primary_group(self) -> None:
+        """When mixed profile (all SUPPORTING), groups appear in fixed order."""
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [
+            self._make_frag("knowledge_base", "SUPPORTING", "confluence", "Doc1"),
+            self._make_frag("task_tracker", "SUPPORTING", "jira", "MTRNIX-99"),
+        ]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        # Fixed order: knowledge_base before task_tracker
+        kb_pos = ctx.find("## Knowledge base sources")
+        tt_pos = ctx.find("## Task tracker sources")
+        assert kb_pos < tt_pos
+
+    def test_graph_context_preserved(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [self._make_frag("task_tracker", "PRIMARY", "jira", "J1")]
+        g_ents = [{"name": "Metatron", "type": "System"}]
+        g_rels = [{"source": "Metatron", "target": "RAG", "type": "uses"}]
+        g_docs = ["doc:1"]
+        ctx = _build_ctx("query", "en", frags, g_ents, g_rels, g_docs)
+        assert "## Graph context" in ctx
+        assert "Metatron" in ctx
+
+    def test_date_in_fragment_header(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104", "2026-03-25")]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        assert "(2026-03-25)" in ctx
+
+    def test_fragment_without_date(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104", "")]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        assert "()" not in ctx  # no empty parens
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestBuildCtxGrouped -v`
+Expected: FAIL — `_build_ctx` still takes `list[str]` frags
+
+- [ ] **Step 3: Rewrite `_build_ctx` for grouped format**
+
+In `src/metatron/retrieval/search.py`, replace `_build_ctx` (lines 319-329):
+
+```python
+# Fixed display order for source_role groups (when no PRIMARY group takes priority)
+_SOURCE_ROLE_ORDER = ["knowledge_base", "task_tracker", "user_upload", "communication"]
+_SOURCE_ROLE_LABELS = {
+    "knowledge_base": "Knowledge base sources",
+    "task_tracker": "Task tracker sources",
+    "user_upload": "User upload sources",
+    "communication": "Communication sources",
+}
+
+
+def _build_ctx(q, lang, frags, g_ents, g_rels, g_docs):
+    jd = lambda o: json.dumps(o, ensure_ascii=False, indent=2)  # noqa: E731
+
+    # -- Group fragments by source_role --
+    groups: dict[str, list[dict]] = {}
+    primary_group: str | None = None
+    for f in frags:
+        role = f["source_role"] if isinstance(f, dict) else "knowledge_base"
+        groups.setdefault(role, []).append(f)
+        if isinstance(f, dict) and f.get("evidence_marker") == "PRIMARY" and primary_group is None:
+            primary_group = role
+
+    # Build ordered list: primary group first, then fixed order
+    ordered_roles: list[str] = []
+    if primary_group:
+        ordered_roles.append(primary_group)
+    for role in _SOURCE_ROLE_ORDER:
+        if role != primary_group and role in groups:
+            ordered_roles.append(role)
+    # Any unknown roles appended at end
+    for role in groups:
+        if role not in ordered_roles:
+            ordered_roles.append(role)
+
+    # -- Assemble fragment sections --
+    frag_sections: list[str] = []
+    for role in ordered_roles:
+        label = _SOURCE_ROLE_LABELS.get(role, f"{role} sources")
+        lines = [f"## {label}"]
+        for f in groups[role]:
+            marker = f.get("evidence_marker", "SUPPORTING")
+            date_suffix = f" ({f['date']})" if f.get("date") else ""
+            # Text already has [TYPE] Title\ncontent prefix from _collect_frags
+            # Replace the first line with marker-prefixed version
+            text_lines = f["text"].split("\n", 1)
+            header = text_lines[0]
+            body = text_lines[1] if len(text_lines) > 1 else ""
+            lines.append(f"[{marker}] {header}{date_suffix}")
+            if body:
+                lines.append(body)
+            lines.append("")  # blank line between fragments
+        frag_sections.append("\n".join(lines))
+
+    fragment_text = "\n".join(frag_sections)
+
+    # -- Graph context (unchanged format) --
+    graph_parts: list[str] = []
+    if g_ents or g_rels or g_docs:
+        graph_parts.append("## Graph context")
+        if g_ents:
+            graph_parts.append(f"Entities: {jd(g_ents)}")
+        if g_rels:
+            graph_parts.append(f"Relationships: {jd(g_rels)}")
+        if g_docs:
+            graph_parts.append(f"Related documents: {jd(g_docs)}")
+    graph_text = "\n".join(graph_parts)
+
+    return (
+        f"⚠️ RESPOND ONLY IN {lang.upper()}. Translate all information to {lang} if needed.\n\n"
+        f"User question:\n{q}\n\n"
+        f"{fragment_text}\n\n"
+        f"{graph_text}\n\n"
+        f"Provide a coherent answer. LANGUAGE: {lang.upper()} ONLY."
+    )
+```
+
+- [ ] **Step 4: Update caller to pass dict frags directly**
+
+In `src/metatron/retrieval/search.py`, update line 570 — remove the text extraction:
+
+```python
+    ctx = _build_ctx(rq if use_schema else query, lang, frags, g_ents, g_rels, g_docs)
+```
+
+(No change needed here — `frags` is already `list[dict]` from Task 4, and `_build_ctx` now handles dicts.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestBuildCtxGrouped -v`
+Expected: PASS (6/6)
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pytest tests/unit/ -v --tb=short`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/metatron/retrieval/search.py tests/unit/test_evidence_packs.py
+git commit -m "feat: _build_ctx groups fragments by source_role with markdown sections"
+```
+
+---
+
+### Task 8: Update HYBRID_SYSTEM_PROMPT with evidence rules
+
+**Files:**
+- Modify: `src/metatron/retrieval/prompts.py:4-48` — add evidence rules, remove deduplicated lines
+- Test: `tests/unit/test_evidence_packs.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestSystemPromptEvidenceRules:
+    """HYBRID_SYSTEM_PROMPT contains evidence rules and no deduplicated lines."""
+
+    def test_evidence_rules_section_exists(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "## Evidence rules" in HYBRID_SYSTEM_PROMPT
+
+    def test_primary_supporting_mentioned(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "[PRIMARY]" in HYBRID_SYSTEM_PROMPT
+        assert "[SUPPORTING]" in HYBRID_SYSTEM_PROMPT
+
+    def test_citation_rule_present(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "cite the source" in HYBRID_SYSTEM_PROMPT
+
+    def test_contradiction_handling_present(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "contradict" in HYBRID_SYSTEM_PROMPT
+
+    def test_insufficient_context_rule_present(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "insufficient" in HYBRID_SYSTEM_PROMPT
+
+    def test_deduplicated_line_removed_invent_facts(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "Do not invent facts that are not in the provided fragments." not in HYBRID_SYSTEM_PROMPT
+
+    def test_deduplicated_line_removed_primary_source(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "Use text fragments as the primary source of facts." not in HYBRID_SYSTEM_PROMPT
+
+    def test_source_references_preserved(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "[$[" in HYBRID_SYSTEM_PROMPT  # source reference markers preserved
+
+    def test_language_rules_preserved(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "CRITICAL RULE: RESPONSE LANGUAGE" in HYBRID_SYSTEM_PROMPT
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestSystemPromptEvidenceRules -v`
+Expected: FAIL — no "## Evidence rules" section, deduplicated lines still present
+
+- [ ] **Step 3: Update HYBRID_SYSTEM_PROMPT**
+
+In `src/metatron/retrieval/prompts.py`, replace `HYBRID_SYSTEM_PROMPT` (lines 4-48):
+
+```python
+HYBRID_SYSTEM_PROMPT = """\
+You are a hybrid question-answering system that combines vector search results and knowledge graph data.
+
+## CRITICAL RULE: RESPONSE LANGUAGE
+You MUST respond ENTIRELY in {response_language}. This is non-negotiable.
+- If the user's question is in English, your ENTIRE response must be in English, even if all context documents are in Russian.
+- If the user's question is in Russian, your ENTIRE response must be in Russian, even if all context documents are in English.
+- NEVER mix languages in your response.
+- Translate any facts from the context into {response_language} if needed.
+
+## Your task:
+- Answer the user's question using the provided context.
+- Search results are labeled with their source: [CONFLUENCE], [JIRA], etc.
+- Use ALL available sources to build a complete answer.
+- For questions about team activities: combine Jira tasks (specific work items) with Confluence context (processes, architecture, decisions).
+- For technical questions: prefer Confluence documentation, supplement with Jira implementation details.
+- Use entities and relationships from the graph to clarify context and explain connections.
+- If there are non-trivial dependencies between entities, mention them.
+- Respond with coherent text, not JSON or raw data listings.
+- If the user greets you or engages in small talk, respond warmly and briefly describe your \
+capabilities. Do NOT reference search results for greetings.
+
+## Evidence rules
+- Fragments marked [PRIMARY] are the most relevant sources. Prioritize them.
+- Fragments marked [SUPPORTING] provide additional context. Use to corroborate.
+- When stating a fact, cite the source: "according to [JIRA] MTRNIX-104..." \
+or "per [CONFLUENCE] Architecture Overview..."
+- If a fact appears in only one source, note this: "(based on [SOURCE] only)"
+- If sources contradict each other, state both versions with their sources.
+- If the context is insufficient to answer, say so directly. Do not guess.
+- Never mix facts from context with hypotheses or general knowledge.
+
+## Source references
+When you mention a specific document, ticket, or page title in your answer, wrap its name in \
+reference markers: [$[title]$]. Examples:
+- "According to [$[Architecture Overview]$], the system uses 6 layers..."
+- "In [$[MTRNIX-108]$], Vadim is implementing the auth module..."
+- "The report [$[report.pdf]$] contains Q4 results."
+Only wrap titles that come from the provided context (search results, graph data). \
+Do NOT wrap generic terms, concepts, or made-up names.
+
+## Response length guidelines
+- For questions about team activity ("what is the team doing", "what did the team do last week"):
+  Keep it concise. List tasks with assignee and status. Max 5-7 bullet points. No architectural context unless explicitly asked.
+- For questions about a specific person ("what is [person] doing", "who is working on [task]"):
+  List only their tasks with status. 3-5 sentences max.
+- For factual questions ("what is Metatron", "what is RAG", "explain [concept]"):
+  2-3 paragraphs max. Focus on the core answer, skip implementation details.
+- For general questions: answer in proportion to complexity. Simple question = short answer.
+- NEVER pad the answer with architectural context, development methodology, or background information unless the user specifically asks for it.
+
+REMINDER: Your response MUST be entirely in {response_language}. No exceptions.\
+"""
+```
+
+Changes from original:
+1. **Removed**: `"Use text fragments as the primary source of facts."` (line 16) — replaced by evidence rules
+2. **Removed**: `"Do not invent facts that are not in the provided fragments."` (line 23) — replaced by "Never mix facts..." + "If the context is insufficient..."
+3. **Added**: `## Evidence rules` section after `## Your task`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestSystemPromptEvidenceRules -v`
+Expected: PASS (9/9)
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pytest tests/unit/ -v --tb=short`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/metatron/retrieval/prompts.py tests/unit/test_evidence_packs.py
+git commit -m "feat: add evidence rules to HYBRID_SYSTEM_PROMPT, remove deduplicated lines"
+```
+
+---
+
+### Task 9: Integration — verify full pipeline and update trace logging
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py` — final cleanup of trace logging
+- Test: `tests/unit/test_evidence_packs.py` — integration test
+
+- [ ] **Step 1: Write integration test**
+
+Append to `tests/unit/test_evidence_packs.py`:
+
+```python
+class TestEvidencePacksIntegration:
+    """End-to-end test: marking + grouping + context assembly."""
+
+    def test_full_pipeline_execution_profile(self) -> None:
+        """Execution profile: task_tracker = PRIMARY, knowledge_base = SUPPORTING."""
+        from metatron.retrieval.search import _collect_frags, _mark_evidence_role, _build_ctx
+
+        base = [
+            {
+                "memory": "Implementing auth module, status: in progress",
+                "data": "Implementing auth module, status: in progress",
+                "title": "MTRNIX-104",
+                "type": "jira",
+                "source_role": "task_tracker",
+                "doc_label": "jira:104",
+                "date": "2026-03-25",
+                "payload": {},
+            },
+            {
+                "memory": "The system uses 6 architectural layers for separation of concerns",
+                "data": "The system uses 6 architectural layers for separation of concerns",
+                "title": "Architecture Overview",
+                "type": "confluence",
+                "source_role": "knowledge_base",
+                "doc_label": "confluence:arch",
+                "date": "2026-03-20",
+                "payload": {},
+            },
+        ]
+
+        frags, _, _, doc_stats = _collect_frags(base, set(), 0)
+        assert len(frags) == 2
+        assert all(isinstance(f, dict) for f in frags)
+
+        _mark_evidence_role(frags, "execution")
+        # Jira = task_tracker → PRIMARY for execution profile
+        jira_frag = next(f for f in frags if f["source_type"] == "jira")
+        conf_frag = next(f for f in frags if f["source_type"] == "confluence")
+        assert jira_frag["evidence_marker"] == "PRIMARY"
+        assert conf_frag["evidence_marker"] == "SUPPORTING"
+
+        ctx = _build_ctx("What is the team doing?", "en", frags, [], [], [])
+        # Task tracker section appears first (has PRIMARY)
+        assert ctx.index("## Task tracker sources") < ctx.index("## Knowledge base sources")
+        assert "[PRIMARY]" in ctx
+        assert "[SUPPORTING]" in ctx
+        assert "MTRNIX-104" in ctx
+        assert "Architecture Overview" in ctx
+
+    def test_full_pipeline_mixed_profile(self) -> None:
+        """Mixed profile: all fragments SUPPORTING, fixed group order."""
+        from metatron.retrieval.search import _collect_frags, _mark_evidence_role, _build_ctx
+
+        base = [
+            {
+                "memory": "Some jira content",
+                "data": "Some jira content",
+                "title": "MTRNIX-99",
+                "type": "jira",
+                "source_role": "task_tracker",
+                "doc_label": "jira:99",
+                "payload": {},
+            },
+            {
+                "memory": "Some confluence content",
+                "data": "Some confluence content",
+                "title": "Doc",
+                "type": "confluence",
+                "source_role": "knowledge_base",
+                "doc_label": "confluence:1",
+                "payload": {},
+            },
+        ]
+
+        frags, _, _, _ = _collect_frags(base, set(), 0)
+        _mark_evidence_role(frags, "mixed")
+
+        assert all(f["evidence_marker"] == "SUPPORTING" for f in frags)
+
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        # No PRIMARY group → fixed order: knowledge_base before task_tracker
+        kb_pos = ctx.find("## Knowledge base sources")
+        tt_pos = ctx.find("## Task tracker sources")
+        assert kb_pos < tt_pos
+
+    def test_trace_format_with_dict_frags(self) -> None:
+        """Trace logging calculations work with dict fragments."""
+        frags = [
+            {"text": "word1 word2 word3", "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "word4 word5", "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+        ]
+        token_budget_used = sum(len(f["text"]) for f in frags) // 4
+        source_word_count = sum(len(f["text"].split()) for f in frags)
+        assert token_budget_used > 0
+        assert source_word_count == 5
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `pytest tests/unit/test_evidence_packs.py::TestEvidencePacksIntegration -v`
+Expected: PASS (3/3)
+
+- [ ] **Step 3: Run full test suite — final regression check**
+
+Run: `pytest tests/unit/ -v --tb=short`
+Expected: All 915+ tests pass (may be slightly higher with new tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/test_evidence_packs.py
+git commit -m "test: add integration tests for evidence packs pipeline"
+```
+
+---
+
+## Post-Implementation
+
+After all tasks are complete:
+1. **Run eval** — verify P@10/MRR/NDCG don't regress (context format change, not recall)
+2. **Reindex** — full reindex to populate `source_role` in Qdrant payloads
+3. **Manual spot-check** — 10 queries checking proper citation, uncertainty marking, PRIMARY/SUPPORTING behavior

--- a/docs/superpowers/specs/2026-03-26-evidence-packs-design.md
+++ b/docs/superpowers/specs/2026-03-26-evidence-packs-design.md
@@ -22,7 +22,7 @@
 
 ### Where source_role is defined
 
-1. **`ConnectorInterface`** — new property `source_role: str` with default `"knowledge_base"` (safest fallback — most connectors are documentation sources).
+1. **`ConnectorInterface`** — new non-abstract class attribute `source_role: str = "knowledge_base"` (safest fallback — most connectors are documentation sources). This is a concrete attribute, not an abstract property, since it has a sensible default. Note: `ConnectorInterface` is in `core/interfaces.py` — changes require coordination with enterprise repo per project rules.
 
 2. **Each connector class** — overrides the default:
    - `JiraConnector.source_role = "task_tracker"`
@@ -31,17 +31,26 @@
    - `FilesConnector.source_role = "user_upload"`
    - `ConfluenceConnector`, `NotionConnector`, `GDriveConnector` — keep default `"knowledge_base"`
 
-3. **Connection record (DB)** — optional `source_role_override` field. If set, takes precedence over the connector class default. Allows admin to override per-connection (e.g., Confluence used as task tracker).
+3. **Connection record (DB)** — **Descoped for this task.** Per-connection `source_role_override` would require an Alembic migration and API changes. The class-level default covers all current use cases. Override can be added later when an admin UI exists. YAGNI.
 
 ### How source_role reaches fragments
 
-During ingestion (`pipeline.py`), `source_role` is written into the Qdrant chunk payload alongside existing fields (`source_type`, `doc_label`, `title`, `date`). At recall time, each result's metadata already contains `source_role`.
+Data flow: connector class → `Document` model → ingestion pipeline → Qdrant payload → recall result.
 
-**Reindex required** after deployment — existing chunks lack `source_role` in payload. No backward-compatibility fallback needed (confirmed: dataset is small, full reindex is acceptable).
+1. **`Document` model** (`core/models.py`) — new optional field `source_role: str = ""`.
+2. **`ingest_documents()`** (`pipeline.py`) — already accepts `connector_type: str` param. Add `source_role: str = "knowledge_base"` param. Written into Qdrant chunk payload (line 210, alongside `"type": doc.source_type`). Callers (sync triggers in `api/routes/connections.py` and `api/routes/chat.py` upload) pass `source_role` from the connector instance or connection config.
+3. **`_format_result()`** (`storage/qdrant.py`) — extract `source_role` from payload into result dict: `"source_role": payload.get("source_role", "knowledge_base")`. The default `"knowledge_base"` provides graceful fallback for chunks indexed before reindex.
+4. **Recall results** — each result dict now includes `source_role` key, consumed by `_collect_frags()`.
+
+**Reindex required** after deployment — existing chunks lack `source_role` in payload. Full reindex is acceptable (dataset is small). During the window between deployment and reindex, `_format_result()` defaults to `"knowledge_base"`.
 
 ---
 
 ## 2. Evidence Marking
+
+### Descoped: Contradictory evidence category
+
+The original task mentions 4 categories including "contradictory evidence". This is descoped as a structural category. Reason: detecting contradiction requires semantic analysis (NLI), not metadata. Instead, the system prompt instructs the LLM to identify and flag contradictions at answer generation time (see Section 4). This is sufficient because the LLM already reads all fragments and can reason about semantic conflicts — no pre-classification needed.
 
 ### Profile → primary role mapping
 
@@ -60,16 +69,22 @@ When `mixed` or classifier disabled → `primary_role = None` → all fragments 
 
 ### Marking logic
 
-New function `_mark_evidence_role(frags, query_profile)`:
+New function `_mark_evidence_role(frags, query_profile)` in `search.py`, called after `_collect_frags()` and before `_build_ctx()`:
 
-For each fragment:
-- If `source_role == primary_role` for current profile → marker = `"PRIMARY"`
-- Else → marker = `"SUPPORTING"`
+```python
+# In hybrid_search_and_answer(), after line 521:
+frags, seen_h, total_c, doc_stats = _collect_frags(base, set(), 0)
+_mark_evidence_role(frags, classification["profile"])
+```
+
+For each fragment dict:
+- If `frag["source_role"] == primary_role` for current profile → `frag["evidence_marker"] = "PRIMARY"`
+- Else → `frag["evidence_marker"] = "SUPPORTING"`
 - If `primary_role is None` → all `"SUPPORTING"`
 
 Unknown `source_role` values → `"SUPPORTING"` (safe fallback).
 
-### Fragment text format
+### Fragment text format in context
 
 ```
 [PRIMARY] [CONFLUENCE] Architecture Overview (2026-03-20)
@@ -119,9 +134,10 @@ Related documents: [...]
 ### Grouping rules
 
 - Fragments grouped by `source_role`
-- PRIMARY group appears first in context
+- The source_role group that contains PRIMARY-marked fragments appears first (only one `primary_role` per profile, so exactly one group has PRIMARY fragments)
 - Remaining groups in fixed order: `knowledge_base`, `task_tracker`, `user_upload`, `communication`
-- Empty groups are skipped (no empty sections)
+- Empty groups are skipped (no empty sections in output)
+- If all fragments are from one source_role (e.g., all Confluence) — single section, all PRIMARY for matching profile. This is acceptable.
 - Graph context remains as-is (already a separate section)
 
 ### `_collect_frags()` return type change
@@ -131,24 +147,31 @@ New: `list[dict]` where each dict:
 
 ```python
 {
-    "text": str,          # fragment text (without markers — added later)
-    "source_type": str,   # "jira", "confluence", etc.
-    "source_role": str,   # "task_tracker", "knowledge_base", etc.
-    "title": str,         # document title
-    "date": str | None,   # document date if available
-    "doc_label": str,     # for FinOps tracking
+    "text": str,              # fragment text (without markers — added by _build_ctx)
+    "source_type": str,       # "jira", "confluence", etc.
+    "source_role": str,       # "task_tracker", "knowledge_base", etc.
+    "title": str,             # document title
+    "date": str | None,       # document date if available
+    "doc_label": str,         # for FinOps tracking
+    "evidence_marker": str,   # "PRIMARY" or "SUPPORTING" (set by _mark_evidence_role)
 }
 ```
 
-Downstream consumers updated: `select_fragments_within_budget()` operates on `frag["text"]`, trace logging adapted.
+### Downstream consumers updated
+
+- **`select_fragments_within_budget(frags, ...)`** — new signature accepts `list[dict]`, operates on `frag["text"]` for token estimation, returns `list[dict]` (preserving metadata). Callers updated.
+- **Trace logging** (`return_trace` path, line 594-598) — `"fragments"` field in trace result becomes `list[dict]`. `_token_budget_used` computed as `sum(len(f["text"]) for f in frags)`. `source_word_count` computed as `sum(len(f["text"].split()) for f in frags)`. Benchmarker API consumers must handle dict format.
+- **`_append_sources()`** — unchanged, operates on `base` (result dicts), not `frags`.
 
 ### Token budget
 
-Total context size does not increase meaningfully. Section headers (`## Task tracker sources` etc.) + dates add ~30-50 tokens. With a budget of 6000-8000 tokens, this is <1%.
+Overhead from grouped format: section headers (~4-5 per context × ~5 tokens each = ~25 tokens) + `[PRIMARY]`/`[SUPPORTING]` markers (~3 tokens × ~25 fragments = ~75 tokens) + dates (~3 tokens × ~25 fragments = ~75 tokens) ≈ **~175 extra tokens**. With a budget of 6000-8000 tokens, this is ~2-3%. Acceptable.
 
 ---
 
 ## 4. System Prompt Update
+
+### New evidence rules section
 
 Add to `HYBRID_SYSTEM_PROMPT` after existing "Your task" section:
 
@@ -164,18 +187,27 @@ Add to `HYBRID_SYSTEM_PROMPT` after existing "Your task" section:
 - Never mix facts from context with hypotheses or general knowledge.
 ```
 
+### Lines removed from existing prompt (deduplication)
+
+These existing lines in `HYBRID_SYSTEM_PROMPT` overlap with evidence rules and are removed:
+
+- `"Do not invent facts that are not in the provided fragments."` → replaced by "Never mix facts from context with hypotheses or general knowledge." + "If the context is insufficient to answer, say so directly."
+- `"Use text fragments as the primary source of facts."` → replaced by evidence rules about PRIMARY/SUPPORTING.
+
+All other existing lines (language rules, source references with `[$[title]$]`, response length guidelines) remain unchanged.
+
 ### Design principles for on-premise models
 
 - Each rule is one sentence, one concrete action
 - No abstract instructions ("evaluate trustworthiness") — small models fail on these
 - `[PRIMARY]`/`[SUPPORTING]` are explicit text markers — model follows pattern, not reasoning
-- Rules overlap with existing prompt lines ("do not invent facts") — deduplicate, keep one version
 
 ### Approximate token impact
 
 Current `HYBRID_SYSTEM_PROMPT`: ~400 tokens.
+Removed lines: ~-30 tokens.
 New evidence rules section: ~130 tokens.
-Total: ~530 tokens. Increase: ~33% of prompt, <2% of total context budget.
+Net change: ~+100 tokens → ~500 tokens total. <2% of total context budget.
 
 ---
 
@@ -183,17 +215,20 @@ Total: ~530 tokens. Increase: ~33% of prompt, <2% of total context budget.
 
 | File | Action |
 |------|--------|
-| `core/interfaces.py` | Add `source_role: str` property to `ConnectorInterface` (default `"knowledge_base"`) |
+| `core/interfaces.py` | Add `source_role: str = "knowledge_base"` class attribute to `ConnectorInterface`. **Requires enterprise repo coordination.** |
+| `core/models.py` | Add `source_role: str = ""` field to `Document` dataclass |
 | `connectors/jira.py` | Set `source_role = "task_tracker"` |
 | `connectors/github.py` | Set `source_role = "task_tracker"` |
 | `connectors/slack_history.py` | Set `source_role = "communication"` |
 | `connectors/files.py` | Set `source_role = "user_upload"` |
 | `connectors/confluence.py`, `notion.py`, `gdrive.py` | Keep default `"knowledge_base"` (no change needed) |
-| `ingestion/pipeline.py` | Write `source_role` into Qdrant chunk payload |
-| `retrieval/search.py` | `_collect_frags()` returns `list[dict]`, new `_mark_evidence_role()`, refactored `_build_ctx()` |
-| `retrieval/prompts.py` | Add evidence rules to `HYBRID_SYSTEM_PROMPT` |
-| `retrieval/token_budget.py` | Adapt `select_fragments_within_budget()` for `list[dict]` |
-| `tests/unit/test_evidence_packs.py` | New: tests for marking, grouping, context assembly, connector roles |
+| `ingestion/pipeline.py` | Add `source_role` param to `ingest_documents()`, write into Qdrant chunk payload |
+| `api/routes/connections.py` | Pass `connector.source_role` to `ingest_documents()` during sync |
+| `storage/qdrant.py` | Add `"source_role": payload.get("source_role", "knowledge_base")` to `_format_result()` |
+| `retrieval/search.py` | `_collect_frags()` returns `list[dict]`, new `_mark_evidence_role()`, refactored `_build_ctx()`, updated trace logging |
+| `retrieval/prompts.py` | Add evidence rules to `HYBRID_SYSTEM_PROMPT`, remove deduplicated lines |
+| `retrieval/token_budget.py` | Adapt `select_fragments_within_budget()`: accepts `list[dict]`, returns `list[dict]`, operates on `frag["text"]` |
+| `tests/unit/test_evidence_packs.py` | New: tests for marking, grouping, context assembly, connector roles, budget with dicts |
 
 ---
 
@@ -211,13 +246,16 @@ Total: ~530 tokens. Increase: ~33% of prompt, <2% of total context budget.
 ## 7. Acceptance Criteria
 
 - [ ] Connectors declare `source_role`; written to Qdrant payload at ingestion
+- [ ] `Document` model has `source_role` field; populated during sync
+- [ ] `_format_result()` extracts `source_role` from payload with fallback
 - [ ] `_collect_frags()` returns enriched dicts with source_role, title, date
 - [ ] `_mark_evidence_role()` labels PRIMARY/SUPPORTING based on query profile
 - [ ] `_build_ctx()` groups fragments by source_role with markdown sections
-- [ ] PRIMARY group appears first in context
+- [ ] Source_role group containing PRIMARY fragments appears first in context
 - [ ] `mixed` profile → all SUPPORTING (zero behavior change)
-- [ ] `HYBRID_SYSTEM_PROMPT` contains atomic evidence rules
-- [ ] `select_fragments_within_budget()` works with dict format
+- [ ] `HYBRID_SYSTEM_PROMPT` contains atomic evidence rules; deduplicated lines removed
+- [ ] `select_fragments_within_budget()` works with `list[dict]` format
+- [ ] Trace logging (`return_trace`) adapted for dict fragments
 - [ ] Eval: P@10/MRR/NDCG do not regress (context format change, not recall)
 - [ ] Manual spot-check on 10 queries: proper citation, uncertainty marking
-- [ ] Tests cover: marking per profile, grouping, empty groups, connector roles, budget with dicts
+- [ ] Tests cover: marking per profile, grouping, empty groups, single source_role, connector roles, budget with dicts, trace format

--- a/docs/superpowers/specs/2026-03-26-evidence-packs-design.md
+++ b/docs/superpowers/specs/2026-03-26-evidence-packs-design.md
@@ -1,0 +1,223 @@
+# Structured Evidence Packs — Design Spec
+
+> **Task 6** of the "Investigate and improve search quality" epic.
+> Depends on Task 4 (unified reranking with configurable weights).
+
+**Goal:** Replace flat fragment list with structured evidence packs grouped by source role, with explicit PRIMARY/SUPPORTING markers, so the LLM produces better-grounded answers with proper attribution.
+
+**Architecture:** Three changes — (1) connectors declare `source_role`, written into Qdrant payload at ingestion; (2) `_collect_frags()` returns enriched dicts, `_mark_evidence_role()` labels fragments, `_build_ctx()` groups by source role; (3) `HYBRID_SYSTEM_PROMPT` gets atomic evidence rules for citation, uncertainty, and conflict handling.
+
+---
+
+## 1. Source Roles
+
+4 source roles describing the function of a connector:
+
+| source_role | Description | Default connectors |
+|---|---|---|
+| `task_tracker` | Tasks, statuses, sprints, work items | jira, github |
+| `knowledge_base` | Documentation, architecture, processes, wikis | confluence, notion, gdrive |
+| `user_upload` | User-uploaded files, reports, PDFs | upload (files connector) |
+| `communication` | Conversations, threads, messages | slack_history |
+
+### Where source_role is defined
+
+1. **`ConnectorInterface`** — new property `source_role: str` with default `"knowledge_base"` (safest fallback — most connectors are documentation sources).
+
+2. **Each connector class** — overrides the default:
+   - `JiraConnector.source_role = "task_tracker"`
+   - `GithubConnector.source_role = "task_tracker"`
+   - `SlackHistoryConnector.source_role = "communication"`
+   - `FilesConnector.source_role = "user_upload"`
+   - `ConfluenceConnector`, `NotionConnector`, `GDriveConnector` — keep default `"knowledge_base"`
+
+3. **Connection record (DB)** — optional `source_role_override` field. If set, takes precedence over the connector class default. Allows admin to override per-connection (e.g., Confluence used as task tracker).
+
+### How source_role reaches fragments
+
+During ingestion (`pipeline.py`), `source_role` is written into the Qdrant chunk payload alongside existing fields (`source_type`, `doc_label`, `title`, `date`). At recall time, each result's metadata already contains `source_role`.
+
+**Reindex required** after deployment — existing chunks lack `source_role` in payload. No backward-compatibility fallback needed (confirmed: dataset is small, full reindex is acceptable).
+
+---
+
+## 2. Evidence Marking
+
+### Profile → primary role mapping
+
+```python
+PROFILE_PRIMARY_ROLE: dict[str, str | None] = {
+    "execution":     "task_tracker",
+    "documentation": "knowledge_base",
+    "user_file":     "user_upload",
+    "relationship":  "knowledge_base",
+    "temporal":      "task_tracker",
+    "mixed":         None,  # all SUPPORTING — current behavior
+}
+```
+
+When `mixed` or classifier disabled → `primary_role = None` → all fragments get `[SUPPORTING]`. This ensures zero behavior change when classifier is off.
+
+### Marking logic
+
+New function `_mark_evidence_role(frags, query_profile)`:
+
+For each fragment:
+- If `source_role == primary_role` for current profile → marker = `"PRIMARY"`
+- Else → marker = `"SUPPORTING"`
+- If `primary_role is None` → all `"SUPPORTING"`
+
+Unknown `source_role` values → `"SUPPORTING"` (safe fallback).
+
+### Fragment text format
+
+```
+[PRIMARY] [CONFLUENCE] Architecture Overview (2026-03-20)
+The system uses 6 architectural layers...
+
+[SUPPORTING] [JIRA] MTRNIX-104 (2026-03-25)
+Implementing auth module, status: in progress
+```
+
+Marker is the first token — even small (7B) models can follow "prioritize [PRIMARY]" as simple pattern matching.
+
+---
+
+## 3. Context Assembly (`_build_ctx`)
+
+### Current format (flat)
+
+```
+Vector search results (texts):
+["[JIRA] MTRNIX-104\ntext...", "[CONFLUENCE] Architecture\ntext...", ...]
+
+Graph entities: [...]
+Entity relationships: [...]
+Related documents: [...]
+```
+
+### New format (grouped)
+
+```
+## Task tracker sources
+[PRIMARY] [JIRA] MTRNIX-104 (2026-03-25)
+Implementing auth module...
+
+[PRIMARY] [JIRA] MTRNIX-99 (2026-03-22)
+RBAC integration complete...
+
+## Knowledge base sources
+[SUPPORTING] [CONFLUENCE] Architecture Overview (2026-03-20)
+The system uses 6 architectural layers...
+
+## Graph context
+Entities: [...]
+Relationships: [...]
+Related documents: [...]
+```
+
+### Grouping rules
+
+- Fragments grouped by `source_role`
+- PRIMARY group appears first in context
+- Remaining groups in fixed order: `knowledge_base`, `task_tracker`, `user_upload`, `communication`
+- Empty groups are skipped (no empty sections)
+- Graph context remains as-is (already a separate section)
+
+### `_collect_frags()` return type change
+
+Current: `list[str]`
+New: `list[dict]` where each dict:
+
+```python
+{
+    "text": str,          # fragment text (without markers — added later)
+    "source_type": str,   # "jira", "confluence", etc.
+    "source_role": str,   # "task_tracker", "knowledge_base", etc.
+    "title": str,         # document title
+    "date": str | None,   # document date if available
+    "doc_label": str,     # for FinOps tracking
+}
+```
+
+Downstream consumers updated: `select_fragments_within_budget()` operates on `frag["text"]`, trace logging adapted.
+
+### Token budget
+
+Total context size does not increase meaningfully. Section headers (`## Task tracker sources` etc.) + dates add ~30-50 tokens. With a budget of 6000-8000 tokens, this is <1%.
+
+---
+
+## 4. System Prompt Update
+
+Add to `HYBRID_SYSTEM_PROMPT` after existing "Your task" section:
+
+```
+## Evidence rules
+- Fragments marked [PRIMARY] are the most relevant sources. Prioritize them.
+- Fragments marked [SUPPORTING] provide additional context. Use to corroborate.
+- When stating a fact, cite the source: "according to [JIRA] MTRNIX-104..."
+  or "per [CONFLUENCE] Architecture Overview..."
+- If a fact appears in only one source, note this: "(based on [SOURCE] only)"
+- If sources contradict each other, state both versions with their sources.
+- If the context is insufficient to answer, say so directly. Do not guess.
+- Never mix facts from context with hypotheses or general knowledge.
+```
+
+### Design principles for on-premise models
+
+- Each rule is one sentence, one concrete action
+- No abstract instructions ("evaluate trustworthiness") — small models fail on these
+- `[PRIMARY]`/`[SUPPORTING]` are explicit text markers — model follows pattern, not reasoning
+- Rules overlap with existing prompt lines ("do not invent facts") — deduplicate, keep one version
+
+### Approximate token impact
+
+Current `HYBRID_SYSTEM_PROMPT`: ~400 tokens.
+New evidence rules section: ~130 tokens.
+Total: ~530 tokens. Increase: ~33% of prompt, <2% of total context budget.
+
+---
+
+## 5. File Changes Summary
+
+| File | Action |
+|------|--------|
+| `core/interfaces.py` | Add `source_role: str` property to `ConnectorInterface` (default `"knowledge_base"`) |
+| `connectors/jira.py` | Set `source_role = "task_tracker"` |
+| `connectors/github.py` | Set `source_role = "task_tracker"` |
+| `connectors/slack_history.py` | Set `source_role = "communication"` |
+| `connectors/files.py` | Set `source_role = "user_upload"` |
+| `connectors/confluence.py`, `notion.py`, `gdrive.py` | Keep default `"knowledge_base"` (no change needed) |
+| `ingestion/pipeline.py` | Write `source_role` into Qdrant chunk payload |
+| `retrieval/search.py` | `_collect_frags()` returns `list[dict]`, new `_mark_evidence_role()`, refactored `_build_ctx()` |
+| `retrieval/prompts.py` | Add evidence rules to `HYBRID_SYSTEM_PROMPT` |
+| `retrieval/token_budget.py` | Adapt `select_fragments_within_budget()` for `list[dict]` |
+| `tests/unit/test_evidence_packs.py` | New: tests for marking, grouping, context assembly, connector roles |
+
+---
+
+## 6. What Stays Unchanged
+
+- Recall channels — retrieval logic untouched, only context formatting changes
+- Scoring / reranking — ranking order preserved
+- Query classifier — used as-is for profile → primary_role mapping
+- Graph enrichment — graph context format unchanged
+- `_append_sources()` — source citation appended to answer unchanged
+- `TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT` — team workflow schema path unchanged
+
+---
+
+## 7. Acceptance Criteria
+
+- [ ] Connectors declare `source_role`; written to Qdrant payload at ingestion
+- [ ] `_collect_frags()` returns enriched dicts with source_role, title, date
+- [ ] `_mark_evidence_role()` labels PRIMARY/SUPPORTING based on query profile
+- [ ] `_build_ctx()` groups fragments by source_role with markdown sections
+- [ ] PRIMARY group appears first in context
+- [ ] `mixed` profile → all SUPPORTING (zero behavior change)
+- [ ] `HYBRID_SYSTEM_PROMPT` contains atomic evidence rules
+- [ ] `select_fragments_within_budget()` works with dict format
+- [ ] Eval: P@10/MRR/NDCG do not regress (context format change, not recall)
+- [ ] Manual spot-check on 10 queries: proper citation, uncertainty marking
+- [ ] Tests cover: marking per profile, grouping, empty groups, connector roles, budget with dicts

--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -347,6 +347,7 @@ def _ingest_text(
         "workspace_id": workspace_id,
         "user_id": user_id,
         "doc_label": doc_label,
+        "source_role": "user_upload",
         "url": f"/api/v1/files/{file_id}/download?workspace_id={workspace_id}" if file_id and workspace_id else "",
     }
     if doc_date:

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -667,6 +667,7 @@ async def _run_connection_sync(
             # ingest_documents is sync — run in thread pool
             result = await asyncio.to_thread(
                 ingest_documents, documents, workspace_id, connector_type,
+                source_role=connector.source_role,
             )
             documents_new = result.documents_new
             documents_updated = result.documents_updated

--- a/src/metatron/connectors/files.py
+++ b/src/metatron/connectors/files.py
@@ -24,6 +24,8 @@ class FilesConnector(ConnectorInterface):
     - file_store_path: Base path for file storage (from Settings).
     """
 
+    source_role: str = "user_upload"
+
     def __init__(self) -> None:
         self._file_store: FileStore | None = None
         self._config: dict[str, str] = {}

--- a/src/metatron/connectors/github.py
+++ b/src/metatron/connectors/github.py
@@ -25,6 +25,8 @@ class GitHubConnector(ConnectorInterface):
     - repos: Comma-separated repo names (or "*" for all)
     """
 
+    source_role: str = "task_tracker"
+
     def __init__(self) -> None:
         self._client = None
         self._config: dict[str, str] = {}

--- a/src/metatron/connectors/jira.py
+++ b/src/metatron/connectors/jira.py
@@ -31,6 +31,8 @@ class JiraConnector(ConnectorInterface):
     - project_key: Jira project to index (optional — syncs all if empty)
     """
 
+    source_role: str = "task_tracker"
+
     def __init__(self) -> None:
         self._client = None  # type: ignore[assignment]
         self._config: dict[str, str] = {}

--- a/src/metatron/connectors/slack_history.py
+++ b/src/metatron/connectors/slack_history.py
@@ -24,6 +24,8 @@ class SlackHistoryConnector(ConnectorInterface):
     - channels: Comma-separated channel names or IDs (or "*" for all)
     """
 
+    source_role: str = "communication"
+
     def __init__(self) -> None:
         self._config: dict[str, str] = {}
 

--- a/src/metatron/core/interfaces.py
+++ b/src/metatron/core/interfaces.py
@@ -32,6 +32,8 @@ class ConnectorInterface(ABC):
     Lifecycle: configure(connection) → fetch(workspace_id) → documents
     """
 
+    source_role: str = "knowledge_base"
+
     @abstractmethod
     async def configure(self, connection: Connection, decrypted_config: dict[str, str]) -> None:
         """Initialize the connector with decrypted credentials.

--- a/src/metatron/core/interfaces.py
+++ b/src/metatron/core/interfaces.py
@@ -32,7 +32,21 @@ class ConnectorInterface(ABC):
     Lifecycle: configure(connection) → fetch(workspace_id) → documents
     """
 
+    VALID_SOURCE_ROLES = frozenset(
+        {"knowledge_base", "task_tracker", "user_upload", "communication"},
+    )
+
     source_role: str = "knowledge_base"
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        role = cls.__dict__.get("source_role")
+        if role is not None and role not in ConnectorInterface.VALID_SOURCE_ROLES:
+            msg = (
+                f"{cls.__name__}.source_role = {role!r} is not valid. "
+                f"Must be one of: {sorted(ConnectorInterface.VALID_SOURCE_ROLES)}"
+            )
+            raise ValueError(msg)
 
     @abstractmethod
     async def configure(self, connection: Connection, decrypted_config: dict[str, str]) -> None:

--- a/src/metatron/core/models.py
+++ b/src/metatron/core/models.py
@@ -56,6 +56,7 @@ class Document:
     author: str = ""
     tags: list[str] = field(default_factory=list)
     metadata: dict[str, str] = field(default_factory=dict)
+    source_role: str = ""              # e.g. "knowledge_base", "task_tracker", "communication", "user_upload"
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
 

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -131,6 +131,7 @@ def ingest_documents(
     connector_type: str = "",
     incremental: bool = False,
     plugin_manager=None,
+    source_role: str = "knowledge_base",
 ) -> SyncResult:
     """Ingest documents into Qdrant + Memgraph (sync, uses existing stores).
 
@@ -214,6 +215,7 @@ def ingest_documents(
                     "author": doc.author,
                     "date": doc_date,
                     "simhash": chunk_hash,
+                    "source_role": doc.source_role or source_role,
                     **(doc.metadata or {}),
                     "url": doc.url,  # after spread so doc.url takes precedence
                 }

--- a/src/metatron/retrieval/prompts.py
+++ b/src/metatron/retrieval/prompts.py
@@ -13,17 +13,25 @@ You MUST respond ENTIRELY in {response_language}. This is non-negotiable.
 
 ## Your task:
 - Answer the user's question using the provided context.
-- Use text fragments as the primary source of facts.
 - Search results are labeled with their source: [CONFLUENCE], [JIRA], etc.
 - Use ALL available sources to build a complete answer.
 - For questions about team activities: combine Jira tasks (specific work items) with Confluence context (processes, architecture, decisions).
 - For technical questions: prefer Confluence documentation, supplement with Jira implementation details.
 - Use entities and relationships from the graph to clarify context and explain connections.
 - If there are non-trivial dependencies between entities, mention them.
-- Do not invent facts that are not in the provided fragments.
 - Respond with coherent text, not JSON or raw data listings.
 - If the user greets you or engages in small talk, respond warmly and briefly describe your \
 capabilities. Do NOT reference search results for greetings.
+
+## Evidence rules
+- Fragments marked [PRIMARY] are the most relevant sources. Prioritize them.
+- Fragments marked [SUPPORTING] provide additional context. Use to corroborate.
+- When stating a fact, cite the source: "according to [JIRA] MTRNIX-104..." \
+or "per [CONFLUENCE] Architecture Overview..."
+- If a fact appears in only one source, note this: "(based on [SOURCE] only)"
+- If sources contradict each other, state both versions with their sources.
+- If the context is insufficient to answer, say so directly. Do not guess.
+- Never mix facts from context with hypotheses or general knowledge.
 
 ## Source references
 When you mention a specific document, ticket, or page title in your answer, wrap its name in \

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -298,6 +298,31 @@ def _collect_frags(
 
 _SOURCE_ICONS = {"confluence": "\U0001f4c4", "jira": "\U0001f4cb", "upload": "\U0001f4ce", "notion": "\U0001f4d3"}
 
+# Maps query classifier profile → which source_role gets PRIMARY evidence marker.
+# None means all fragments get SUPPORTING (zero behavior change for mixed/unknown).
+PROFILE_PRIMARY_ROLE: dict[str, str | None] = {
+    "execution":     "task_tracker",
+    "documentation": "knowledge_base",
+    "user_file":     "user_upload",
+    "relationship":  "knowledge_base",
+    "temporal":      "task_tracker",
+    "mixed":         None,
+}
+
+
+def _mark_evidence_role(frags: list[dict], query_profile: str) -> None:
+    """Label each fragment as PRIMARY or SUPPORTING based on query profile.
+
+    Mutates frags in place. PRIMARY = source_role matches the expected
+    primary source for this query profile. Everything else is SUPPORTING.
+    """
+    primary_role = PROFILE_PRIMARY_ROLE.get(query_profile)
+    for frag in frags:
+        if primary_role and frag["source_role"] == primary_role:
+            frag["evidence_marker"] = "PRIMARY"
+        else:
+            frag["evidence_marker"] = "SUPPORTING"
+
 
 def _append_sources(answer: str, results: list) -> str:
     """Append a sources section to the answer with document titles and types.
@@ -536,6 +561,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
         base = ctx.get("chunks", base)
 
     frags, seen_h, total_c, doc_stats = _collect_frags(base, set(), 0)
+    _mark_evidence_role(frags, classification["profile"])
 
     # -- Graph enrichment (graceful degradation: continue without graph if unavailable) --
     g_ents: list = []

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -238,8 +238,8 @@ def _doc_labels(results: List[Dict]) -> List[str]:
 
 def _collect_frags(
     base: list[dict], seen: set[int], total: int,
-) -> tuple[list[str], set[int], int, dict[str, dict]]:
-    frags: List[str] = []
+) -> tuple[list[dict], set[int], int, dict[str, dict]]:
+    frags: list[dict] = []
     doc_stats: Dict[str, Dict] = {}  # {doc_label: {title, word_count, fetch_count}}
     for mem in base:
         text = mem.get("memory") or mem.get("data") or ""
@@ -264,10 +264,27 @@ def _collect_frags(
             continue
         if total + len(text) > _MAX_TOTAL:
             break
-        frags.append(text); seen.add(th); total += len(text)
+        seen.add(th); total += len(text)
+
+        source_role = (mem.get("source_role")
+                       or (mem.get("payload") or {}).get("source_role")
+                       or "knowledge_base")
+        date = (mem.get("date")
+                or (mem.get("payload") or {}).get("date")
+                or "")
+        dl = mem.get("doc_label") or (mem.get("payload") or {}).get("doc_label") or ""
+
+        frags.append({
+            "text": text,
+            "source_type": source_type,
+            "source_role": source_role,
+            "title": title,
+            "date": date,
+            "doc_label": dl,
+            "evidence_marker": "",  # set later by _mark_evidence_role
+        })
 
         # Track per-document stats for FinOps cost savings
-        dl = mem.get("doc_label") or (mem.get("payload") or {}).get("doc_label") or ""
         if dl:
             words = len(text.split())
             if dl not in doc_stats:
@@ -526,7 +543,8 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     g_docs: list = []
     try:
         dl = _doc_labels(base)
-        g_ents = get_entities_by_doc_labels(dl, workspace_id) if dl else get_graph_entities(frags, workspace_id)
+        frag_texts = [f["text"] for f in frags]
+        g_ents = get_entities_by_doc_labels(dl, workspace_id) if dl else get_graph_entities(frag_texts, workspace_id)
         names: set[str] = set()
         for e in g_ents:
             if e.get("name"):
@@ -558,16 +576,20 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             g_ents, g_rels, g_docs, MAX_GRAPH_TOKENS,
         )
         g_tokens = estimate_graph_tokens(g_ents, g_rels, g_docs)
-    frags = select_fragments_within_budget(
-        frags,
+    frag_texts_for_budget = [f["text"] for f in frags]
+    selected_texts = select_fragments_within_budget(
+        frag_texts_for_budget,
         max_tokens=_s.llm_context_max_tokens,
         answer_reserve_tokens=_s.llm_answer_reserve_tokens,
         graph_tokens=g_tokens,
     )
+    # Filter frags to only those whose text was selected
+    selected_text_set = set(selected_texts)
+    frags = [f for f in frags if f["text"] in selected_text_set]
 
     # use_schema mode: use only current question (rq) to avoid history noise in structured output
     # regular mode: use full composite query to leverage conversation context for follow-ups
-    ctx = _build_ctx(rq if use_schema else query, lang, frags, g_ents, g_rels, g_docs)
+    ctx = _build_ctx(rq if use_schema else query, lang, [f["text"] for f in frags], g_ents, g_rels, g_docs)
     try:
         if use_schema:
             sys_prompt = TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT.format(response_language=lang)
@@ -591,7 +613,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
 
     # Return full trace for benchmarker integration when requested
     if return_trace:
-        _token_budget_used = sum(len(f) for f in frags) // 4 if frags else 0
+        _token_budget_used = sum(len(f["text"]) for f in frags) // 4 if frags else 0
         result = {
             "answer": _append_sources(answer, base),
             "source_results": base,
@@ -632,7 +654,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             total_ms = (time.time() - start_time) * 1000
             # Count total words in source fragments sent to LLM context.
             # Used by FinOps time-savings calculation: manual_reading_time = (words / 150 WPM) * 1.5
-            source_word_count = sum(len(frag.split()) for frag in frags) if frags else 0
+            source_word_count = sum(len(f["text"].split()) for f in frags) if frags else 0
             trace_data = {
                 "query": rq,
                 "user_id": user_id,

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -576,16 +576,12 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             g_ents, g_rels, g_docs, MAX_GRAPH_TOKENS,
         )
         g_tokens = estimate_graph_tokens(g_ents, g_rels, g_docs)
-    frag_texts_for_budget = [f["text"] for f in frags]
-    selected_texts = select_fragments_within_budget(
-        frag_texts_for_budget,
+    frags = select_fragments_within_budget(
+        frags,
         max_tokens=_s.llm_context_max_tokens,
         answer_reserve_tokens=_s.llm_answer_reserve_tokens,
         graph_tokens=g_tokens,
     )
-    # Filter frags to only those whose text was selected
-    selected_text_set = set(selected_texts)
-    frags = [f for f in frags if f["text"] in selected_text_set]
 
     # use_schema mode: use only current question (rq) to avoid history noise in structured output
     # regular mode: use full composite query to leverage conversation context for follow-ups

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -375,9 +375,9 @@ def _build_ctx(q, lang, frags, g_ents, g_rels, g_docs):
     groups: dict[str, list[dict]] = {}
     primary_group: str | None = None
     for f in frags:
-        role = f.get("source_role", "knowledge_base") if isinstance(f, dict) else "knowledge_base"
+        role = f.get("source_role", "knowledge_base")
         groups.setdefault(role, []).append(f)
-        if isinstance(f, dict) and f.get("evidence_marker") == "PRIMARY" and primary_group is None:
+        if f.get("evidence_marker") == "PRIMARY" and primary_group is None:
             primary_group = role
 
     # Build ordered list: primary group first, then fixed order
@@ -721,6 +721,12 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
                 "signal_scored_count": total_merged,
                 "rerank_pool_count": pool_size,
                 "fragment_count": len(frags),
+                "primary_fragment_count": sum(
+                    1 for f in frags if f.get("evidence_marker") == "PRIMARY"
+                ),
+                "supporting_fragment_count": sum(
+                    1 for f in frags if f.get("evidence_marker") != "PRIMARY"
+                ),
                 "token_budget_used": _token_budget_used,
                 "query_profile": classification["profile"],
                 "query_profile_method": classification["method"],

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -358,15 +358,78 @@ def _append_sources(answer: str, results: list) -> str:
     return answer
 
 
+# Fixed display order for source_role groups (when no PRIMARY group takes priority)
+_SOURCE_ROLE_ORDER = ["knowledge_base", "task_tracker", "user_upload", "communication"]
+_SOURCE_ROLE_LABELS = {
+    "knowledge_base": "Knowledge base sources",
+    "task_tracker": "Task tracker sources",
+    "user_upload": "User upload sources",
+    "communication": "Communication sources",
+}
+
+
 def _build_ctx(q, lang, frags, g_ents, g_rels, g_docs):
     jd = lambda o: json.dumps(o, ensure_ascii=False, indent=2)  # noqa: E731
+
+    # -- Group fragments by source_role --
+    groups: dict[str, list[dict]] = {}
+    primary_group: str | None = None
+    for f in frags:
+        role = f.get("source_role", "knowledge_base") if isinstance(f, dict) else "knowledge_base"
+        groups.setdefault(role, []).append(f)
+        if isinstance(f, dict) and f.get("evidence_marker") == "PRIMARY" and primary_group is None:
+            primary_group = role
+
+    # Build ordered list: primary group first, then fixed order
+    ordered_roles: list[str] = []
+    if primary_group:
+        ordered_roles.append(primary_group)
+    for role in _SOURCE_ROLE_ORDER:
+        if role != primary_group and role in groups:
+            ordered_roles.append(role)
+    # Any unknown roles appended at end
+    for role in groups:
+        if role not in ordered_roles:
+            ordered_roles.append(role)
+
+    # -- Assemble fragment sections --
+    frag_sections: list[str] = []
+    for role in ordered_roles:
+        label = _SOURCE_ROLE_LABELS.get(role, f"{role} sources")
+        lines = [f"## {label}"]
+        for f in groups[role]:
+            marker = f.get("evidence_marker", "SUPPORTING")
+            date_suffix = f" ({f['date']})" if f.get("date") else ""
+            # Text already has [TYPE] Title\ncontent prefix from _collect_frags
+            # Replace the first line with marker-prefixed version
+            text_lines = f["text"].split("\n", 1)
+            header = text_lines[0]
+            body = text_lines[1] if len(text_lines) > 1 else ""
+            lines.append(f"[{marker}] {header}{date_suffix}")
+            if body:
+                lines.append(body)
+            lines.append("")  # blank line between fragments
+        frag_sections.append("\n".join(lines))
+
+    fragment_text = "\n".join(frag_sections)
+
+    # -- Graph context (unchanged format) --
+    graph_parts: list[str] = []
+    if g_ents or g_rels or g_docs:
+        graph_parts.append("## Graph context")
+        if g_ents:
+            graph_parts.append(f"Entities: {jd(g_ents)}")
+        if g_rels:
+            graph_parts.append(f"Relationships: {jd(g_rels)}")
+        if g_docs:
+            graph_parts.append(f"Related documents: {jd(g_docs)}")
+    graph_text = "\n".join(graph_parts)
+
     return (
         f"⚠️ RESPOND ONLY IN {lang.upper()}. Translate all information to {lang} if needed.\n\n"
         f"User question:\n{q}\n\n"
-        f"Vector search results (texts):\n{jd(frags)}\n\n"
-        f"Graph entities:\n{jd(g_ents)}\n\n"
-        f"Entity relationships:\n{jd(g_rels)}\n\n"
-        f"Related documents:\n{jd(g_docs)}\n\n"
+        f"{fragment_text}\n\n"
+        f"{graph_text}\n\n"
         f"Provide a coherent answer. LANGUAGE: {lang.upper()} ONLY."
     )
 
@@ -611,7 +674,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
 
     # use_schema mode: use only current question (rq) to avoid history noise in structured output
     # regular mode: use full composite query to leverage conversation context for follow-ups
-    ctx = _build_ctx(rq if use_schema else query, lang, [f["text"] for f in frags], g_ents, g_rels, g_docs)
+    ctx = _build_ctx(rq if use_schema else query, lang, frags, g_ents, g_rels, g_docs)
     try:
         if use_schema:
             sys_prompt = TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT.format(response_language=lang)

--- a/src/metatron/retrieval/token_budget.py
+++ b/src/metatron/retrieval/token_budget.py
@@ -101,12 +101,12 @@ def truncate_graph_context(
 
 
 def select_fragments_within_budget(
-    fragments: list[str],
+    fragments: list[str] | list[dict],
     max_tokens: int = 10000,
     system_prompt_tokens: int = 500,
     answer_reserve_tokens: int = 1500,
     graph_tokens: int = 0,
-) -> list[str]:
+) -> list[str] | list[dict]:
     """Select as many fragments as fit within the token budget.
 
     Budget = max_tokens - system_prompt - answer_reserve - graph_context,
@@ -114,28 +114,35 @@ def select_fragments_within_budget(
     Fragments are already ranked by relevance (best first).
     Greedily adds fragments until the budget is exhausted.
 
+    Accepts both list[str] (legacy) and list[dict] (evidence packs)
+    where dict has a "text" key.
+
     Args:
-        fragments: Relevance-ranked text fragments.
+        fragments: Relevance-ranked fragments (str or dict with "text" key).
         max_tokens: Total token budget for the LLM context window.
         system_prompt_tokens: Estimated tokens for the system prompt.
         answer_reserve_tokens: Tokens reserved for LLM answer generation.
         graph_tokens: Tokens already allocated to graph context.
 
     Returns:
-        List of fragments that fit within the budget.
+        List of fragments (same type as input) that fit within the budget.
     """
     computed = max_tokens - system_prompt_tokens - answer_reserve_tokens - graph_tokens
     available = max(computed, MIN_FRAGMENT_TOKENS)
 
-    selected: list[str] = []
+    selected: list = []
     used = 0
 
     for frag in fragments:
-        frag_tokens = estimate_tokens(frag)
+        frag_text = frag["text"] if isinstance(frag, dict) else frag
+        frag_tokens = estimate_tokens(frag_text)
         if used + frag_tokens > available:
             if not selected:
                 ratio = available / max(frag_tokens, 1)
-                truncated = frag[: int(len(frag) * ratio)]
+                if isinstance(frag, dict):
+                    truncated = {**frag, "text": frag_text[: int(len(frag_text) * ratio)]}
+                else:
+                    truncated = frag_text[: int(len(frag_text) * ratio)]
                 selected.append(truncated)
             break
         selected.append(frag)

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -96,6 +96,7 @@ class QdrantVectorStore:
             "url": payload.get("url", ""),
             "date": payload.get("date", ""), "doc_label": payload.get("doc_label", ""),
             "workspace_id": payload.get("workspace_id", ""), "payload": payload,
+            "source_role": payload.get("source_role", "knowledge_base"),
         }
 
     def add_document(self, text: str, metadata: Optional[Dict[str, Any]] = None,

--- a/tests/unit/test_diversify_results.py
+++ b/tests/unit/test_diversify_results.py
@@ -37,19 +37,19 @@ class TestCollectFragsLabeling:
         ]
         frags, _, _, _ = _collect_frags(base, set(), 0)
         assert len(frags) == 2
-        assert frags[0].startswith("[JIRA] MTRNIX-78\n")
-        assert frags[1].startswith("[CONFLUENCE] Architecture\n")
+        assert frags[0]["text"].startswith("[JIRA] MTRNIX-78\n")
+        assert frags[1]["text"].startswith("[CONFLUENCE] Architecture\n")
 
     def test_no_label_for_unknown(self) -> None:
         base = [{"memory": "plain text"}]
         frags, _, _, _ = _collect_frags(base, set(), 0)
         assert len(frags) == 1
-        assert not frags[0].startswith("[")
+        assert not frags[0]["text"].startswith("[")
 
     def test_label_with_payload_type(self) -> None:
         base = [{"memory": "content", "payload": {"type": "jira", "title": "Issue"}}]
         frags, _, _, _ = _collect_frags(base, set(), 0)
-        assert "[JIRA]" in frags[0]
+        assert "[JIRA]" in frags[0]["text"]
 
 
 class TestAppendSources:
@@ -153,7 +153,7 @@ class TestUploadTypeSupport:
         base = [{"memory": "uploaded file content", "type": "upload", "title": "report.txt"}]
         frags, _, _, _ = _collect_frags(base, set(), 0)
         assert len(frags) == 1
-        assert frags[0].startswith("[UPLOAD] report.txt\n")
+        assert frags[0]["text"].startswith("[UPLOAD] report.txt\n")
 
     def test_append_sources_upload_icon(self) -> None:
         results = [

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -38,3 +38,50 @@ class TestConnectorSourceRoles:
     def test_gdrive_connector_role(self) -> None:
         from metatron.connectors.gdrive import GDriveConnector
         assert GDriveConnector.source_role == "knowledge_base"
+
+
+class TestSourceRoleDataFlow:
+    """Verify source_role flows through Document → pipeline → Qdrant payload."""
+
+    def test_document_has_source_role_field(self) -> None:
+        from metatron.core.models import Document
+        doc = Document(title="test", source_role="task_tracker")
+        assert doc.source_role == "task_tracker"
+
+    def test_document_source_role_default_empty(self) -> None:
+        from metatron.core.models import Document
+        doc = Document(title="test")
+        assert doc.source_role == ""
+
+    def test_format_result_includes_source_role(self) -> None:
+        """_format_result extracts source_role from Qdrant payload."""
+        from unittest.mock import MagicMock
+        from metatron.storage.qdrant import QdrantVectorStore
+
+        store = QdrantVectorStore.__new__(QdrantVectorStore)
+        point = MagicMock()
+        point.payload = {
+            "data": "some text",
+            "title": "Test",
+            "type": "jira",
+            "source_role": "task_tracker",
+            "url": "",
+            "date": "",
+            "doc_label": "jira:123",
+            "workspace_id": "ws1",
+        }
+        point.id = "abc123"
+        result = store._format_result(point, 0.95)
+        assert result["source_role"] == "task_tracker"
+
+    def test_format_result_source_role_defaults_to_knowledge_base(self) -> None:
+        """Chunks indexed before reindex get default source_role."""
+        from unittest.mock import MagicMock
+        from metatron.storage.qdrant import QdrantVectorStore
+
+        store = QdrantVectorStore.__new__(QdrantVectorStore)
+        point = MagicMock()
+        point.payload = {"data": "some text", "title": "Old"}
+        point.id = "old123"
+        result = store._format_result(point, 0.8)
+        assert result["source_role"] == "knowledge_base"

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -301,3 +301,84 @@ class TestMarkEvidenceRole:
         frags = [self._make_frag("some_new_connector")]
         _mark_evidence_role(frags, "execution")
         assert frags[0]["evidence_marker"] == "SUPPORTING"
+
+
+class TestBuildCtxGrouped:
+    """_build_ctx groups fragments by source_role with markdown sections."""
+
+    def _make_frag(self, source_role: str, marker: str, source_type: str = "jira",
+                   title: str = "Doc", date: str = "2026-03-25") -> dict:
+        return {
+            "text": f"[{source_type.upper()}] {title}\nContent from {source_role}",
+            "source_type": source_type,
+            "source_role": source_role,
+            "title": title,
+            "date": date,
+            "doc_label": f"{source_type}:1",
+            "evidence_marker": marker,
+        }
+
+    def test_primary_group_appears_first(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [
+            self._make_frag("knowledge_base", "SUPPORTING", "confluence", "Arch Overview"),
+            self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104"),
+        ]
+        ctx = _build_ctx("What is the team doing?", "en", frags, [], [], [])
+        # Task tracker section (has PRIMARY) should appear before knowledge base
+        tt_pos = ctx.find("## Task tracker sources")
+        kb_pos = ctx.find("## Knowledge base sources")
+        assert tt_pos < kb_pos
+        assert "[PRIMARY]" in ctx
+        assert "[SUPPORTING]" in ctx
+
+    def test_empty_groups_skipped(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [
+            self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104"),
+        ]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        assert "## Task tracker sources" in ctx
+        assert "## Knowledge base sources" not in ctx
+        assert "## Communication sources" not in ctx
+
+    def test_all_supporting_no_primary_group(self) -> None:
+        """When mixed profile (all SUPPORTING), groups appear in fixed order."""
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [
+            self._make_frag("knowledge_base", "SUPPORTING", "confluence", "Doc1"),
+            self._make_frag("task_tracker", "SUPPORTING", "jira", "MTRNIX-99"),
+        ]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        # Fixed order: knowledge_base before task_tracker
+        kb_pos = ctx.find("## Knowledge base sources")
+        tt_pos = ctx.find("## Task tracker sources")
+        assert kb_pos < tt_pos
+
+    def test_graph_context_preserved(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [self._make_frag("task_tracker", "PRIMARY", "jira", "J1")]
+        g_ents = [{"name": "Metatron", "type": "System"}]
+        g_rels = [{"source": "Metatron", "target": "RAG", "type": "uses"}]
+        g_docs = ["doc:1"]
+        ctx = _build_ctx("query", "en", frags, g_ents, g_rels, g_docs)
+        assert "## Graph context" in ctx
+        assert "Metatron" in ctx
+
+    def test_date_in_fragment_header(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104", "2026-03-25")]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        assert "(2026-03-25)" in ctx
+
+    def test_fragment_without_date(self) -> None:
+        from metatron.retrieval.search import _build_ctx
+
+        frags = [self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104", "")]
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        assert "()" not in ctx  # no empty parens

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -85,3 +85,23 @@ class TestSourceRoleDataFlow:
         point.id = "old123"
         result = store._format_result(point, 0.8)
         assert result["source_role"] == "knowledge_base"
+
+
+class TestSourceRoleInCallers:
+    """Verify source_role is passed from both sync and upload callers."""
+
+    def test_ingest_documents_accepts_source_role_param(self) -> None:
+        """ingest_documents signature includes source_role."""
+        import inspect
+        from metatron.ingestion.pipeline import ingest_documents
+        sig = inspect.signature(ingest_documents)
+        assert "source_role" in sig.parameters
+        assert sig.parameters["source_role"].default == "knowledge_base"
+
+    def test_chat_upload_metadata_has_source_role(self) -> None:
+        """_ingest_text metadata dict includes source_role for uploads."""
+        import inspect
+        from metatron.api.routes import chat
+        source = inspect.getsource(chat._ingest_text)
+        assert "source_role" in source
+        assert "user_upload" in source

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -1,0 +1,40 @@
+# tests/unit/test_evidence_packs.py
+"""Tests for structured evidence packs — source roles, marking, grouping, context assembly."""
+
+from __future__ import annotations
+
+
+class TestConnectorSourceRoles:
+    """Verify each connector declares the correct source_role."""
+
+    def test_connector_interface_default(self) -> None:
+        from metatron.core.interfaces import ConnectorInterface
+        assert ConnectorInterface.source_role == "knowledge_base"
+
+    def test_jira_connector_role(self) -> None:
+        from metatron.connectors.jira import JiraConnector
+        assert JiraConnector.source_role == "task_tracker"
+
+    def test_github_connector_role(self) -> None:
+        from metatron.connectors.github import GitHubConnector
+        assert GitHubConnector.source_role == "task_tracker"
+
+    def test_slack_history_connector_role(self) -> None:
+        from metatron.connectors.slack_history import SlackHistoryConnector
+        assert SlackHistoryConnector.source_role == "communication"
+
+    def test_files_connector_role(self) -> None:
+        from metatron.connectors.files import FilesConnector
+        assert FilesConnector.source_role == "user_upload"
+
+    def test_confluence_connector_role(self) -> None:
+        from metatron.connectors.confluence import ConfluenceConnector
+        assert ConfluenceConnector.source_role == "knowledge_base"
+
+    def test_notion_connector_role(self) -> None:
+        from metatron.connectors.notion import NotionConnector
+        assert NotionConnector.source_role == "knowledge_base"
+
+    def test_gdrive_connector_role(self) -> None:
+        from metatron.connectors.gdrive import GDriveConnector
+        assert GDriveConnector.source_role == "knowledge_base"

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -56,6 +56,7 @@ class TestSourceRoleDataFlow:
     def test_format_result_includes_source_role(self) -> None:
         """_format_result extracts source_role from Qdrant payload."""
         from unittest.mock import MagicMock
+
         from metatron.storage.qdrant import QdrantVectorStore
 
         store = QdrantVectorStore.__new__(QdrantVectorStore)
@@ -77,6 +78,7 @@ class TestSourceRoleDataFlow:
     def test_format_result_source_role_defaults_to_knowledge_base(self) -> None:
         """Chunks indexed before reindex get default source_role."""
         from unittest.mock import MagicMock
+
         from metatron.storage.qdrant import QdrantVectorStore
 
         store = QdrantVectorStore.__new__(QdrantVectorStore)
@@ -93,6 +95,7 @@ class TestSourceRoleInCallers:
     def test_ingest_documents_accepts_source_role_param(self) -> None:
         """ingest_documents signature includes source_role."""
         import inspect
+
         from metatron.ingestion.pipeline import ingest_documents
         sig = inspect.signature(ingest_documents)
         assert "source_role" in sig.parameters
@@ -101,6 +104,7 @@ class TestSourceRoleInCallers:
     def test_chat_upload_metadata_has_source_role(self) -> None:
         """_ingest_text metadata dict includes source_role for uploads."""
         import inspect
+
         from metatron.api.routes import chat
         source = inspect.getsource(chat._ingest_text)
         assert "source_role" in source
@@ -128,7 +132,8 @@ class TestCollectFragsDicts:
         frags, seen, total, doc_stats = _collect_frags(base, set(), 0)
         assert len(frags) == 1
         assert isinstance(frags[0], dict)
-        assert frags[0]["text"] == "[CONFLUENCE] Architecture Overview\nSome text about architecture"
+        expected = "[CONFLUENCE] Architecture Overview\nSome text about architecture"
+        assert frags[0]["text"] == expected
         assert frags[0]["source_type"] == "confluence"
         assert frags[0]["source_role"] == "knowledge_base"
         assert frags[0]["title"] == "Architecture Overview"
@@ -196,8 +201,10 @@ class TestTokenBudgetWithDicts:
         from metatron.retrieval.token_budget import select_fragments_within_budget
 
         frags = [
-            {"text": "Short fragment one.", "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
-            {"text": "Short fragment two.", "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+            {"text": "Short fragment one.",
+             "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "Short fragment two.",
+             "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
         ]
         result = select_fragments_within_budget(frags, max_tokens=10000)
         assert len(result) == 2
@@ -410,7 +417,8 @@ class TestSystemPromptEvidenceRules:
 
     def test_deduplicated_line_removed_invent_facts(self) -> None:
         from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
-        assert "Do not invent facts that are not in the provided fragments." not in HYBRID_SYSTEM_PROMPT
+        removed = "Do not invent facts that are not in the provided fragments."
+        assert removed not in HYBRID_SYSTEM_PROMPT
 
     def test_deduplicated_line_removed_primary_source(self) -> None:
         from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
@@ -430,7 +438,7 @@ class TestEvidencePacksIntegration:
 
     def test_full_pipeline_execution_profile(self) -> None:
         """Execution profile: task_tracker = PRIMARY, knowledge_base = SUPPORTING."""
-        from metatron.retrieval.search import _collect_frags, _mark_evidence_role, _build_ctx
+        from metatron.retrieval.search import _build_ctx, _collect_frags, _mark_evidence_role
 
         base = [
             {
@@ -476,7 +484,7 @@ class TestEvidencePacksIntegration:
 
     def test_full_pipeline_mixed_profile(self) -> None:
         """Mixed profile: all fragments SUPPORTING, fixed group order."""
-        from metatron.retrieval.search import _collect_frags, _mark_evidence_role, _build_ctx
+        from metatron.retrieval.search import _build_ctx, _collect_frags, _mark_evidence_role
 
         base = [
             {
@@ -513,8 +521,10 @@ class TestEvidencePacksIntegration:
     def test_trace_format_with_dict_frags(self) -> None:
         """Trace logging calculations work with dict fragments."""
         frags = [
-            {"text": "word1 word2 word3", "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
-            {"text": "word4 word5", "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+            {"text": "word1 word2 word3",
+             "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "word4 word5",
+             "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
         ]
         token_budget_used = sum(len(f["text"]) for f in frags) // 4
         source_word_count = sum(len(f["text"].split()) for f in frags)

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -423,3 +423,100 @@ class TestSystemPromptEvidenceRules:
     def test_language_rules_preserved(self) -> None:
         from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
         assert "CRITICAL RULE: RESPONSE LANGUAGE" in HYBRID_SYSTEM_PROMPT
+
+
+class TestEvidencePacksIntegration:
+    """End-to-end test: marking + grouping + context assembly."""
+
+    def test_full_pipeline_execution_profile(self) -> None:
+        """Execution profile: task_tracker = PRIMARY, knowledge_base = SUPPORTING."""
+        from metatron.retrieval.search import _collect_frags, _mark_evidence_role, _build_ctx
+
+        base = [
+            {
+                "memory": "Implementing auth module, status: in progress",
+                "data": "Implementing auth module, status: in progress",
+                "title": "MTRNIX-104",
+                "type": "jira",
+                "source_role": "task_tracker",
+                "doc_label": "jira:104",
+                "date": "2026-03-25",
+                "payload": {},
+            },
+            {
+                "memory": "The system uses 6 architectural layers for separation of concerns",
+                "data": "The system uses 6 architectural layers for separation of concerns",
+                "title": "Architecture Overview",
+                "type": "confluence",
+                "source_role": "knowledge_base",
+                "doc_label": "confluence:arch",
+                "date": "2026-03-20",
+                "payload": {},
+            },
+        ]
+
+        frags, _, _, doc_stats = _collect_frags(base, set(), 0)
+        assert len(frags) == 2
+        assert all(isinstance(f, dict) for f in frags)
+
+        _mark_evidence_role(frags, "execution")
+        # Jira = task_tracker → PRIMARY for execution profile
+        jira_frag = next(f for f in frags if f["source_type"] == "jira")
+        conf_frag = next(f for f in frags if f["source_type"] == "confluence")
+        assert jira_frag["evidence_marker"] == "PRIMARY"
+        assert conf_frag["evidence_marker"] == "SUPPORTING"
+
+        ctx = _build_ctx("What is the team doing?", "en", frags, [], [], [])
+        # Task tracker section appears first (has PRIMARY)
+        assert ctx.index("## Task tracker sources") < ctx.index("## Knowledge base sources")
+        assert "[PRIMARY]" in ctx
+        assert "[SUPPORTING]" in ctx
+        assert "MTRNIX-104" in ctx
+        assert "Architecture Overview" in ctx
+
+    def test_full_pipeline_mixed_profile(self) -> None:
+        """Mixed profile: all fragments SUPPORTING, fixed group order."""
+        from metatron.retrieval.search import _collect_frags, _mark_evidence_role, _build_ctx
+
+        base = [
+            {
+                "memory": "Some jira content",
+                "data": "Some jira content",
+                "title": "MTRNIX-99",
+                "type": "jira",
+                "source_role": "task_tracker",
+                "doc_label": "jira:99",
+                "payload": {},
+            },
+            {
+                "memory": "Some confluence content",
+                "data": "Some confluence content",
+                "title": "Doc",
+                "type": "confluence",
+                "source_role": "knowledge_base",
+                "doc_label": "confluence:1",
+                "payload": {},
+            },
+        ]
+
+        frags, _, _, _ = _collect_frags(base, set(), 0)
+        _mark_evidence_role(frags, "mixed")
+
+        assert all(f["evidence_marker"] == "SUPPORTING" for f in frags)
+
+        ctx = _build_ctx("query", "en", frags, [], [], [])
+        # No PRIMARY group → fixed order: knowledge_base before task_tracker
+        kb_pos = ctx.find("## Knowledge base sources")
+        tt_pos = ctx.find("## Task tracker sources")
+        assert kb_pos < tt_pos
+
+    def test_trace_format_with_dict_frags(self) -> None:
+        """Trace logging calculations work with dict fragments."""
+        frags = [
+            {"text": "word1 word2 word3", "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "word4 word5", "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+        ]
+        token_budget_used = sum(len(f["text"]) for f in frags) // 4
+        source_word_count = sum(len(f["text"].split()) for f in frags)
+        assert token_budget_used > 0
+        assert source_word_count == 5

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -382,3 +382,44 @@ class TestBuildCtxGrouped:
         frags = [self._make_frag("task_tracker", "PRIMARY", "jira", "MTRNIX-104", "")]
         ctx = _build_ctx("query", "en", frags, [], [], [])
         assert "()" not in ctx  # no empty parens
+
+
+class TestSystemPromptEvidenceRules:
+    """HYBRID_SYSTEM_PROMPT contains evidence rules and no deduplicated lines."""
+
+    def test_evidence_rules_section_exists(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "## Evidence rules" in HYBRID_SYSTEM_PROMPT
+
+    def test_primary_supporting_mentioned(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "[PRIMARY]" in HYBRID_SYSTEM_PROMPT
+        assert "[SUPPORTING]" in HYBRID_SYSTEM_PROMPT
+
+    def test_citation_rule_present(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "cite the source" in HYBRID_SYSTEM_PROMPT
+
+    def test_contradiction_handling_present(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "contradict" in HYBRID_SYSTEM_PROMPT
+
+    def test_insufficient_context_rule_present(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "insufficient" in HYBRID_SYSTEM_PROMPT
+
+    def test_deduplicated_line_removed_invent_facts(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "Do not invent facts that are not in the provided fragments." not in HYBRID_SYSTEM_PROMPT
+
+    def test_deduplicated_line_removed_primary_source(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "Use text fragments as the primary source of facts." not in HYBRID_SYSTEM_PROMPT
+
+    def test_source_references_preserved(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "[$[" in HYBRID_SYSTEM_PROMPT
+
+    def test_language_rules_preserved(self) -> None:
+        from metatron.retrieval.prompts import HYBRID_SYSTEM_PROMPT
+        assert "CRITICAL RULE: RESPONSE LANGUAGE" in HYBRID_SYSTEM_PROMPT

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -105,3 +105,85 @@ class TestSourceRoleInCallers:
         source = inspect.getsource(chat._ingest_text)
         assert "source_role" in source
         assert "user_upload" in source
+
+
+class TestCollectFragsDicts:
+    """_collect_frags returns list[dict] with metadata."""
+
+    def test_returns_list_of_dicts(self) -> None:
+        from metatron.retrieval.search import _collect_frags
+
+        base = [
+            {
+                "memory": "Some text about architecture",
+                "data": "Some text about architecture",
+                "title": "Architecture Overview",
+                "type": "confluence",
+                "source_role": "knowledge_base",
+                "doc_label": "confluence:123",
+                "date": "2026-03-20",
+                "payload": {},
+            },
+        ]
+        frags, seen, total, doc_stats = _collect_frags(base, set(), 0)
+        assert len(frags) == 1
+        assert isinstance(frags[0], dict)
+        assert frags[0]["text"] == "[CONFLUENCE] Architecture Overview\nSome text about architecture"
+        assert frags[0]["source_type"] == "confluence"
+        assert frags[0]["source_role"] == "knowledge_base"
+        assert frags[0]["title"] == "Architecture Overview"
+        assert frags[0]["date"] == "2026-03-20"
+        assert frags[0]["doc_label"] == "confluence:123"
+
+    def test_default_source_role_knowledge_base(self) -> None:
+        """Fragments without source_role get default 'knowledge_base'."""
+        from metatron.retrieval.search import _collect_frags
+
+        base = [
+            {
+                "memory": "Old chunk without source_role",
+                "data": "Old chunk without source_role",
+                "title": "Old Doc",
+                "type": "confluence",
+                "doc_label": "c:1",
+                "payload": {},
+            },
+        ]
+        frags, _, _, _ = _collect_frags(base, set(), 0)
+        assert frags[0]["source_role"] == "knowledge_base"
+
+    def test_dedup_by_text_hash(self) -> None:
+        """Duplicate fragments are deduplicated by hash of first 200 chars."""
+        from metatron.retrieval.search import _collect_frags
+
+        item = {
+            "memory": "Same text",
+            "data": "Same text",
+            "title": "Doc",
+            "type": "confluence",
+            "source_role": "knowledge_base",
+            "doc_label": "c:1",
+            "payload": {},
+        }
+        frags, _, _, _ = _collect_frags([item, item], set(), 0)
+        assert len(frags) == 1
+
+    def test_doc_stats_still_tracked(self) -> None:
+        """FinOps doc_stats tracking works with dict fragments."""
+        from metatron.retrieval.search import _collect_frags
+
+        base = [
+            {
+                "memory": "Task implementation details",
+                "data": "Task implementation details",
+                "title": "MTRNIX-104",
+                "type": "jira",
+                "source_role": "task_tracker",
+                "doc_label": "jira:104",
+                "payload": {},
+            },
+        ]
+        frags, _, _, doc_stats = _collect_frags(base, set(), 0)
+        assert "jira:104" in doc_stats
+        assert doc_stats["jira:104"]["title"] == "MTRNIX-104"
+        assert doc_stats["jira:104"]["fetch_count"] == 1

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -225,3 +225,79 @@ class TestTokenBudgetWithDicts:
         result = select_fragments_within_budget(frags, max_tokens=10000)
         assert len(result) == 2
         assert all(isinstance(f, str) for f in result)
+
+
+class TestMarkEvidenceRole:
+    """_mark_evidence_role labels fragments PRIMARY/SUPPORTING based on query profile."""
+
+    def _make_frag(self, source_role: str) -> dict:
+        return {
+            "text": f"Fragment from {source_role}",
+            "source_type": "test",
+            "source_role": source_role,
+            "title": "Test",
+            "date": "",
+            "doc_label": "t:1",
+            "evidence_marker": "",
+        }
+
+    def test_execution_profile_primary_is_task_tracker(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "execution")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_documentation_profile_primary_is_knowledge_base(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "documentation")
+        assert frags[0]["evidence_marker"] == "SUPPORTING"
+        assert frags[1]["evidence_marker"] == "PRIMARY"
+
+    def test_user_file_profile_primary_is_user_upload(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("user_upload"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "user_file")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_mixed_profile_all_supporting(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("knowledge_base")]
+        _mark_evidence_role(frags, "mixed")
+        assert all(f["evidence_marker"] == "SUPPORTING" for f in frags)
+
+    def test_relationship_profile_primary_is_knowledge_base(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("knowledge_base"), self._make_frag("task_tracker")]
+        _mark_evidence_role(frags, "relationship")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_temporal_profile_primary_is_task_tracker(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker"), self._make_frag("communication")]
+        _mark_evidence_role(frags, "temporal")
+        assert frags[0]["evidence_marker"] == "PRIMARY"
+        assert frags[1]["evidence_marker"] == "SUPPORTING"
+
+    def test_unknown_profile_all_supporting(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("task_tracker")]
+        _mark_evidence_role(frags, "unknown_profile")
+        assert frags[0]["evidence_marker"] == "SUPPORTING"
+
+    def test_unknown_source_role_gets_supporting(self) -> None:
+        from metatron.retrieval.search import _mark_evidence_role
+
+        frags = [self._make_frag("some_new_connector")]
+        _mark_evidence_role(frags, "execution")
+        assert frags[0]["evidence_marker"] == "SUPPORTING"

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -39,6 +39,25 @@ class TestConnectorSourceRoles:
         from metatron.connectors.gdrive import GDriveConnector
         assert GDriveConnector.source_role == "knowledge_base"
 
+    def test_invalid_source_role_rejected(self) -> None:
+        """A connector with a typo in source_role is caught at class definition time."""
+        import pytest
+
+        from metatron.core.interfaces import ConnectorInterface
+
+        with pytest.raises(ValueError, match="is not valid"):
+            class BadConnector(ConnectorInterface):
+                source_role = "taks_tracker"  # typo
+
+                async def configure(self, connection, decrypted_config):
+                    pass
+
+                async def fetch(self, workspace_id, since=None):
+                    return []
+
+                async def health_check(self):
+                    return True
+
 
 class TestSourceRoleDataFlow:
     """Verify source_role flows through Document → pipeline → Qdrant payload."""

--- a/tests/unit/test_evidence_packs.py
+++ b/tests/unit/test_evidence_packs.py
@@ -187,3 +187,41 @@ class TestCollectFragsDicts:
         assert "jira:104" in doc_stats
         assert doc_stats["jira:104"]["title"] == "MTRNIX-104"
         assert doc_stats["jira:104"]["fetch_count"] == 1
+
+
+class TestTokenBudgetWithDicts:
+    """select_fragments_within_budget works with list[dict] fragments."""
+
+    def test_accepts_dict_fragments(self) -> None:
+        from metatron.retrieval.token_budget import select_fragments_within_budget
+
+        frags = [
+            {"text": "Short fragment one.", "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "Short fragment two.", "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+        ]
+        result = select_fragments_within_budget(frags, max_tokens=10000)
+        assert len(result) == 2
+        assert all(isinstance(f, dict) for f in result)
+        assert result[0]["source_role"] == "task_tracker"
+
+    def test_budget_truncation_preserves_metadata(self) -> None:
+        from metatron.retrieval.token_budget import select_fragments_within_budget
+
+        frags = [
+            {"text": "A" * 4000, "source_role": "task_tracker", "evidence_marker": "PRIMARY"},
+            {"text": "B" * 4000, "source_role": "knowledge_base", "evidence_marker": "SUPPORTING"},
+            {"text": "C" * 4000, "source_role": "communication", "evidence_marker": "SUPPORTING"},
+        ]
+        # Budget of 2500 tokens ~ 10000 chars, should fit first 2 but not 3rd
+        result = select_fragments_within_budget(frags, max_tokens=2500)
+        assert len(result) <= 2
+        assert all("source_role" in f for f in result)
+
+    def test_backwards_compat_with_str_fragments(self) -> None:
+        """Still works with list[str] for backward compatibility during migration."""
+        from metatron.retrieval.token_budget import select_fragments_within_budget
+
+        frags = ["Fragment one text.", "Fragment two text."]
+        result = select_fragments_within_budget(frags, max_tokens=10000)
+        assert len(result) == 2
+        assert all(isinstance(f, str) for f in result)

--- a/tests/unit/test_search_trace_extended.py
+++ b/tests/unit/test_search_trace_extended.py
@@ -49,7 +49,12 @@ def _patch_search_internals():
         ),
         "select_fragments_within_budget": patch(
             f"{_SEARCH_MODULE}.select_fragments_within_budget",
-            return_value=["fragment one", "fragment two"],
+            return_value=[
+                {"text": "fragment one", "source_role": "knowledge_base", "source_type": "confluence",
+                 "title": "Doc One", "doc_label": "c:1", "date": ""},
+                {"text": "fragment two", "source_role": "knowledge_base", "source_type": "confluence",
+                 "title": "Doc Two", "doc_label": "c:2", "date": ""},
+            ],
         ),
         "estimate_graph_tokens": patch(
             f"{_SEARCH_MODULE}.estimate_graph_tokens", return_value=0,

--- a/tests/unit/test_search_trace_extended.py
+++ b/tests/unit/test_search_trace_extended.py
@@ -131,6 +131,8 @@ class TestPipelineStagesInTrace:
                 "signal_scored_count",
                 "rerank_pool_count",
                 "fragment_count",
+                "primary_fragment_count",
+                "supporting_fragment_count",
                 "token_budget_used",
                 "query_profile",
                 "query_profile_method",


### PR DESCRIPTION
## Summary
- Connectors declare `source_role` (task_tracker, knowledge_base, user_upload, communication), flowing through Document → pipeline → Qdrant payload → recall
- `_collect_frags()` returns enriched dicts instead of flat strings; `_mark_evidence_role()` labels fragments as PRIMARY/SUPPORTING based on query classifier profile
- `_build_ctx()` groups fragments by source_role with markdown sections, PRIMARY group first
- System prompt updated with atomic evidence rules for citation, contradiction handling, and uncertainty marking
- `select_fragments_within_budget()` supports dict fragments with backward compat
- `ConnectorInterface.__init_subclass__` validates source_role against allowed values (catches typos at class definition time)

## Eval results
| Metric | Before | After | Δ |
|---|---|---|---|
| P@10 | 0.3530 | 0.3663 | +0.0133 |
| MRR | 0.6724 | 0.6897 | +0.0172 |
| NDCG@10 | 0.6109 | 0.6326 | +0.0218 |

6 query improvements, 5 minor regressions. All three metrics improved.

## Files changed (18)
- `core/interfaces.py`, `core/models.py` — source_role attribute/field + validation
- 4 connectors — source_role overrides
- `ingestion/pipeline.py`, `storage/qdrant.py` — source_role in payload
- `api/routes/connections.py`, `api/routes/chat.py` — pass source_role to callers
- `retrieval/search.py` — _collect_frags, _mark_evidence_role, _build_ctx refactor, trace markers
- `retrieval/token_budget.py` — dict fragment support
- `retrieval/prompts.py` — evidence rules in system prompt
- `tests/unit/test_evidence_packs.py` — 48 new tests
- 2 existing test files adapted for dict frags

## Test plan
- [x] 118 evidence-packs related tests pass
- [x] Eval: P@10/MRR/NDCG all improved (no regression)

## Post-deploy checklist
- [ ] Manual spot-check on 10 queries: proper citation, uncertainty marking
- [ ] Full reindex (pre-reindex chunks fall back to "knowledge_base")

🤖 Generated with [Claude Code](https://claude.com/claude-code)