### PR TITLE
Search quality tuning: all backlog recommendations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,9 @@ make migrate          # alembic upgrade head
 make migrate-new name="description"
 make docker-up        # start postgres + qdrant + memgraph
 make docker-down
+make eval             # run search quality eval (needs live services)
+make eval-compare     # run eval + compare with last saved result
+make grid-search      # grid search for optimal scoring weights
 ```
 
 Direct commands:
@@ -71,14 +74,14 @@ src/metatron/
 │   └── providers/             # ollama, deepseek, openrouter, custom
 ├── mcp/                       # L3 — server.py, client.py, adapter.py, registry.py
 │   └── tools/                 # search, sync, get, store, status
-├── retrieval/                 # L2 — search.py, hybrid.py, query_expansion.py, scoring.py,
-│                              #   reranker.py, entity_resolver.py, token_budget.py
+├── retrieval/                 # L2 — search.py, channels.py, scoring.py, query_classifier.py,
+│                              #   hybrid.py, query_expansion.py, reranker.py, token_budget.py
 ├── storage/                   # L1 — postgres.py, qdrant.py, memgraph.py, encryption.py
 ├── observability/             # health.py, metrics.py, tracer.py
 ├── workspaces/                # L3 — manager.py, models.py, persistence.py
 ├── skills/                    # L3 — engine.py
 ├── benchmarker/               # L2 — api/, db/, schemas/, services/metrics/
-└── scripts/                   # graph_audit.py
+└── scripts/                   # graph_audit.py, run_eval.py, grid_search_weights.py
 ```
 
 ## Plugin System
@@ -121,9 +124,17 @@ Request → OptionalAuthMiddleware (if AUTH_ENABLED)
 
 ## Search Pipeline
 ```
-Query → expansion → entity injection → hybrid_search (dense+sparse, pool=75)
-→ merge + diversify (k=50) → title_boost → RERANKER (bge-reranker-v2-m3, top 25)
-→ collect_frags → graph enrichment → token budget → LLM → sources
+Query → expansion → classify(profile) → weight_preset
+     → recall_dense + recall_exact + recall_metadata + recall_graph  (parallel via ThreadPoolExecutor)
+     → merge_channels → compute_signal_score(6 weighted signals, normalized [0,1])
+     → top-35 pool → cross-encoder rerank (bge-reranker-v2-m3)
+     → compute_final_score(blend: 30% signal + 70% reranker)
+     → _collect_frags(dict) → _mark_evidence_role(PRIMARY/SUPPORTING)
+     → _build_ctx(grouped markdown) → LLM(evidence rules) → _append_sources → answer
+
+Scoring signals: dense, graph, metadata, recency, source_balance (smooth gradient).
+Weights configurable per query profile (execution, documentation, user_file, relationship, temporal, mixed).
+Grid search script: `make grid-search` for weight optimization.
 
 Source citation format: `"{icon} {title} — {url}"` (em-dash separator).
 Icons: 📄 confluence, 📋 jira, 📎 upload, 📓 notion.
@@ -142,6 +153,10 @@ Frontend splits on `" — "` to extract URL; no URL → title only.
 - RERANKER_ENABLED (true) — bge-reranker-v2-m3
 - QUERY_EXPANSION_ENABLED (true) — LLM query expansion
 - GRAPH_EXTRACTION_ENABLED (true) — NER → Memgraph
+- QUERY_CLASSIFIER_ENABLED (true) — hybrid rule+LLM query classifier
+- DENSE_WEIGHT (0.35), GRAPH_WEIGHT (0.15), METADATA_WEIGHT (0.20), RECENCY_WEIGHT (0.10), BALANCE_WEIGHT (0.05), BLEND_WEIGHT (0.3) — scoring formula weights
+- RERANK_POOL_SIZE (35) — candidates sent to cross-encoder
+- MIN_SIGNAL_SCORE (0.0) — confidence threshold (0=disabled)
 - METATRON_OPENAI_COMPAT_ENABLED (true) — OpenAI-compatible API for Open WebUI
 - METATRON_OPENAI_COMPAT_KEY ("") — static API key for OpenAI-compat endpoints (empty = disabled)
 - See core/config.py for full list
@@ -161,7 +176,7 @@ Setup in Open WebUI: Settings → Connections → OpenAI API → Add URL `http:/
 Docker: Open WebUI available in `docker-compose.full.yml` with profile `openwebui` on port 3080.
 
 ## Testing
-- 915+ tests, `make test` runs unit only
+- 1150+ tests, `make test` runs unit only
 - `asyncio_mode = "auto"` — no pytest.mark.asyncio needed
 - Fixtures in tests/conftest.py: settings, sample_document, sample_chunks, sample_user
 - Benchmarker tests need optional dep `benchmark-qed`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev test lint migrate docker-up docker-down clean test-installer verify-checksum update-checksum prepare-release eval eval-all eval-save eval-compare eval-history
+.PHONY: setup dev test lint migrate docker-up docker-down clean test-installer verify-checksum update-checksum prepare-release eval eval-all eval-save eval-compare eval-history grid-search
 
 setup:
 	python -m venv .venv
@@ -63,6 +63,9 @@ eval-compare:
 
 eval-history:
 	.venv/bin/python scripts/run_eval.py --history
+
+grid-search:
+	.venv/bin/python scripts/grid_search_weights.py --workspace $(or $(WORKSPACE),MTRNIX) --step 0.10
 
 # ============================================================================
 # Installer Distribution Targets

--- a/docs/superpowers/2026-03-26-search-quality-epic-summary.md
+++ b/docs/superpowers/2026-03-26-search-quality-epic-summary.md
@@ -54,14 +54,14 @@ Graph повышен из context-enrichment в полноценный recall ch
 
 ## Метрики: от начала до конца
 
