### PR TITLE
feat(MTRNIX-210): activate root-child hierarchical chunking

### DIFF
--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -124,6 +124,11 @@ class Settings(BaseSettings):
     llm_context_max_tokens: int = Field(10000, alias="LLM_CONTEXT_MAX_TOKENS")
     llm_answer_reserve_tokens: int = Field(1500, alias="LLM_ANSWER_RESERVE_TOKENS")
 
+    # --- Hierarchical chunking ---
+    hierarchical_chunking_enabled: bool = Field(
+        True, alias="METATRON_HIERARCHICAL_CHUNKING_ENABLED"
+    )
+
     # --- Graph extraction ---
     graph_extraction_enabled: bool = Field(True, alias="GRAPH_EXTRACTION_ENABLED")
     graph_extraction_workers: int = Field(4, alias="GRAPH_EXTRACTION_WORKERS")

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -18,7 +18,7 @@ from metatron.core.interfaces import (
     ProcessorInterface,
     VectorStoreInterface,
 )
-from metatron.core.models import Document, SyncResult
+from metatron.core.models import Chunk, Document, SyncResult
 from metatron.ingestion.chunking import root_child_chunk, simple_chunk
 from metatron.ingestion.dedup import DeduplicationIndex, simhash
 from metatron.ingestion.processors.dates import extract_date_from_text
