### PR TITLE
feat: user mapping Metatron <-> Open WebUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,9 @@ Frontend splits on `" — "` to extract URL; no URL → title only.
 - QUERY_EXPANSION_ENABLED (true) — LLM query expansion
 - GRAPH_EXTRACTION_ENABLED (true) — NER → Memgraph
 - METATRON_OPENAI_COMPAT_ENABLED (true) — OpenAI-compatible API for Open WebUI
-- METATRON_OPENAI_COMPAT_KEY ("") — static API key for OpenAI-compat endpoints (empty = disabled)
+- METATRON_OPENAI_COMPAT_KEY ("") — static API key for OpenAI-compat endpoints (Home scenario)
+- METATRON_OPENWEBUI_URL ("") — Open WebUI URL for bundled user sync
+- METATRON_OPENWEBUI_METATRON_URL ("") — external Metatron URL written into Direct Connections
 - See core/config.py for full list
 
 ## Open WebUI Integration
@@ -154,9 +156,16 @@ Endpoints:
 - `POST /v1/chat/completions` — chat completions (streaming + non-streaming)
 - `GET /v1/openapi.json` — stub for connection verification
 
-Auth: `Authorization: Bearer <METATRON_OPENAI_COMPAT_KEY>`
+Auth: personal API key (`mtk_...`) per user, or static `METATRON_OPENAI_COMPAT_KEY` fallback (Home scenario).
 
-Setup in Open WebUI: Settings → Connections → OpenAI API → Add URL `http://metatron:8000/v1` + key.
+Three deployment scenarios:
+1. **Home** — single user, no auth, static API key via global Open WebUI connection
+2. **Bundled** — multi-user, Metatron syncs users to Open WebUI, each gets personal API key + Direct Connection
+3. **External** — import users from existing Open WebUI via `POST /api/v1/admin/import-openwebui-users`
+
+In Bundled/External, `ENABLE_DIRECT_CONNECTIONS=true` is mandatory in Open WebUI. Without it users share a global API key and can spoof each other's identity.
+
+Bundled sync: on startup Metatron auto-registers `admin@metatron.local` in Open WebUI. On user CRUD, changes are mirrored. OWUI admin password is the same as `AUTH_PASSWORD` (default: `metatron`).
 
 Docker: Open WebUI available in `docker-compose.full.yml` with profile `openwebui` on port 3080.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1336,7 +1336,7 @@ Delete a test run and all its results.
 
 OpenAI-compatible endpoints for connecting Open WebUI or any OpenAI-compatible client to Metatron.
 
-**Authentication:** `Authorization: Bearer <METATRON_OPENAI_COMPAT_KEY>`
+**Authentication:** `Authorization: Bearer <personal API key (mtk_...)>` or `Bearer <METATRON_OPENAI_COMPAT_KEY>` (Home scenario fallback)
 
 **Error format:** `{"error": {"message": "...", "type": "invalid_request_error"}}`
 
@@ -1423,12 +1423,56 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 
 ### Open WebUI Setup
 
-1. Add Open WebUI to docker-compose: `docker compose -f docker-compose.full.yml --profile openwebui up`
-2. Open `http://localhost:3080`
-3. Settings → Connections → OpenAI API → Add
-4. URL: `http://metatron-core:8000/v1` (docker) or `http://host.docker.internal:8000/v1` (local dev)
-5. Auth: Bearer, Key: `<METATRON_OPENAI_COMPAT_KEY>`
-6. New Chat → select `metatron-rag-MTRNIX`
+**Home (single user, no auth):**
+1. `docker compose -f docker-compose.full.yml --profile openwebui up`
+2. Open `http://localhost:3080` — no login required
+3. Global connection pre-configured via env vars
+
+**Bundled (multi-user):**
+1. Set `METATRON_OPENWEBUI_URL` and `METATRON_OPENWEBUI_METATRON_URL` in Metatron env
+2. Open WebUI must have `WEBUI_AUTH=true`, `ENABLE_DIRECT_CONNECTIONS=true`
+3. Do NOT set `OPENAI_API_BASE_URL`/`OPENAI_API_KEY` in Open WebUI (no global connection)
+4. Create users in Metatron — they auto-sync to Open WebUI with personal API keys
+5. OWUI admin password = Metatron `AUTH_PASSWORD` (default: `metatron`)
+
+**External (existing Open WebUI):**
+1. Open WebUI must have `ENABLE_DIRECT_CONNECTIONS=true` (mandatory for security)
+2. Import users: `POST /api/v1/admin/import-openwebui-users` with OWUI URL + admin credentials
+3. Download JSON with generated Metatron passwords and API keys
+4. Each user sets Direct Connection in Open WebUI: Settings → Connections → URL + personal API key
+
+### POST /api/v1/admin/import-openwebui-users
+
+Import users from an external Open WebUI instance. Admin only.
+
+**Request Body:**
+```json
+{
+  "owui_url": "http://openwebui.company.com",
+  "admin_email": "admin@company.com",
+  "admin_password": "password"
+}
+```
+
+**Response:**
+```json
+{
+  "imported": [
+    {"email": "user@company.com", "name": "User", "role": "viewer", "metatron_password": "...", "api_key": "mtk_..."}
+  ],
+  "skipped": 0,
+  "already_existed": 1,
+  "total_in_owui": 5
+}
+```
+
+Role mapping: OWUI admin → Metatron admin, OWUI user → Metatron viewer, OWUI pending → skipped.
+
+### Personal API Key Management
+
+- `POST /api/v1/users/{user_id}/api-keys` — create key (returns raw key once, 201)
+- `GET /api/v1/users/{user_id}/api-keys` — list keys (prefix + label, no secrets)
+- `DELETE /api/v1/users/{user_id}/api-keys/{key_prefix}` — revoke key (204)
 
 ## Error Responses
 

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -87,11 +87,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.warning("env_migration.failed", error=str(exc))
 
     # --- Shared DB engine for user store + API key store ---
-    from sqlalchemy.ext.asyncio import create_async_engine as _create_engine
-    _user_engine = _create_engine(settings.postgres_dsn)
+    _user_engine = None
+    try:
+        from sqlalchemy.ext.asyncio import create_async_engine as _create_engine
+        _user_engine = _create_engine(settings.postgres_dsn)
+    except Exception as exc:
+        logger.error("db_engine.init.failed", error=str(exc))
 
     # --- User store ---
     try:
+        if _user_engine is None:
+            raise RuntimeError("DB engine not initialized")
         from metatron.auth.user_store import UserStore
         user_store = UserStore(_user_engine)
         logger.info("user_store.init.starting")
@@ -109,6 +115,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # --- API Key store (personal keys for /v1 endpoints) ---
     try:
+        if _user_engine is None:
+            raise RuntimeError("DB engine not initialized")
         from metatron.auth.api_key_store import ApiKeyStore
         api_key_store = ApiKeyStore(_user_engine)
         await api_key_store.ensure_schema()
@@ -166,6 +174,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     cm = getattr(app.state, "channel_manager", None)
     if cm is not None:
         await cm.stop_all()