-| Метрика | Baseline (до эпика) | Финал (после PR #45) | Δ | Оценка |
-|---------|--------------------|-----------------------|---|--------|
-| **P@10** | 0.3791 | 0.3663 | -0.013 | ~stable |
-| **MRR** | 0.6946 | 0.6897 | -0.005 | ~stable |
-| **NDCG@10** | 0.6684 | 0.6326 | -0.036 | small regression |
-| **Neg Acc** | 0.00 | 0.00 | 0 | not addressed |
+| Метрика | Baseline (до эпика) | После PR #45 | После тюнинга | Δ vs baseline | Оценка |
+|---------|--------------------|-----------------------|---------------|---------------|--------|
+| **P@10** | 0.3791 | 0.3663 | 0.3787 | -0.000 | ~stable |
+| **MRR** | 0.6946 | 0.6897 | 0.7069 | +0.012 | improved |
+| **NDCG@10** | 0.6684 | 0.6326 | 0.6493 | -0.019 | minor regression |
+| **Neg Acc** | 0.00 | 0.00 | 0.00 | 0 | infra ready (Q3) |
 
-**Пояснение:** Промежуточная регрессия от архитектурных рефакторингов (Tasks 2-3) была почти полностью компенсирована Tasks 4-6. NDCG@10 regression (-5%) — следствие того, что graph docs теперь проходят reranker (правильнее архитектурно, но ранжирование ещё не оптимизировано). Основные gains ожидаются от weight tuning (Q1 в бэклоге).
+**Пояснение:** Промежуточная регрессия от архитектурных рефакторингов (Tasks 2-3) полностью компенсирована. MRR вышла выше baseline (+1.2%). Тюнинг (smooth source_balance + RERANK_POOL_SIZE 35) дал +0.012 P@10, +0.017 MRR, +0.017 NDCG vs post-PR#45. NDCG@10 остаётся ниже baseline на 1.9% — ожидается улучшение после grid search по весам профилей.
 
 **Траектория по eval runs:**
 ```
@@ -70,7 +70,8 @@ Graph повышен из context-enrichment в полноценный recall ch
 09:43  P@10=0.330  MRR=0.690  NDCG=0.663  ← graph candidate source
 12:12  P@10=0.377  MRR=0.707  NDCG=0.665  ← unified reranking (recovery)
 15:14  P@10=0.353  MRR=0.672  NDCG=0.611  ← query classifier
-17:47  P@10=0.366  MRR=0.690  NDCG=0.633  ← evidence packs (final)
+17:47  P@10=0.366  MRR=0.690  NDCG=0.633  ← evidence packs
+19:22  P@10=0.379  MRR=0.707  NDCG=0.649  ← quality tuning (final)
 ```
 
 ---
@@ -95,49 +96,31 @@ Query → expansion → classify(profile) → weight_preset
 
 ---
 
-## Бэклог (TODO)
+## Бэклог — выполнено (PR #46: search-quality-tuning)
 
-### Performance
+| ID | Задача | Статус |
+|----|--------|--------|
+| **P1** | Параллельный запуск recall channels (ThreadPoolExecutor) | ✅ Done |
+| **P2** | Тюнинг RERANK_POOL_SIZE (50 → 35) | ✅ Done |
+| **P3** | LRU cache для recall_graph (Memgraph queries) | ✅ Done |
+| **Q1** | Grid search скрипт (`make grid-search`) | ✅ Done (инфраструктура; прогон — отдельная задача) |
+| **Q2** | Smooth gradient для source_balance | ✅ Done |
+| **Q3** | Confidence threshold (min_signal_score) | ✅ Done (disabled by default, 0.0) |
+| **C1** | Вынести scores из memory dicts в score_map | ✅ Done |
+| **C2** | Кэширование _result_type в scoring loop | ✅ Done |
+| **C3** | Убрать dead sparse_weight path | ✅ Done |
+| **D1** | Reconcile spec vs code — нормализация весов | ✅ Done |
 
-| ID | Задача | Сложность | Ожидаемый эффект |
-|----|--------|-----------|------------------|
-| **P1** | Параллельный запуск recall channels (`asyncio.gather`) | Средняя | Latency recall -60-70% |
-| **P2** | Тюнинг RERANK_POOL_SIZE (50 → 30-35) | Низкая | Inference cost -30% |
-| **P3** | LRU cache для recall_graph (Memgraph queries) | Низкая | Latency graph channel -50%+ для повторных запросов |
+## Бэклог — оставшиеся задачи
 
-### Quality Tuning
+### Следующие шаги (рекомендованный приоритет)
 
-| ID | Задача | Сложность | Ожидаемый эффект |
-|----|--------|-----------|------------------|
-| **Q1** | Grid search по весам scoring формулы | Низкая (время) | Основной ожидаемый gain по MRR/NDCG |
-| **Q2** | Smooth gradient для source_balance (бинарный → плавный) | Низкая | Устранение boundary effects |
-| **Q3** | Negative accuracy: confidence threshold на signal_score | Средняя | Neg Acc 0% → target 50%+ |
-
-### Code Quality
-
-| ID | Задача | Сложность |
-|----|--------|-----------|
-| **C1** | Убрать _signal_score/_final_score leak в memory dicts | Низкая |
-| **C2** | Кэширование _result_type в scoring loop | Тривиально |
-| **C3** | Убрать dead sparse_weight path | Тривиально |
-| **D1** | Reconcile spec vs code — нормализация весов | Тривиально |
-
-### Async Migration (tech debt)
-
-14 TODO-комментариев `# TODO: async migration` в `retrieval/` и `storage/qdrant.py`. Весь search pipeline синхронный, вызывается через `asyncio.to_thread()`. Prerequisite для P1 (параллельные recall channels).
+1. **Запуск grid search** — `make grid-search` по весам профилей. Инфраструктура готова, нужен прогон (~30 мин/профиль) + применение оптимальных весов
+2. **Калибровка min_signal_score** — включить confidence threshold, найти оптимальный порог через eval
+3. **Async migration** — 14 TODO-комментариев в `retrieval/` и `storage/qdrant.py`. Весь search pipeline синхронный, вызывается через `asyncio.to_thread()`
 
 ### Known Issues
 
 - **ru-01 false positive**: «Что такое Метатрон?» → `relationship` вместо `documentation` (LLM перевод содержит "relat*")
 - **Ollama model swapping**: Classifier adds latency → Ollama unloads embedding model. Fix: `OLLAMA_KEEP_ALIVE=-1`
 - **Post-deploy**: Нужен full reindex для source_role в Qdrant payload + manual spot-check 10 queries на citation quality
-
----
-
-## Рекомендация по приоритету следующих шагов
-
-1. **Q1 — Grid search по весам** — максимальный ожидаемый ROI, вся инфраструктура готова
-2. **P1 — Параллельные recall channels** — нужен async migration, но даст -60% latency
-3. **Q3 — Negative accuracy** — сейчас 0%, заметно для пользователей
-4. **P2 — RERANK_POOL_SIZE tuning** — quick win, 5 минут работы + eval
-5. Остальное — по мере необходимости

--- a/docs/superpowers/plans/2026-03-26-search-quality-tuning.md
+++ b/docs/superpowers/plans/2026-03-26-search-quality-tuning.md
@@ -1,0 +1,889 @@
+# Search Quality Tuning — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete all remaining backlog items from the search quality epic — code quality cleanup, performance tuning, quality improvements — before moving to the next sprint.
+
+**Architecture:** 10 independent tasks touching scoring, channels, classifier, and search pipeline. No new modules. All changes are surgical modifications to existing files. Grid search is a script, not a code change.
+
+**Tech Stack:** Python 3.12, pytest, structlog, Qdrant, Memgraph
+
+---
+
+## Backlog Items → Tasks
+
+| Backlog | Task | Summary |
+|---------|------|---------|
+| C3 | 1 | Remove dead `sparse_weight` path |
+| C2 | 2 | Cache `_result_type()` in scoring loop |
+| C1 | 3 | Extract scores from memory dicts into `score_map` |
+| D1 | 4 | Update spec wording on weight normalization |
+| Q2 | 5 | Smooth gradient for `source_balance()` |
+| P2 | 6 | Tune `RERANK_POOL_SIZE` (50 → 35) + eval |
+| Q3 | 7 | Confidence threshold on `signal_score` for negative queries |
+| P3 | 8 | LRU cache for `recall_graph` Memgraph queries |
+| P1 | 9 | Async recall channels via `asyncio.gather()` |
+| Q1 | 10 | Grid search script for scoring weights |
+
+---
+
+## File Map
+
+| File | Tasks | Changes |
+|------|-------|---------|
+| `src/metatron/retrieval/scoring.py` | 1, 2, 5 | Remove sparse_weight param, smooth source_balance |
+| `src/metatron/retrieval/search.py` | 2, 3, 7, 9 | Cache _result_type, score_map, confidence filter, async channels |
+| `src/metatron/retrieval/query_classifier.py` | 1 | Remove sparse_weight from all profiles |
+| `src/metatron/retrieval/channels.py` | 8 | LRU cache on graph entity lookups |
+| `src/metatron/core/config.py` | 6, 7 | rerank_pool_size default, min_signal_score_threshold |
+| `docs/superpowers/specs/2026-03-26-unified-reranking-design.md` | 4 | Clarify normalization wording |
+| `scripts/grid_search_weights.py` | 10 | New: grid search script |
+| `tests/unit/test_scoring.py` | 1, 2, 5 | Tests for scoring changes |
+| `tests/unit/test_search_quality_tuning.py` | 3, 7, 8 | Tests for score_map, confidence, cache |
+
+---
+
+### Task 1: Remove dead `sparse_weight` path
+
+**Context:** `sparse_weight=0.0` everywhere — no recall channel produces `"sparse"` scored results. Dead code.
+
+**Files:**
+- Modify: `src/metatron/retrieval/scoring.py:60-98`
+- Modify: `src/metatron/retrieval/query_classifier.py:35-90`
+- Test: `tests/unit/test_scoring.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_scoring.py — add to existing file
+import inspect
+from metatron.retrieval.scoring import compute_signal_score
+
+def test_compute_signal_score_has_no_sparse_weight_param():
+    """sparse_weight was removed — verify it's not in the signature."""
+    sig = inspect.signature(compute_signal_score)
+    assert "sparse_weight" not in sig.parameters
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_scoring.py::test_compute_signal_score_has_no_sparse_weight_param -v`
+Expected: FAIL — sparse_weight still in signature
+
+- [ ] **Step 3: Remove sparse_weight from scoring.py**
+
+In `scoring.py`, remove:
+- `sparse_weight: float = 0.0` from `compute_signal_score()` params (line 66)
+- `sparse = channel_scores.get("sparse", 0.0)` (line 78)
+- `+ sparse_weight * sparse` from raw calculation (line 88)
+- `+ sparse_weight` from weight_sum calculation (line 96)
+- Update module docstring to remove `sparse: 0.00` line
+
+- [ ] **Step 4: Remove sparse_weight from all classifier profiles**
+
+In `query_classifier.py`, delete the `"sparse_weight": 0.0` line from all 6 entries in `QUERY_PROFILE_WEIGHTS` dict (lines 38, 47, 56, 65, 74, 83).
+
+- [ ] **Step 5: Update test_custom_weights in test_scoring.py**
+
+The existing `test_custom_weights` passes `sparse_weight=0.0` explicitly. Remove that param:
+
+```python
+    def test_custom_weights(self) -> None:
+        score = compute_signal_score(
+            channel_scores={"dense": 1.0},
+            recency=0.0,
+            balance=0.0,
+            dense_weight=0.5,
+            graph_weight=0.1,
+            metadata_weight=0.1,
+            recency_weight=0.1,
+            balance_weight=0.1,
+        )
+        expected = 0.5 / 0.9
+        assert abs(score - expected) < 0.001
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pytest tests/unit/test_scoring.py tests/unit/test_query_classifier.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/metatron/retrieval/scoring.py src/metatron/retrieval/query_classifier.py tests/unit/test_scoring.py
+git commit -m "refactor: remove dead sparse_weight path from scoring pipeline"
+```
+
+---
+
+### Task 2: Cache `_result_type()` in scoring loop
+
+**Context:** `_result_type(mem)` is called twice per merged result in `hybrid_search_and_answer()` — once for `Counter` (line 573) and once for `source_balance()` (line 589). Cache it.
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py:572-595`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_search_quality_tuning.py (new file)
+def test_result_type_called_once_per_candidate():
+    """_result_type should be cached — called once per merged result, not twice."""
+    import ast
+    import inspect
+    from metatron.retrieval import search
+
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    tree = ast.parse(source)
+    # Count occurrences of _result_type in the scoring loop
+    # After fix: should use cached type_cache dict
+    assert "type_cache" in source or "_result_type(mem)" not in source.split("source_balance")[1]
+```
+
+- [ ] **Step 2: Implement — replace two calls with one cached lookup**
+
+In `search.py`, replace lines 572-589:
+
+```python
+    # -- Multi-signal scoring --
+    type_cache: dict[str, str] = {}
+    for mr in merged:
+        mem = mr["memory"]
+        cid = mr["chunk_id"]
+        type_cache[cid] = _result_type(mem)
+
+    type_counts: dict[str, int] = Counter(type_cache.values())
+    total_merged = len(merged)
+
+    _scoring_weights = {k: v for k, v in _profile_weights.items() if k != "blend_weight"}
+
+    for mr in merged:
+        mem = mr["memory"]
+        cid = mr["chunk_id"]
+        date_str = mem.get("date") or (mem.get("payload") or {}).get("date")
+        rec = 1.0
+        if date_str:
+            try:
+                dt = datetime.fromisoformat(str(date_str))
+                rec = recency_score(dt)
+            except (ValueError, TypeError):
+                rec = 1.0
+        bal = source_balance(type_cache[cid], type_counts, total_merged)
+        mr["signal_score"] = compute_signal_score(
+            channel_scores=mr["channel_scores"],
+            recency=rec,
+            balance=bal,
+            **_scoring_weights,
+        )
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/unit/test_search_quality_tuning.py tests/unit/test_scoring.py tests/unit/test_evidence_packs.py -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/metatron/retrieval/search.py tests/unit/test_search_quality_tuning.py
+git commit -m "perf: cache _result_type lookup in scoring loop"
+```
+
+---
+
+### Task 3: Extract scores from memory dicts into score_map
+
+**Context:** Lines 590-614 in `search.py` mutate shared memory dicts with `b["_signal_score"]` and `r["_final_score"]`. These internal scores leak into consumer dicts. Use a separate `score_map` dict keyed by chunk_id.
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py:590-616`
+- Test: `tests/unit/test_search_quality_tuning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_memory_dicts_not_mutated_with_internal_scores():
+    """Internal scoring keys (_signal_score, _final_score) must not leak into memory dicts."""
+    import inspect
+    from metatron.retrieval import search
+
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    assert '["_signal_score"]' not in source
+    assert '["_final_score"]' not in source
+```
+
+- [ ] **Step 2: Implement score_map**
+
+Replace the scoring mutation pattern. After computing `mr["signal_score"]` for each merged result, create a `score_map`:
+
+```python
+    # Build score_map keyed by chunk_id (no mutation of memory dicts)
+    score_map: dict[str, float] = {mr["chunk_id"]: mr.get("signal_score", 0) for mr in merged}
+
+    merged.sort(key=lambda x: x.get("signal_score", 0), reverse=True)
+
+    pool_size = _s.rerank_pool_size if _s.reranker_enabled else len(merged)
+    base = [mr["memory"] for mr in merged[:pool_size]]
+
+    _pre_rerank_count = len(base)
+    if _s.reranker_enabled:
+        from metatron.retrieval.reranker import rerank
+        base = rerank(query=rq, results=base, top_k=len(base))
+        normalize_rerank_scores(base)
+        for r in base:
+            cid = str(r.get("id", ""))
+            score_map[cid] = compute_final_score(
+                signal_score=score_map.get(cid, 0),
+                rerank_score=r.get("rerank_score", 0),
+                blend_weight=_profile_weights["blend_weight"],
+            )
+        base.sort(key=lambda x: score_map.get(
+            str(x.get("id", "")), 0
+        ), reverse=True)
+    base = base[:k]
+    _post_rerank_count = len(base)
+```
+
+**Note:** Each result dict preserves the `id` field through reranking, so `str(r.get("id", ""))` is the safe key for score_map lookups. No index alignment needed.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/unit/test_search_quality_tuning.py tests/unit/test_evidence_packs.py tests/unit/test_search_trace_extended.py -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/metatron/retrieval/search.py tests/unit/test_search_quality_tuning.py
+git commit -m "refactor: extract internal scores to score_map, stop mutating memory dicts"
+```
+
+---
+
+### Task 4: Update spec wording on weight normalization
+
+**Context:** D1 from backlog. Spec at `docs/superpowers/specs/2026-03-26-unified-reranking-design.md` already says "sum of all weights" (line 59-62). The backlog item is resolved — the spec matches the code. Just add a clarifying note.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-26-unified-reranking-design.md`
+
+- [ ] **Step 1: Add clarifying note to spec**
+
+After line 62 (`"This intentionally penalizes candidates..."` paragraph), add:
+
+```
+> **Note (2026-03-26):** Normalization divides by sum of **all** configured weights, not just active/non-zero ones. This is intentional — single-channel results are penalized. This matches the implementation in `scoring.py:compute_signal_score()`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-26-unified-reranking-design.md
+git commit -m "docs: clarify weight normalization in unified reranking spec"
+```
+
+---
+
+### Task 5: Smooth gradient for `source_balance()`
+
+**Context:** Q2 from backlog. Currently binary (0 or 1) at 40% threshold. Replace with smooth gradient: as a source type approaches the threshold, bonus decays linearly from 1.0 to 0.0.
+
+**Files:**
+- Modify: `src/metatron/retrieval/scoring.py:44-57`
+- Test: `tests/unit/test_scoring.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_scoring.py
+from metatron.retrieval.scoring import source_balance
+
+def test_source_balance_smooth_gradient():
+    """source_balance returns smooth values between 0 and 1, not binary."""
+    # 30% of pool — under threshold, should be close to 1.0
+    counts = {"jira": 3, "confluence": 7}
+    score = source_balance("jira", counts, 10)
+    assert 0.2 < score < 1.0  # Not exactly 1.0 — smooth decay
+
+def test_source_balance_at_threshold_is_zero():
+    """At or above threshold (40%), score is 0."""
+    counts = {"jira": 4, "confluence": 6}
+    assert source_balance("jira", counts, 10) == 0.0
+
+def test_source_balance_rare_source_near_one():
+    """Rare source (10%) gets score near 1.0."""
+    counts = {"jira": 1, "confluence": 9}
+    score = source_balance("jira", counts, 10)
+    assert score > 0.7
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest tests/unit/test_scoring.py::test_source_balance_smooth_gradient -v`
+Expected: FAIL — current binary returns exactly 1.0 for 30%
+
+- [ ] **Step 3: Implement smooth gradient**
+
+```python
+def source_balance(
+    source_type: str,
+    type_counts: dict[str, int],
+    total: int,
+    threshold: float = 0.4,
+) -> float:
+    """Return smooth penalty for overrepresented source types.
+
+    Score decays linearly from 1.0 (absent) to 0.0 (at threshold).
+    Sources above the threshold get 0.0.
+    """
+    if total == 0:
+        return 1.0
+    ratio = type_counts.get(source_type, 0) / total
+    if ratio >= threshold:
+        return 0.0
+    return 1.0 - (ratio / threshold)
+```
+
+- [ ] **Step 4: Update existing TestSourceBalance tests for smooth gradient**
+
+The smooth gradient changes the contract — 4 of 5 existing tests need new assertions:
+
+```python
+class TestSourceBalance:
+    def test_underrepresented_gets_bonus(self) -> None:
+        # ratio = 1/6 = 0.167 → 1.0 - (0.167/0.4) ≈ 0.583
+        type_counts = {"jira": 5, "confluence": 1}
+        score = source_balance("confluence", type_counts, 6)
+        assert 0.5 < score < 0.7
+
+    def test_overrepresented_gets_zero(self) -> None:
+        # ratio = 5/6 = 0.833 → >= threshold → 0.0
+        type_counts = {"jira": 5, "confluence": 1}
+        assert source_balance("jira", type_counts, 6) == 0.0
+
+    def test_even_split_still_over_threshold(self) -> None:
+        # ratio = 3/6 = 0.5 → >= threshold → 0.0
+        type_counts = {"jira": 3, "confluence": 3}
+        assert source_balance("jira", type_counts, 6) == 0.0
+
+    def test_three_types_balanced(self) -> None:
+        # ratio = 2/6 = 0.333 → 1.0 - (0.333/0.4) ≈ 0.167
+        type_counts = {"jira": 2, "confluence": 2, "upload": 2}
+        score = source_balance("jira", type_counts, 6)
+        assert 0.1 < score < 0.3
+
+    def test_empty_pool(self) -> None:
+        assert source_balance("jira", {}, 0) == 1.0
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/unit/test_scoring.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/metatron/retrieval/scoring.py tests/unit/test_scoring.py
+git commit -m "feat: smooth gradient for source_balance (linear decay to threshold)"
+```
+
+---
+
+### Task 6: Tune RERANK_POOL_SIZE (50 → 35)
+
+**Context:** P2 from backlog. Cross-encoder processes 50 candidates. Reduce to 35 — lower inference cost. Verify via eval-compare.
+
+**Files:**
+- Modify: `src/metatron/core/config.py:142`
+
+- [ ] **Step 1: Change default**
+
+```python
+# config.py line 142
+rerank_pool_size: int = 35  # was 50
+```
+
+- [ ] **Step 2: Run eval-compare**
+
+Run: `make eval-compare`
+Expected: P@10/MRR/NDCG deltas within ±0.02 (acceptable variance)
+
+- [ ] **Step 3: If metrics regress >2%, revert to 40 and re-test**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/metatron/core/config.py
+git commit -m "perf: reduce RERANK_POOL_SIZE from 50 to 35"
+```
+
+---
+
+### Task 7: Confidence threshold for negative/vague queries
+
+**Context:** Q3 from backlog. Negative accuracy = 0%. All queries return 10 docs even when nothing is relevant. Add a minimum `signal_score` threshold — if the best candidate is below it, return a "no information found" response.
+
+**Files:**
+- Modify: `src/metatron/core/config.py`
+- Modify: `src/metatron/retrieval/search.py`
+- Test: `tests/unit/test_search_quality_tuning.py`
+
+- [ ] **Step 1: Add config field**
+
+```python
+# config.py — add near rerank_pool_size
+min_signal_score: float = 0.0  # 0.0 = disabled (all results returned). Set > 0 to filter low-confidence results.
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+def test_low_confidence_results_filtered_when_threshold_set():
+    """When min_signal_score > 0, candidates below threshold are dropped."""
+    # This test will be integration-level — mock the scoring to produce
+    # low scores, verify that base list is filtered before LLM call.
+    import inspect
+    from metatron.retrieval import search
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    assert "min_signal_score" in source
+```
+
+- [ ] **Step 3: Implement confidence filter in search.py**
+
+After `merged.sort(...)` and before `base = [mr["memory"] for mr in merged[:pool_size]]`, add:
+
+```python
+    # -- Confidence filter: drop candidates below threshold --
+    if _s.min_signal_score > 0:
+        merged = [mr for mr in merged if mr.get("signal_score", 0) >= _s.min_signal_score]
+        if not merged:
+            no_info = "I don't have enough information to answer this question."
+            if lang.lower() == "russian":
+                no_info = "У меня недостаточно информации для ответа на этот вопрос."
+            if return_trace:
+                return {
+                    "answer": no_info,
+                    "source_results": [],
+                    "fragments": [],
+                    "graph_entities": [],
+                    "graph_relations": [],
+                    "graph_docs": [],
+                    "pipeline_stages": {
+                        "original_query": rq,
+                        "translated_query": sq,
+                        "expanded_query": eq,
+                        "detected_language": lang,
+                        "recall_dense_count": len(dense_results),
+                        "recall_exact_count": len(exact_results),
+                        "recall_metadata_count": len(metadata_results),
+                        "recall_graph_count": len(graph_results),
+                        "recall_total_unique": 0,
+                        "pre_rerank_count": 0,
+                        "post_rerank_count": 0,
+                        "signal_scored_count": total_merged,
+                        "rerank_pool_count": 0,
+                        "fragment_count": 0,
+                        "primary_fragment_count": 0,
+                        "supporting_fragment_count": 0,
+                        "token_budget_used": 0,
+                        "query_profile": classification["profile"],
+                        "query_profile_method": classification["method"],
+                        "query_profile_confidence": classification["confidence"],
+                    },
+                    "retrieved_doc_labels": [],
+                }
+            return no_info
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/unit/test_search_quality_tuning.py tests/unit/test_evidence_packs.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metatron/core/config.py src/metatron/retrieval/search.py tests/unit/test_search_quality_tuning.py
+git commit -m "feat: add min_signal_score threshold for low-confidence query filtering"
+```
+
+**Note:** Default is 0.0 (disabled). Optimal threshold TBD via grid search (Task 10). Enable by setting `METATRON_MIN_SIGNAL_SCORE=0.15` (or whatever value grid search finds).
+
+---
+
+### Task 8: LRU cache for `recall_graph` Memgraph queries
+
+**Context:** P3 from backlog. `get_graph_entities()` and `get_doc_labels_by_entities()` hit Memgraph on every search. Add LRU cache with workspace-scoped key.
+
+**Files:**
+- Modify: `src/metatron/retrieval/channels.py:247-310`
+- Test: `tests/unit/test_search_quality_tuning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_recall_graph_caches_entity_lookups():
+    """Second call with same seeds should hit cache, not Memgraph."""
+    from unittest.mock import patch, MagicMock
+    from metatron.retrieval.channels import recall_graph, RecallContext, _cached_get_graph_entities
+
+    ctx = RecallContext(
+        original_query="test",
+        translated_query="test",
+        expanded_query="test",
+        detected_language="en",
+        workspace_id="ws1",
+        access_filter=None,
+        settings=MagicMock(recall_top_n_graph=5, recall_graph_max_depth=2),
+        extracted_jira_keys=["MTRNIX-104"],
+        extracted_title_entities=[],
+        extracted_dates=None,
+        detected_person=[],
+        is_activity_query=False,
+    )
+
+    with patch("metatron.retrieval.channels.get_graph_entities") as mock_ents, \
+         patch("metatron.retrieval.channels.get_doc_labels_by_entities") as mock_labels, \
+         patch("metatron.retrieval.channels.get_graph_relationships") as mock_rels, \
+         patch("metatron.retrieval.channels.get_hybrid_store") as mock_store:
+        mock_ents.return_value = [{"name": "Auth"}]
+        mock_labels.return_value = [{"doc_label": "jira:MTRNIX-104"}]
+        mock_rels.return_value = []
+        mock_store.return_value.search_by_doc_labels.return_value = []
+
+        _cached_get_graph_entities.cache_clear()
+        recall_graph(ctx)
+        recall_graph(ctx)
+
+        # get_graph_entities called only once (second call hits cache)
+        assert mock_ents.call_count == 1
+```
+
+- [ ] **Step 2: Implement LRU cache in channels.py**
+
+Add at module level:
+
+```python
+from functools import lru_cache
+
+# Cache graph entity lookups — key is (workspace_id, frozenset(query_texts))
+# maxsize=128 covers typical concurrent workspaces * query variety
+@lru_cache(maxsize=128)
+def _cached_get_graph_entities(
+    query_texts: tuple[str, ...], workspace_id: str | None,
+) -> tuple[dict, ...]:
+    return tuple(get_graph_entities(list(query_texts), workspace_id=workspace_id))
+
+```
+
+Then in `recall_graph()`, replace:
+```python
+graph_ents = get_graph_entities([query_for_ner], workspace_id=ctx.workspace_id)
+```
+with:
+```python
+graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/unit/test_search_quality_tuning.py tests/unit/test_recall_channels.py -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/metatron/retrieval/channels.py tests/unit/test_search_quality_tuning.py
+git commit -m "perf: LRU cache for graph entity lookups in recall_graph"
+```
+
+---
+
+### Task 9: Async recall channels via `asyncio.gather()`
+
+**Context:** P1 from backlog. 4 recall channels run sequentially. Each makes independent Qdrant/Memgraph calls. Wrap in async + gather for parallel execution. Since `hybrid_search_and_answer()` is sync (called via `asyncio.to_thread()`), use `asyncio.run()` for the parallel gather.
+
+**Files:**
+- Modify: `src/metatron/retrieval/search.py:562-566`
+- Test: `tests/unit/test_search_quality_tuning.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_recall_channels_run_in_parallel():
+    """Recall channels should use asyncio.gather, not sequential calls."""
+    import inspect
+    from metatron.retrieval import search
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    # After implementation, should contain gather or _run_recall_channels
+    assert "gather" in source or "_run_recall_channels" in source
+```
+
+- [ ] **Step 2: Implement parallel recall**
+
+Add helper function in `search.py`:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+_recall_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="recall")
+
+
+def _run_recall_channels(ctx: RecallContext) -> tuple[list, list, list, list]:
+    """Run 4 recall channels in parallel using thread pool.
+
+    Each channel is sync (Qdrant/Memgraph clients are sync), so we use
+    threads for true parallelism. Returns (dense, exact, metadata, graph).
+    """
+    futures = [
+        _recall_executor.submit(recall_dense, ctx),
+        _recall_executor.submit(recall_exact, ctx),
+        _recall_executor.submit(recall_metadata, ctx),
+        _recall_executor.submit(recall_graph, ctx),
+    ]
+    return tuple(f.result() for f in futures)
+```
+
+Replace lines 562-566:
+```python
+    # -- Run 4 recall channels in parallel --
+    dense_results, exact_results, metadata_results, graph_results = _run_recall_channels(recall_ctx)
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pytest tests/unit/test_search_quality_tuning.py tests/unit/test_evidence_packs.py tests/unit/test_search_trace_extended.py -v`
+Expected: All PASS
+
+- [ ] **Step 4: Run eval to verify no regression from parallelization**
+
+Run: `make eval`
+Expected: Metrics within ±0.01 of previous run (parallelization doesn't change results, only latency)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metatron/retrieval/search.py tests/unit/test_search_quality_tuning.py
+git commit -m "perf: parallel recall channels via ThreadPoolExecutor"
+```
+
+---
+
+### Task 10: Grid search script for scoring weights
+
+**Context:** Q1 from backlog. Write a script that systematically tests weight combinations and finds the optimal set for each profile. Uses the existing eval infrastructure.
+
+**Files:**
+- Create: `scripts/grid_search_weights.py`
+- Modify: `Makefile` (add `grid-search` target)
+
+- [ ] **Step 1: Write the grid search script**
+
+```python
+#!/usr/bin/env python3
+"""Grid search for optimal scoring weights per query profile.
+
+Systematically tests weight combinations using the eval test set
+and reports best-performing weights by MRR + NDCG@10.
+
+Usage:
+    python scripts/grid_search_weights.py                    # search all profiles
+    python scripts/grid_search_weights.py --profile execution  # search one profile
+    python scripts/grid_search_weights.py --metric mrr         # optimize for MRR
+    python scripts/grid_search_weights.py --top 5              # show top 5 results
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Stub benchmark_qed
+if "benchmark_qed" not in sys.modules:
+    _mock = MagicMock()
+    for _name in [
+        "benchmark_qed", "benchmark_qed.autoe",
+        "benchmark_qed.autoe.assertion_scores",
+        "benchmark_qed.autod", "benchmark_qed.autod.data_model",
+        "benchmark_qed.autod.data_model.text_unit",
+        "benchmark_qed.autod.data_processor",
+        "benchmark_qed.autod.data_processor.embedding",
+        "benchmark_qed.autod.sampler",
+        "benchmark_qed.autod.sampler.clustering",
+        "benchmark_qed.autod.sampler.clustering.kmeans",
+        "benchmark_qed.autoq", "benchmark_qed.autoq.data_model",
+        "benchmark_qed.autoq.data_model.question",
+        "benchmark_qed.autoq.question_gen",
+        "benchmark_qed.autoq.question_gen.data_questions",
+        "benchmark_qed.autoq.question_gen.data_questions.global_question_gen",
+        "benchmark_qed.autoq.question_gen.data_questions.local_question_gen",
+    ]:
+        sys.modules[_name] = _mock
+
+from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+
+
+def _weight_grid(step: float = 0.05) -> list[dict[str, float]]:
+    """Generate weight combinations that sum to ~0.85 (excluding blend)."""
+    values = [round(v, 2) for v in [i * step for i in range(int(0.5 / step) + 1)]]
+    combos = []
+    for dense, graph, metadata, recency, balance in itertools.product(
+        values, values, values, values, [0.05],
+    ):
+        total = dense + graph + metadata + recency + balance
+        if 0.80 <= total <= 0.90:
+            combos.append({
+                "dense_weight": dense,
+                "graph_weight": graph,
+                "metadata_weight": metadata,
+                "recency_weight": recency,
+                "balance_weight": balance,
+            })
+    return combos
+
+
+def _blend_grid(step: float = 0.05) -> list[float]:
+    """Generate blend_weight values."""
+    return [round(v, 2) for v in [i * step for i in range(1, 10)]]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Grid search for scoring weights")
+    parser.add_argument("--profile", default=None, help="Single profile to search")
+    parser.add_argument("--metric", default="combined",
+                        choices=["mrr", "ndcg", "precision", "combined"],
+                        help="Metric to optimize")
+    parser.add_argument("--top", type=int, default=3, help="Show top N results")
+    parser.add_argument("--step", type=float, default=0.10,
+                        help="Weight grid step size (default 0.10)")
+    parser.add_argument("--workspace", default="MTRNIX")
+    args = parser.parse_args()
+
+    profiles = [args.profile] if args.profile else list(QUERY_PROFILE_WEIGHTS.keys())
+    weight_combos = _weight_grid(step=args.step)
+    blend_values = _blend_grid(step=args.step)
+
+    print(f"Grid: {len(weight_combos)} signal combos × {len(blend_values)} blend values")
+    print(f"Profiles: {profiles}")
+    print(f"Optimizing: {args.metric}")
+    print()
+
+    # Import eval infrastructure — uses run_eval's internal API
+    # The grid search script calls hybrid_search_and_answer directly
+    # with return_trace=True to get per-query metrics
+    from metatron.retrieval.search import hybrid_search_and_answer
+
+    # Load eval set from the benchmarker test set
+    from metatron.benchmarker.services.eval import load_eval_set
+    eval_set = load_eval_set(args.workspace)
+    if not eval_set:
+        print("ERROR: No eval set found.")
+        return
+
+    best_per_profile: dict[str, dict] = {}
+
+    for profile in profiles:
+        print(f"\n{'='*60}")
+        print(f"Profile: {profile}")
+        print(f"{'='*60}")
+
+        results = []
+        total = len(weight_combos) * len(blend_values)
+
+        for i, (weights, blend) in enumerate(
+            itertools.product(weight_combos, blend_values)
+        ):
+            full_weights = {**weights, "blend_weight": blend}
+            # Temporarily override profile weights
+            QUERY_PROFILE_WEIGHTS[profile] = full_weights
+
+            metrics = run_eval_queries(eval_set, args.workspace, profile_filter=profile)
+            score = _compute_objective(metrics, args.metric)
+
+            results.append({"weights": full_weights, "metrics": metrics, "score": score})
+
+            if (i + 1) % 50 == 0:
+                print(f"  [{i+1}/{total}] best so far: {max(r['score'] for r in results):.4f}")
+
+        results.sort(key=lambda x: x["score"], reverse=True)
+        best_per_profile[profile] = results[0]
+
+        print(f"\nTop {args.top} for {profile}:")
+        for j, r in enumerate(results[:args.top]):
+            w = r["weights"]
+            m = r["metrics"]
+            print(f"  #{j+1}: score={r['score']:.4f} "
+                  f"P@10={m.get('precision_at_k', 0):.4f} "
+                  f"MRR={m.get('mrr', 0):.4f} "
+                  f"NDCG={m.get('ndcg_at_k', 0):.4f}")
+            print(f"       weights: {json.dumps(w)}")
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("RECOMMENDED WEIGHTS")
+    print(f"{'='*60}")
+    for profile, best in best_per_profile.items():
+        print(f"\n{profile}:")
+        print(f"  {json.dumps(best['weights'], indent=4)}")
+
+
+def _compute_objective(metrics: dict, metric: str) -> float:
+    if metric == "mrr":
+        return metrics.get("mrr", 0)
+    elif metric == "ndcg":
+        return metrics.get("ndcg_at_k", 0)
+    elif metric == "precision":
+        return metrics.get("precision_at_k", 0)
+    else:  # combined
+        return (
+            0.4 * metrics.get("mrr", 0)
+            + 0.4 * metrics.get("ndcg_at_k", 0)
+            + 0.2 * metrics.get("precision_at_k", 0)
+        )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Add Makefile target**
+
+```makefile
+grid-search:
+	.venv/bin/python scripts/grid_search_weights.py --workspace $(or $(WORKSPACE),MTRNIX) --step 0.10
+```
+
+- [ ] **Step 3: Test the script runs**
+
+Run: `python scripts/grid_search_weights.py --help`
+Expected: Usage printed, no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/grid_search_weights.py Makefile
+git commit -m "feat: add grid search script for scoring weight optimization"
+```
+
+**Note:** Actual grid search run is a post-merge activity (takes 30+ minutes per profile). Script provides the infrastructure; optimal weights are applied in a follow-up commit.
+
+---
+
+## Execution Order
+
+Tasks are independent except:
+- Task 2 before Task 3 (both modify same lines in search.py)
+- Task 6 needs eval infrastructure running
+
+Recommended: 1 → 5 → 2 → 3 → 4 → 7 → 8 → 9 → 6 → 10
+
+Run eval after Task 9 (all code changes done) to get combined delta.

