### PR TITLE
feat: LLM-based query resolver for context-dependent references

### DIFF
--- a/src/metatron/retrieval/prompts.py
+++ b/src/metatron/retrieval/prompts.py
@@ -74,3 +74,27 @@ TEAM_WORKFLOW_SCHEMA_SPEC = (
     "}\n\n"
     "IMPORTANT: 'steps' can be placeholder steps for now.\n"
 )
+
+QUERY_RESOLVER_SYSTEM_PROMPT = """\
+You are a query reference resolver for a corporate knowledge base search system.
+You receive a search query that may include conversation context from previous questions.
+Your job is to replace all contextual references with concrete values so the query \
+can be understood standalone.
+
+Resolve:
+- Relative dates ("the day before that", "за день до этого", "next day", \
+"на следующий день", "a week before", "за неделю до") → concrete dates based \
+on context and current date
+- Pronouns and demonstratives referring to prior context ("about it", "про это", \
+"what happened there", "что там было") → the actual subject from context
+- Any other references that require conversation history to understand
+
+Rules:
+- Return ONLY the rewritten query, nothing else
+- If there is nothing to resolve, return the query unchanged
+- Preserve the original language of the question
+- Do NOT add information that isn't in the query or context
+- Keep the rewritten query concise — a search query, not a sentence
+- When the query has "context: ... | question: ..." format, output only the \
+resolved question, not the context prefix\
+"""

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -17,8 +17,8 @@ from metatron.ingestion.processors.dates import (
 )
 from metatron.observability.metrics import timed
 from metatron.retrieval.prompts import (
-    HYBRID_SYSTEM_PROMPT, TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT,
-    TEAM_WORKFLOW_SCHEMA_SPEC,
+    HYBRID_SYSTEM_PROMPT, QUERY_RESOLVER_SYSTEM_PROMPT,
+    TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT, TEAM_WORKFLOW_SCHEMA_SPEC,
 )
 from metatron.retrieval.alias_registry import get_alias_registry
 from metatron.retrieval.aliases import resolve_person_name
@@ -58,6 +58,51 @@ _GRAPH_DEPTH = int(getattr(_s, "search_graph_depth", 2))
 _TRANSLATE_SYS = "Translate the following query to English. Return ONLY the translation, nothing else."
 
 _recall_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="recall")
+
+
+@timed("resolve_query")
+def resolve_query(query: str) -> str:
+    """Rewrite context-dependent references in the query to concrete values.
+
+    Uses LLM to resolve relative dates ("the day before that" → "March 11"),
+    pronouns ("tell me about it" → "tell me about Project Aurora"), and other
+    references that depend on conversation context.
+
+    Falls back to original query on any error.
+    """
+    try:
+        today = datetime.now().strftime("%Y-%m-%d")
+        user_msg = f"Current date: {today}\n\nQuery: {query}"
+        resolved = chat_completion(
+            messages=[
+                {"role": "system", "content": QUERY_RESOLVER_SYSTEM_PROMPT},
+                {"role": "user", "content": user_msg},
+            ],
+            temperature=0,
+            max_tokens=200,
+            timeout=10,
+        )
+        resolved = resolved.strip()
+
+        if not resolved or len(resolved) < 3 or len(resolved) > len(query) * 3:
+            logger.warning(
+                "query.resolve_fallback",
+                reason="invalid_response",
+                original=query[:100],
+                response_len=len(resolved) if resolved else 0,
+            )
+            return query
+
+        if resolved != query:
+            logger.info(
+                "query.resolved",
+                original=query[:100],
+                resolved=resolved[:200],
+            )
+        return resolved
+    except Exception as e:
+        logger.warning("query.resolve_failed", error=str(e))
+        return query
 
 
 def _run_recall_channels(ctx: RecallContext) -> tuple[list, list, list, list]:
@@ -531,7 +576,12 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     import time
     start_time = time.time()
     
-    rq = (intent_query or query or "").strip()
+    raw_query = (intent_query or query or "").strip()
+    # Resolve contextual references (relative dates, pronouns) using the full
+    # composite query which contains conversation history.  When intent_query
+    # is provided (OpenAI-compat), query carries the context we need.
+    rq = resolve_query(query.strip() if intent_query and query else raw_query)
+    rq_original = raw_query
     use_schema = should_use_team_workflow_schema(rq)
     lang = detect_response_language(rq)
 
