### PR TITLE
feat(MTRNIX-263): implement platform user mapping for Telegram/Slack/Discord

### DIFF
--- a/migrations/versions/010_user_platform_mappings.py
+++ b/migrations/versions/010_user_platform_mappings.py
@@ -4,6 +4,7 @@ Revision ID: 010
 Revises: 009
 Create Date: 2026-03-27
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -38,13 +39,17 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("NOW()"),
         ),
-        sa.UniqueConstraint(
-            "channel", "channel_user_id", "workspace_id",
-            name="uq_user_platform_mapping",
+        sa.PrimaryKeyConstraint(
+            "channel",
+            "channel_user_id",
+            "workspace_id",
+            name="pk_user_platform_mapping",
         ),
     )
     op.create_index(
-        "ix_upm_user_id", "user_platform_mappings", ["user_id"],
+        "ix_upm_user_id",
+        "user_platform_mappings",
+        ["user_id"],
     )
 
 

--- a/migrations/versions/010_user_platform_mappings.py
+++ b/migrations/versions/010_user_platform_mappings.py
@@ -1,0 +1,52 @@
+"""Add user_platform_mappings table for channel identity resolution.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-03-27
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "010"
+down_revision: str | None = "009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_platform_mappings",
+        sa.Column("channel", sa.Text, nullable=False),
+        sa.Column("channel_user_id", sa.Text, nullable=False),
+        sa.Column("workspace_id", sa.Text, nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Text,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.UniqueConstraint(
+            "channel", "channel_user_id", "workspace_id",
+            name="uq_user_platform_mapping",
+        ),
+    )
+    op.create_index(
+        "ix_upm_user_id", "user_platform_mappings", ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_platform_mappings")

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -118,6 +118,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.error("user_store.init.failed", error=str(exc))
         traceback.print_exc()
 
+    # --- Platform user mapper ---
+    try:
+        if _user_engine is None:
+            raise RuntimeError("DB engine not initialized")
+        from metatron.auth.user_mapping import PlatformUserMapper
+
+        platform_mapper = PlatformUserMapper(_user_engine, user_store)
+        await platform_mapper.ensure_schema()
+        app.state.platform_mapper = platform_mapper
+        logger.info("platform_mapper.ready")
+    except Exception as exc:
+        logger.warning("platform_mapper.init.failed", error=str(exc))
+
     # --- API Key store (personal keys for /v1 endpoints) ---
     try:
         if _user_engine is None:

--- a/src/metatron/api/routes/users.py
+++ b/src/metatron/api/routes/users.py
@@ -207,3 +207,108 @@ async def revoke_api_key(user_id: str, key_prefix: str, request: Request) -> Non
     api_store = _get_api_key_store(request)
     if not await api_store.revoke_key(key_prefix=key_prefix, user_id=user_id):
         raise HTTPException(status_code=404, detail="Key not found")
+
+
+# --- Platform user mappings (admin CRUD) ---
+
+
+def _get_mapper(request: Request):
+    mapper = getattr(request.app.state, "platform_mapper", None)
+    if not mapper:
+        raise HTTPException(
+            status_code=503, detail="Platform mapper not available",
+        )
+    return mapper
+
+
+def _get_workspace_id(request: Request, workspace_id: str | None) -> str:
+    if workspace_id and workspace_id != "*":
+        return workspace_id
+    user = getattr(request.state, "user", {}) or {}
+    ws_ids = user.get("workspace_ids", [])
+    if ws_ids and ws_ids[0] != "*":
+        return ws_ids[0]
+    settings = request.app.state.settings
+    return settings.default_workspace_id
+
+
+class UpdateMappingRequest(BaseModel):
+    user_id: str
+
+
+@router.get("/users/platform-mappings")
+async def list_platform_mappings(
+    request: Request,
+    channel: str | None = Query(None),
+    workspace_id: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> dict:
+    _require_admin(request)
+    mapper = _get_mapper(request)
+    ws = _get_workspace_id(request, workspace_id)
+    mappings = await mapper.list_mappings(
+        workspace_id=ws, channel=channel, limit=limit, offset=offset,
+    )
+    return {"mappings": mappings, "workspace_id": ws}
+
+
+@router.get("/users/{user_id}/platform-mappings")
+async def get_user_platform_mappings(
+    user_id: str,
+    request: Request,
+    workspace_id: str | None = Query(None),
+) -> dict:
+    _require_admin(request)
+    mapper = _get_mapper(request)
+    ws = _get_workspace_id(request, workspace_id)
+    mappings = await mapper.get_mappings_for_user(
+        user_id=user_id, workspace_id=ws,
+    )
+    return {"mappings": mappings, "user_id": user_id}
+
+
+@router.put(
+    "/users/platform-mappings/{channel}/{channel_user_id}",
+)
+async def update_platform_mapping(
+    channel: str,
+    channel_user_id: str,
+    req: UpdateMappingRequest,
+    request: Request,
+    workspace_id: str | None = Query(None),
+) -> dict:
+    _require_admin(request)
+    mapper = _get_mapper(request)
+    ws = _get_workspace_id(request, workspace_id)
+    updated = await mapper.update_mapping(
+        channel=channel,
+        channel_user_id=channel_user_id,
+        workspace_id=ws,
+        new_user_id=req.user_id,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Mapping not found")
+    return {"status": "updated"}
+
+
+@router.delete(
+    "/users/platform-mappings/{channel}/{channel_user_id}",
+    status_code=204,
+)
+async def delete_platform_mapping(
+    channel: str,
+    channel_user_id: str,
+    request: Request,
+    workspace_id: str | None = Query(None),
+) -> None:
+    _require_admin(request)
+    mapper = _get_mapper(request)
+    ws = _get_workspace_id(request, workspace_id)
+    deleted = await mapper.delete_mapping(
+        channel=channel,
+        channel_user_id=channel_user_id,
+        workspace_id=ws,
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Mapping not found")

--- a/src/metatron/app.py
+++ b/src/metatron/app.py
@@ -76,7 +76,30 @@ async def run_all() -> None:
     from metatron.storage.postgres import PostgresStore
 
     store = PostgresStore(settings.postgres_dsn)
-    channel_manager = ChannelManager(router=router, store=store)
+
+    # Platform user mapper — resolves channel identities to internal users
+    mapper = None
+    event_bus = None
+    try:
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from metatron.auth.user_mapping import PlatformUserMapper
+        from metatron.auth.user_store import UserStore
+        from metatron.core.events import EventBus
+
+        _engine = create_async_engine(settings.postgres_dsn)
+        _user_store = UserStore(_engine)
+        await _user_store.ensure_schema()
+        mapper = PlatformUserMapper(_engine, _user_store)
+        await mapper.ensure_schema()
+        event_bus = EventBus()
+        logger.info("app.user_mapper.ready")
+    except Exception as exc:
+        logger.warning("app.user_mapper.init_failed", error=str(exc))
+
+    channel_manager = ChannelManager(
+        router=router, store=store, mapper=mapper, event_bus=event_bus,
+    )
     try:
         started = await channel_manager.start_channels_from_db(
             fernet_key=settings.fernet_key,

--- a/src/metatron/auth/user_mapping.py
+++ b/src/metatron/auth/user_mapping.py
@@ -208,3 +208,129 @@ class PlatformUserMapper:
             })
 
         return user
+
+    # ------------------------------------------------------------------
+    # Admin CRUD
+    # ------------------------------------------------------------------
+
+    async def list_mappings(
+        self,
+        workspace_id: str,
+        channel: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Paginated list of mappings for a workspace."""
+        params: dict[str, Any] = {
+            "ws": workspace_id, "limit": limit, "offset": offset,
+        }
+        where = "WHERE workspace_id = :ws"
+        if channel:
+            where += " AND channel = :channel"
+            params["channel"] = channel
+
+        async with self._engine.connect() as conn:
+            rows = (await conn.execute(
+                text(f"""
+                    SELECT channel, channel_user_id, workspace_id,
+                           user_id, created_at
+                    FROM user_platform_mappings
+                    {where}
+                    ORDER BY created_at DESC
+                    LIMIT :limit OFFSET :offset
+                """),
+                params,
+            )).fetchall()
+
+        return [
+            {
+                "channel": r[0],
+                "channel_user_id": r[1],
+                "workspace_id": r[2],
+                "user_id": r[3],
+                "created_at": str(r[4]) if r[4] else None,
+            }
+            for r in rows
+        ]
+
+    async def get_mappings_for_user(
+        self, user_id: str, workspace_id: str,
+    ) -> list[dict[str, Any]]:
+        """All mappings for a specific user within a workspace."""
+        async with self._engine.connect() as conn:
+            rows = (await conn.execute(
+                text("""
+                    SELECT channel, channel_user_id, workspace_id,
+                           user_id, created_at
+                    FROM user_platform_mappings
+                    WHERE user_id = :uid AND workspace_id = :ws
+                    ORDER BY created_at DESC
+                """),
+                {"uid": user_id, "ws": workspace_id},
+            )).fetchall()
+
+        return [
+            {
+                "channel": r[0],
+                "channel_user_id": r[1],
+                "workspace_id": r[2],
+                "user_id": r[3],
+                "created_at": str(r[4]) if r[4] else None,
+            }
+            for r in rows
+        ]
+
+    async def update_mapping(
+        self,
+        channel: str,
+        channel_user_id: str,
+        workspace_id: str,
+        new_user_id: str,
+    ) -> bool:
+        """Reassign a mapping to a different internal user."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    UPDATE user_platform_mappings
+                    SET user_id = :new_uid
+                    WHERE channel = :channel
+                      AND channel_user_id = :cuid
+                      AND workspace_id = :ws
+                """),
+                {
+                    "new_uid": new_user_id,
+                    "channel": channel,
+                    "cuid": channel_user_id,
+                    "ws": workspace_id,
+                },
+            )
+        # Invalidate cache
+        cache_key = (channel, channel_user_id, workspace_id)
+        self._cache.pop(cache_key, None)
+        return result.rowcount > 0
+
+    async def delete_mapping(
+        self,
+        channel: str,
+        channel_user_id: str,
+        workspace_id: str,
+    ) -> bool:
+        """Remove a platform mapping."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    DELETE FROM user_platform_mappings
+                    WHERE channel = :channel
+                      AND channel_user_id = :cuid
+                      AND workspace_id = :ws
+                """),
+                {
+                    "channel": channel,
+                    "cuid": channel_user_id,
+                    "ws": workspace_id,
+                },
+            )
+        # Invalidate cache
+        cache_key = (channel, channel_user_id, workspace_id)
+        self._cache.pop(cache_key, None)
+        return result.rowcount > 0