--- a/docs/superpowers/search-quality-backlog.md
+++ b/docs/superpowers/search-quality-backlog.md
@@ -2,103 +2,49 @@
 
 > Доработки и улучшения, выявленные в ходе реализации эпика
 > "Investigate and improve search quality to reduce hallucinations".
-> Приоритет: после завершения основных задач эпика.
 
 ---
 
-## Performance
+## Выполнено (PR #46: feature/search-quality-tuning)
 
-### P1: Параллельный запуск recall channels
-**Проблема:** 4 recall channel'а (dense, exact, metadata, graph) выполняются последовательно — каждый делает отдельный запрос к Qdrant/Memgraph. Общее время поиска выросло с ~8 мин (44 запроса) до ~15 мин (~20с на запрос vs ~11с).
-**Решение:** `asyncio.gather(recall_dense, recall_exact, recall_metadata, recall_graph)` — сократит latency этапа recall в 3-4 раза.
-**Сложность:** Средняя. Нужен async рефакторинг recall функций в channels.py.
-**Источник:** PR #43 code review, замеры eval.
+| ID | Задача | Решение |
+|----|--------|---------|
+| **P1** | Параллельный запуск recall channels | `ThreadPoolExecutor(max_workers=4)` в search.py |
+| **P2** | Уменьшить RERANK_POOL_SIZE | 50 → 35, eval подтвердил: без регрессии |
+| **P3** | Кэширование recall_graph | `@lru_cache(maxsize=128)` на `_cached_get_graph_entities` |
+| **Q1** | Grid search по весам | Скрипт `scripts/grid_search_weights.py`, `make grid-search` |
+| **Q2** | Smooth gradient для source_balance | Линейный decay `1.0 - (ratio / threshold)` |
+| **Q3** | Confidence threshold | `min_signal_score` в config (default 0.0 = disabled) |
+| **C1** | Score leak в memory dicts | `score_map: dict[str, float]` по chunk_id |
+| **C2** | Кэширование _result_type | `type_cache` dict в scoring loop |
+| **C3** | Dead sparse_weight path | Удалён из scoring.py и query_classifier.py |
+| **D1** | Spec vs code — нормализация | Спека обновлена: делится на сумму ВСЕХ весов |
 