@@ -634,7 +684,8 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
                     "graph_relations": [],
                     "graph_docs": [],
                     "pipeline_stages": {
-                        "original_query": rq,
+                        "original_query": rq_original,
+                        "resolved_query": rq if rq != rq_original else None,
                         "translated_query": sq,
                         "expanded_query": eq,
                         "detected_language": lang,
@@ -772,7 +823,8 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             "graph_relations": g_rels,
             "graph_docs": g_docs,
             "pipeline_stages": {
-                "original_query": rq,
+                "original_query": rq_original,
+                "resolved_query": rq if rq != rq_original else None,
                 "translated_query": sq,
                 "expanded_query": eq,
                 "detected_language": lang,

--- a/tests/unit/test_query_resolver.py
+++ b/tests/unit/test_query_resolver.py
@@ -1,0 +1,100 @@
+"""Tests for LLM-based query reference resolver."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from metatron.retrieval.search import resolve_query
+
+
+class TestResolveQuery:
+    """Tests for resolve_query() — LLM query reference resolver."""
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_resolves_relative_date_from_context(self, mock_llm) -> None:
+        mock_llm.return_value = "what was discussed on March 11?"
+        query = (
+            "context: what happened on March 12?"
+            " | question: what was discussed the day before that?"
+        )
+        result = resolve_query(query)
+        assert "March 11" in result
+        assert "the day before that" not in result
+        mock_llm.assert_called_once()
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_resolves_pronoun_reference(self, mock_llm) -> None:
+        mock_llm.return_value = "tell me more about Project Aurora"
+        result = resolve_query(
+            "context: What is Project Aurora? | question: tell me more about it"
+        )
+        assert "Project Aurora" in result
+        mock_llm.assert_called_once()
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_passthrough_standalone_query(self, mock_llm) -> None:
+        mock_llm.return_value = "What is Metatron?"
+        result = resolve_query("What is Metatron?")
+        assert result == "What is Metatron?"
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_fallback_on_llm_error(self, mock_llm) -> None:
+        mock_llm.side_effect = Exception("LLM timeout")
+        result = resolve_query("context: March 12 | question: day before that?")
+        assert result == "context: March 12 | question: day before that?"
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_fallback_on_empty_response(self, mock_llm) -> None:
+        mock_llm.return_value = ""
+        query = "context: March 12 | question: day before?"
+        result = resolve_query(query)
+        assert result == query
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_fallback_on_too_short_response(self, mock_llm) -> None:
+        mock_llm.return_value = "ab"
+        query = "context: March 12 | question: what happened?"
+        result = resolve_query(query)
+        assert result == query
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_fallback_on_too_long_response(self, mock_llm) -> None:
+        query = "short query"
+        mock_llm.return_value = "x" * (len(query) * 3 + 1)
+        result = resolve_query(query)
+        assert result == query
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_russian_query_resolved(self, mock_llm) -> None:
+        mock_llm.return_value = "что обсуждали 11 марта?"
+        result = resolve_query(
+            "context: что было 12 марта? | question: что обсуждали за день до этого?"
+        )
+        assert "11 марта" in result
+        mock_llm.assert_called_once()
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_prompt_contains_current_date(self, mock_llm) -> None:
+        mock_llm.return_value = "resolved query"
+        resolve_query("test query")
+        call_args = mock_llm.call_args
+        messages = call_args.kwargs.get("messages") or call_args[0][0]
+        user_msg = messages[1]["content"]
+        assert "Current date:" in user_msg
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_chat_history_format_resolved(self, mock_llm) -> None:
+        mock_llm.return_value = "что обсуждали 11 марта?"
+        query = (
+            "Previous question: что было на митинге 12 марта?\n"
+            "Current question: а за день до этого?"
+        )
+        result = resolve_query(query)
+        assert "11 марта" in result
+        mock_llm.assert_called_once()
+
+    @patch("metatron.retrieval.search.chat_completion")
+    def test_strips_whitespace(self, mock_llm) -> None:
+        mock_llm.return_value = "  resolved query  \n"
+        result = resolve_query("test query")
+        assert result == "resolved query"


### PR DESCRIPTION
Adds resolve_query() step to the search pipeline that uses LLM to rewrite contextual references (relative dates, pronouns) into concrete values before search. Fixes bug where "the day before that?" relative to March 12 returned wrong results because the date extractor couldn't resolve context-dependent expressions.

- New QUERY_RESOLVER_SYSTEM_PROMPT in prompts.py
- resolve_query() in search.py with graceful fallback on LLM errors
- Wired into hybrid_search_and_answer() using composite query (not intent_query) so conversation context is available for resolution
- Added resolved_query field to pipeline trace for debugging
- 11 unit tests covering resolution, fallback, and validation