### PR TITLE
fix: bugfixes and resilience improvements

### DIFF
--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -12,6 +12,7 @@ Usage:
     python scripts/run_eval.py --compare eval_results/2026-03-25T14:30:00.json
     python scripts/run_eval.py --history
 """
+
 from __future__ import annotations
 
 import argparse
@@ -71,8 +72,13 @@ RESULTS_DIR = Path(__file__).parent.parent / "eval_results"
 # Run eval
 # ---------------------------------------------------------------------------
 
+
 def run_eval(
-    workspace: str, k: int, testset_path: Path, *, include_unstable: bool = False,
+    workspace: str,
+    k: int,
+    testset_path: Path,
+    *,
+    include_unstable: bool = False,
 ) -> dict:
     """Run eval and return structured results."""
     ts = load_eval_testset_from_path(testset_path)
@@ -102,26 +108,30 @@ def run_eval(
         print("POSITIVE (should find relevant docs):")
     for q in positive_queries:
         trace = hybrid_search_and_answer(
-            q.text, workspace, k, None, None, return_trace=True,
+            q.text,
+            workspace,
+            k,
+            None,
+            None,
+            return_trace=True,
         )
-        retrieved = (
-            trace.get("retrieved_doc_labels", [])
-            if isinstance(trace, dict)
-            else []
-        )
+        retrieved = trace.get("retrieved_doc_labels", []) if isinstance(trace, dict) else []
+        retrieved = list(dict.fromkeys(retrieved))  # deduplicate preserving order
         result = rm.compute(retrieved, q.expected_doc_labels, k=k)
         pairs.append((retrieved, q.expected_doc_labels))
-        per_query.append({
-            "id": q.id,
-            "text": q.text,
-            "category": q.category,
-            "is_negative": False,
-            "precision_at_k": result["precision_at_k"],
-            "mrr": result["mrr"],
-            "ndcg_at_k": result["ndcg_at_k"],
-            "retrieved": retrieved,
-            "expected": sorted(q.expected_doc_labels),
-        })
+        per_query.append(
+            {
+                "id": q.id,
+                "text": q.text,
+                "category": q.category,
+                "is_negative": False,
+                "precision_at_k": result["precision_at_k"],
+                "mrr": result["mrr"],
+                "ndcg_at_k": result["ndcg_at_k"],
+                "retrieved": retrieved,
+                "expected": sorted(q.expected_doc_labels),
+            }
+        )
         print(
             f"  [{q.id:<8}] "
             f"P@{k}={result['precision_at_k']:.2f}  "
@@ -135,29 +145,33 @@ def run_eval(
         print("\nNEGATIVE (should NOT find relevant docs):")
     for q in negative_queries:
         trace = hybrid_search_and_answer(
-            q.text, workspace, k, None, None, return_trace=True,
+            q.text,
+            workspace,
+            k,
+            None,
+            None,
+            return_trace=True,
         )
-        retrieved = (
-            trace.get("retrieved_doc_labels", [])
-            if isinstance(trace, dict)
-            else []
-        )
+        retrieved = trace.get("retrieved_doc_labels", []) if isinstance(trace, dict) else []
+        retrieved = list(dict.fromkeys(retrieved))  # deduplicate preserving order
         n_retrieved = len(retrieved)
         # For negative queries: success = no docs retrieved (or very few)
         is_correct = n_retrieved == 0
         if is_correct:
             neg_correct += 1
         status = "OK" if is_correct else f"NOISE ({n_retrieved} docs)"
-        per_query.append({
-            "id": q.id,
-            "text": q.text,
-            "category": q.category,
-            "is_negative": True,
-            "retrieved_count": n_retrieved,
-            "is_correct": is_correct,
-            "retrieved": retrieved,
-            "expected": [],
-        })
+        per_query.append(
+            {
+                "id": q.id,
+                "text": q.text,
+                "category": q.category,
+                "is_negative": True,
+                "retrieved_count": n_retrieved,
+                "is_correct": is_correct,
+                "retrieved": retrieved,
+                "expected": [],
+            }
+        )
         print(f"  [{q.id:<8}] {status}")
 
     # --- Summary ---
@@ -203,6 +217,7 @@ def run_eval(
 # Save / load results
 # ---------------------------------------------------------------------------
 
+
 def save_results(data: dict) -> Path:
     """Save results to eval_results/ as JSON."""
     RESULTS_DIR.mkdir(exist_ok=True)
@@ -231,6 +246,7 @@ def load_result(path: str) -> dict:
 # ---------------------------------------------------------------------------
 # Compare
 # ---------------------------------------------------------------------------
+
 
 def _delta_str(before: float, after: float) -> str:
     """Format delta with arrow indicator."""
@@ -294,13 +310,10 @@ def compare_results(before: dict, after: dict) -> None:
             a_ok = aq.get("is_correct", True)
             if b_ok and not a_ok:
                 regressions.append(
-                    f"  [{qid:<8}] was clean, now returns "
-                    f"{aq.get('retrieved_count', '?')} docs"
+                    f"  [{qid:<8}] was clean, now returns {aq.get('retrieved_count', '?')} docs"
                 )
             elif not b_ok and a_ok:
-                improvements.append(
-                    f"  [{qid:<8}] was noisy, now clean"
-                )
+                improvements.append(f"  [{qid:<8}] was noisy, now clean")
             continue
 
         # Positive queries: compare metrics
@@ -309,13 +322,9 @@ def compare_results(before: dict, after: dict) -> None:
             av = aq.get(m, 0.0)
             diff = av - bv
             if diff < -0.01:
-                regressions.append(
-                    f"  [{qid:<8}] {labels[m]}  {bv:.2f} -> {av:.2f}"
-                )
+                regressions.append(f"  [{qid:<8}] {labels[m]}  {bv:.2f} -> {av:.2f}")
             elif diff > 0.01:
-                improvements.append(
-                    f"  [{qid:<8}] {labels[m]}  {bv:.2f} -> {av:.2f}"
-                )
+                improvements.append(f"  [{qid:<8}] {labels[m]}  {bv:.2f} -> {av:.2f}")
 
     if regressions:
         print(f"\nRegressions ({len(regressions)}):")
@@ -334,6 +343,7 @@ def compare_results(before: dict, after: dict) -> None:
 # ---------------------------------------------------------------------------
 # History
 # ---------------------------------------------------------------------------
+
 
 def show_history() -> None:
     """List all saved eval results."""
@@ -365,35 +375,47 @@ def show_history() -> None:
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Search quality eval")
     parser.add_argument(
-        "--workspace", "-w",
+        "--workspace",
+        "-w",
         default=os.environ.get("METATRON_EVAL_WORKSPACE", "MTRNIX"),
         help="Workspace ID (default: $METATRON_EVAL_WORKSPACE or MTRNIX)",
     )
     parser.add_argument(
-        "--k", type=int, default=10,
+        "--k",
+        type=int,
+        default=10,
         help="Top-K for metrics (default: 10)",
     )
     parser.add_argument(
-        "--testset", type=str, default=None,
+        "--testset",
+        type=str,
+        default=None,
         help="Path to custom YAML test set (default: built-in)",
     )
     parser.add_argument(
-        "--save", action="store_true",
+        "--save",
+        action="store_true",
         help="Save results to eval_results/",
     )
     parser.add_argument(
-        "--compare", nargs="?", const="latest", default=None,
+        "--compare",
+        nargs="?",
+        const="latest",
+        default=None,
         help="Run eval and compare with saved result (default: latest)",
     )
     parser.add_argument(
-        "--history", action="store_true",
+        "--history",
+        action="store_true",
         help="List all saved eval results",
     )
     parser.add_argument(
-        "--all", action="store_true",
+        "--all",
+        action="store_true",
         help="Include unstable queries (test data that may not survive reindex)",
     )
     args = parser.parse_args()
@@ -406,7 +428,10 @@ def main() -> None:
     # Run eval
     testset_path = Path(args.testset) if args.testset else DEFAULT_TESTSET_PATH
     results = run_eval(
-        args.workspace, args.k, testset_path, include_unstable=args.all,
+        args.workspace,
+        args.k,
+        testset_path,
+        include_unstable=args.all,
     )
 
     # Save if requested

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -67,6 +67,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         import asyncio
 
         from metatron.storage.migrations import run_migrations_sync
+
         await asyncio.to_thread(
             run_migrations_sync, settings.postgres_sync_dsn, settings.postgres_dsn
         )
@@ -91,6 +92,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     _user_engine = None
     try:
         from sqlalchemy.ext.asyncio import create_async_engine as _create_engine
+
         _user_engine = _create_engine(settings.postgres_dsn)
     except Exception as exc:
         logger.error("db_engine.init.failed", error=str(exc))
@@ -100,6 +102,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         if _user_engine is None:
             raise RuntimeError("DB engine not initialized")
         from metatron.auth.user_store import UserStore
+
         user_store = UserStore(_user_engine)
         logger.info("user_store.init.starting")
         await user_store.ensure_schema()
@@ -111,6 +114,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.info("user_store.ready")
     except Exception as exc:
         import traceback
+
         logger.error("user_store.init.failed", error=str(exc))
         traceback.print_exc()
 
@@ -119,6 +123,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         if _user_engine is None:
             raise RuntimeError("DB engine not initialized")
         from metatron.auth.api_key_store import ApiKeyStore
+
         api_key_store = ApiKeyStore(_user_engine)
         await api_key_store.ensure_schema()
         app.state.api_key_store = api_key_store
@@ -130,6 +135,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     if settings.openwebui_url:
         try:
             from metatron.auth.openwebui_sync import OpenWebUISync
+
             owui_sync = OpenWebUISync(
                 owui_url=settings.openwebui_url,
                 metatron_url=settings.openwebui_metatron_url,
@@ -206,6 +212,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     discover_plugins(plugin_manager)
     app.state.plugin_manager = plugin_manager
 
+    # --- Subscribe core event handlers ---
+    from metatron.core.events import SYNC_COMPLETED
+    from metatron.retrieval.channels import on_sync_completed
+
+    plugin_manager.get_event_bus().subscribe(SYNC_COMPLETED, on_sync_completed)
+
     # Enterprise plugin requires auth — auto-enable if any plugin loaded
     if plugin_manager.loaded_plugins and not settings.auth_enabled:
         settings = settings.model_copy(update={"auth_enabled": True})
@@ -251,19 +263,23 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(users.router, prefix="/api/v1")
 
     from metatron.api.routes.finops import router as finops_router
+
     app.include_router(finops_router, prefix="/api/v1")
 
     from metatron.api.routes.openwebui_import import router as owui_import_router
+
     app.include_router(owui_import_router, prefix="/api/v1")
 
     # OpenAI-compatible API (for Open WebUI integration)
     if settings.openai_compat_enabled:
         from metatron.api.routes.openai_compat import router as openai_compat_router
+
         app.include_router(openai_compat_router)
 
     # Lazy import benchmarker module router (optional dependency)
     try:
         from metatron.benchmarker.api import router as benchmarker_module_router
+
         app.include_router(benchmarker_module_router, prefix="/api/v1/benchmarker")
         logger.info("Benchmarker module loaded successfully")
     except ImportError as e:

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -17,6 +17,7 @@ from metatron.connectors.schemas import (
     validate_config,
 )
 from metatron.core.config import Settings
+from metatron.core.events import SYNC_COMPLETED, EventBus
 from metatron.core.models import Connection
 from metatron.storage.postgres import PostgresStore
 
@@ -568,6 +569,10 @@ async def trigger_sync(
         connection_id, status="syncing",
     )
 
+    # Extract event bus for post-sync notification (graceful if unavailable)
+    pm = getattr(request.app.state, "plugin_manager", None)
+    event_bus = pm.get_event_bus() if pm is not None else None
+
     background_tasks.add_task(
         _run_connection_sync,
         connection_id=connection_id,
@@ -575,6 +580,7 @@ async def trigger_sync(
         config=conn["config"],
         workspace_id=ws_id,
         store=store,
+        event_bus=event_bus,
     )
 
     return {
@@ -615,6 +621,7 @@ async def _run_connection_sync(
     config: dict[str, Any],
     workspace_id: str,
     store: PostgresStore,
+    event_bus: EventBus | None = None,
 ) -> None:
     """Run sync for a DB-based connection. Async background task."""
     import asyncio
@@ -758,3 +765,20 @@ async def _run_connection_sync(
             logger.warning(
                 "sync.log_failed", sync_id=sync_id, error=str(e),
             )
+
+        # Emit SYNC_COMPLETED for cache invalidation and plugin hooks
+        if event_bus is not None:
+            try:
+                await event_bus.emit(SYNC_COMPLETED, {
+                    "workspace_id": workspace_id,
+                    "connection_id": connection_id,
+                    "connector_type": connector_type,
+                    "sync_id": sync_id,
+                    "status": status,
+                })
+            except Exception as e:
+                logger.warning(
+                    "sync.event_emit.error",
+                    sync_id=sync_id,
+                    error=str(e),
+                )

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -131,7 +131,7 @@ class Settings(BaseSettings):
 
     # --- Graph extraction ---
     graph_extraction_enabled: bool = Field(True, alias="GRAPH_EXTRACTION_ENABLED")
-    graph_extraction_workers: int = Field(4, alias="GRAPH_EXTRACTION_WORKERS")
+    graph_extraction_workers: int = Field(1, alias="GRAPH_EXTRACTION_WORKERS")
     graph_extraction_min_chars: int = Field(100, alias="GRAPH_EXTRACTION_MIN_CHARS")
 
     # --- Embedding cache ---

--- a/src/metatron/retrieval/channels.py
+++ b/src/metatron/retrieval/channels.py
@@ -1,4 +1,5 @@
 """Independent recall channels for the retrieval pipeline."""
+
 from __future__ import annotations
 
 import uuid
@@ -167,13 +168,17 @@ def recall_exact(ctx: RecallContext) -> list[ScoredResult]:
         hits: list[dict] = []
 
         if ctx.extracted_jira_keys:
-            hits.extend(_post_filter_acl(
-                store.search_by_doc_labels(ctx.extracted_jira_keys), ctx.access_filter,
-            ))
+            hits.extend(
+                _post_filter_acl(
+                    store.search_by_doc_labels(ctx.extracted_jira_keys),
+                    ctx.access_filter,
+                )
+            )
 
         for entity in ctx.extracted_title_entities:
             title_hits = _post_filter_acl(
-                store.scroll_by_title(entity, limit=5), ctx.access_filter,
+                store.scroll_by_title(entity, limit=5),
+                ctx.access_filter,
             )
             hits.extend(title_hits)
 
@@ -208,7 +213,8 @@ def recall_metadata(ctx: RecallContext) -> list[ScoredResult]:
 
         if ctx.extracted_dates:
             date_hits = _post_filter_acl(
-                store.search_by_date(ctx.extracted_dates, limit=limit), ctx.access_filter,
+                store.search_by_date(ctx.extracted_dates, limit=limit),
+                ctx.access_filter,
             )
             hits.extend(date_hits)
 
@@ -216,13 +222,15 @@ def recall_metadata(ctx: RecallContext) -> list[ScoredResult]:
         if ctx.detected_person:
             for name in ctx.detected_person:
                 assignee_hits = _post_filter_acl(
-                    store.search_by_assignee(name, limit=limit), ctx.access_filter,
+                    store.search_by_assignee(name, limit=limit),
+                    ctx.access_filter,
                 )
                 hits.extend(assignee_hits)
         elif ctx.is_activity_query:
             for status in _ACTIVITY_STATUSES:
                 status_hits = _post_filter_acl(
-                    store.search_by_status(status, limit=limit), ctx.access_filter,
+                    store.search_by_status(status, limit=limit),
+                    ctx.access_filter,
                 )
                 hits.extend(status_hits)
 
@@ -247,15 +255,25 @@ _MAX_FRONTIER = 50  # Cap BFS frontier to prevent explosion on highly-connected 
 
 @lru_cache(maxsize=128)
 def _cached_get_graph_entities(
-    query_texts: tuple[str, ...], workspace_id: str | None,
+    query_texts: tuple[str, ...],
+    workspace_id: str | None,
 ) -> tuple[dict, ...]:
     """Cached graph entity lookup. No TTL — evicts by LRU only.
 