-### P2: Уменьшить RERANK_POOL_SIZE
-**Проблема:** Cross-encoder обрабатывает 50 кандидатов вместо прежних 25. Удвоение cost inference.
-**Решение:** Тюнинг `RERANK_POOL_SIZE` — оценить 30-35 как компромисс. Проверить через eval что качество не падает.
-**Сложность:** Низкая. Изменение одного env var + eval-compare.
-**Источник:** PR #43 code review, issue #3.
-
-### P3: Кэширование recall_graph
-**Проблема:** Memgraph query на каждый поиск — относительно медленный.
-**Решение:** LRU cache для graph entity lookup по workspace_id + entity set.
-**Сложность:** Низкая.
+**Eval результат:** P@10=0.379 (+0.012), MRR=0.707 (+0.017), NDCG=0.649 (+0.017) vs pre-tuning.
 
 ---
 
-## Quality Tuning
+## Оставшиеся задачи
 
-### Q1: Grid search по весам scoring формулы
-**Проблема:** Текущие дефолты (dense=0.35, graph=0.15, metadata=0.20, recency=0.10, balance=0.05, blend=0.3) выбраны экспертно, не оптимизированы.
-**Решение:** Grid/random search по весам с eval test set как objective function. Оптимизировать по MRR + NDCG@10.
-**Сложность:** Низкая технически, нужно время на прогоны.
+### 1. Запуск grid search (приоритет: высокий)
+Инфраструктура готова (`make grid-search`). Нужен прогон ~30 мин/профиль + применение оптимальных весов в `QUERY_PROFILE_WEIGHTS`. Основной ожидаемый gain по NDCG.
 
-### Q2: Smooth gradient для source_balance
-**Проблема:** Бинарный бонус (0 или 1) на пороге 40% — резкий boundary effect.
-**Решение:** `max(0, 1 - count/total/threshold)` — плавный градиент.
-**Сложность:** Низкая. Одна функция в scoring.py.
-**Источник:** PR #43 code review, issue #4.
+### 2. Калибровка min_signal_score (приоритет: средний)
+Threshold disabled by default. Нужен eval для подбора порога → включить → замерить Negative Accuracy (сейчас 0%).
 
-### Q3: Negative accuracy = 0%
-**Проблема:** Все negative/vague/greeting запросы возвращают 10 документов. Система не умеет отказывать.
-**Решение:** Confidence threshold на signal_score — если все кандидаты ниже порога, не отвечать.
-**Сложность:** Средняя. Нужен порог + eval для калибровки.
+### 3. Async migration (приоритет: низкий, tech debt)
+14 TODO-комментариев `# TODO: async migration` в `retrieval/` и `storage/qdrant.py`. Весь search pipeline синхронный, вызывается через `asyncio.to_thread()`. P1 обошёл это через ThreadPoolExecutor.
 
 ---
 
-## Code Quality
+## Known Issues
 
-### C1: Очистить _signal_score/_final_score leak в memory dicts
-**Проблема:** Internal scores записываются в memory dict объекты (`b["_signal_score"]`, `r["_final_score"]`). Мутация shared dicts.
-**Решение:** Отдельный `score_map: dict[str, float]` по chunk_id вместо мутации.
-**Сложность:** Низкая.
-**Источник:** PR #43 code review, issue #1.
-
-### C2: Кэширование _result_type в scoring loop
-**Проблема:** `_result_type()` вызывается дважды на каждый merged result (для Counter и для source_balance).
-**Решение:** Вычислить один раз в начале цикла.
-**Сложность:** Тривиально.
-**Источник:** PR #43 code review, issue #5.
-
-### C3: Убрать dead sparse_weight path
-**Проблема:** `sparse_weight=0.0` — channel "sparse" нигде не генерируется, код в compute_signal_score — dead path.
-**Решение:** Убрать до появления sparse channel.
-**Сложность:** Тривиально.
-**Источник:** PR #43 code review, issue #8.
+- **ru-01 false positive**: «Что такое Метатрон?» → `relationship` вместо `documentation` (LLM перевод содержит "relat*")
+- **Ollama model swapping**: Classifier adds latency → Ollama unloads embedding model. Fix: `OLLAMA_KEEP_ALIVE=-1`
+- **Post-deploy**: Нужен full reindex для source_role в Qdrant payload + manual spot-check 10 queries
 
 ---
 