--- a/src/metatron/channels/discord.py
+++ b/src/metatron/channels/discord.py
@@ -127,6 +127,21 @@ class DiscordChannel:
         """Handle file uploads from Discord DM."""
         user_id = str(message.author.id)
 
+        # Map platform user to internal user
+        if self._mapper:
+            display_name = (
+                message.author.display_name or message.author.name
+            )
+            user = await self._mapper.map_platform_user(
+                channel="discord",
+                channel_user_id=str(message.author.id),
+                workspace_id=self._workspace_id,
+                event_bus=self._event_bus,
+                display_name=display_name,
+            )
+            if user:
+                user_id = user.id
+
         for attachment in message.attachments:
             logger.info(
                 "discord.document.received",

--- a/src/metatron/channels/slack.py
+++ b/src/metatron/channels/slack.py
@@ -43,9 +43,7 @@ class SlackChannel:
         self._bot_token = bot_token
         self._app_token = app_token
         self._router = router
-        self._workspace_id = (
-            workspace_id or router._settings.default_workspace_id
-        )
+        self._workspace_id = workspace_id or router._settings.default_workspace_id
         self._mapper = mapper
         self._event_bus = event_bus
 
@@ -103,7 +101,10 @@ class SlackChannel:
             await self._handler.close_async()
 
     async def _handle_message(
-        self, text: str, user_id: str, say: Callable,
+        self,
+        text: str,
+        user_id: str,
+        say: Callable,
     ) -> None:
         """Handle an incoming DM text message."""
         logger.info(
@@ -143,6 +144,17 @@ class SlackChannel:
         say: Callable,
     ) -> None:
         """Handle file uploads from Slack DM."""
+        if self._mapper:
+            user = await self._mapper.map_platform_user(
+                channel="slack",
+                channel_user_id=user_id,
+                workspace_id=self._workspace_id,
+                event_bus=self._event_bus,
+                display_name=user_id,
+            )
+            if user:
+                user_id = user.id
+
         for file_info in files:
             filename = file_info.get("name", "unknown")
             file_size = file_info.get("size", 0)
@@ -172,7 +184,8 @@ class SlackChannel:
             except Exception as e:
                 logger.error(
                     "slack.document.download_error",
-                    error=str(e), exc_info=True,
+                    error=str(e),
+                    exc_info=True,
                 )
                 await say("Could not download the file. Please try again.")
                 continue
@@ -187,7 +200,9 @@ class SlackChannel:
                 )
             except Exception as e:
                 logger.error(
-                    "slack.document.error", error=str(e), exc_info=True,
+                    "slack.document.error",
+                    error=str(e),
+                    exc_info=True,
                 )
                 answer = "Something went wrong. The error has been logged."
 