-    Stale entries persist until evicted. Call cache_clear() after sync
-    if freshness matters. TODO: hook into SYNC_COMPLETED event when
-    EventBus is wired for sync lifecycle.
+    Cache is cleared on SYNC_COMPLETED event (subscribed in create_app).
     """
     return tuple(get_graph_entities(list(query_texts), workspace_id=workspace_id))
+
+
+def clear_graph_cache() -> None:
+    """Clear the graph entity LRU cache (called on SYNC_COMPLETED)."""
+    _cached_get_graph_entities.cache_clear()
+    logger.info("retrieval.graph_cache.cleared")
+
+
+async def on_sync_completed(event_name: str, payload: dict) -> None:
+    """Event handler: clear graph entity cache after sync."""
+    clear_graph_cache()
 
 
 def recall_graph(ctx: RecallContext) -> list[ScoredResult]:

--- a/src/metatron/storage/memgraph.py
+++ b/src/metatron/storage/memgraph.py
@@ -60,24 +60,38 @@ def get_memgraph_driver(uri: str | None = None,
     """Get shared Memgraph/Neo4j driver instance (singleton).
 
     Parameters default to values from Settings (env vars) when not provided.
+
+    Verifies connectivity on cached driver; recreates if stale (e.g. after long LLM calls).
     """
     global _driver
-    if _driver is None:
-        with _driver_lock:
-            if _driver is None:
-                if uri is None or user is None or password is None:
-                    from metatron.core.config import get_settings
-                    s = get_settings()
-                    uri = uri or s.memgraph_uri
-                    user = user if user is not None else s.memgraph_user
-                    password = password if password is not None else s.memgraph_password
-                auth = (user, password) if user else None
-                _driver = GraphDatabase.driver(
-                    uri, auth=auth,
-                    max_connection_pool_size=50,
-                    connection_acquisition_timeout=30,
-                )
-                logger.info("memgraph.driver.initialized", uri=uri)
+    with _driver_lock:
+        if _driver is not None:
+            try:
+                _driver.verify_connectivity()
+            except AttributeError:
+                pass  # older driver version without verify_connectivity
+            except Exception as e:
+                logger.warning("memgraph.driver.stale", error=str(e))
+                try:
+                    _driver.close()
+                except Exception:
+                    pass
+                _driver = None
+
+        if _driver is None:
+            if uri is None or user is None or password is None:
+                from metatron.core.config import get_settings
+                s = get_settings()
+                uri = uri or s.memgraph_uri
+                user = user if user is not None else s.memgraph_user
+                password = password if password is not None else s.memgraph_password
+            auth = (user, password) if user else None
+            _driver = GraphDatabase.driver(
+                uri, auth=auth,
+                max_connection_pool_size=50,
+                connection_acquisition_timeout=30,
+            )
+            logger.info("memgraph.driver.initialized", uri=uri)
     return _driver
 
 

--- a/tests/unit/test_hierarchical_ingestion.py
+++ b/tests/unit/test_hierarchical_ingestion.py
@@ -229,12 +229,11 @@ class TestGraphRetry:
             if doc.source_id == "doc1" and call_count["doc1"] == 1:
                 raise ConnectionError("Memgraph down")
 
-        with patch("metatron.ingestion.pipeline._write_jira_to_graph"):
-            with patch(
-                "metatron.ingestion.pipeline._write_doc_to_graph",
-                side_effect=flaky_write,
-            ):
-                result = _extract_graphs_parallel(queue, max_workers=1)
+        with patch("metatron.ingestion.pipeline._write_jira_to_graph"), patch(
+            "metatron.ingestion.pipeline._write_doc_to_graph",
+            side_effect=flaky_write,
+        ):
+            result = _extract_graphs_parallel(queue, max_workers=1)
 
         assert result["ok"] == 2
         assert result["errors"] == 0
@@ -245,12 +244,11 @@ class TestGraphRetry:
         doc = _make_doc("A" * 200, source_id="doc1")
         queue = [(doc, "ws")]
 
-        with patch("metatron.ingestion.pipeline._write_jira_to_graph"):
-            with patch(
-                "metatron.ingestion.pipeline._write_doc_to_graph",
-                side_effect=ConnectionError("Memgraph permanently down"),
-            ):
-                result = _extract_graphs_parallel(queue, max_workers=1)
+        with patch("metatron.ingestion.pipeline._write_jira_to_graph"), patch(
+            "metatron.ingestion.pipeline._write_doc_to_graph",
+            side_effect=ConnectionError("Memgraph permanently down"),
+        ):
+            result = _extract_graphs_parallel(queue, max_workers=1)
 
         # Still fails after retry
         assert result["errors"] == 1

--- a/tests/unit/test_memgraph_retry.py
+++ b/tests/unit/test_memgraph_retry.py
@@ -1,12 +1,13 @@
-"""Tests for memgraph_retry decorator."""
+"""Tests for memgraph_retry decorator and get_memgraph_driver liveness check."""
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from neo4j.exceptions import ServiceUnavailable, SessionExpired
 
+import metatron.storage.memgraph as memgraph_mod
 from metatron.storage.memgraph import memgraph_retry
 
 
@@ -105,3 +106,61 @@ class TestMemgraphRetry:
 
         assert add(2, 3) == "5"
         assert add(1, 2, extra="!") == "3!"
+
+
+class TestGetMemgraphDriverLiveness:
+    def setup_method(self):
+        # Reset singleton before each test
+        memgraph_mod._driver = None
+
+    def teardown_method(self):
+        memgraph_mod._driver = None
+
+    def test_stale_driver_is_recreated(self) -> None:
+        """A cached driver that fails verify_connectivity is replaced with a fresh one."""
+        stale_driver = MagicMock()
+        stale_driver.verify_connectivity.side_effect = ServiceUnavailable("stale")
+
+        fresh_driver = MagicMock()
+        fresh_driver.verify_connectivity.return_value = None
+
+        memgraph_mod._driver = stale_driver
+
+        with patch("metatron.storage.memgraph.GraphDatabase") as mock_gdb, \
+             patch("metatron.core.config.get_settings") as mock_settings:
+            mock_settings.return_value = MagicMock(
+                memgraph_uri="bolt://localhost:7687",
+                memgraph_user="",
+                memgraph_password="",
+            )
+            mock_gdb.driver.return_value = fresh_driver
+
+            result = memgraph_mod.get_memgraph_driver()
+
+        assert result is fresh_driver
+        mock_gdb.driver.assert_called_once()
+
+    def test_healthy_driver_is_reused(self) -> None:
+        """A cached driver that passes verify_connectivity is returned as-is."""
+        healthy_driver = MagicMock()
+        healthy_driver.verify_connectivity.return_value = None
+
+        memgraph_mod._driver = healthy_driver
+
+        with patch("metatron.storage.memgraph.GraphDatabase") as mock_gdb:
+            result = memgraph_mod.get_memgraph_driver()
+
+        assert result is healthy_driver
+        mock_gdb.driver.assert_not_called()
+
+    def test_driver_without_verify_connectivity_is_reused(self) -> None:
+        """Older drivers without verify_connectivity are returned without error."""
+        old_driver = MagicMock(spec=[])  # no verify_connectivity attribute
+
+        memgraph_mod._driver = old_driver
+
+        with patch("metatron.storage.memgraph.GraphDatabase") as mock_gdb:
+            result = memgraph_mod.get_memgraph_driver()
+
+        assert result is old_driver
+        mock_gdb.driver.assert_not_called()


### PR DESCRIPTION
## Summary
- **Eval P@K dedup** — deduplicate retrieved doc_labels before computing P@K/MRR/NDCG (fixes inflated metrics from duplicate chunks)
- **Memgraph connection resilience** — `verify_connectivity()` check before reusing cached bolt driver (eliminates 30s timeout on defunct connections)
- **Reduce GRAPH_EXTRACTION_WORKERS** — default 4→1 to prevent Memgraph conflicting transactions
- **Graph cache invalidation** — clear LRU cache on SYNC_COMPLETED event (stale entity cache after sync)

## Commits
- `1a9b10b` fix: deduplicate eval P@K by doc_label
- `cb8804c` fix: reduce GRAPH_EXTRACTION_WORKERS default to 1
- `ed6bab4` fix: verify Memgraph connection liveness before reuse
- `456582c` feat: clear graph cache on SYNC_COMPLETED event

## Test plan
- [x] 74 related tests pass (recall channels, scoring, hierarchical ingestion/search)
- [x] No regressions in full test suite (1203 passed)
- [ ] Run `make eval-compare` after merge to verify P@K metric improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)