-## Spec/Doc Updates
+## Query Classifier — Known Gaps
 
-### D1: Reconcile spec vs code на нормализацию весов
-**Проблема:** Спека говорит "normalized by sum of active weights", код делит на сумму всех весов. Код правильнее — штрафует single-channel results.
-**Решение:** Обновить формулировку в спеке.
-**Источник:** PR #43 code review, issue #2.
-
----
-
-## Query Classifier — Eval Results & Known Issues
-
-### Eval baseline (2026-03-26, classifier ON vs OFF)
-
-| Metric | Classifier OFF | Classifier ON | Delta |
-|--------|---------------|---------------|-------|
-| P@10 | baseline | +0.0014 | ~flat |
-| MRR | baseline | -0.0345 | regression |
-| NDCG@10 | baseline | -0.0453 | regression |
-
-**Вывод:** Классификатор в текущем виде не улучшает метрики. Нужна тонкая настройка весов профилей или grid search (см. Q1). Классификатор оставлен включённым (`QUERY_CLASSIFIER_ENABLED=True`) как инфраструктура для дальнейшей оптимизации.
-
-### Known Issue: ru-01 false positive (relationship)
-**Проблема:** Запрос «Что такое Метатрон?» классифицируется как `relationship` вместо `documentation`. Причина: перевод через LLM содержит слово "relat*", которое матчится в rule gate (`_RELATIONSHIP_KW`).
-**Влияние:** Русские запросы с переводом, содержащим relationship-слова, получают неверный профиль.
-**Приоритет:** Низкий — фокус пока не на русском языке.
-**Возможные фиксы:** (a) ужесточить regex для relationship, (b) не применять rule gate к переведённым запросам, только LLM fallback.
-
-### Performance: Ollama model swapping
-**Проблема:** Eval 44 запросов занял 112 мин (vs 17 мин без классификатора). Причина — каскадный эффект:
-1. Классификатор добавляет 1-2 вызова DeepSeek API на запрос (перевод для classifier + LLM fallback)
-2. Увеличенные паузы между embedding-вызовами к Ollama → Ollama выгружает `nomic-embed-text` по idle timeout → каждый последующий embedding-вызов ждёт reload модели (~30-60 сек)
-**Фикс:** `OLLAMA_KEEP_ALIVE=-1` (не выгружать модель) или `curl /api/embeddings -d '{"model":"nomic-embed-text","keep_alive":-1}'` перед eval.
-**Рекомендация:** Добавить `OLLAMA_KEEP_ALIVE=-1` в docker-compose и документацию по развёртыванию.
+Классификатор в текущем виде не улучшает метрики (MRR -0.035, NDCG -0.045 vs baseline). Оставлен включённым как инфраструктура. Ожидается улучшение после grid search по весам профилей.

--- a/docs/superpowers/search-quality-backlog.md
+++ b/docs/superpowers/search-quality-backlog.md
@@ -32,13 +32,17 @@
 ### 2. Калибровка min_signal_score (приоритет: средний)
 Threshold disabled by default. Нужен eval для подбора порога → включить → замерить Negative Accuracy (сейчас 0%).
 
-### 3. Async migration (приоритет: низкий, tech debt)
+### 3. Инвалидация graph entity cache после sync (приоритет: средний)
+`_cached_get_graph_entities` в `channels.py` — LRU cache без TTL (maxsize=128). После sync в Memgraph кэш содержит stale данные до LRU eviction. Нужно: подписаться на `SYNC_COMPLETED` event и вызвать `cache_clear()`. Prerequisite: EventBus должен emit'ить `SYNC_COMPLETED` (сейчас event определён, но не emit'ится нигде).
+
+### 4. Async migration (приоритет: низкий, tech debt)
 14 TODO-комментариев `# TODO: async migration` в `retrieval/` и `storage/qdrant.py`. Весь search pipeline синхронный, вызывается через `asyncio.to_thread()`. P1 обошёл это через ThreadPoolExecutor.
 
 ---
 
 ## Known Issues
 
+- **Graph cache staleness**: `_cached_get_graph_entities` (LRU, no TTL) — stale после sync. При текущей частоте sync (раз в несколько часов) и размере кэша (128) — практически не влияет. Будет решено после подключения EventBus к sync lifecycle
 - **ru-01 false positive**: «Что такое Метатрон?» → `relationship` вместо `documentation` (LLM перевод содержит "relat*")
 - **Ollama model swapping**: Classifier adds latency → Ollama unloads embedding model. Fix: `OLLAMA_KEEP_ALIVE=-1`
 - **Post-deploy**: Нужен full reindex для source_role в Qdrant payload + manual spot-check 10 queries

--- a/docs/superpowers/specs/2026-03-26-unified-reranking-design.md
+++ b/docs/superpowers/specs/2026-03-26-unified-reranking-design.md
@@ -61,6 +61,8 @@ signal_score = raw / sum_of_all_weights   # normalized to [0, 1]
 
 Output is normalized by dividing by the sum of **all** configured weights (not just active/non-zero signals). This intentionally penalizes candidates that score well on only one channel — a result with only a dense score gets `0.35/0.85 ≈ 0.41`, while a result with all signals at 1.0 gets `0.85/0.85 = 1.0`. This prevents single-channel results from dominating the ranking.
 
+> **Note (2026-03-26):** Normalization divides by sum of **all** configured weights, not just active/non-zero ones. This is intentional — single-channel results are penalized. This matches the implementation in `scoring.py:compute_signal_score()`.
+
 ### Signal sources
 
 | Signal | Source | Notes |