--- a/src/metatron/channels/telegram.py
+++ b/src/metatron/channels/telegram.py
@@ -112,14 +112,38 @@ class TelegramChannel:
 
         await self._bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
 
+        # Map platform user to internal user
+        if self._mapper:
+            display_name = ""
+            if message.from_user:
+                parts = [message.from_user.first_name or ""]
+                if message.from_user.last_name:
+                    parts.append(message.from_user.last_name)
+                display_name = " ".join(parts).strip()
+            user = await self._mapper.map_platform_user(
+                channel="telegram",
+                channel_user_id=user_id,
+                workspace_id=self._workspace_id,
+                event_bus=self._event_bus,
+                display_name=display_name,
+            )
+            if user:
+                user_id = user.id
+
         # Download file
         try:
             file_obj = await self._bot.get_file(doc.file_id)
             bio = await self._bot.download_file(file_obj.file_path)
             content = bio.read()
         except Exception as e:
-            logger.error("telegram.document.download_error", error=str(e), exc_info=True)
-            await self._send_response(chat_id, "Could not download the file. Please try again.")
+            logger.error(
+                "telegram.document.download_error",
+                error=str(e), exc_info=True,
+            )
+            await self._send_response(
+                chat_id,
+                "Could not download the file. Please try again.",
+            )
             return
 
         # Process through router (sync)