+    owui_sync = getattr(app.state, "owui_sync", None)
+    if owui_sync and owui_sync._client:
+        await owui_sync._client.close()
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -86,11 +86,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception as exc:
         logger.warning("env_migration.failed", error=str(exc))
 
+    # --- Shared DB engine for user store + API key store ---
+    from sqlalchemy.ext.asyncio import create_async_engine as _create_engine
+    _user_engine = _create_engine(settings.postgres_dsn)
+
     # --- User store ---
     try:
         from metatron.auth.user_store import UserStore
-        from sqlalchemy.ext.asyncio import create_async_engine as _create_engine
-        _user_engine = _create_engine(settings.postgres_dsn)
         user_store = UserStore(_user_engine)
         logger.info("user_store.init.starting")
         await user_store.ensure_schema()
@@ -104,6 +106,32 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         import traceback
         logger.error("user_store.init.failed", error=str(exc))
         traceback.print_exc()
+
+    # --- API Key store (personal keys for /v1 endpoints) ---
+    try:
+        from metatron.auth.api_key_store import ApiKeyStore
+        api_key_store = ApiKeyStore(_user_engine)
+        await api_key_store.ensure_schema()
+        app.state.api_key_store = api_key_store
+        logger.info("api_key_store.ready")
+    except Exception as exc:
+        logger.error("api_key_store.init.failed", error=str(exc))
+
+    # --- Open WebUI sync (bundled scenario) ---
+    if settings.openwebui_url:
+        try:
+            from metatron.auth.openwebui_sync import OpenWebUISync
+            owui_sync = OpenWebUISync(
+                owui_url=settings.openwebui_url,
+                metatron_url=settings.openwebui_metatron_url,
+                admin_email="admin@metatron.local",
+                admin_password=settings.auth_password,
+            )
+            await owui_sync.ensure_admin()
+            app.state.owui_sync = owui_sync
+            logger.info("owui_sync.configured", url=settings.openwebui_url)
+        except Exception as exc:
+            logger.warning("owui_sync.init.failed", error=str(exc))
 
     # --- PostgresStore (shared) ---
     from metatron.storage.postgres import PostgresStore
@@ -212,6 +240,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     from metatron.api.routes.finops import router as finops_router
     app.include_router(finops_router, prefix="/api/v1")
+
+    from metatron.api.routes.openwebui_import import router as owui_import_router
+    app.include_router(owui_import_router, prefix="/api/v1")
 
     # OpenAI-compatible API (for Open WebUI integration)
     if settings.openai_compat_enabled:

--- a/src/metatron/api/routes/openai_compat.py
+++ b/src/metatron/api/routes/openai_compat.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import re
-import threading
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -38,16 +37,33 @@ MODEL_PREFIX = "metatron-rag-"
 
 
 async def verify_openai_compat_key(request: Request) -> None:
-    """Validate static API key for OpenAI-compat endpoints."""
-    import hmac
-
+    """Validate API key — personal key or static fallback."""
     settings: Settings = request.app.state.settings
-    expected = settings.openai_compat_key
-    if not expected:
-        raise HTTPException(status_code=404, detail="OpenAI-compatible API is not configured")
     auth = request.headers.get("authorization", "")
-    if not auth.startswith("Bearer ") or not hmac.compare_digest(auth[7:], expected):
-        raise HTTPException(status_code=401, detail="Invalid API key")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing API key")
+
+    raw_key = auth[7:]
+    api_key_store = getattr(request.app.state, "api_key_store", None)
+
+    if api_key_store is not None:
+        resolved = await api_key_store.resolve_key(
+            raw_key, static_key=settings.openai_compat_key
+        )
+        if resolved is not None:
+            request.state.openai_user_id = resolved["user_id"]
+            request.state.openai_key_source = resolved["source"]
+            return
+
+    # Fallback: legacy static key check (no api_key_store available)
+    import hmac
+    expected = settings.openai_compat_key
+    if expected and hmac.compare_digest(raw_key, expected):
+        request.state.openai_user_id = "openai-default"
+        request.state.openai_key_source = "static"
+        return
+
+    raise HTTPException(status_code=401, detail="Invalid API key")
 
 
 # ---------------------------------------------------------------------------