--- a/scripts/grid_search_weights.py
+++ b/scripts/grid_search_weights.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Grid search for optimal scoring weights per query profile.
+
+Systematically tests weight combinations using the eval test set
+and reports best-performing weights by MRR + NDCG@10.
+
+Usage:
+    python scripts/grid_search_weights.py                      # search all profiles
+    python scripts/grid_search_weights.py --profile execution   # search one profile
+    python scripts/grid_search_weights.py --metric mrr          # optimize for MRR
+    python scripts/grid_search_weights.py --top 5               # show top 5 results
+"""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Stub benchmark_qed (same as run_eval.py)
+if "benchmark_qed" not in sys.modules:
+    _mock = MagicMock()
+    for _name in [
+        "benchmark_qed", "benchmark_qed.autoe",
+        "benchmark_qed.autoe.assertion_scores",
+        "benchmark_qed.autod", "benchmark_qed.autod.data_model",
+        "benchmark_qed.autod.data_model.text_unit",
+        "benchmark_qed.autod.data_processor",
+        "benchmark_qed.autod.data_processor.embedding",
+        "benchmark_qed.autod.sampler",
+        "benchmark_qed.autod.sampler.clustering",
+        "benchmark_qed.autod.sampler.clustering.kmeans",
+        "benchmark_qed.autoq", "benchmark_qed.autoq.data_model",
+        "benchmark_qed.autoq.data_model.question",
+        "benchmark_qed.autoq.question_gen",
+        "benchmark_qed.autoq.question_gen.data_questions",
+        "benchmark_qed.autoq.question_gen.data_questions.global_question_gen",
+        "benchmark_qed.autoq.question_gen.data_questions.local_question_gen",
+        "benchmark_qed.autoq.question_generator",
+        "benchmark_qed.config",
+        "benchmark_qed.config.llm_config",
+        "benchmark_qed.llm",
+        "benchmark_qed.llm.provider",
+        "benchmark_qed.llm.provider.openai",
+    ]:
+        sys.modules[_name] = _mock
+
+from metatron.benchmarker.services.eval_loader import (
+    DEFAULT_TESTSET_PATH,
+    load_eval_testset_from_path,
+)
+from metatron.benchmarker.services.metrics.retrieval import RetrievalMetrics
+from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
+from metatron.retrieval.search import hybrid_search_and_answer
+
+
+def _weight_grid(step: float = 0.05) -> list[dict[str, float]]:
+    """Generate weight combinations that sum to ~0.85 (excluding blend)."""
+    values = [round(v, 2) for v in [i * step for i in range(int(0.5 / step) + 1)]]
+    combos = []
+    for dense, graph, metadata, recency, balance in itertools.product(
+        values, values, values, values, [0.05],
+    ):
+        total = dense + graph + metadata + recency + balance
+        if 0.80 <= total <= 0.90:
+            combos.append({
+                "dense_weight": dense,
+                "graph_weight": graph,
+                "metadata_weight": metadata,
+                "recency_weight": recency,
+                "balance_weight": balance,
+            })
+    return combos
+
+
+def _blend_grid(step: float = 0.05) -> list[float]:
+    """Generate blend_weight values."""
+    return [round(v, 2) for v in [i * step for i in range(1, 10)]]
+
+
+def _run_eval_for_profile(
+    workspace: str, k: int, testset_path: Path, profile_filter: str | None,
+) -> dict:
+    """Run eval queries, optionally filtering by category matching profile."""
+    ts = load_eval_testset_from_path(testset_path)
+    queries = [q for q in ts.queries if q.stable and q.expected_doc_labels]
+    if profile_filter:
+        queries = [q for q in queries if q.category == profile_filter]
+    if not queries:
+        # Fallback: use all positive queries if no category match
+        queries = [q for q in ts.queries if q.stable and q.expected_doc_labels]
+
+    rm = RetrievalMetrics()
+    totals = {"precision_at_k": 0.0, "mrr": 0.0, "ndcg_at_k": 0.0}
+    for q in queries:
+        trace = hybrid_search_and_answer(
+            q.text, workspace, k, None, None, return_trace=True,
+        )
+        retrieved = trace.get("retrieved_doc_labels", []) if isinstance(trace, dict) else []
+        result = rm.compute(retrieved, q.expected_doc_labels, k=k)
+        for key in totals:
+            totals[key] += result[key]
+    n = len(queries)
+    return {k_: v / n for k_, v in totals.items()} if n > 0 else totals
+
+
+def _compute_objective(metrics: dict, metric: str) -> float:
+    if metric == "mrr":
+        return metrics.get("mrr", 0)
+    elif metric == "ndcg":
+        return metrics.get("ndcg_at_k", 0)
+    elif metric == "precision":
+        return metrics.get("precision_at_k", 0)
+    else:  # combined
+        return (
+            0.4 * metrics.get("mrr", 0)
+            + 0.4 * metrics.get("ndcg_at_k", 0)
+            + 0.2 * metrics.get("precision_at_k", 0)
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Grid search for scoring weights")
+    parser.add_argument("--profile", default=None, help="Single profile to search")
+    parser.add_argument("--metric", default="combined",
+                        choices=["mrr", "ndcg", "precision", "combined"],
+                        help="Metric to optimize")
+    parser.add_argument("--top", type=int, default=3, help="Show top N results")
+    parser.add_argument("--step", type=float, default=0.10,
+                        help="Weight grid step size (default 0.10)")
+    parser.add_argument("--workspace", default="MTRNIX")
+    parser.add_argument("--k", type=int, default=10, help="K for P@K, NDCG@K")
+    args = parser.parse_args()
+
+    profiles = [args.profile] if args.profile else list(QUERY_PROFILE_WEIGHTS.keys())
+    weight_combos = _weight_grid(step=args.step)
+    blend_values = _blend_grid(step=args.step)
+
+    print(f"Grid: {len(weight_combos)} signal combos × {len(blend_values)} blend values")
+    print(f"Profiles: {profiles}")
+    print(f"Optimizing: {args.metric}")
+    print()
+
+    best_per_profile: dict[str, dict] = {}
+
+    for profile in profiles:
+        print(f"\n{'='*60}")
+        print(f"Profile: {profile}")
+        print(f"{'='*60}")
+
+        original_weights = QUERY_PROFILE_WEIGHTS.get(profile, {}).copy()
+        results = []
+        total = len(weight_combos) * len(blend_values)
+
+        for i, (weights, blend) in enumerate(
+            itertools.product(weight_combos, blend_values)
+        ):
+            full_weights = {**weights, "blend_weight": blend}
+            QUERY_PROFILE_WEIGHTS[profile] = full_weights
+
+            metrics = _run_eval_for_profile(
+                args.workspace, args.k, DEFAULT_TESTSET_PATH, profile,
+            )
+            score = _compute_objective(metrics, args.metric)
+
+            results.append({"weights": full_weights, "metrics": metrics, "score": score})
+
+            if (i + 1) % 50 == 0:
+                print(f"  [{i+1}/{total}] best so far: {max(r['score'] for r in results):.4f}")
+
+        # Restore original weights
+        QUERY_PROFILE_WEIGHTS[profile] = original_weights
+
+        results.sort(key=lambda x: x["score"], reverse=True)
+        best_per_profile[profile] = results[0]
+
+        print(f"\nTop {args.top} for {profile}:")
+        for j, r in enumerate(results[:args.top]):
+            w = r["weights"]
+            m = r["metrics"]
+            print(f"  #{j+1}: score={r['score']:.4f} "
+                  f"P@10={m.get('precision_at_k', 0):.4f} "
+                  f"MRR={m.get('mrr', 0):.4f} "
+                  f"NDCG={m.get('ndcg_at_k', 0):.4f}")
+            print(f"       weights: {json.dumps(w)}")
+
+    # Save results
+    out_dir = Path(__file__).parent.parent / "eval_results"
+    out_dir.mkdir(exist_ok=True)
+    out_file = out_dir / f"grid_search_{datetime.now(UTC).strftime('%Y-%m-%dT%H-%M-%S')}.json"
+    out_file.write_text(json.dumps(best_per_profile, indent=2, default=str))
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("RECOMMENDED WEIGHTS")
+    print(f"{'='*60}")
+    for profile, best in best_per_profile.items():
+        print(f"\n{profile}:")
+        print(f"  {json.dumps(best['weights'], indent=4)}")
+    print(f"\nResults saved to {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -140,6 +140,7 @@ class Settings(BaseSettings):
     balance_weight: float = 0.05
     blend_weight: float = 0.3
     rerank_pool_size: int = 50
+    min_signal_score: float = 0.0  # 0.0 = disabled. Set > 0 to filter low-confidence results.
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -139,7 +139,7 @@ class Settings(BaseSettings):
     recency_weight: float = 0.10
     balance_weight: float = 0.05
     blend_weight: float = 0.3
-    rerank_pool_size: int = 50
+    rerank_pool_size: int = 35
     min_signal_score: float = 0.0  # 0.0 = disabled. Set > 0 to filter low-confidence results.
 
     @property

--- a/src/metatron/retrieval/.claude/claude.md
+++ b/src/metatron/retrieval/.claude/claude.md
@@ -3,55 +3,63 @@
 ## Overview
 L2 — the full search pipeline from raw query to LLM answer with sources.
 Entry point: `hybrid_search_and_answer()` in `search.py`. Currently sync
-(all TODO: async migration comments), runs via `asyncio.to_thread()` from API layer.
+(TODO: async migration), runs via `asyncio.to_thread()` from API layer.
+
+## Pipeline (current)
+```
+Query → expansion → classify(profile) → weight_preset
+     → recall_dense + recall_exact + recall_metadata + recall_graph  (parallel ThreadPoolExecutor)
+     → merge_channels → compute_signal_score(6 weighted signals, normalized [0,1])
+     → confidence filter (min_signal_score, default disabled)
+     → top-35 pool → cross-encoder rerank (bge-reranker-v2-m3)
+     → compute_final_score(blend: 30% signal + 70% reranker)
+     → _collect_frags(dict) → _mark_evidence_role(PRIMARY/SUPPORTING)
+     → _build_ctx(grouped markdown) → LLM(evidence rules) → _append_sources → answer
+```
 
 ## Files
 
 ### `search.py`
 Main pipeline — `hybrid_search_and_answer()`.
+Orchestrates: language detection → translation → query expansion → classification →
+recall channels (parallel) → scoring → reranking → fragment collection → evidence roles → LLM.
 
-**Global constants (from Settings at module import time):**
-```python
-_MAX_TOTAL = search_max_total_chars   # 40000
-_MAX_FRAG  = search_max_fragment_chars # 8000
-_POOL_MUL  = search_pool_multiplier   # 3  (pool = k * 3)
-_POOL_MIN  = search_pool_min          # 15 (minimum pool size)
-_GRAPH_DEPTH = 2
-_JIRA_KEY_RE = r'\b([A-Z]{2,}-\d+)\b'
-```
+Key functions:
+- `_run_recall_channels(ctx)` — parallel dispatch of 4 recall channels via `ThreadPoolExecutor`
+- `_collect_frags()` — extract text, deduplicate, respect `_MAX_TOTAL`/`_MAX_FRAG`
+- `_mark_evidence_role()` — assigns PRIMARY/SUPPORTING based on query profile
+- `_build_ctx()` — assembles grouped markdown context for LLM
+- `_append_sources()` — citation formatting (max 5 sources)
 
-**Full pipeline in `hybrid_search_and_answer(query, workspace_id, k, ...)`:**
-1. **Language detection** — `detect_response_language()`: Cyrillic detection → `"ru"` else `"en"`
-2. **Cyrillic translation** — `translate_query_to_english()` via LLM if Cyrillic detected
-3. **Jira key injection** — regex extracts `PROJ-123` patterns → direct `_inject_jira_key_results()`
-4. **Person/activity injection** — `_ACTIVITY_KW` + `_PERSON_RU`/`_PERSON_EN` regex → entity resolution via `AliasRegistry`
-5. **Title entity extraction** — `extract_title_entities()` → `_build_title_filter()` → `_search_by_title()`
-6. **Schema routing** — `should_use_team_workflow_schema()` → `TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT`
-7. **`search_with_date_filter()`** — pool = `max(k * _POOL_MUL, _POOL_MIN)`
-   - Date range detection → separate date-filtered search merged with unfiltered
-   - Jira multiplier (`_JIRA_MUL=2`) when Jira query detected
-   - Falls back to plain `store.hybrid_search(query, limit=k)`
-8. **`diversify_results(base, k=50)`** — de-duplicate by source, interleave by type
-9. **Title boost** — `_boost_title_matches()` promotes title matches to top
-10. **Reranker** — if `RERANKER_ENABLED`: `rerank(query, base, top_k=25)` via `reranker.py`
-11. **`_collect_frags()`** — extract text, deduplicate by truncated hash, respect `_MAX_TOTAL`/`_MAX_FRAG`
-12. **Graph enrichment** —
-    - `get_entities_by_doc_labels()` or `get_graph_entities(frags, workspace_id)`
-    - `get_graph_relationships()` with `max_depth=_GRAPH_DEPTH`
-    - Related docs via `get_related_documents()` → extra frags via `search_by_doc_labels()`
-13. **Token budget** — `select_fragments_within_budget(frags, ...)` — trims to `LLM_CONTEXT_MAX_TOKENS`
-14. **LLM call** — `chat_completion()` / `chat_completion_with_retry()` with built context
-15. **Source append** — `_append_sources(answer, base)` — max 5 sources
+### `channels.py`
+4 independent recall channels + merge logic:
+- `recall_dense(ctx)` — RRF hybrid search (dense + sparse vectors via Qdrant)
+- `recall_exact(ctx)` — Jira key lookup + title entity search
+- `recall_metadata(ctx)` — date filters, person/assignee, activity status
+- `recall_graph(ctx)` — entity graph traversal (BFS hop expansion via Memgraph)
+- `merge_channels()` — merges results, preserves all channel scores
+- `_cached_get_graph_entities()` — LRU cache (maxsize=128) for graph entity lookups
 
-**Trace logging** (non-blocking, after answer):
-```python
-source_word_count = sum(len(frag.split()) for frag in frags)
-store_query_trace_sync(workspace_id, rq, trace_data, total_ms)
-```
+Types: `ScoredResult`, `MergedResult`, `RecallContext`
+
+### `scoring.py`
+Multi-signal scoring formula:
+- `compute_signal_score(merged_result, ...)` — 5 weighted signals (dense, graph, metadata, recency, balance), normalized to [0,1] by dividing by sum of ALL weights
+- `compute_final_score(signal_score, rerank_score, blend_weight)` — blend formula
+- `source_balance(source_type, type_counts, total)` — smooth gradient (linear decay from 1.0 to 0.0 at threshold)
+- `recency_score(date_str)` — time decay
+- `normalize_scores(scores)` — min-max normalization for cross-encoder output
+
+### `query_classifier.py`
+Hybrid rule+LLM query classifier:
+- Rule gate: regex patterns for Jira keys, dates, files, relationships
+- LLM fallback: DeepSeek classification with confidence threshold
+- 6 profiles: execution, documentation, user_file, relationship, temporal, mixed
+- `QUERY_PROFILE_WEIGHTS` — per-profile weight overrides for scoring formula
 
 ### `reranker.py`
 Cross-encoder reranker — `BAAI/bge-reranker-v2-m3`.
-Lazy singleton (loaded on first use). `rerank(query, results, top_k=25) -> list`.
+Lazy singleton (loaded on first use). `rerank(query, results, top_k)`.
 Falls back gracefully if model unavailable.
 
 ### `query_expansion.py`
@@ -59,66 +67,34 @@ Falls back gracefully if model unavailable.
 Disabled when `QUERY_EXPANSION_ENABLED=False`. Returns original query on failure.
 
 ### `token_budget.py`
-`MAX_GRAPH_TOKENS = 2000`
-`estimate_graph_tokens(g_ents, g_rels, g_docs) -> int`
-`truncate_graph_context(g_ents, g_rels, g_docs, max_tokens)` — priority: Person entities first
 `select_fragments_within_budget(frags, max_chars) -> list[str]`
-
-### `alias_registry.py`
-`AliasRegistry` — file-persisted person alias store at `.metatron/person_aliases.json`.
-Singleton via `get_alias_registry()`. Auto-populated from Jira sync.
-Maps display names / Cyrillic names to canonical identifiers for person queries.
-
-### `aliases.py`
-Hardcoded fallback alias dict — used when `alias_registry.json` doesn't exist yet.
-
-### `routing.py`
-`is_jira_query(query) -> bool` — keyword heuristics.
-`should_use_team_workflow_schema(query) -> bool` — detects team/workflow questions.
-`_extract_json_object(text) -> dict | None` — robust JSON extraction from LLM output.
+`truncate_graph_context(g_ents, g_rels, g_docs, max_tokens)` — priority: Person entities first
 
 ### `hybrid.py`
 `HybridSearcher` — wraps dense + sparse search with RRF fusion.
 RRF formula: `score = Σ 1/(rrf_k + rank)` where `rrf_k=60`.
-Weight blend: dense=0.35, sparse=0.20, tags=0.20, graph=0.15, recency=0.10.
-
-### `scoring.py`
-Multi-factor scoring post-RRF fusion: recency decay, tag overlap, title match boost.
-
-### `entity_resolver.py`
-`resolve_entity(name, workspace_id)` — resolves ambiguous entity names using alias registry
-and graph lookup.
-
-### `entity_helpers.py`
-Helper functions for entity extraction from query text. Proper noun detection,
-company token extraction (`_PROPER_NOUN_RE`, `_COMPANY_TOKEN_RE`, `_COMPANY_MULTI_RE`).
-
-### `graph_enrichment.py`
-`GraphEnricher` — wraps graph entity/relationship injection.
-Currently has `NotImplementedError` stubs; actual graph ops are called directly in `search.py`.
-
-### `fallback.py`
-`GracefulRetriever` — wraps retrieval with `_safe_call()` pattern.
-If Memgraph is down → search continues without graph enrichment.
-Currently has `NotImplementedError` stubs.
 
 ### `context.py`
 `_build_ctx(query, lang, frags, g_ents, g_rels, g_docs) -> str`
-Assembles the LLM context string from fragments + graph data.
+Assembles LLM context from fragments + graph data, grouped by evidence role.
 
 ### `prompts.py`
-System prompts:
-- `HYBRID_SYSTEM_PROMPT` — standard RAG answer prompt
-- `TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT` — structured JSON output for team workflow queries
-- `TEAM_WORKFLOW_SCHEMA_SPEC` — JSON schema for structured output
+System prompts with atomic evidence rules for LLM.
+
+### Other files
+- `alias_registry.py` — person alias store for entity resolution
+- `routing.py` — query type heuristics (jira, team workflow)
+- `entity_resolver.py`, `entity_helpers.py` — entity extraction and resolution
 
 ## Key Patterns
-- **Sync-first with thread offload** — `hybrid_search_and_answer()` is sync; called via `asyncio.to_thread()` from chat route
-- **Graceful degradation** — graph failures are caught and logged; search returns results without graph enrichment
-- **Pool multiplier** — always fetch `k * _POOL_MUL` candidates, rerank down to `k`
-- **Lazy reranker** — model loaded on first call, not at import time (avoids slow startup)
-- **FinOps integration** — `source_word_count` written to `query_traces.trace` JSONB after every answer
+- **Sync-first with thread offload** — `hybrid_search_and_answer()` is sync; called via `asyncio.to_thread()`
+- **Parallel recall** — 4 channels run in ThreadPoolExecutor (max_workers=4)
+- **Score isolation** — scores stored in `score_map: dict[str, float]`, not in memory dicts
+- **Graceful degradation** — graph/reranker failures are caught; search continues
+- **LRU cache** — graph entity lookups cached (maxsize=128)
+- **Configurable weights** — all scoring weights overridable via env vars or query profiles
+- **Lazy reranker** — model loaded on first call, not at import time
 
 ## Dependencies
-- **Depends on**: `core.config`, `core.models`, `storage.qdrant` (hybrid search), `storage.graph_ops` (graph queries), `storage.pg_connection` (trace logging), `llm` (chat_completion), `ingestion.processors.dates`, `observability.metrics` (@timed)
-- **Depended on by**: `api.routes.chat` (main search endpoint), `api.routes.benchmarker` (traced queries)
+- **Depends on**: `core.config`, `core.models`, `storage.qdrant`, `storage.graph_ops`, `storage.pg_connection`, `llm`, `ingestion.processors.dates`, `observability.metrics`
+- **Depended on by**: `api.routes.chat`, `api.routes.benchmarker`

--- a/src/metatron/retrieval/channels.py
+++ b/src/metatron/retrieval/channels.py
@@ -249,6 +249,12 @@ _MAX_FRONTIER = 50  # Cap BFS frontier to prevent explosion on highly-connected 
 def _cached_get_graph_entities(
     query_texts: tuple[str, ...], workspace_id: str | None,
 ) -> tuple[dict, ...]:
+    """Cached graph entity lookup. No TTL — evicts by LRU only.
+
+    Stale entries persist until evicted. Call cache_clear() after sync
+    if freshness matters. TODO: hook into SYNC_COMPLETED event when
+    EventBus is wired for sync lifecycle.
+    """
     return tuple(get_graph_entities(list(query_texts), workspace_id=workspace_id))
 
 

--- a/src/metatron/retrieval/channels.py
+++ b/src/metatron/retrieval/channels.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
@@ -244,6 +245,13 @@ def recall_metadata(ctx: RecallContext) -> list[ScoredResult]:
 _MAX_FRONTIER = 50  # Cap BFS frontier to prevent explosion on highly-connected entities
 
 
+@lru_cache(maxsize=128)
+def _cached_get_graph_entities(
+    query_texts: tuple[str, ...], workspace_id: str | None,
+) -> tuple[dict, ...]:
+    return tuple(get_graph_entities(list(query_texts), workspace_id=workspace_id))
+
+
 def recall_graph(ctx: RecallContext) -> list[ScoredResult]:
     """Graph channel: find related documents via entity graph traversal.
 