--- a/src/metatron/storage/pg_models.py
+++ b/src/metatron/storage/pg_models.py
@@ -182,6 +182,34 @@ class ConfigRow(Base):  # type: ignore[misc]
     )
 
 
+class UserPlatformMappingRow(Base):  # type: ignore[misc]
+    """Maps channel platform identities to internal users."""
+
+    __tablename__ = "user_platform_mappings"
+
+    channel = Column(Text, nullable=False, primary_key=True)
+    channel_user_id = Column(Text, nullable=False, primary_key=True)
+    workspace_id = Column(Text, nullable=False, primary_key=True)
+    user_id = Column(
+        Text,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("NOW()"),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "channel", "channel_user_id", "workspace_id",
+            name="uq_user_platform_mapping",
+        ),
+        Index("ix_upm_user_id", "user_id"),
+    )
+
+
 class SyncLogRow(Base):  # type: ignore[misc]
     """Sync log entry for connector synchronization runs."""
 

--- a/tests/unit/test_user_mapping.py
+++ b/tests/unit/test_user_mapping.py
@@ -206,3 +206,174 @@ class TestMapPlatformUser:
             display_name="NoBus",
         )
         assert user is not None
+
+
+class TestCRUD:
+    """Tests for admin CRUD methods on PlatformUserMapper."""
+
+    @pytest.mark.asyncio
+    async def test_list_mappings(self, mapper, event_bus):
+        """List mappings with pagination and channel filter."""
+        # Create mappings across two channels
+        await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+        await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t2",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+        await mapper.map_platform_user(
+            channel="slack", channel_user_id="s1",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+
+        # All mappings
+        all_m = await mapper.list_mappings(workspace_id="ws_1")
+        assert len(all_m) == 3
+        assert all(m["workspace_id"] == "ws_1" for m in all_m)
+
+        # Filter by channel
+        tg_only = await mapper.list_mappings(
+            workspace_id="ws_1", channel="telegram",
+        )
+        assert len(tg_only) == 2
+        assert all(m["channel"] == "telegram" for m in tg_only)
+
+        # Pagination
+        page = await mapper.list_mappings(
+            workspace_id="ws_1", limit=2, offset=0,
+        )
+        assert len(page) == 2
+        page2 = await mapper.list_mappings(
+            workspace_id="ws_1", limit=2, offset=2,
+        )
+        assert len(page2) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_mappings_workspace_isolation(self, mapper, event_bus):
+        """Listing mappings only returns those for the given workspace."""
+        await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+        await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_2", event_bus=event_bus,
+        )
+        ws1 = await mapper.list_mappings(workspace_id="ws_1")
+        assert len(ws1) == 1
+        assert ws1[0]["workspace_id"] == "ws_1"
+
+    @pytest.mark.asyncio
+    async def test_get_mappings_for_user(self, mapper, event_bus):
+        """Get all mappings for a specific user."""
+        user = await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+        # Same internal user mapped from a second channel
+        from sqlalchemy import text as sa_text
+
+        async with mapper._engine.begin() as conn:
+            await conn.execute(
+                sa_text("""
+                    INSERT OR IGNORE INTO user_platform_mappings
+                        (channel, channel_user_id, workspace_id, user_id)
+                    VALUES (:ch, :cuid, :ws, :uid)
+                """),
+                {
+                    "ch": "slack", "cuid": "s1",
+                    "ws": "ws_1", "uid": user.id,
+                },
+            )
+
+        mappings = await mapper.get_mappings_for_user(
+            user_id=user.id, workspace_id="ws_1",
+        )
+        assert len(mappings) == 2
+        channels = {m["channel"] for m in mappings}
+        assert channels == {"telegram", "slack"}
+
+    @pytest.mark.asyncio
+    async def test_update_mapping(self, mapper, event_bus):
+        """Update mapping to a new user and verify cache invalidated."""
+        await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+        # Create a second internal user to reassign to
+        new_user = await mapper.map_platform_user(
+            channel="discord", channel_user_id="d1",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+
+        # Cache should exist
+        cache_key = ("telegram", "t1", "ws_1")
+        assert cache_key in mapper._cache
+
+        updated = await mapper.update_mapping(
+            channel="telegram",
+            channel_user_id="t1",
+            workspace_id="ws_1",
+            new_user_id=new_user.id,
+        )
+        assert updated is True
+
+        # Cache should be invalidated
+        assert cache_key not in mapper._cache
+
+        # Re-lookup should return new user
+        resolved = await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_1", auto_create=False,
+        )
+        assert resolved is not None
+        assert resolved.id == new_user.id
+
+    @pytest.mark.asyncio
+    async def test_update_mapping_not_found(self, mapper):
+        """Updating a non-existent mapping returns False."""
+        result = await mapper.update_mapping(
+            channel="telegram",
+            channel_user_id="nonexistent",
+            workspace_id="ws_1",
+            new_user_id="fake-id",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_mapping(self, mapper, event_bus):
+        """Delete mapping and verify cache invalidated."""
+        await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_1", event_bus=event_bus,
+        )
+
+        cache_key = ("telegram", "t1", "ws_1")
+        assert cache_key in mapper._cache
+
+        deleted = await mapper.delete_mapping(
+            channel="telegram",
+            channel_user_id="t1",
+            workspace_id="ws_1",
+        )
+        assert deleted is True
+        assert cache_key not in mapper._cache
+
+        # Verify gone from DB
+        resolved = await mapper.map_platform_user(
+            channel="telegram", channel_user_id="t1",
+            workspace_id="ws_1", auto_create=False,
+        )
+        assert resolved is None
+
+    @pytest.mark.asyncio
+    async def test_delete_mapping_not_found(self, mapper):
+        """Deleting a non-existent mapping returns False."""
+        result = await mapper.delete_mapping(
+            channel="telegram",
+            channel_user_id="nonexistent",
+            workspace_id="ws_1",
+        )
+        assert result is False