@@ -70,42 +86,30 @@ class ChatCompletionRequest(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Conversation history (own store, independent from chat.py)
+# Conversation history — extracted from req.messages (no in-memory store)
 # ---------------------------------------------------------------------------
 
-_conversation_history: dict[str, list[dict[str, str]]] = {}
-_history_lock = threading.Lock()
-_MAX_HISTORY_TURNS = 20
-_MAX_HISTORY_USERS = 100
 _MAX_HISTORY_CHARS = 4000
 
 
-def _record_history(user_id: str, question: str, answer: str) -> None:
-    with _history_lock:
-        hist = _conversation_history.setdefault(user_id, [])
-        hist.append({"user": question, "assistant": answer[:2000]})
-        if len(hist) > _MAX_HISTORY_TURNS:
-            del hist[:-_MAX_HISTORY_TURNS]
-        if len(_conversation_history) > _MAX_HISTORY_USERS:
-            oldest = list(_conversation_history.keys())[: _MAX_HISTORY_USERS // 2]
-            for uid in oldest:
-                del _conversation_history[uid]
-
-
 def _build_composite_query(
-    user_id: str,
+    messages: list[ChatMessage],
     question: str,
     history_turns: int = 6,
 ) -> str:
-    """Build composite query with history context (same logic as chat.py)."""
-    with _history_lock:
-        history = _conversation_history.get(user_id, [])[-history_turns:]
+    """Build composite query from previous user messages in the conversation.
+
+    Takes the last `history_turns` user messages from the OpenAI-format
+    messages list (sent by Open WebUI) instead of maintaining a separate
+    in-memory history store.
+    """
+    previous = [m.content for m in messages if m.role == "user" and m.content != question]
+    previous = previous[-history_turns:]
 
     history_lines: list[str] = []
     total_chars = 0
-    for turn in reversed(history):
-        user_msg = turn.get("user", "")[:500]
-        line = f"Previous question: {user_msg}"
+    for msg in reversed(previous):
+        line = f"Previous question: {msg[:500]}"
         if total_chars + len(line) > _MAX_HISTORY_CHARS:
             break
         history_lines.insert(0, line)
@@ -362,9 +366,6 @@ async def _stream_response(
         yield "data: [DONE]\n\n"
         return
 
-    # Record history
-    _record_history(user_id, user_message, answer)
-
     # Parse sources and convert to markdown
     body, sources = extract_sources_section(answer)
     body = _resolve_reference_markers(body, sources)
@@ -412,13 +413,13 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
     if not manager.get_workspace(workspace_id):
         return _openai_error(404, f"Model not found: {req.model}")
 
-    user_id = req.user or "openai-default"
+    user_id = getattr(request.state, "openai_user_id", None) or req.user or "openai-default"
     completion_id = f"chatcmpl-{uuid4().hex[:24]}"
     created = int(time.time())
     plugin_manager = getattr(request.app.state, "plugin_manager", None)
 
-    # Build composite query with our history
-    composite_query = _build_composite_query(user_id, user_message)
+    # Build composite query from conversation messages
+    composite_query = _build_composite_query(req.messages, user_message)
 
     if req.stream:
         return StreamingResponse(
@@ -452,9 +453,6 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
     except Exception as exc:
         logger.error("openai_compat.search_error", error=str(exc), exc_info=True)
         return _openai_error(500, "Internal error", "server_error")
-
-    # Record history
-    _record_history(user_id, user_message, answer)
 
     # Convert sources to markdown
     from metatron.api.routes.chat import extract_sources_section

--- a/src/metatron/api/routes/openwebui_import.py
+++ b/src/metatron/api/routes/openwebui_import.py
@@ -15,6 +15,13 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(tags=["admin"])
 
 
+def _require_admin(request: Request) -> dict:
+    user = getattr(request.state, "user", {})
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return user
+
+
 def _generate_password(length: int = 16) -> str:
     alphabet = string.ascii_letters + string.digits
     return "".join(secrets.choice(alphabet) for _ in range(length))
@@ -34,9 +41,7 @@ class ImportRequest(BaseModel):
 
 @router.post("/admin/import-openwebui-users")
 async def import_openwebui_users(req: ImportRequest, request: Request) -> dict:
-    user = getattr(request.state, "user", {})
-    if user.get("role") != "admin":
-        raise HTTPException(status_code=403, detail="Admin access required")
+    _require_admin(request)
 
     user_store = getattr(request.app.state, "user_store", None)
     api_key_store = getattr(request.app.state, "api_key_store", None)

--- a/src/metatron/api/routes/openwebui_import.py
+++ b/src/metatron/api/routes/openwebui_import.py
@@ -1,0 +1,107 @@
+"""Import users from external Open WebUI instance."""
+from __future__ import annotations
+
+import secrets
+import string
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from metatron.auth.openwebui_client import OpenWebUIClient
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["admin"])
+
+
+def _generate_password(length: int = 16) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def _map_role_from_owui(owui_role: str) -> str:
+    if owui_role == "admin":
+        return "admin"
+    return "viewer"
+
+
+class ImportRequest(BaseModel):
+    owui_url: str
+    admin_email: str
+    admin_password: str
+
+
+@router.post("/admin/import-openwebui-users")
+async def import_openwebui_users(req: ImportRequest, request: Request) -> dict:
+    user = getattr(request.state, "user", {})
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    user_store = getattr(request.app.state, "user_store", None)
+    api_key_store = getattr(request.app.state, "api_key_store", None)
+    if not user_store or not api_key_store:
+        raise HTTPException(status_code=503, detail="Stores not available")
+
+    client = OpenWebUIClient(req.owui_url)
+    try:
+        await client.login(req.admin_email, req.admin_password)
+    except Exception as exc:
+        logger.warning("owui_import.login_failed", url=req.owui_url, error=str(exc))
+        raise HTTPException(
+            status_code=400, detail="Failed to login to Open WebUI. Check URL and credentials."
+        ) from exc
+
+    owui_users = await client.list_users()
+
+    imported = []
+    skipped = 0
+    already_existed = 0
+
+    for owui_user in owui_users:
+        email = owui_user.get("email", "")
+        name = owui_user.get("name", "")
+        owui_role = owui_user.get("role", "user")
+
+        if owui_role == "pending":
+            skipped += 1
+            continue
+
+        existing = await user_store.get_user_by_email(email)
+        if existing:
+            already_existed += 1
+            continue
+
+        metatron_role = _map_role_from_owui(owui_role)
+        password = _generate_password()
+
+        try:
+            new_user = await user_store.create_user(
+                email=email, password=password,
+                display_name=name, role=metatron_role,
+            )
+        except Exception as exc:
+            if "unique" in str(exc).lower() or "duplicate" in str(exc).lower():
+                already_existed += 1
+                continue
+            raise
+        raw_key = await api_key_store.create_key(user_id=new_user["id"], label="openwebui")
+
+        imported.append({
+            "email": email,
+            "name": name,
+            "role": metatron_role,
+            "metatron_password": password,
+            "api_key": raw_key,
+        })
+
+    logger.info(
+        "owui_import.done",
+        imported=len(imported), skipped=skipped, existed=already_existed,
+    )
+    return {
+        "imported": imported,
+        "skipped": skipped,
+        "already_existed": already_existed,
+        "total_in_owui": len(owui_users),
+    }

--- a/src/metatron/api/routes/users.py
+++ b/src/metatron/api/routes/users.py
@@ -60,6 +60,30 @@ async def create_user(req: CreateUserRequest, request: Request) -> dict:
         if "unique" in str(e).lower() or "duplicate" in str(e).lower():
             raise HTTPException(status_code=409, detail="Email already exists")
         raise
+
+    # Generate API key and sync to Open WebUI
+    api_key_store = getattr(request.app.state, "api_key_store", None)
+    if api_key_store:
+        raw_key = await api_key_store.create_key(user_id=user["id"], label="default")
+        user["api_key"] = raw_key
+
+        owui_sync = getattr(request.app.state, "owui_sync", None)
+        if owui_sync and owui_sync.enabled:
+            sync_result = await owui_sync.sync_user_created(
+                email=req.email,
+                name=req.display_name or req.email,
+                password=req.password,
+                role=req.role,
+                api_key=raw_key,
+            )
+            if sync_result:
+                user["owui_synced"] = True
+                await user_store.update_user(
+                    user["id"],
+                    owui_user_id=sync_result["owui_user_id"],
+                    owui_token=sync_result["owui_token"],
+                )
+
     return user
 
 
@@ -102,6 +126,19 @@ async def update_user(user_id: str, req: UpdateUserRequest, request: Request) ->
     user = await user_store.update_user(user_id, **updates)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+
+    # Sync update to Open WebUI
+    owui_sync = getattr(request.app.state, "owui_sync", None)
+    owui_id = user.get("owui_user_id")
+    if owui_sync and owui_sync.enabled and owui_id:
+        await owui_sync.sync_user_updated(
+            owui_user_id=owui_id,
+            name=user.get("display_name", ""),
+            email=user.get("email", ""),
+            role=user.get("role", "viewer"),
+            password=updates.get("password"),
+        )
+
     return user
 
 
@@ -111,11 +148,60 @@ async def delete_user(user_id: str, request: Request) -> None:
     if caller.get("user_id") == user_id:
         raise HTTPException(status_code=400, detail="Cannot delete yourself")
     user_store = _get_user_store(request)
+
+    # Get owui_user_id before deleting
+    user = await user_store.get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
     if not await user_store.delete_user(user_id):
         raise HTTPException(status_code=404, detail="User not found")
+
+    # Sync delete to Open WebUI
+    owui_sync = getattr(request.app.state, "owui_sync", None)
+    owui_id = user.get("owui_user_id")
+    if owui_sync and owui_sync.enabled and owui_id:
+        await owui_sync.sync_user_deleted(owui_user_id=owui_id)
 
 
     # Workspace management removed — workspace access is managed through
     # enterprise access groups. Adding a user to a group automatically
     # grants workspace access. Removing from all groups in a workspace
     # revokes access.
+
+
+# --- Personal API keys for /v1 endpoints ---
+
+
+def _get_api_key_store(request: Request):
+    store = getattr(request.app.state, "api_key_store", None)
+    if not store:
+        raise HTTPException(status_code=503, detail="API key store not available")
+    return store
+
+
+@router.post("/users/{user_id}/api-keys", status_code=201)
+async def create_api_key(user_id: str, request: Request) -> dict:
+    _require_admin(request)
+    api_store = _get_api_key_store(request)
+    user_store = _get_user_store(request)
+    if not await user_store.get_user_by_id(user_id):
+        raise HTTPException(status_code=404, detail="User not found")
+    raw_key = await api_store.create_key(user_id=user_id, label="default")
+    return {"raw_key": raw_key, "user_id": user_id}
+
+
+@router.get("/users/{user_id}/api-keys")
+async def list_api_keys(user_id: str, request: Request) -> dict:
+    _require_admin(request)
+    api_store = _get_api_key_store(request)
+    keys = await api_store.list_keys(user_id=user_id)
+    return {"keys": keys, "user_id": user_id}
+
+
+@router.delete("/users/{user_id}/api-keys/{key_prefix}", status_code=204)
+async def revoke_api_key(user_id: str, key_prefix: str, request: Request) -> None:
+    _require_admin(request)
+    api_store = _get_api_key_store(request)
+    if not await api_store.revoke_key(key_prefix=key_prefix, user_id=user_id):
+        raise HTTPException(status_code=404, detail="Key not found")

--- a/src/metatron/api/routes/users.py
+++ b/src/metatron/api/routes/users.py
@@ -81,7 +81,6 @@ async def create_user(req: CreateUserRequest, request: Request) -> dict:
                 await user_store.update_user(
                     user["id"],
                     owui_user_id=sync_result["owui_user_id"],
-                    owui_token=sync_result["owui_token"],
                 )
 
     return user
@@ -99,6 +98,11 @@ async def list_users(
     return {"users": users, "total": total}
 
 
+def _sanitize_user(user: dict) -> dict:
+    """Remove internal fields from user dict before returning to API."""
+    return {k: v for k, v in user.items() if k not in ("owui_user_id",)}
+
+
 @router.get("/users/{user_id}")
 async def get_user(user_id: str, request: Request) -> dict:
     _require_admin(request)
@@ -106,7 +110,7 @@ async def get_user(user_id: str, request: Request) -> dict:
     user = await user_store.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    return user
+    return _sanitize_user(user)
 
 
 @router.patch("/users/{user_id}")

--- a/src/metatron/auth/api_key_store.py
+++ b/src/metatron/auth/api_key_store.py
@@ -1,0 +1,135 @@
+"""Personal API key store for OpenAI-compat endpoints.
+
+Keys are random hex strings prefixed with 'mtk_'. The DB stores
+SHA-256 hashes — a DB leak does not expose raw keys.
+
+Table: api_keys (created lazily via ensure_schema)
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = structlog.get_logger(__name__)
+
+KEY_PREFIX = "mtk_"
+KEY_BYTES = 32
+
+
+def _generate_raw_key() -> str:
+    return f"{KEY_PREFIX}{secrets.token_hex(KEY_BYTES)}"
+
+
+def _hash_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+class ApiKeyStore:
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+        self._schema_ensured = False
+
+    async def ensure_schema(self) -> None:
+        async with self._engine.begin() as conn:
+            dialect = conn.dialect.name
+            if dialect == "postgresql":
+                await conn.execute(text("""
+                    CREATE TABLE IF NOT EXISTS api_keys (
+                        id         TEXT PRIMARY KEY,
+                        user_id    TEXT NOT NULL,
+                        key_hash   TEXT NOT NULL UNIQUE,
+                        key_prefix TEXT NOT NULL,
+                        label      TEXT NOT NULL DEFAULT '',
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                    )
+                """))
+            else:
+                await conn.execute(text("""
+                    CREATE TABLE IF NOT EXISTS api_keys (
+                        id         TEXT PRIMARY KEY,
+                        user_id    TEXT NOT NULL,
+                        key_hash   TEXT NOT NULL UNIQUE,
+                        key_prefix TEXT NOT NULL,
+                        label      TEXT NOT NULL DEFAULT '',
+                        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                    )
+                """))
+        self._schema_ensured = True
+        logger.info("api_key_store.schema.ensured")
+
+    async def _ensure(self) -> None:
+        if not self._schema_ensured:
+            await self.ensure_schema()
+
+    async def create_key(self, user_id: str, label: str = "") -> str:
+        """Create a new API key. Returns the raw key (shown once)."""
+        await self._ensure()
+        raw_key = _generate_raw_key()
+        key_hash = _hash_key(raw_key)
+        key_id = secrets.token_hex(16)
+        async with self._engine.begin() as conn:
+            await conn.execute(text("""
+                INSERT INTO api_keys (id, user_id, key_hash, key_prefix, label)
+                VALUES (:id, :user_id, :key_hash, :key_prefix, :label)
+            """), {
+                "id": key_id,
+                "user_id": user_id,
+                "key_hash": key_hash,
+                "key_prefix": raw_key[:12],
+                "label": label,
+            })
+        logger.info("api_key.created", user_id=user_id, prefix=raw_key[:12])
+        return raw_key
+
+    async def resolve_key(
+        self, raw_key: str, static_key: str = ""
+    ) -> dict[str, Any] | None:
+        """Resolve a raw API key to user info. Returns None if invalid."""
+        if static_key and raw_key == static_key:
+            return {"user_id": "openai-default", "source": "static"}
+
+        await self._ensure()
+        key_hash = _hash_key(raw_key)
+        async with self._engine.connect() as conn:
+            row = (await conn.execute(text("""
+                SELECT user_id, key_prefix, label, created_at
+                FROM api_keys WHERE key_hash = :key_hash
+            """), {"key_hash": key_hash})).first()
+        if row is None:
+            return None
+        return {
+            "user_id": row[0],
+            "key_prefix": row[1],
+            "label": row[2],
+            "created_at": row[3],
+            "source": "personal",
+        }
+
+    async def list_keys(self, user_id: str) -> list[dict[str, Any]]:
+        """List all keys for a user (without hashes)."""
+        await self._ensure()
+        async with self._engine.connect() as conn:
+            rows = await conn.execute(text("""
+                SELECT id, key_prefix, label, created_at
+                FROM api_keys WHERE user_id = :user_id
+                ORDER BY created_at
+            """), {"user_id": user_id})
+            return [
+                {"id": r[0], "key_prefix": r[1], "label": r[2], "created_at": r[3]}
+                for r in rows
+            ]
+
+    async def revoke_key(self, key_prefix: str, user_id: str) -> bool:
+        """Revoke a key by its prefix. Returns True if deleted."""
+        await self._ensure()
+        async with self._engine.begin() as conn:
+            result = await conn.execute(text("""
+                DELETE FROM api_keys
+                WHERE key_prefix = :prefix AND user_id = :user_id
+            """), {"prefix": key_prefix, "user_id": user_id})
+            return result.rowcount > 0

--- a/src/metatron/auth/api_key_store.py
+++ b/src/metatron/auth/api_key_store.py
@@ -8,6 +8,7 @@ Table: api_keys (created lazily via ensure_schema)
 from __future__ import annotations
 
 import hashlib
+import hmac
 import secrets
 from typing import Any
 
@@ -90,7 +91,7 @@ class ApiKeyStore:
         self, raw_key: str, static_key: str = ""
     ) -> dict[str, Any] | None:
         """Resolve a raw API key to user info. Returns None if invalid."""
-        if static_key and raw_key == static_key:
+        if static_key and hmac.compare_digest(raw_key, static_key):
             return {"user_id": "openai-default", "source": "static"}
 
         await self._ensure()

--- a/src/metatron/auth/openwebui_client.py
+++ b/src/metatron/auth/openwebui_client.py
@@ -1,0 +1,145 @@
+"""HTTP client for Open WebUI user management API."""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_TIMEOUT = httpx.Timeout(30.0)
+
+
+class OpenWebUIClient:
+    """Async client for Open WebUI REST API.
+
+    Reuses a single httpx.AsyncClient for connection pooling.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._admin_token: str | None = None
+        self._http = httpx.AsyncClient(timeout=_TIMEOUT)
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self._admin_token is not None
+
+    def _headers(self, token: str | None = None) -> dict[str, str]:
+        t = token or self._admin_token
+        h = {"Content-Type": "application/json"}
+        if t:
+            h["Authorization"] = f"Bearer {t}"
+        return h
+
+    async def login(self, email: str, password: str) -> dict[str, Any]:
+        """Sign in as admin, store JWT for subsequent calls."""
+        resp = await self._http.post(
+            f"{self.base_url}/api/v1/auths/signin",
+            json={"email": email, "password": password},
+            headers={"Content-Type": "application/json"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        self._admin_token = data.get("token")
+        logger.info("owui.login.ok", email=email)
+        return data
+
+    async def signup(self, name: str, email: str, password: str) -> dict[str, Any]:
+        """Sign up (first user becomes admin)."""
+        resp = await self._http.post(
+            f"{self.base_url}/api/v1/auths/signup",
+            json={"name": name, "email": email, "password": password},
+            headers={"Content-Type": "application/json"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        self._admin_token = data.get("token")
+        logger.info("owui.signup.ok", email=email)
+        return data
+
+    async def list_users(self) -> list[dict[str, Any]]:
+        """List all users (admin only)."""
+        resp = await self._http.get(
+            f"{self.base_url}/api/v1/users/",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("users", data) if isinstance(data, dict) else data
+
+    async def create_user(
+        self, name: str, email: str, password: str, role: str = "user"
+    ) -> dict[str, Any]:
+        """Create a user (admin only). Returns user dict with JWT token."""
+        resp = await self._http.post(
+            f"{self.base_url}/api/v1/auths/add",
+            json={"name": name, "email": email, "password": password, "role": role},
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def update_user(
+        self, user_id: str, name: str, email: str, role: str,
+        profile_image_url: str = "/user.png",
+        password: str | None = None,
+    ) -> dict[str, Any]:
+        """Update a user (admin only). All fields required by OWUI API."""
+        body: dict[str, Any] = {
+            "name": name, "email": email, "role": role,
+            "profile_image_url": profile_image_url,
+        }
+        if password:
+            body["password"] = password
+        resp = await self._http.post(
+            f"{self.base_url}/api/v1/users/{user_id}/update",
+            json=body,
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def delete_user(self, user_id: str) -> bool:
+        """Delete a user (admin only)."""
+        resp = await self._http.delete(
+            f"{self.base_url}/api/v1/users/{user_id}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        return True
+
+    async def set_direct_connection(
+        self, user_token: str, metatron_url: str, api_key: str
+    ) -> None:
+        """Set Direct Connection settings for a user (needs user's own JWT)."""
+        body = {
+            "ui": {
+                "directConnections": {
+                    "OPENAI_API_BASE_URLS": [metatron_url],
+                    "OPENAI_API_KEYS": [api_key],
+                    "OPENAI_API_CONFIGS": {
+                        "0": {
+                            "enable": True,
+                            "tags": [],
+                            "prefix_id": "",
+                            "model_ids": [],
+                            "connection_type": "external",
+                            "auth_type": "bearer",
+                        }
+                    },
+                }
+            }
+        }
+        resp = await self._http.post(
+            f"{self.base_url}/api/v1/users/user/settings/update",
+            json=body,
+            headers=self._headers(token=user_token),
+        )
+        resp.raise_for_status()
+        logger.info("owui.direct_connection.set", metatron_url=metatron_url)
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._http.aclose()

--- a/src/metatron/auth/openwebui_sync.py
+++ b/src/metatron/auth/openwebui_sync.py
@@ -1,0 +1,126 @@
+"""Sync Metatron users to Open WebUI (bundled scenario).
+
+Uses admin@metatron.local credentials (same as core's seed admin)
+to authenticate with Open WebUI. On first startup, registers
+the admin account in Open WebUI via signup (first user = admin).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from metatron.auth.openwebui_client import OpenWebUIClient
+
+logger = structlog.get_logger(__name__)
+
+
+class OpenWebUISync:
+    """Handles user sync from Metatron -> Open WebUI."""
+
+    def __init__(
+        self,
+        owui_url: str,
+        metatron_url: str,
+        admin_email: str = "admin@metatron.local",
+        admin_password: str = "metatron",
+    ) -> None:
+        self._owui_url = owui_url
+        self._metatron_url = metatron_url
+        self._admin_email = admin_email
+        self._admin_password = admin_password
+        self._client = OpenWebUIClient(owui_url) if owui_url else None
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._owui_url)
+
+    def _map_role_to_owui(self, metatron_role: str) -> str:
+        return "admin" if metatron_role == "admin" else "user"
+
+    async def ensure_admin(self) -> None:
+        """Ensure admin@metatron.local exists in Open WebUI.
+
+        Tries signin first. If it fails, tries signup (first user = admin).
+        """
+        if not self.enabled:
+            return
+        try:
+            await self._client.login(self._admin_email, self._admin_password)
+            logger.info("owui_sync.admin.login_ok")
+        except Exception:
+            try:
+                await self._client.signup(
+                    name="Metatron Admin",
+                    email=self._admin_email,
+                    password=self._admin_password,
+                )
+                logger.info("owui_sync.admin.signup_ok")
+            except Exception as exc:
+                logger.warning("owui_sync.admin.failed", error=str(exc))
+
+    async def _ensure_login(self) -> None:
+        if self._client and not self._client.is_authenticated:
+            await self.ensure_admin()
+
+    async def sync_user_created(
+        self,
+        email: str,
+        name: str,
+        password: str,
+        role: str,
+        api_key: str,
+    ) -> dict[str, Any] | None:
+        """Create user in Open WebUI + set Direct Connection."""
+        if not self.enabled:
+            return None
+        try:
+            await self._ensure_login()
+            owui_user = await self._client.create_user(
+                name=name, email=email, password=password,
+                role=self._map_role_to_owui(role),
+            )
+            owui_token = owui_user.get("token", "")
+            if owui_token and self._metatron_url:
+                await self._client.set_direct_connection(
+                    user_token=owui_token,
+                    metatron_url=self._metatron_url,
+                    api_key=api_key,
+                )
+            logger.info("owui_sync.user_created", email=email)
+            return {"owui_user_id": owui_user.get("id", ""), "owui_token": owui_token}
+        except Exception as exc:
+            logger.warning("owui_sync.create_failed", email=email, error=str(exc))
+            return None
+
+    async def sync_user_updated(
+        self, owui_user_id: str, name: str, email: str, role: str,
+        password: str | None = None,
+    ) -> bool:
+        """Update user in Open WebUI."""
+        if not self.enabled:
+            return False
+        try:
+            await self._ensure_login()
+            await self._client.update_user(
+                user_id=owui_user_id, name=name, email=email,
+                role=self._map_role_to_owui(role), password=password,
+            )
+            logger.info("owui_sync.user_updated", email=email)
+            return True
+        except Exception as exc:
+            logger.warning("owui_sync.update_failed", email=email, error=str(exc))
+            return False
+
+    async def sync_user_deleted(self, owui_user_id: str) -> bool:
+        """Delete user from Open WebUI."""
+        if not self.enabled:
+            return False
+        try:
+            await self._ensure_login()
+            await self._client.delete_user(owui_user_id)
+            logger.info("owui_sync.user_deleted", owui_user_id=owui_user_id)
+            return True
+        except Exception as exc:
+            logger.warning("owui_sync.delete_failed", error=str(exc))
+            return False

--- a/src/metatron/auth/user_store.py
+++ b/src/metatron/auth/user_store.py
@@ -54,6 +54,8 @@ class UserStore:
                     ("display_name", "TEXT NOT NULL DEFAULT ''"),
                     ("is_active", "BOOLEAN NOT NULL DEFAULT true"),
                     ("updated_at", "TIMESTAMPTZ"),
+                    ("owui_user_id", "TEXT"),
+                    ("owui_token", "TEXT"),
                 ]:
                     try:
                         await conn.execute(text(
@@ -88,7 +90,9 @@ class UserStore:
                         role          TEXT NOT NULL DEFAULT 'viewer',
                         is_active     INTEGER NOT NULL DEFAULT 1,
                         created_at    TEXT NOT NULL DEFAULT (datetime('now')),
-                        updated_at    TEXT
+                        updated_at    TEXT,
+                        owui_user_id  TEXT,
+                        owui_token    TEXT
                     )
                 """))
                 await conn.execute(text("""
@@ -151,7 +155,7 @@ class UserStore:
     async def get_user_by_id(self, user_id: str) -> dict[str, Any] | None:
         async with self._engine.connect() as conn:
             row = (await conn.execute(
-                text("SELECT id, email, display_name, role, is_active, created_at, updated_at FROM users WHERE id = :id"),
+                text("SELECT id, email, display_name, role, is_active, created_at, updated_at, owui_user_id, owui_token FROM users WHERE id = :id"),
                 {"id": user_id},
             )).first()
             if not row:
@@ -182,7 +186,7 @@ class UserStore:
         # Handle password separately
         if "password" in fields:
             fields["password_hash"] = hash_password(fields.pop("password"))
-        allowed = {"email", "password_hash", "display_name", "role", "is_active"}
+        allowed = {"email", "password_hash", "display_name", "role", "is_active", "owui_user_id", "owui_token"}
         updates = {k: v for k, v in fields.items() if k in allowed}
         if not updates:
             return await self.get_user_by_id(user_id)

--- a/src/metatron/auth/user_store.py
+++ b/src/metatron/auth/user_store.py
@@ -55,7 +55,6 @@ class UserStore:
                     ("is_active", "BOOLEAN NOT NULL DEFAULT true"),
                     ("updated_at", "TIMESTAMPTZ"),
                     ("owui_user_id", "TEXT"),
-                    ("owui_token", "TEXT"),
                 ]:
                     try:
                         await conn.execute(text(
@@ -91,8 +90,7 @@ class UserStore:
                         is_active     INTEGER NOT NULL DEFAULT 1,
                         created_at    TEXT NOT NULL DEFAULT (datetime('now')),
                         updated_at    TEXT,
-                        owui_user_id  TEXT,
-                        owui_token    TEXT
+                        owui_user_id  TEXT
                     )
                 """))
                 await conn.execute(text("""
@@ -155,7 +153,7 @@ class UserStore:
     async def get_user_by_id(self, user_id: str) -> dict[str, Any] | None:
         async with self._engine.connect() as conn:
             row = (await conn.execute(
-                text("SELECT id, email, display_name, role, is_active, created_at, updated_at, owui_user_id, owui_token FROM users WHERE id = :id"),
+                text("SELECT id, email, display_name, role, is_active, created_at, updated_at, owui_user_id FROM users WHERE id = :id"),
                 {"id": user_id},
             )).first()
             if not row:
@@ -186,7 +184,7 @@ class UserStore:
         # Handle password separately
         if "password" in fields:
             fields["password_hash"] = hash_password(fields.pop("password"))
-        allowed = {"email", "password_hash", "display_name", "role", "is_active", "owui_user_id", "owui_token"}
+        allowed = {"email", "password_hash", "display_name", "role", "is_active", "owui_user_id"}
         updates = {k: v for k, v in fields.items() if k in allowed}
         if not updates:
             return await self.get_user_by_id(user_id)

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -35,6 +35,10 @@ class Settings(BaseSettings):
     openai_compat_enabled: bool = Field(True, alias="METATRON_OPENAI_COMPAT_ENABLED")
     openai_compat_key: str = Field("", alias="METATRON_OPENAI_COMPAT_KEY")
 
+    # --- Open WebUI sync (bundled scenario) ---
+    openwebui_url: str = Field("", alias="METATRON_OPENWEBUI_URL")
+    openwebui_metatron_url: str = Field("", alias="METATRON_OPENWEBUI_METATRON_URL")
+
     # --- PostgreSQL ---
     postgres_host: str = Field("localhost", alias="POSTGRES_HOST")
     postgres_port: int = Field(5432, alias="POSTGRES_PORT")

--- a/tests/unit/test_api_key_store.py
+++ b/tests/unit/test_api_key_store.py
@@ -1,0 +1,61 @@
+"""Tests for personal API key store."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.auth.api_key_store import ApiKeyStore
+
+
+@pytest.fixture
+async def store():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    s = ApiKeyStore(engine)
+    await s.ensure_schema()
+    return s
+
+
+@pytest.mark.asyncio
+async def test_create_and_verify(store):
+    raw_key = await store.create_key(user_id="user-1", label="default")
+    assert raw_key.startswith("mtk_")
+    resolved = await store.resolve_key(raw_key)
+    assert resolved is not None
+    assert resolved["user_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_resolve_invalid_key(store):
+    resolved = await store.resolve_key("mtk_nonexistent")
+    assert resolved is None
+
+
+@pytest.mark.asyncio
+async def test_list_keys(store):
+    await store.create_key(user_id="user-1", label="key-a")
+    await store.create_key(user_id="user-1", label="key-b")
+    keys = await store.list_keys(user_id="user-1")
+    assert len(keys) == 2
+    assert "key_hash" not in keys[0]
+
+
+@pytest.mark.asyncio
+async def test_revoke_key(store):
+    raw_key = await store.create_key(user_id="user-1", label="temp")
+    revoked = await store.revoke_key(key_prefix=raw_key[:12], user_id="user-1")
+    assert revoked is True
+    assert await store.resolve_key(raw_key) is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_nonexistent(store):
+    revoked = await store.revoke_key(key_prefix="mtk_xxxxxxx", user_id="user-1")
+    assert revoked is False
+
+
+@pytest.mark.asyncio
+async def test_static_key_fallback(store):
+    """When a static key is configured, resolve_key should check it too."""
+    resolved = await store.resolve_key("static-key-123", static_key="static-key-123")
+    assert resolved is not None
+    assert resolved["user_id"] == "openai-default"

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -80,8 +80,8 @@ class TestModelsEndpoint:
         r = client.get("/v1/models", headers={"Authorization": "Bearer test-key"})
         assert r.status_code == 404
 
-    def test_list_models_no_key_configured_returns_404(self):
-        """When METATRON_OPENAI_COMPAT_KEY is empty, feature is disabled."""
+    def test_list_models_no_key_configured_returns_401(self):
+        """When METATRON_OPENAI_COMPAT_KEY is empty and no api_key_store, returns 401."""
         settings = Settings(
             METATRON_ENV="development",
             METATRON_OPENAI_COMPAT_KEY="",
@@ -90,7 +90,7 @@ class TestModelsEndpoint:
         app = create_app(settings)
         client = TestClient(app, raise_server_exceptions=False)
         r = client.get("/v1/models", headers={"Authorization": "Bearer anything"})
-        assert r.status_code == 404
+        assert r.status_code == 401
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_openwebui_client.py
+++ b/tests/unit/test_openwebui_client.py
@@ -1,0 +1,86 @@
+"""Tests for Open WebUI API client."""
+from __future__ import annotations
+
+import json
+import pytest
+import httpx
+import respx
+
+from metatron.auth.openwebui_client import OpenWebUIClient
+
+
+@pytest.fixture
+def owui():
+    return OpenWebUIClient(base_url="http://owui:8080")
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_login(owui):
+    respx.post("http://owui:8080/api/v1/auths/signin").mock(
+        return_value=httpx.Response(200, json={
+            "id": "admin-1", "token": "jwt-admin", "role": "admin",
+        })
+    )
+    result = await owui.login("admin@test.local", "pass")
+    assert result["token"] == "jwt-admin"
+    assert owui._admin_token == "jwt-admin"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_list_users(owui):
+    owui._admin_token = "jwt-admin"
+    respx.get("http://owui:8080/api/v1/users/").mock(
+        return_value=httpx.Response(200, json={
+            "users": [
+                {"id": "u1", "email": "a@test.local", "name": "A", "role": "admin"},
+                {"id": "u2", "email": "b@test.local", "name": "B", "role": "user"},
+            ],
+            "total": 2,
+        })
+    )
+    users = await owui.list_users()
+    assert len(users) == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_create_user(owui):
+    owui._admin_token = "jwt-admin"
+    respx.post("http://owui:8080/api/v1/auths/add").mock(
+        return_value=httpx.Response(200, json={
+            "id": "u3", "email": "c@test.local", "name": "C",
+            "role": "user", "token": "jwt-u3",
+        })
+    )
+    result = await owui.create_user("C", "c@test.local", "pass123", "user")
+    assert result["token"] == "jwt-u3"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_set_direct_connection(owui):
+    respx.post("http://owui:8080/api/v1/users/user/settings/update").mock(
+        return_value=httpx.Response(200, json={"ui": {"directConnections": {}}})
+    )
+    await owui.set_direct_connection(
+        user_token="jwt-u3",
+        metatron_url="http://metatron:8000/v1",
+        api_key="mtk_abc123",
+    )
+    req = respx.calls.last.request
+    assert req.headers["authorization"] == "Bearer jwt-u3"
+    body = json.loads(req.content)
+    assert body["ui"]["directConnections"]["OPENAI_API_KEYS"] == ["mtk_abc123"]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_delete_user(owui):
+    owui._admin_token = "jwt-admin"
+    respx.delete("http://owui:8080/api/v1/users/u3").mock(
+        return_value=httpx.Response(200, text="true")
+    )
+    result = await owui.delete_user("u3")
+    assert result is True

--- a/tests/unit/test_openwebui_import.py
+++ b/tests/unit/test_openwebui_import.py
@@ -1,0 +1,104 @@
+"""Tests for Open WebUI user import endpoint."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.api.app import create_app
+from metatron.auth.api_key_store import ApiKeyStore
+from metatron.auth.user_store import UserStore
+from metatron.core.config import Settings
+
+
+@pytest.fixture
+async def client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    settings = Settings(
+        METATRON_ENV="development",
+        METATRON_SECRET_KEY="test-secret",
+        AUTH_ENABLED=True,
+        METATRON_OPENAI_COMPAT_ENABLED=True,
+        METATRON_OPENAI_COMPAT_KEY="test-key",
+    )
+    app = create_app(settings)
+
+    user_store = UserStore(engine)
+    await user_store.ensure_schema()
+    api_key_store = ApiKeyStore(engine)
+    await api_key_store.ensure_schema()
+
+    app.state.user_store = user_store
+    app.state.api_key_store = api_key_store
+
+    from metatron.auth.jwt import create_token
+    admin = await user_store.create_user(
+        email="admin@metatron.local", password="admin12345", role="admin",
+    )
+    token = create_token(
+        user_id=admin["id"], role="admin",
+        workspace_ids=[], secret_key="test-secret",
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_import_users(client):
+    mock_owui_users = [
+        {"id": "u1", "email": "alice@ext.local", "name": "Alice", "role": "admin"},
+        {"id": "u2", "email": "bob@ext.local", "name": "Bob", "role": "user"},
+        {"id": "u3", "email": "pending@ext.local", "name": "Pending", "role": "pending"},
+    ]
+
+    with patch("metatron.api.routes.openwebui_import.OpenWebUIClient") as MockClient:
+        instance = MockClient.return_value
+        instance.login = AsyncMock(return_value={"token": "admin-jwt"})
+        instance.list_users = AsyncMock(return_value=mock_owui_users)
+
+        resp = await client.post("/api/v1/admin/import-openwebui-users", json={
+            "owui_url": "http://owui:8080",
+            "admin_email": "admin@ext.local",
+            "admin_password": "pass",
+        })
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["imported"]) == 2
+    assert data["skipped"] == 1
+    alice = next(u for u in data["imported"] if u["email"] == "alice@ext.local")
+    assert "metatron_password" in alice
+    assert "api_key" in alice
+    assert alice["api_key"].startswith("mtk_")
+    assert alice["role"] == "admin"
+    bob = next(u for u in data["imported"] if u["email"] == "bob@ext.local")
+    assert bob["role"] == "viewer"
+
+
+@pytest.mark.asyncio
+async def test_import_skips_existing(client):
+    mock_owui_users = [
+        {"id": "u1", "email": "admin@metatron.local", "name": "Admin", "role": "admin"},
+        {"id": "u2", "email": "new@ext.local", "name": "New", "role": "user"},
+    ]
+
+    with patch("metatron.api.routes.openwebui_import.OpenWebUIClient") as MockClient:
+        instance = MockClient.return_value
+        instance.login = AsyncMock(return_value={"token": "jwt"})
+        instance.list_users = AsyncMock(return_value=mock_owui_users)
+
+        resp = await client.post("/api/v1/admin/import-openwebui-users", json={
+            "owui_url": "http://owui:8080",
+            "admin_email": "admin@ext.local",
+            "admin_password": "pass",
+        })
+
+    data = resp.json()
+    assert len(data["imported"]) == 1
+    assert data["already_existed"] == 1

--- a/tests/unit/test_openwebui_sync.py
+++ b/tests/unit/test_openwebui_sync.py
@@ -1,0 +1,101 @@
+"""Tests for Open WebUI sync on user CRUD."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from metatron.auth.openwebui_sync import OpenWebUISync
+
+
+@pytest.fixture
+def sync_service():
+    svc = OpenWebUISync(
+        owui_url="http://owui:8080",
+        metatron_url="http://metatron:8000/v1",
+        admin_email="admin@metatron.local",
+        admin_password="metatron",
+    )
+    svc._client.login = AsyncMock(return_value={"token": "admin-jwt"})
+    svc._client._admin_token = "admin-jwt"
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_sync_create_user(sync_service):
+    sync_service._client.create_user = AsyncMock(return_value={
+        "id": "owui-1", "token": "user-jwt",
+    })
+    sync_service._client.set_direct_connection = AsyncMock()
+
+    result = await sync_service.sync_user_created(
+        email="new@test.local",
+        name="New User",
+        password="pass123",
+        role="viewer",
+        api_key="mtk_abc",
+    )
+
+    sync_service._client.create_user.assert_called_once_with(
+        name="New User", email="new@test.local",
+        password="pass123", role="user",
+    )
+    sync_service._client.set_direct_connection.assert_called_once_with(
+        user_token="user-jwt",
+        metatron_url="http://metatron:8000/v1",
+        api_key="mtk_abc",
+    )
+    assert result["owui_user_id"] == "owui-1"
+
+
+@pytest.mark.asyncio
+async def test_sync_disabled_when_no_url():
+    svc = OpenWebUISync(owui_url="", metatron_url="")
+    result = await svc.sync_user_created(
+        email="x@test.local", name="X", password="p", role="viewer", api_key="k",
+    )
+    assert result is None
+    assert svc.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_role_mapping(sync_service):
+    assert sync_service._map_role_to_owui("admin") == "admin"
+    assert sync_service._map_role_to_owui("editor") == "user"
+    assert sync_service._map_role_to_owui("viewer") == "user"
+
+
+@pytest.mark.asyncio
+async def test_sync_user_updated(sync_service):
+    sync_service._client.update_user = AsyncMock(return_value={})
+    result = await sync_service.sync_user_updated(
+        owui_user_id="owui-1", name="Updated", email="u@test.local", role="admin",
+    )
+    assert result is True
+    sync_service._client.update_user.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_user_deleted(sync_service):
+    sync_service._client.delete_user = AsyncMock(return_value=True)
+    result = await sync_service.sync_user_deleted(owui_user_id="owui-1")
+    assert result is True
+    sync_service._client.delete_user.assert_called_once_with("owui-1")
+
+
+@pytest.mark.asyncio
+async def test_ensure_admin_signin(sync_service):
+    """If signin works, no signup needed."""
+    sync_service._client.login = AsyncMock(return_value={"token": "jwt"})
+    sync_service._client.signup = AsyncMock()
+    await sync_service.ensure_admin()
+    sync_service._client.login.assert_called_once()
+    sync_service._client.signup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_admin_signup_fallback(sync_service):
+    """If signin fails, try signup."""
+    sync_service._client.login = AsyncMock(side_effect=Exception("401"))
+    sync_service._client.signup = AsyncMock(return_value={"token": "jwt"})
+    await sync_service.ensure_admin()
+    sync_service._client.signup.assert_called_once()

--- a/tests/unit/test_user_api_keys.py
+++ b/tests/unit/test_user_api_keys.py
@@ -1,0 +1,78 @@
+"""Tests for per-user API key management endpoints."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+from httpx import AsyncClient, ASGITransport
+
+from metatron.api.app import create_app
+from metatron.auth.api_key_store import ApiKeyStore
+from metatron.auth.user_store import UserStore
+from metatron.core.config import Settings
+
+
+@pytest.fixture
+async def client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    settings = Settings(
+        METATRON_ENV="development",
+        METATRON_SECRET_KEY="test-secret",
+        AUTH_ENABLED=True,
+        METATRON_OPENAI_COMPAT_ENABLED=True,
+        METATRON_OPENAI_COMPAT_KEY="test-static-key",
+    )
+    app = create_app(settings)
+
+    user_store = UserStore(engine)
+    await user_store.ensure_schema()
+    api_key_store = ApiKeyStore(engine)
+    await api_key_store.ensure_schema()
+
+    app.state.user_store = user_store
+    app.state.api_key_store = api_key_store
+
+    from metatron.auth.jwt import create_token
+    admin = await user_store.create_user(
+        email="admin@test.local", password="admin12345",
+        role="admin", workspace_ids=["ws1"],
+    )
+    token = create_token(
+        user_id=admin["id"], role="admin",
+        workspace_ids=["ws1"], secret_key="test-secret",
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as c:
+        c.admin_user_id = admin["id"]
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_create_api_key(client):
+    resp = await client.post(f"/api/v1/users/{client.admin_user_id}/api-keys")
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "raw_key" in data
+    assert data["raw_key"].startswith("mtk_")
+
+
+@pytest.mark.asyncio
+async def test_list_api_keys(client):
+    await client.post(f"/api/v1/users/{client.admin_user_id}/api-keys")
+    resp = await client.get(f"/api/v1/users/{client.admin_user_id}/api-keys")
+    assert resp.status_code == 200
+    keys = resp.json()["keys"]
+    assert len(keys) >= 1
+    assert "raw_key" not in keys[0]
+
+
+@pytest.mark.asyncio
+async def test_revoke_api_key(client):
+    create_resp = await client.post(f"/api/v1/users/{client.admin_user_id}/api-keys")
+    raw_key = create_resp.json()["raw_key"]
+    prefix = raw_key[:12]
+    resp = await client.delete(f"/api/v1/users/{client.admin_user_id}/api-keys/{prefix}")
+    assert resp.status_code == 204


### PR DESCRIPTION
- Personal API keys (api_keys table, mtk_ prefix, SHA-256 hashed)
- Per-user auth in /v1/chat/completions (replaces static key)
- API key management endpoints (POST/GET/DELETE /api/v1/users/{id}/api-keys)
- OpenWebUIClient for CRUD sync via Open WebUI REST API
- Bundled sync: auto-create users in Open WebUI on Metatron CRUD
- External import: POST /api/v1/admin/import-openwebui-users
- Conversation history from req.messages instead of in-memory store
- Config: METATRON_OPENWEBUI_URL, METATRON_OPENWEBUI_METATRON_URL