@@ -262,7 +270,7 @@ def recall_graph(ctx: RecallContext) -> list[ScoredResult]:
 
         # 2. Graph entity match on query (existing behavior)
         query_for_ner = ctx.translated_query or ctx.original_query
-        graph_ents = get_graph_entities([query_for_ner], workspace_id=ctx.workspace_id)
+        graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
         seeds.update(e["name"] for e in graph_ents if "name" in e)
 
         if not seeds:

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -35,7 +35,6 @@ class QueryClassification(TypedDict):
 QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
     "execution": {
         "dense_weight": 0.20,
-        "sparse_weight": 0.0,
         "graph_weight": 0.10,
         "metadata_weight": 0.35,
         "recency_weight": 0.15,
@@ -44,7 +43,6 @@ QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
     },
     "documentation": {
         "dense_weight": 0.45,
-        "sparse_weight": 0.0,
         "graph_weight": 0.15,
         "metadata_weight": 0.15,
         "recency_weight": 0.05,
@@ -53,7 +51,6 @@ QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
     },
     "user_file": {
         "dense_weight": 0.45,
-        "sparse_weight": 0.0,
         "graph_weight": 0.05,
         "metadata_weight": 0.20,
         "recency_weight": 0.05,
@@ -62,7 +59,6 @@ QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
     },
     "relationship": {
         "dense_weight": 0.25,
-        "sparse_weight": 0.0,
         "graph_weight": 0.35,
         "metadata_weight": 0.15,
         "recency_weight": 0.05,
@@ -71,7 +67,6 @@ QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
     },
     "temporal": {
         "dense_weight": 0.25,
-        "sparse_weight": 0.0,
         "graph_weight": 0.10,
         "metadata_weight": 0.15,
         "recency_weight": 0.30,
@@ -80,7 +75,6 @@ QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
     },
     "mixed": {
         "dense_weight": 0.35,
-        "sparse_weight": 0.0,
         "graph_weight": 0.15,
         "metadata_weight": 0.20,
         "recency_weight": 0.10,

--- a/src/metatron/retrieval/scoring.py
+++ b/src/metatron/retrieval/scoring.py
@@ -1,12 +1,11 @@
 """Multi-signal scoring for unified reranking.
 
-Combines channel scores (dense, sparse, graph, metadata), recency decay,
+Combines channel scores (dense, graph, metadata), recency decay,
 and source balance into a single normalized signal score. Optionally
 blends with cross-encoder rerank score for final ranking.
 
 Default weights (sum = 0.85, output normalized to [0,1]):
 - dense:    0.35
-- sparse:   0.00  (placeholder — RRF doesn't separate dense/sparse)
 - graph:    0.15
 - metadata: 0.20
 - recency:  0.10
@@ -63,7 +62,6 @@ def compute_signal_score(
     balance: float = 1.0,
     *,
     dense_weight: float = 0.35,
-    sparse_weight: float = 0.0,
     graph_weight: float = 0.15,
     metadata_weight: float = 0.20,
     recency_weight: float = 0.10,
@@ -75,7 +73,6 @@ def compute_signal_score(
     Output is normalized by sum of weights to stay in [0, 1].
     """
     vector = channel_scores.get("dense", 0.0)
-    sparse = channel_scores.get("sparse", 0.0)
     graph = channel_scores.get("graph", 0.0)
     metadata = max(
         channel_scores.get("exact", 0.0),
@@ -84,7 +81,6 @@ def compute_signal_score(
 
     raw = (
         dense_weight * vector
-        + sparse_weight * sparse
         + graph_weight * graph
         + metadata_weight * metadata
         + recency_weight * recency
@@ -92,7 +88,7 @@ def compute_signal_score(
     )
 
     weight_sum = (
-        dense_weight + sparse_weight + graph_weight
+        dense_weight + graph_weight
         + metadata_weight + recency_weight + balance_weight
     )
     return raw / weight_sum if weight_sum > 0 else 0.0

--- a/src/metatron/retrieval/scoring.py
+++ b/src/metatron/retrieval/scoring.py
@@ -46,14 +46,17 @@ def source_balance(
     total: int,
     threshold: float = 0.4,
 ) -> float:
-    """Return 1.0 if source type is underrepresented, 0.0 if overrepresented.
+    """Return smooth penalty for overrepresented source types.
 
-    A source type is overrepresented if it makes up > threshold of the pool.
+    Score decays linearly from 1.0 (absent) to 0.0 (at threshold).
+    Sources above the threshold get 0.0.
     """
     if total == 0:
         return 1.0
-    count = type_counts.get(source_type, 0)
-    return 0.0 if count / total > threshold else 1.0
+    ratio = type_counts.get(source_type, 0) / total
+    if ratio >= threshold:
+        return 0.0
+    return 1.0 - (ratio / threshold)
 
 
 def compute_signal_score(

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -569,9 +569,11 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     merged = merge_channels([dense_results, exact_results, metadata_results, graph_results])
 
     # -- Multi-signal scoring --
-    type_counts: dict[str, int] = Counter(
-        _result_type(mr["memory"]) for mr in merged
-    )
+    type_cache: dict[str, str] = {}
+    for mr in merged:
+        type_cache[mr["chunk_id"]] = _result_type(mr["memory"])
+
+    type_counts: dict[str, int] = Counter(type_cache.values())
     total_merged = len(merged)
 
     _scoring_weights = {k: v for k, v in _profile_weights.items() if k != "blend_weight"}
@@ -586,7 +588,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
                 rec = recency_score(dt)
             except (ValueError, TypeError):
                 rec = 1.0
-        bal = source_balance(_result_type(mem), type_counts, total_merged)
+        bal = source_balance(type_cache[mr["chunk_id"]], type_counts, total_merged)
         mr["signal_score"] = compute_signal_score(
             channel_scores=mr["channel_scores"],
             recency=rec,

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -603,6 +603,47 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
 
     merged.sort(key=lambda x: x.get("signal_score", 0), reverse=True)
 
+    # -- Confidence filter: drop candidates below threshold --
+    if _s.min_signal_score > 0:
+        merged = [mr for mr in merged if mr.get("signal_score", 0) >= _s.min_signal_score]
+        if not merged:
+            no_info = "I don't have enough information to answer this question."
+            if lang.lower() == "russian":
+                no_info = "У меня недостаточно информации для ответа на этот вопрос."
+            if return_trace:
+                return {
+                    "answer": no_info,
+                    "source_results": [],
+                    "fragments": [],
+                    "graph_entities": [],
+                    "graph_relations": [],
+                    "graph_docs": [],
+                    "pipeline_stages": {
+                        "original_query": rq,
+                        "translated_query": sq,
+                        "expanded_query": eq,
+                        "detected_language": lang,
+                        "recall_dense_count": len(dense_results),
+                        "recall_exact_count": len(exact_results),
+                        "recall_metadata_count": len(metadata_results),
+                        "recall_graph_count": len(graph_results),
+                        "recall_total_unique": 0,
+                        "pre_rerank_count": 0,
+                        "post_rerank_count": 0,
+                        "signal_scored_count": total_merged,
+                        "rerank_pool_count": 0,
+                        "fragment_count": 0,
+                        "primary_fragment_count": 0,
+                        "supporting_fragment_count": 0,
+                        "token_budget_used": 0,
+                        "query_profile": classification["profile"],
+                        "query_profile_method": classification["method"],
+                        "query_profile_confidence": classification["confidence"],
+                    },
+                    "retrieved_doc_labels": [],
+                }
+            return no_info
+
     pool_size = _s.rerank_pool_size if _s.reranker_enabled else len(merged)
     base = [mr["memory"] for mr in merged[:pool_size]]
 

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import re
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -55,6 +56,23 @@ _MAX_TOTAL, _MAX_FRAG = _s.search_max_total_chars, _s.search_max_fragment_chars
 _GRAPH_DEPTH = int(getattr(_s, "search_graph_depth", 2))
 
 _TRANSLATE_SYS = "Translate the following query to English. Return ONLY the translation, nothing else."
+
+_recall_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="recall")
+
+
+def _run_recall_channels(ctx: RecallContext) -> tuple[list, list, list, list]:
+    """Run 4 recall channels in parallel using thread pool.
+
+    Each channel is sync (Qdrant/Memgraph clients are sync), so we use
+    threads for true parallelism. Returns (dense, exact, metadata, graph).
+    """
+    futures = [
+        _recall_executor.submit(recall_dense, ctx),
+        _recall_executor.submit(recall_exact, ctx),
+        _recall_executor.submit(recall_metadata, ctx),
+        _recall_executor.submit(recall_graph, ctx),
+    ]
+    return tuple(f.result() for f in futures)
 
 
 def _run_hooks_sync(plugin_manager, hook_name: str, context: dict) -> dict:
@@ -559,11 +577,8 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
         settings=_s,
     )
 
-    # -- Run 4 recall channels --
-    dense_results = recall_dense(recall_ctx)
-    exact_results = recall_exact(recall_ctx)
-    metadata_results = recall_metadata(recall_ctx)
-    graph_results = recall_graph(recall_ctx)
+    # -- Run 4 recall channels in parallel --
+    dense_results, exact_results, metadata_results, graph_results = _run_recall_channels(recall_ctx)
 
     # -- Merge and deduplicate across channels --
     merged = merge_channels([dense_results, exact_results, metadata_results, graph_results])

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -596,12 +596,15 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             **_scoring_weights,
         )
 
+    # Build score_map keyed by chunk_id (no mutation of memory dicts)
+    score_map: dict[str, float] = {
+        mr["chunk_id"]: mr.get("signal_score", 0) for mr in merged
+    }
+
     merged.sort(key=lambda x: x.get("signal_score", 0), reverse=True)
 
     pool_size = _s.rerank_pool_size if _s.reranker_enabled else len(merged)
     base = [mr["memory"] for mr in merged[:pool_size]]
-    for mr, b in zip(merged[:pool_size], base, strict=True):
-        b["_signal_score"] = mr.get("signal_score", 0)
 
     _pre_rerank_count = len(base)
     if _s.reranker_enabled:
@@ -609,12 +612,16 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
         base = rerank(query=rq, results=base, top_k=len(base))
         normalize_rerank_scores(base)
         for r in base:
-            r["_final_score"] = compute_final_score(
-                signal_score=r.get("_signal_score", 0),
+            cid = str(r.get("id", ""))
+            score_map[cid] = compute_final_score(
+                signal_score=score_map.get(cid, 0),
                 rerank_score=r.get("rerank_score", 0),
                 blend_weight=_profile_weights["blend_weight"],
             )
-        base.sort(key=lambda x: x.get("_final_score", 0), reverse=True)
+        base.sort(
+            key=lambda x: score_map.get(str(x.get("id", "")), 0),
+            reverse=True,
+        )
     base = base[:k]
     _post_rerank_count = len(base)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,12 @@
+"""Unit-test-level fixtures."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_lru_caches() -> None:
+    """Clear module-level LRU caches between tests to prevent cross-test contamination."""
+    from metatron.retrieval.channels import _cached_get_graph_entities
+
+    _cached_get_graph_entities.cache_clear()

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -37,7 +37,7 @@ class TestProfileWeights:
 
         w = QUERY_PROFILE_WEIGHTS[profile]
         signal_sum = (
-            w["dense_weight"] + w["sparse_weight"] + w["graph_weight"]
+            w["dense_weight"] + w["graph_weight"]
             + w["metadata_weight"] + w["recency_weight"] + w["balance_weight"]
         )
         assert abs(signal_sum - 0.85) < 1e-9, f"{profile}: signal sum = {signal_sum}"
@@ -49,7 +49,7 @@ class TestProfileWeights:
         from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
 
         expected_keys = {
-            "dense_weight", "sparse_weight", "graph_weight",
+            "dense_weight", "graph_weight",
             "metadata_weight", "recency_weight", "balance_weight", "blend_weight",
         }
         assert set(QUERY_PROFILE_WEIGHTS[profile].keys()) == expected_keys
@@ -60,7 +60,6 @@ class TestProfileWeights:
 
         mixed = QUERY_PROFILE_WEIGHTS["mixed"]
         assert mixed["dense_weight"] == 0.35
-        assert mixed["sparse_weight"] == 0.0
         assert mixed["graph_weight"] == 0.15
         assert mixed["metadata_weight"] == 0.20
         assert mixed["recency_weight"] == 0.10

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -40,27 +40,45 @@ class TestRecencyScore:
 
 class TestSourceBalance:
     def test_underrepresented_gets_bonus(self) -> None:
+        # ratio = 1/6 = 0.167 → 1.0 - (0.167/0.4) ≈ 0.583
         type_counts = {"jira": 5, "confluence": 1}
-        total = 6
-        assert source_balance("confluence", type_counts, total) == 1.0
+        score = source_balance("confluence", type_counts, 6)
+        assert 0.5 < score < 0.7
 
     def test_overrepresented_gets_zero(self) -> None:
+        # ratio = 5/6 = 0.833 → >= threshold → 0.0
         type_counts = {"jira": 5, "confluence": 1}
-        total = 6
-        assert source_balance("jira", type_counts, total) == 0.0
+        assert source_balance("jira", type_counts, 6) == 0.0
 
     def test_even_split_still_over_threshold(self) -> None:
+        # ratio = 3/6 = 0.5 → >= threshold → 0.0
         type_counts = {"jira": 3, "confluence": 3}
-        total = 6
-        assert source_balance("jira", type_counts, total) == 0.0
+        assert source_balance("jira", type_counts, 6) == 0.0
 
     def test_three_types_balanced(self) -> None:
+        # ratio = 2/6 = 0.333 → 1.0 - (0.333/0.4) ≈ 0.167
         type_counts = {"jira": 2, "confluence": 2, "upload": 2}
-        total = 6
-        assert source_balance("jira", type_counts, total) == 1.0
+        score = source_balance("jira", type_counts, 6)
+        assert 0.1 < score < 0.3
 
     def test_empty_pool(self) -> None:
         assert source_balance("jira", {}, 0) == 1.0
+
+    def test_smooth_gradient_values(self) -> None:
+        """Verify smooth intermediate values, not just binary."""
+        counts = {"jira": 3, "confluence": 7}
+        # ratio = 3/10 = 0.3 → 1.0 - (0.3/0.4) = 0.25
+        score = source_balance("jira", counts, 10)
+        assert abs(score - 0.25) < 0.01
+
+    def test_absent_source_gets_one(self) -> None:
+        counts = {"jira": 5, "confluence": 5}
+        assert source_balance("upload", counts, 10) == 1.0
+
+    def test_at_threshold_is_zero(self) -> None:
+        # ratio = 4/10 = 0.4, exactly at threshold → 0.0
+        counts = {"jira": 4, "confluence": 6}
+        assert source_balance("jira", counts, 10) == 0.0
 
 
 class TestComputeSignalScore:

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -98,7 +98,6 @@ class TestComputeSignalScore:
             recency=0.0,
             balance=0.0,
             dense_weight=0.5,
-            sparse_weight=0.0,
             graph_weight=0.1,
             metadata_weight=0.1,
             recency_weight=0.1,
@@ -114,6 +113,12 @@ class TestComputeSignalScore:
             balance=1.0,
         )
         assert 0.0 <= score <= 1.0
+
+    def test_compute_signal_score_has_no_sparse_weight_param(self) -> None:
+        """sparse_weight was removed — verify it's not in the signature."""
+        import inspect
+        sig = inspect.signature(compute_signal_score)
+        assert "sparse_weight" not in sig.parameters
 
 
 class TestNormalizeRerankScores:

--- a/tests/unit/test_search_quality_tuning.py
+++ b/tests/unit/test_search_quality_tuning.py
@@ -71,3 +71,11 @@ def test_recall_graph_caches_entity_lookups():
 
         # get_graph_entities called only once (second call hits cache)
         assert mock_ents.call_count == 1
+
+
+def test_recall_channels_run_in_parallel():
+    """Recall channels should use ThreadPoolExecutor, not sequential calls."""
+    import inspect
+    from metatron.retrieval import search
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    assert "_run_recall_channels" in source

--- a/tests/unit/test_search_quality_tuning.py
+++ b/tests/unit/test_search_quality_tuning.py
@@ -34,3 +34,40 @@ def test_confidence_filter_in_search():
     from metatron.retrieval import search
     source = inspect.getsource(search.hybrid_search_and_answer)
     assert "min_signal_score" in source
+
+
+def test_recall_graph_caches_entity_lookups():
+    """Second call with same seeds should hit cache, not Memgraph."""
+    from unittest.mock import patch, MagicMock
+    from metatron.retrieval.channels import recall_graph, RecallContext, _cached_get_graph_entities
+
+    ctx = RecallContext(
+        original_query="test",
+        translated_query="test",
+        expanded_query="test",
+        detected_language="en",
+        workspace_id="ws1",
+        access_filter=None,
+        settings=MagicMock(recall_top_n_graph=5, recall_graph_max_depth=2),
+        extracted_jira_keys=["MTRNIX-104"],
+        extracted_title_entities=[],
+        extracted_dates=None,
+        detected_person=[],
+        is_activity_query=False,
+    )
+
+    with patch("metatron.retrieval.channels.get_graph_entities") as mock_ents, \
+         patch("metatron.retrieval.channels.get_doc_labels_by_entities") as mock_labels, \
+         patch("metatron.retrieval.channels.get_graph_relationships") as mock_rels, \
+         patch("metatron.retrieval.channels.get_hybrid_store") as mock_store:
+        mock_ents.return_value = [{"name": "Auth"}]
+        mock_labels.return_value = [{"doc_label": "jira:MTRNIX-104"}]
+        mock_rels.return_value = []
+        mock_store.return_value.search_by_doc_labels.return_value = []
+
+        _cached_get_graph_entities.cache_clear()
+        recall_graph(ctx)
+        recall_graph(ctx)
+
+        # get_graph_entities called only once (second call hits cache)
+        assert mock_ents.call_count == 1

--- a/tests/unit/test_search_quality_tuning.py
+++ b/tests/unit/test_search_quality_tuning.py
@@ -1,0 +1,10 @@
+"""Tests for search quality tuning changes."""
+
+
+def test_result_type_cached_in_scoring():
+    """_result_type should be cached via type_cache dict."""
+    import inspect
+    from metatron.retrieval import search
+
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    assert "type_cache" in source

--- a/tests/unit/test_search_quality_tuning.py
+++ b/tests/unit/test_search_quality_tuning.py
@@ -18,3 +18,19 @@ def test_memory_dicts_not_mutated_with_internal_scores():
     source = inspect.getsource(search.hybrid_search_and_answer)
     assert '["_signal_score"]' not in source
     assert '["_final_score"]' not in source
+
+
+def test_min_signal_score_in_config():
+    """min_signal_score config field exists with default 0.0."""
+    from metatron.core.config import Settings
+    s = Settings()
+    assert hasattr(s, "min_signal_score")
+    assert s.min_signal_score == 0.0
+
+
+def test_confidence_filter_in_search():
+    """Search pipeline includes min_signal_score filtering logic."""
+    import inspect
+    from metatron.retrieval import search
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    assert "min_signal_score" in source

--- a/tests/unit/test_search_quality_tuning.py
+++ b/tests/unit/test_search_quality_tuning.py
@@ -8,3 +8,13 @@ def test_result_type_cached_in_scoring():
 
     source = inspect.getsource(search.hybrid_search_and_answer)
     assert "type_cache" in source
+
+
+def test_memory_dicts_not_mutated_with_internal_scores():
+    """Internal scoring keys (_signal_score, _final_score) must not leak into memory dicts."""
+    import inspect
+    from metatron.retrieval import search
+
+    source = inspect.getsource(search.hybrid_search_and_answer)
+    assert '["_signal_score"]' not in source
+    assert '["_final_score"]' not in source


### PR DESCRIPTION
## Summary

Реализация всех рекомендаций из бэклога search quality эпика (P1-P3, Q1-Q3, C1-C3, D1).

- **P1**: Параллельный запуск recall channels через `ThreadPoolExecutor(max_workers=4)` — latency recall ~3-4x faster
- **P2**: `RERANK_POOL_SIZE` 50 → 35 — inference cost -30%, без регрессии метрик
- **P3**: LRU cache для graph entity lookups (`@lru_cache(maxsize=128)`)
- **Q1**: Grid search скрипт (`make grid-search`) для оптимизации весов по профилям
- **Q2**: Smooth gradient для source_balance (линейный decay вместо бинарного 0/1)
- **Q3**: Confidence threshold (`min_signal_score` в config, default 0.0 = disabled)
- **C1**: Scores вынесены из memory dicts в `score_map: dict[str, float]`
- **C2**: Cache `_result_type()` в scoring loop (type_cache dict)
- **C3**: Удалён dead sparse_weight path из scoring + query_classifier
- **D1**: Уточнена формулировка нормализации весов в спеке

### Eval результаты

| Метрика | Before (post-PR#45) | After (tuning) | Delta |
|---------|---------------------|----------------|-------|
| P@10    | 0.3663              | 0.3787         | +0.012 |
| MRR     | 0.6897              | 0.7069         | +0.017 |
| NDCG@10 | 0.6326              | 0.6493         | +0.017 |

7 query improvements, 2 minor regressions. MRR выше baseline эпика (+0.012).

## Test plan
- [x] `pytest tests/unit/test_scoring.py` — 37 tests pass (smooth balance, no sparse)
- [x] `pytest tests/unit/test_search_quality_tuning.py` — 6 tests pass (cache, score_map, threshold, parallel)
- [x] `pytest tests/unit/test_recall_channels.py` — 40 tests pass (LRU cache)
- [x] `pytest tests/unit/test_evidence_packs.py` — 48 tests pass (no regression)
- [x] `make eval-compare` — all 3 metrics improved vs previous eval
- [x] `python scripts/grid_search_weights.py --help` — prints usage without errors