### PR DESCRIPTION
## Summary
- Wire up `PlatformUserMapper` at startup in `app.py` — channels now auto-map platform users to internal User objects
- Alembic migration `010_user_platform_mappings` for the mapping table
- Admin CRUD API: list, get, update, delete platform mappings
- Fix Telegram `_handle_document()` and Discord `_handle_attachments()` to use mapper

## Key changes
- **app.py** — instantiate mapper + event_bus, pass to ChannelManager
- **api/app.py** — store mapper on app.state for API routes
- **auth/user_mapping.py** — add list/get/update/delete CRUD methods with cache invalidation
- **api/routes/users.py** — 4 new admin endpoints for platform mappings
- **channels/telegram.py** — use mapper in document upload handler
- **channels/discord.py** — use mapper in attachment handler
- **storage/pg_models.py** — UserPlatformMappingRow ORM model
- **migrations/** — 010_user_platform_mappings

## API Endpoints
- `GET /api/v1/users/platform-mappings` — list mappings (admin)
- `GET /api/v1/users/{user_id}/platform-mappings` — user's mappings (admin)
- `PUT /api/v1/users/platform-mappings/{channel}/{channel_user_id}` — update (admin)
- `DELETE /api/v1/users/platform-mappings/{channel}/{channel_user_id}` — delete (admin)

## Test plan
- [x] 16 tests pass (9 existing + 7 new CRUD tests)
- [x] Workspace isolation verified in tests
- [x] Cache invalidation on update/delete verified