@@ -289,7 +289,7 @@ def ingest_documents(
 
 
 def _write_chunk_hierarchy(
-    chunk_objs: list,
+    chunk_objs: list[Chunk],
     workspace_id: str,
     doc_label: str,
 ) -> None:

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -19,7 +19,7 @@ from metatron.core.interfaces import (
     VectorStoreInterface,
 )
 from metatron.core.models import Document, SyncResult
-from metatron.ingestion.chunking import chunk_text, simple_chunk
+from metatron.ingestion.chunking import root_child_chunk, simple_chunk
 from metatron.ingestion.dedup import DeduplicationIndex, simhash
 from metatron.ingestion.processors.dates import extract_date_from_text
 
@@ -150,9 +150,8 @@ def ingest_documents(
     Returns:
         SyncResult with ingestion statistics.
     """
-    from metatron.storage.qdrant import get_hybrid_store
-
     from metatron.core.config import Settings
+    from metatron.storage.qdrant import get_hybrid_store
 
     _settings = Settings()
     t0 = time.time()
@@ -183,12 +182,18 @@ def ingest_documents(
                     dedup_index.remove_doc(doc.source_id)
                     _delete_graph_node(doc.source_id, workspace_id)
 
-            chunk_objs = simple_chunk(
-                doc.content,
-                document_id=doc.source_id or "",
-                workspace_id=workspace_id,
-            )
-            chunks = [c.content for c in chunk_objs]
+            if _settings.hierarchical_chunking_enabled:
+                chunk_objs = root_child_chunk(
+                    doc.content,
+                    document_id=doc.source_id or "",
+                    workspace_id=workspace_id,
+                )
+            else:
+                chunk_objs = simple_chunk(
+                    doc.content,
+                    document_id=doc.source_id or "",
+                    workspace_id=workspace_id,
+                )
 
             doc_date = extract_document_date(
                 title=doc.title or "",
@@ -197,7 +202,8 @@ def ingest_documents(
                 created_at=doc.created_at,
             )
 
-            for chunk in chunks:
+            for chunk_obj in chunk_objs:
+                chunk = chunk_obj.content
                 # Dedup: skip near-duplicate chunks from different documents
                 if dedup_index.check_and_add(chunk, doc.source_id):
                     dedup_count += 1
@@ -216,6 +222,9 @@ def ingest_documents(
                     "date": doc_date,
                     "simhash": chunk_hash,
                     "source_role": doc.source_role or source_role,
+                    "chunk_id": chunk_obj.id,
+                    "chunk_type": chunk_obj.chunk_type.value,
+                    "parent_id": chunk_obj.parent_id or "",
                     **(doc.metadata or {}),
                     "url": doc.url,  # after spread so doc.url takes precedence
                 }
@@ -234,6 +243,10 @@ def ingest_documents(
                 updated_count += 1
             else:
                 new_count += 1
+
+            # Write chunk hierarchy to Memgraph (graceful degradation)
+            if _settings.hierarchical_chunking_enabled:
+                _write_chunk_hierarchy(chunk_objs, workspace_id, doc.source_id)
 
             # Register people from any source into alias registry
             _register_persons(doc)
@@ -273,6 +286,40 @@ def ingest_documents(
         errors=errors,
         duration_ms=duration_ms,
     )
+
+
+def _write_chunk_hierarchy(
+    chunk_objs: list,
+    workspace_id: str,
+    doc_label: str,
+) -> None:
+    """Write CHILD_OF edges to Memgraph for root-child chunks (best-effort)."""
+    try:
+        from metatron.core.models import ChunkType
+        from metatron.storage.memgraph import write_chunk_hierarchy
+
+        root_ids = [c.id for c in chunk_objs if c.chunk_type == ChunkType.ROOT]
+        if not root_ids:
+            return
+
+        for root_id in root_ids:
+            child_ids = [
+                c.id for c in chunk_objs
+                if c.chunk_type == ChunkType.CHILD and c.parent_id == root_id
+            ]
+            if child_ids:
+                write_chunk_hierarchy(
+                    workspace_id=workspace_id,
+                    root_chunk_id=root_id,
+                    child_chunk_ids=child_ids,
+                    doc_label=doc_label,
+                )
+    except Exception as e:
+        logger.warning(
+            "ingest.chunk_hierarchy.error",
+            doc_label=doc_label,
+            error=str(e),
+        )
 
 
 def _extract_graphs_parallel(

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -1,52 +1,62 @@
 """Hybrid search pipeline -- vector + graph + LLM answer generation."""
 from __future__ import annotations
+
 import asyncio
 import json
 import re
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import Dict, List, Optional
 
 import structlog
 
 from metatron.core.config import Settings
-from metatron.llm import chat_completion, chat_completion_with_retry  # TODO: async migration
 from metatron.ingestion.processors.dates import (
-    extract_date_from_text, extract_date_range,
+    extract_date_from_text,
+    extract_date_range,
 )
+from metatron.llm import chat_completion, chat_completion_with_retry  # TODO: async migration
 from metatron.observability.metrics import timed
-from metatron.retrieval.prompts import (
-    HYBRID_SYSTEM_PROMPT, QUERY_RESOLVER_SYSTEM_PROMPT,
-    TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT, TEAM_WORKFLOW_SCHEMA_SPEC,
-)
 from metatron.retrieval.alias_registry import get_alias_registry
 from metatron.retrieval.aliases import resolve_person_name
 from metatron.retrieval.channels import (
-    RecallContext, merge_channels,
-    recall_dense, recall_exact, recall_metadata, recall_graph,
+    RecallContext,
+    merge_channels,
+    recall_dense,
+    recall_exact,
+    recall_graph,
+    recall_metadata,
+)
+from metatron.retrieval.prompts import (
+    HYBRID_SYSTEM_PROMPT,
+    QUERY_RESOLVER_SYSTEM_PROMPT,
+    TEAM_WORKFLOW_SCHEMA_SPEC,
+    TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT,
 )
 from metatron.retrieval.query_classifier import classify_query, get_profile_weights
 from metatron.retrieval.query_expansion import expand_query
+from metatron.retrieval.routing import (
+    _extract_json_object,
+    should_use_team_workflow_schema,
+)
 from metatron.retrieval.scoring import (
-    compute_signal_score,
     compute_final_score,
+    compute_signal_score,
     normalize_rerank_scores,
     recency_score,
     source_balance,
 )
 from metatron.retrieval.token_budget import (
     MAX_GRAPH_TOKENS,
-    estimate_graph_tokens, select_fragments_within_budget,
+    estimate_graph_tokens,
+    select_fragments_within_budget,
     truncate_graph_context,
 )
-from metatron.retrieval.routing import (
-    _extract_json_object,
-    should_use_team_workflow_schema,
-)
 from metatron.storage.graph_ops import (  # TODO: async migration
-    get_graph_entities, get_doc_labels_by_entities,
-    get_entities_by_doc_labels, get_graph_relationships,
+    get_doc_labels_by_entities,
+    get_entities_by_doc_labels,
+    get_graph_entities,
+    get_graph_relationships,
     get_relationships_at_date,
 )
 
@@ -289,8 +299,8 @@ def _result_type(r: dict) -> str:
 
 
 
-def _doc_labels(results: List[Dict]) -> List[str]:
-    out: List[str] = []
+def _doc_labels(results: list[dict]) -> list[str]:
+    out: list[str] = []
     for m in results:
         lb = m.get("doc_label") or (m.get("payload") or {}).get("doc_label")
         if lb:
@@ -303,7 +313,7 @@ def _collect_frags(
     base: list[dict], seen: set[int], total: int,
 ) -> tuple[list[dict], set[int], int, dict[str, dict]]:
     frags: list[dict] = []
-    doc_stats: Dict[str, Dict] = {}  # {doc_label: {title, word_count, fetch_count}}
+    doc_stats: dict[str, dict] = {}  # {doc_label: {title, word_count, fetch_count}}
     for mem in base:
         text = mem.get("memory") or mem.get("data") or ""
         if len(text) > _MAX_FRAG:
@@ -565,17 +575,78 @@ def _build_recall_context(
     )
 
 
+def _prepend_root_context(
+    results: list[dict], workspace_id: str | None,
+) -> list[dict]:
+    """Fetch root chunks for child results and prepend their content.
+
+    For each result with chunk_type=="child", looks up its parent_id,
+    fetches the root chunk from Qdrant, and prepends the root text to
+    the child's data/memory fields as context.
+
+    Graceful degradation: if root fetch fails, returns results unchanged.
+    """
+    # Collect unique parent_ids from child chunks
+    parent_ids: dict[str, list[dict]] = {}
+    for r in results:
+        payload = r.get("payload") or {}
+        chunk_type = payload.get("chunk_type", "")
+        parent_id = payload.get("parent_id", "")
+        if chunk_type == "child" and parent_id:
+            parent_ids.setdefault(parent_id, []).append(r)
+
+    if not parent_ids:
+        return results
+
+    try:
+        from metatron.storage.qdrant import get_hybrid_store
+        store = get_hybrid_store(workspace_id)
+        root_results = store.fetch_by_chunk_ids(
+            list(parent_ids.keys()), workspace_id,
+        )
+    except Exception:
+        logger.warning("search.root_fetch_failed", exc_info=True)
+        return results
+
+    # Build lookup: chunk_id → root text
+    root_texts: dict[str, str] = {}
+    for rr in root_results:
+        payload = rr.get("payload") or {}
+        chunk_id = payload.get("chunk_id", "")
+        text = rr.get("data") or rr.get("memory") or ""
+        if chunk_id and text:
+            root_texts[chunk_id] = text
+
+    # Prepend root context to child results
+    for pid, children in parent_ids.items():
+        root_text = root_texts.get(pid)
+        if not root_text:
+            continue
+        prefix = f"[ROOT CONTEXT]\n{root_text}\n\n[DETAIL]\n"
+        for child in children:
+            for field in ("data", "memory"):
+                if child.get(field):
+                    child[field] = prefix + child[field]
+            # Also update nested payload
+            p = child.get("payload") or {}
+            for field in ("data", "memory"):
+                if p.get(field):
+                    p[field] = prefix + p[field]
+
+    return results
+
+
 @timed("hybrid_search_and_answer")
 def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     query: str, user_id: str = "user", k: int = 25,
-    workspace_id: Optional[str] = None, intent_query: Optional[str] = None,
+    workspace_id: str | None = None, intent_query: str | None = None,
     return_trace: bool = False,
     plugin_manager=None,
 ) -> str | dict:
     """End-to-end hybrid search and answer generation."""
     import time
     start_time = time.time()
-    
+
     raw_query = (intent_query or query or "").strip()
     # Resolve contextual references (relative dates, pronouns) using the full
     # composite query which contains conversation history.  When intent_query
@@ -732,6 +803,10 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     base = base[:k]
     _post_rerank_count = len(base)
 
+    # -- Hierarchical chunking: prepend root chunk content to child chunks --
+    if _s.hierarchical_chunking_enabled:
+        base = _prepend_root_context(base, workspace_id)
+
     # -- ACL post-rerank: defense-in-depth filter --
     if plugin_manager:
         ctx = _run_hooks_sync(plugin_manager, "search_post_rerank", {
@@ -855,7 +930,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
         }
     else:
         result = _append_sources(answer, base)
-    
+
     # Log query trace to PostgreSQL (async, non-blocking)
     if workspace_id:
         try:
@@ -880,7 +955,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
                 "recall_graph_count": len(graph_results),
                 "recall_total_unique": len(merged),
             }
-            
+
             from metatron.storage.pg_connection import store_query_trace_sync
             store_query_trace_sync(workspace_id, rq, trace_data, total_ms)
 
@@ -890,5 +965,5 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
                 upsert_document_fetch_stats_sync(workspace_id, doc_stats)
         except Exception as e:
             logger.warning("search.trace_logging_failed", error=str(e))
-    
+
     return result

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -602,7 +602,7 @@ def _prepend_root_context(
         from metatron.storage.qdrant import get_hybrid_store
         store = get_hybrid_store(workspace_id)
         root_results = store.fetch_by_chunk_ids(
-            list(parent_ids.keys()), workspace_id,
+            list(parent_ids.keys()),
         )
     except Exception:
         logger.warning("search.root_fetch_failed", exc_info=True)

--- a/src/metatron/storage/memgraph.py
+++ b/src/metatron/storage/memgraph.py
@@ -5,11 +5,13 @@ Migrated from PoC: db/memgraph.py (driver) + indexers/memgraph_workspace.py (wri
 # TODO: async migration
 from __future__ import annotations
 
-import atexit, json, re, time
-from datetime import datetime, UTC
+import atexit
+import json
+import re
+import time
+from datetime import UTC, datetime
 from functools import wraps
 from threading import Lock
-from typing import Optional
 
 import structlog
 from neo4j import GraphDatabase
@@ -46,7 +48,7 @@ _driver = None
 _driver_lock = Lock()
 
 
-def _normalize_workspace_id(workspace_id: Optional[str]) -> str:
+def _normalize_workspace_id(workspace_id: str | None) -> str:
     if workspace_id is None or workspace_id == "default":
         return DEFAULT_WORKSPACE_ID
     return workspace_id.strip()
@@ -201,8 +203,10 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
 
         # Post-process: normalize types, validate names, merge persons
         from metatron.storage.graph_entities import (
-            normalize_entity_type, is_valid_entity_name,
-            is_role_not_person, normalize_person_name,
+            is_role_not_person,
+            is_valid_entity_name,
+            normalize_entity_type,
+            normalize_person_name,
         )
 
         entities: list[dict] = []
@@ -273,10 +277,10 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
 @memgraph_retry()
 def write_doc_graph_to_memgraph(
     text: str, file_name: str, user_id: str = "user",
-    workspace_id: Optional[str] = None,
-    doc_label: Optional[str] = None, upload_time: Optional[str] = None,
-    doc_date: Optional[str] = None,
-    metadata: Optional[dict] = None,
+    workspace_id: str | None = None,
+    doc_label: str | None = None, upload_time: str | None = None,
+    doc_date: str | None = None,
+    metadata: dict | None = None,
 ) -> None:
     """Extract graph from text and write document + entities to Memgraph."""
     workspace_id = _normalize_workspace_id(workspace_id)
@@ -359,6 +363,50 @@ def write_doc_graph_to_memgraph(
                 "MERGE (a)-[:ALIAS]->(c)",
             )
     logger.info("memgraph.write_doc.done", file_name=file_name, workspace_id=workspace_id)
+
+
+@memgraph_retry()
+def write_chunk_hierarchy(
+    workspace_id: str,
+    root_chunk_id: str,
+    child_chunk_ids: list[str],
+    doc_label: str,
+) -> None:
+    """Create Chunk nodes and CHILD_OF edges for root-child hierarchy.
+
+    Creates a root Chunk node and child Chunk nodes, then links each
+    child to the root via a CHILD_OF relationship.  All nodes are
+    scoped to the workspace for isolation.
+    """
+    workspace_id = _normalize_workspace_id(workspace_id)
+    driver = get_memgraph_driver()
+    _ws = _esc(workspace_id)
+    _root = _esc(root_chunk_id)
+    _dl = _esc(doc_label)
+
+    with driver.session() as session:
+        # Create root chunk node
+        session.run(
+            f"MERGE (r:Chunk {{chunk_id: {_root}, workspace_id: {_ws}}}) "
+            f"SET r.chunk_type='root', r.doc_label={_dl}"
+        )
+        # Create child nodes and CHILD_OF edges
+        for child_id in child_chunk_ids:
+            _cid = _esc(child_id)
+            session.run(
+                f"MERGE (c:Chunk {{chunk_id: {_cid}, workspace_id: {_ws}}}) "
+                f"SET c.chunk_type='child', c.doc_label={_dl} "
+                f"WITH c "
+                f"MATCH (r:Chunk {{chunk_id: {_root}, workspace_id: {_ws}}}) "
+                f"MERGE (c)-[:CHILD_OF]->(r)"
+            )
+
+    logger.info(
+        "memgraph.chunk_hierarchy.done",
+        root=root_chunk_id,
+        children=len(child_chunk_ids),
+        workspace_id=workspace_id,
+    )
 
 
 @memgraph_retry()

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -280,7 +280,7 @@ class QdrantVectorStore:
         return [self._format_result(p, 1.0) for p in results]
 
     def fetch_by_chunk_ids(
-        self, chunk_ids: list[str], workspace_id: str | None = None,
+        self, chunk_ids: list[str],
     ) -> list[dict]:
         """Fetch points by chunk_id payload field.
 

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -9,18 +9,30 @@ Migrated from PoC: metatron_experiments/metatron/indexers/hybrid_store_workspace
 from __future__ import annotations
 
 import uuid
-from typing import List, Dict, Optional, Any
+from typing import Any
 
 import structlog
 from qdrant_client import QdrantClient
 from qdrant_client.models import (
-    VectorParams, SparseVectorParams, Distance, PointStruct,
-    SparseVector, Prefetch, FusionQuery, Filter,
-    FieldCondition, MatchValue, MatchAny, MatchText,
+    Distance,
+    FieldCondition,
+    Filter,
+    FusionQuery,
+    MatchAny,
+    MatchText,
+    MatchValue,
+    PointStruct,
+    Prefetch,
+    SparseVector,
+    SparseVectorParams,
+    VectorParams,
 )
 
 from metatron.ingestion.bm25 import compute_bm25_sparse_vector, compute_query_sparse_vector
-from metatron.llm.embeddings import get_cached_embedding, get_cached_embedding_split  # TODO: async migration
+from metatron.llm.embeddings import (  # TODO: async migration
+    get_cached_embedding,
+    get_cached_embedding_split,
+)
 
 logger = structlog.get_logger()
 
@@ -31,14 +43,14 @@ DENSE_DIM = 768  # nomic-embed-text dimensions
 DEFAULT_WORKSPACE_ID = "MTRNIX"
 
 
-def _normalize_workspace_id(workspace_id: Optional[str]) -> str:
+def _normalize_workspace_id(workspace_id: str | None) -> str:
     """Normalize workspace ID to canonical form."""
     if workspace_id is None or workspace_id == "default":
         return DEFAULT_WORKSPACE_ID
     return workspace_id.strip()
 
 
-def get_collection_name(workspace_id: Optional[str] = None) -> str:
+def get_collection_name(workspace_id: str | None = None) -> str:
     """Get Qdrant collection name for a workspace.
     Default workspace uses base name without suffix for backward compat."""
     workspace_id = _normalize_workspace_id(workspace_id)
@@ -51,7 +63,7 @@ class QdrantVectorStore:
     """Workspace-aware hybrid vector store (dense + sparse BM25)."""
     # TODO: async migration
 
-    def __init__(self, workspace_id: Optional[str] = None,
+    def __init__(self, workspace_id: str | None = None,
                  host: str = "localhost", port: int = 6333) -> None:
         self.workspace_id = _normalize_workspace_id(workspace_id)
         self.collection_name = get_collection_name(workspace_id)
@@ -86,7 +98,7 @@ class QdrantVectorStore:
         except Exception:
             pass  # Index may already exist on re-creation
 
-    def _format_result(self, point: Any, score: float) -> Dict:
+    def _format_result(self, point: Any, score: float) -> dict:
         """Format a Qdrant point into a standardized result dict."""
         payload = point.payload or {}
         data = payload.get("data") or payload.get("memory") or ""
@@ -99,8 +111,8 @@ class QdrantVectorStore:
             "source_role": payload.get("source_role", "knowledge_base"),
         }
 
-    def add_document(self, text: str, metadata: Optional[Dict[str, Any]] = None,
-                     doc_id: Optional[str] = None) -> list[str]:
+    def add_document(self, text: str, metadata: dict[str, Any] | None = None,
+                     doc_id: str | None = None) -> list[str]:
         """Add document with both dense and sparse vectors.
 
         If the text exceeds the embedding model context window, it is
@@ -155,8 +167,8 @@ class QdrantVectorStore:
         return qdrant_ids
 
     def hybrid_search(self, query: str, limit: int = 10,
-                      filter_conditions: Optional[Filter] = None,
-                      dense_weight: float = 0.7, sparse_weight: float = 0.3) -> List[Dict]:
+                      filter_conditions: Filter | None = None,
+                      dense_weight: float = 0.7, sparse_weight: float = 0.3) -> list[dict]:
         """Hybrid search via Reciprocal Rank Fusion (RRF)."""
         dense_query = get_cached_embedding(query)
         sparse_indices, sparse_values = compute_query_sparse_vector(query)
@@ -179,7 +191,7 @@ class QdrantVectorStore:
             return self.dense_search(query, limit=limit, filter_conditions=filter_conditions)
 
     def dense_search(self, query: str, limit: int = 10,
-                     filter_conditions: Optional[Filter] = None) -> List[Dict]:
+                     filter_conditions: Filter | None = None) -> list[dict]:
         """Dense-only (semantic) search."""
         dense_query = get_cached_embedding(query)
         results = self.client.query_points(
@@ -190,7 +202,7 @@ class QdrantVectorStore:
         return [self._format_result(p, p.score) for p in results.points]
 
     def keyword_search(self, query: str, limit: int = 10,
-                       filter_conditions: Optional[Filter] = None) -> List[Dict]:
+                       filter_conditions: Filter | None = None) -> list[dict]:
         """Sparse-only (keyword/BM25) search."""
         sparse_indices, sparse_values = compute_query_sparse_vector(query)
         if not sparse_indices:
@@ -212,7 +224,7 @@ class QdrantVectorStore:
             logger.error("qdrant.collection.delete_error", error=str(e))
         self._ensure_collection()
 
-    def search_by_date(self, dates: List[str], limit: int = 10) -> List[Dict]:
+    def search_by_date(self, dates: list[str], limit: int = 10) -> list[dict]:
         """Filter search by date values."""
         if not dates:
             return []
@@ -221,14 +233,14 @@ class QdrantVectorStore:
             scroll_filter=filt, limit=limit, with_payload=True, with_vectors=False)
         return [self._format_result(p, 1.0) for p in results]
 
-    def search_by_type(self, doc_type: str, limit: int = 10) -> List[Dict]:
+    def search_by_type(self, doc_type: str, limit: int = 10) -> list[dict]:
         """Filter search by document type."""
         filt = Filter(must=[FieldCondition(key="type", match=MatchValue(value=doc_type))])
         results, _ = self.client.scroll(collection_name=self.collection_name,
             scroll_filter=filt, limit=limit, with_payload=True, with_vectors=False)
         return [self._format_result(p, 1.0) for p in results]
 
-    def search_by_doc_labels(self, doc_labels: List[str], limit: int = 10) -> List[Dict]:
+    def search_by_doc_labels(self, doc_labels: list[str], limit: int = 10) -> list[dict]:
         """Filter search by document labels."""
         labels = [lb for lb in doc_labels if lb]
         if not labels:
@@ -239,21 +251,21 @@ class QdrantVectorStore:
             scroll_filter=filt, limit=limit, with_payload=True, with_vectors=False)
         return [self._format_result(p, 1.0) for p in results]
 
-    def search_by_status(self, status: str, limit: int = 20) -> List[Dict]:
+    def search_by_status(self, status: str, limit: int = 20) -> list[dict]:
         """Filter search by status metadata field (e.g. 'In Progress', 'Done')."""
         filt = Filter(must=[FieldCondition(key="status", match=MatchValue(value=status))])
         results, _ = self.client.scroll(collection_name=self.collection_name,
             scroll_filter=filt, limit=limit, with_payload=True, with_vectors=False)
         return [self._format_result(p, 1.0) for p in results]
 
-    def search_by_assignee(self, assignee: str, limit: int = 20) -> List[Dict]:
+    def search_by_assignee(self, assignee: str, limit: int = 20) -> list[dict]:
         """Filter search by assignee (exact match)."""
         filt = Filter(must=[FieldCondition(key="assignee", match=MatchValue(value=assignee))])
         results, _ = self.client.scroll(collection_name=self.collection_name,
             scroll_filter=filt, limit=limit, with_payload=True, with_vectors=False)
         return [self._format_result(p, 1.0) for p in results]
 
-    def scroll_by_title(self, title_substring: str, limit: int = 5) -> List[Dict]:
+    def scroll_by_title(self, title_substring: str, limit: int = 5) -> list[dict]:
         """Scroll points where title contains substring (case-insensitive via MatchText)."""
         if not title_substring or not title_substring.strip():
             return []
@@ -266,6 +278,38 @@ class QdrantVectorStore:
             with_payload=True, with_vectors=False,
         )
         return [self._format_result(p, 1.0) for p in results]
+
+    def fetch_by_chunk_ids(
+        self, chunk_ids: list[str], workspace_id: str | None = None,
+    ) -> list[dict]:
+        """Fetch points by chunk_id payload field.
+
+        Used by retrieval to look up root chunks for hierarchical context.
+        """
+        if not chunk_ids:
+            return []
+        match = (
+            MatchAny(any=chunk_ids)
+            if len(chunk_ids) > 1
+            else MatchValue(value=chunk_ids[0])
+        )
+        filt = Filter(must=[FieldCondition(key="chunk_id", match=match)])
+        try:
+            results, _ = self.client.scroll(
+                collection_name=self.collection_name,
+                scroll_filter=filt,
+                limit=len(chunk_ids),
+                with_payload=True,
+                with_vectors=False,
+            )
+            return [self._format_result(p, 1.0) for p in results]
+        except Exception as e:
+            logger.warning(
+                "qdrant.fetch_by_chunk_ids.error",
+                chunk_ids=chunk_ids[:5],
+                error=str(e),
+            )
+            return []
 
     def delete_by_doc_labels(self, doc_labels: list[str]) -> int:
         """Delete all points matching any of the given doc_labels.
@@ -299,7 +343,7 @@ class QdrantVectorStore:
             logger.error("qdrant.delete_by_doc_labels.error", error=str(e))
             return 0
 
-    def get_stats(self) -> Dict:
+    def get_stats(self) -> dict:
         """Get workspace statistics: chunk count and unique file count.
 
         # TODO: Read file_count/chunk_count from PostgreSQL instead of scanning Qdrant.
@@ -350,13 +394,13 @@ class QdrantVectorStore:
 # ---------------------------------------------------------------------------
 from threading import Lock  # noqa: E402
 
-_hybrid_stores: Dict[str, QdrantVectorStore] = {}
+_hybrid_stores: dict[str, QdrantVectorStore] = {}
 _store_lock = Lock()
 
 
-def get_hybrid_store(workspace_id: Optional[str] = None,
-                     host: Optional[str] = None,
-                     port: Optional[int] = None) -> QdrantVectorStore:
+def get_hybrid_store(workspace_id: str | None = None,
+                     host: str | None = None,
+                     port: int | None = None) -> QdrantVectorStore:
     """Get or create QdrantVectorStore for a workspace (cached singleton).
 
     Host/port default to values from Settings (env vars) when not provided.

--- a/tests/unit/test_hierarchical_ingestion.py
+++ b/tests/unit/test_hierarchical_ingestion.py
@@ -1,0 +1,183 @@
+"""Tests for hierarchical chunking in the ingestion pipeline."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from metatron.core.models import ChunkType, Document
+
+
+def _make_doc(content: str, source_id: str = "doc1") -> Document:
+    return Document(
+        id=source_id,
+        workspace_id="ws_test",
+        source_type="confluence",
+        source_id=source_id,
+        title="Test Doc",
+        content=content,
+    )
+
+
+def _long_content() -> str:
+    """Generate content long enough to trigger root-child splitting.
+
+    Default chunk size is 1500 tokens (~6000 chars for Latin text).
+    We need well over that to produce root + children.
+    """
+    paragraphs = []
+    for i in range(40):
+        sentences = [
+            f"Section {i} paragraph about topic number {i}."
+            f" This elaborates on the key concepts of area {i}."
+            f" Additional detail about how component {i} integrates."
+            f" Performance considerations for module {i} are documented here."
+            f" The team reviewed and approved the design for feature {i}."
+        ]
+        paragraphs.append(" ".join(sentences))
+    return "\n\n".join(paragraphs)
+
+
+class TestHierarchicalIngestionEnabled:
+    """Pipeline stores chunk_type and parent_id when hierarchical enabled."""
+
+    @patch("metatron.ingestion.pipeline._register_persons")
+    @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
+    @patch("metatron.ingestion.pipeline._write_chunk_hierarchy")
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_stores_chunk_type_and_parent_id(
+        self, mock_store_fn, mock_hierarchy, mock_graph, mock_persons,
+    ) -> None:
+        from metatron.ingestion.pipeline import ingest_documents
+
+        mock_store = MagicMock()
+        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        content = _long_content()
+        doc = _make_doc(content)
+
+        with patch("metatron.core.config.Settings") as mock_settings_cls:
+            s = mock_settings_cls.return_value
+            s.hierarchical_chunking_enabled = True
+            s.graph_extraction_enabled = False
+
+            ingest_documents([doc], workspace_id="ws_test")
+
+        # Verify add_document was called with chunk_type/parent_id in metadata
+        assert mock_store.add_document.call_count >= 2
+        calls = mock_store.add_document.call_args_list
+
+        # First call should be root chunk
+        first_meta = calls[0].kwargs.get("metadata") or calls[0][1].get("metadata")
+        assert first_meta["chunk_type"] == "root"
+
+        # Subsequent calls should be child chunks with parent_id
+        child_calls = calls[1:]
+        for call in child_calls:
+            meta = call.kwargs.get("metadata") or call[1].get("metadata")
+            assert meta["chunk_type"] == "child"
+            assert meta["parent_id"] != ""
+
+    @patch("metatron.ingestion.pipeline._register_persons")
+    @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
+    @patch("metatron.ingestion.pipeline._write_chunk_hierarchy")
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_writes_chunk_hierarchy_to_memgraph(
+        self, mock_store_fn, mock_hierarchy, mock_graph, mock_persons,
+    ) -> None:
+        from metatron.ingestion.pipeline import ingest_documents
+
+        mock_store = MagicMock()
+        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        content = _long_content()
+        doc = _make_doc(content)
+
+        with patch("metatron.core.config.Settings") as mock_settings_cls:
+            s = mock_settings_cls.return_value
+            s.hierarchical_chunking_enabled = True
+            s.graph_extraction_enabled = False
+
+            ingest_documents([doc], workspace_id="ws_test")
+
+        mock_hierarchy.assert_called_once()
+        call_args = mock_hierarchy.call_args
+        chunk_objs = call_args[0][0]
+        assert any(c.chunk_type == ChunkType.ROOT for c in chunk_objs)
+        assert any(c.chunk_type == ChunkType.CHILD for c in chunk_objs)
+
+
+class TestHierarchicalIngestionDisabled:
+    """Pipeline uses simple_chunk() when hierarchical disabled."""
+
+    @patch("metatron.ingestion.pipeline._register_persons")
+    @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
+    @patch("metatron.ingestion.pipeline._write_chunk_hierarchy")
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_uses_simple_chunk_when_disabled(
+        self, mock_store_fn, mock_hierarchy, mock_graph, mock_persons,
+    ) -> None:
+        from metatron.ingestion.pipeline import ingest_documents
+
+        mock_store = MagicMock()
+        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        content = _long_content()
+        doc = _make_doc(content)
+
+        with patch("metatron.core.config.Settings") as mock_settings_cls:
+            s = mock_settings_cls.return_value
+            s.hierarchical_chunking_enabled = False
+            s.graph_extraction_enabled = False
+
+            ingest_documents([doc], workspace_id="ws_test")
+
+        # All chunks should be standalone (simple_chunk)
+        calls = mock_store.add_document.call_args_list
+        for call in calls:
+            meta = call.kwargs.get("metadata") or call[1].get("metadata")
+            assert meta["chunk_type"] == "standalone"
+
+        # Hierarchy write should NOT be called
+        mock_hierarchy.assert_not_called()
+
+
+class TestGracefulDegradation:
+    """Ingestion continues when Memgraph is unavailable."""
+
+    @patch("metatron.ingestion.pipeline._register_persons")
+    @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_continues_when_memgraph_unavailable(
+        self, mock_store_fn, mock_graph, mock_persons,
+    ) -> None:
+        from metatron.ingestion.pipeline import ingest_documents
+
+        mock_store = MagicMock()
+        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store_fn.return_value = mock_store
+
+        content = _long_content()
+        doc = _make_doc(content)
+
+        with (
+            patch("metatron.core.config.Settings") as mock_settings_cls,
+            patch(
+                "metatron.ingestion.pipeline._write_chunk_hierarchy",
+                side_effect=Exception("Memgraph unavailable"),
+            ),
+        ):
+            s = mock_settings_cls.return_value
+            s.hierarchical_chunking_enabled = True
+            s.graph_extraction_enabled = False
+
+            result = ingest_documents([doc], workspace_id="ws_test")
+
+        # Ingestion should succeed despite Memgraph failure
+        # _write_chunk_hierarchy is called after store.add_document calls,
+        # but its exception is caught inside the per-document try/except.
+        # The document should still be counted (new_count incremented before
+        # hierarchy write).
+        assert result.documents_new == 1
+        assert mock_store.add_document.call_count >= 1

--- a/tests/unit/test_hierarchical_search.py
+++ b/tests/unit/test_hierarchical_search.py
@@ -1,0 +1,136 @@
+"""Tests for hierarchical chunking in the search/retrieval pipeline."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from metatron.retrieval.search import _prepend_root_context
+
+
+def _make_result(
+    chunk_type: str = "child",
+    parent_id: str = "root_001",
+    chunk_id: str = "child_001",
+    data: str = "Child chunk content.",
+) -> dict:
+    return {
+        "id": chunk_id,
+        "score": 0.9,
+        "memory": data,
+        "data": data,
+        "title": "Test Doc",
+        "type": "confluence",
+        "url": "",
+        "date": "",
+        "doc_label": "doc1",
+        "workspace_id": "ws_test",
+        "source_role": "knowledge_base",
+        "payload": {
+            "chunk_type": chunk_type,
+            "parent_id": parent_id,
+            "chunk_id": chunk_id,
+            "data": data,
+            "memory": data,
+        },
+    }
+
+
+def _make_root_result(
+    chunk_id: str = "root_001",
+    data: str = "Root overview content.",
+) -> dict:
+    return {
+        "id": chunk_id,
+        "score": 1.0,
+        "memory": data,
+        "data": data,
+        "title": "Test Doc",
+        "type": "confluence",
+        "url": "",
+        "date": "",
+        "doc_label": "doc1",
+        "workspace_id": "ws_test",
+        "source_role": "knowledge_base",
+        "payload": {
+            "chunk_type": "root",
+            "parent_id": "",
+            "chunk_id": chunk_id,
+            "data": data,
+            "memory": data,
+        },
+    }
+
+
+class TestPrependRootContext:
+    """_prepend_root_context fetches and prepends root chunks."""
+
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_child_chunks_get_root_prepended(self, mock_store_fn) -> None:
+        mock_store = MagicMock()
+        mock_store.fetch_by_chunk_ids.return_value = [
+            _make_root_result(),
+        ]
+        mock_store_fn.return_value = mock_store
+
+        results = [_make_result()]
+        updated = _prepend_root_context(results, "ws_test")
+
+        assert len(updated) == 1
+        assert "[ROOT CONTEXT]" in updated[0]["data"]
+        assert "Root overview content." in updated[0]["data"]
+        assert "Child chunk content." in updated[0]["data"]
+
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_standalone_chunks_unchanged(self, mock_store_fn) -> None:
+        results = [_make_result(chunk_type="standalone", parent_id="")]
+        updated = _prepend_root_context(results, "ws_test")
+
+        # No fetch should happen — no child chunks
+        mock_store_fn.assert_not_called()
+        assert updated[0]["data"] == "Child chunk content."
+
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_deduplicates_root_fetches(self, mock_store_fn) -> None:
+        """Multiple children with same parent_id trigger only one fetch."""
+        mock_store = MagicMock()
+        mock_store.fetch_by_chunk_ids.return_value = [
+            _make_root_result(),
+        ]
+        mock_store_fn.return_value = mock_store
+
+        results = [
+            _make_result(chunk_id="child_001"),
+            _make_result(chunk_id="child_002"),
+        ]
+        _prepend_root_context(results, "ws_test")
+
+        # fetch_by_chunk_ids called once with single parent_id
+        mock_store.fetch_by_chunk_ids.assert_called_once()
+        call_args = mock_store.fetch_by_chunk_ids.call_args[0]
+        assert call_args[0] == ["root_001"]
+
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_graceful_degradation_on_fetch_failure(
+        self, mock_store_fn,
+    ) -> None:
+        mock_store_fn.side_effect = Exception("Qdrant unavailable")
+
+        results = [_make_result()]
+        original_data = results[0]["data"]
+        updated = _prepend_root_context(results, "ws_test")
+
+        # Results should be returned unchanged
+        assert len(updated) == 1
+        assert updated[0]["data"] == original_data
+
+    @patch("metatron.storage.qdrant.get_hybrid_store")
+    def test_missing_root_leaves_child_unchanged(self, mock_store_fn) -> None:
+        """When root chunk not found in Qdrant, child is not modified."""
+        mock_store = MagicMock()
+        mock_store.fetch_by_chunk_ids.return_value = []  # root not found
+        mock_store_fn.return_value = mock_store
+
+        results = [_make_result()]
+        original_data = results[0]["data"]
+        updated = _prepend_root_context(results, "ws_test")
+
+        assert updated[0]["data"] == original_data


### PR DESCRIPTION
## Summary
- Switch ingestion pipeline from `simple_chunk()` to `root_child_chunk()` for hierarchical chunking
- Store `chunk_type`, `chunk_id`, and `parent_id` in Qdrant payload metadata
- Create `CHILD_OF` edges in Memgraph between root and child chunks
- Auto-fetch and prepend root chunk content to child results during retrieval
- Feature flag: `METATRON_HIERARCHICAL_CHUNKING_ENABLED` (default: true)

## Key changes
- **core/config.py** — new config var `hierarchical_chunking_enabled`
- **ingestion/pipeline.py** — switch to `root_child_chunk()`, store hierarchy metadata, write Memgraph edges
- **storage/memgraph.py** — `write_chunk_hierarchy()` for CHILD_OF edges
- **storage/qdrant.py** — `fetch_by_chunk_ids()` for root chunk lookup
- **retrieval/search.py** — `_prepend_root_context()` after reranking

## Test plan
- [x] 4 new ingestion tests (chunk metadata, hierarchy write, fallback, graceful degradation)
- [x] 5 new search tests (root prepend, standalone unchanged, dedup, fetch failure, missing root)
- [x] Full test suite passes (1202 passed, pre-existing failures unrelated)
- [ ] Run `make eval-compare` to verify no search quality regression

## Notes
- Existing documents need re-sync to get hierarchical benefits (no migration needed)
- Chunks without `chunk_type` in payload are treated as standalone (backward compatible)
- Memgraph failures are gracefully handled — ingestion and search continue without graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)