### PR TITLE
feat(MTRNIX-262): add AsyncQdrantVectorStore for async Qdrant access

### DIFF
--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -8,11 +8,13 @@ Migrated from PoC: metatron_experiments/metatron/indexers/hybrid_store_workspace
 # TODO: migrate to AsyncQdrantClient
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import uuid
 from typing import Any
 
 import structlog
-from qdrant_client import QdrantClient
+from qdrant_client import AsyncQdrantClient, QdrantClient
 from qdrant_client.models import (
     Distance,
     FieldCondition,
@@ -389,6 +391,497 @@ class QdrantVectorStore:
             logger.error("qdrant.collection.delete_error", error=str(e))
 
 
+class AsyncQdrantVectorStore:
+    """Async workspace-aware hybrid vector store (dense + sparse BM25).
+
+    Mirrors QdrantVectorStore but uses AsyncQdrantClient for non-blocking I/O.
+    Collection is lazily ensured on first operation (can't await in __init__).
+    """
+
+    def __init__(
+        self,
+        workspace_id: str | None = None,
+        host: str = "localhost",
+        port: int = 6333,
+    ) -> None:
+        self.workspace_id = _normalize_workspace_id(workspace_id)
+        self.collection_name = get_collection_name(workspace_id)
+        self.client = AsyncQdrantClient(host=host, port=port, timeout=60)
+        self._collection_ensured = False
+
+    async def _ensure_collection(self) -> None:
+        """Create collection if it doesn't exist with hybrid vector config."""
+        if self._collection_ensured:
+            return
+        collections = await self.client.get_collections()
+        if any(c.name == self.collection_name for c in collections.collections):
+            logger.debug(
+                "qdrant.async.collection.exists", collection=self.collection_name
+            )
+            self._collection_ensured = True
+            return
+        logger.info(
+            "qdrant.async.collection.creating",
+            workspace_id=self.workspace_id,
+            collection=self.collection_name,
+        )
+        await self.client.create_collection(
+            collection_name=self.collection_name,
+            vectors_config={
+                DENSE_VECTOR_NAME: VectorParams(
+                    size=DENSE_DIM, distance=Distance.COSINE
+                )
+            },
+            sparse_vectors_config={SPARSE_VECTOR_NAME: SparseVectorParams()},
+        )
+        logger.info(
+            "qdrant.async.collection.created", dense_dim=DENSE_DIM, sparse="bm25"
+        )
+
+        with contextlib.suppress(Exception):
+            await self.client.create_payload_index(
+                collection_name=self.collection_name,
+                field_name="access_groups",
+                field_schema="keyword",
+            )
+
+        self._collection_ensured = True
+
+    def _format_result(self, point: Any, score: float) -> dict:
+        """Format a Qdrant point into a standardized result dict."""
+        payload = point.payload or {}
+        data = payload.get("data") or payload.get("memory") or ""
+        return {
+            "id": str(point.id),
+            "score": score,
+            "memory": data,
+            "data": data,
+            "title": payload.get("title", ""),
+            "type": payload.get("type", ""),
+            "url": payload.get("url", ""),
+            "date": payload.get("date", ""),
+            "doc_label": payload.get("doc_label", ""),
+            "workspace_id": payload.get("workspace_id", ""),
+            "payload": payload,
+            "source_role": payload.get("source_role", "knowledge_base"),
+        }
+
+    @staticmethod
+    def _build_sparse_vector(
+        text: str, title: str = "",
+    ) -> tuple[list[int], list[float]]:
+        """Build BM25 sparse vector (sync helper)."""
+        bm25_text = f"{title} {title} {text}" if title else text
+        return compute_bm25_sparse_vector(bm25_text)
+
+    async def add_document(
+        self,
+        text: str,
+        metadata: dict[str, Any] | None = None,
+        doc_id: str | None = None,
+    ) -> list[str]:
+        """Add document with both dense and sparse vectors.
+
+        Returns list of Qdrant UUIDs (one per stored point).
+        """
+        await self._ensure_collection()
+
+        if doc_id is not None:
+            metadata = metadata or {}
+            metadata["original_id"] = doc_id
+        metadata = metadata or {}
+        metadata["workspace_id"] = self.workspace_id
+
+        embedding_pairs = await asyncio.to_thread(get_cached_embedding_split, text)
+
+        title = (metadata or {}).get("title", "")
+        points: list[PointStruct] = []
+        qdrant_ids: list[str] = []
+
+        for chunk_text, dense_vector in embedding_pairs:
+            qdrant_id = str(uuid.uuid4())
+            qdrant_ids.append(qdrant_id)
+
+            sparse_indices, sparse_values = await asyncio.to_thread(
+                self._build_sparse_vector, chunk_text, title
+            )
+
+            payload = {**metadata}
+            payload["data"] = chunk_text
+            payload["memory"] = chunk_text  # backward compatibility
+
+            points.append(
+                PointStruct(
+                    id=qdrant_id,
+                    vector={
+                        DENSE_VECTOR_NAME: dense_vector,
+                        SPARSE_VECTOR_NAME: SparseVector(
+                            indices=sparse_indices, values=sparse_values,
+                        ),
+                    },
+                    payload=payload,
+                )
+            )
+
+        if len(embedding_pairs) > 1:
+            logger.info(
+                "qdrant.async.add_document.split",
+                doc_id=doc_id,
+                sub_chunks=len(embedding_pairs),
+            )
+
+        await self.client.upsert(
+            collection_name=self.collection_name, points=points
+        )
+        return qdrant_ids
+
+    async def hybrid_search(
+        self,
+        query: str,
+        limit: int = 10,
+        filter_conditions: Filter | None = None,
+        dense_weight: float = 0.7,
+        sparse_weight: float = 0.3,
+    ) -> list[dict]:
+        """Hybrid search via Reciprocal Rank Fusion (RRF)."""
+        await self._ensure_collection()
+        dense_query = await asyncio.to_thread(get_cached_embedding, query)
+        sparse_indices, sparse_values = await asyncio.to_thread(
+            compute_query_sparse_vector, query
+        )
+        try:
+            results = await self.client.query_points(
+                collection_name=self.collection_name,
+                prefetch=[
+                    Prefetch(
+                        query=dense_query,
+                        using=DENSE_VECTOR_NAME,
+                        limit=limit * 3,
+                        filter=filter_conditions,
+                    ),
+                    Prefetch(
+                        query=SparseVector(
+                            indices=sparse_indices, values=sparse_values
+                        ),
+                        using=SPARSE_VECTOR_NAME,
+                        limit=limit * 3,
+                        filter=filter_conditions,
+                    ),
+                ],
+                query=FusionQuery(fusion="rrf"),
+                limit=limit,
+                with_payload=True,
+            )
+            return [self._format_result(p, p.score) for p in results.points]
+        except Exception as e:
+            logger.warning(
+                "qdrant.async.hybrid_search.fallback",
+                workspace_id=self.workspace_id,
+                error=str(e),
+            )
+            return await self.dense_search(
+                query, limit=limit, filter_conditions=filter_conditions
+            )
+
+    async def dense_search(
+        self,
+        query: str,
+        limit: int = 10,
+        filter_conditions: Filter | None = None,
+    ) -> list[dict]:
+        """Dense-only (semantic) search."""
+        await self._ensure_collection()
+        dense_query = await asyncio.to_thread(get_cached_embedding, query)
+        results = await self.client.query_points(
+            collection_name=self.collection_name,
+            query=dense_query,
+            using=DENSE_VECTOR_NAME,
+            limit=limit,
+            query_filter=filter_conditions,
+            with_payload=True,
+        )
+        return [self._format_result(p, p.score) for p in results.points]
+
+    async def keyword_search(
+        self,
+        query: str,
+        limit: int = 10,
+        filter_conditions: Filter | None = None,
+    ) -> list[dict]:
+        """Sparse-only (keyword/BM25) search."""
+        await self._ensure_collection()
+        sparse_indices, sparse_values = await asyncio.to_thread(
+            compute_query_sparse_vector, query
+        )
+        if not sparse_indices:
+            return []
+        results = await self.client.query_points(
+            collection_name=self.collection_name,
+            query=SparseVector(indices=sparse_indices, values=sparse_values),
+            using=SPARSE_VECTOR_NAME,
+            limit=limit,
+            query_filter=filter_conditions,
+            with_payload=True,
+        )
+        return [self._format_result(p, p.score) for p in results.points]
+
+    async def clear(self) -> None:
+        """Delete and recreate collection for this workspace."""
+        try:
+            await self.client.delete_collection(self.collection_name)
+            logger.info(
+                "qdrant.async.collection.deleted", collection=self.collection_name
+            )
+        except Exception as e:
+            logger.error("qdrant.async.collection.delete_error", error=str(e))
+        self._collection_ensured = False
+        await self._ensure_collection()
+
+    async def search_by_date(
+        self, dates: list[str], limit: int = 10
+    ) -> list[dict]:
+        """Filter search by date values."""
+        if not dates:
+            return []
+        await self._ensure_collection()
+        filt = Filter(
+            must=[FieldCondition(key="date", match=MatchAny(any=dates))]
+        )
+        results, _ = await self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=filt,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [self._format_result(p, 1.0) for p in results]
+
+    async def search_by_type(
+        self, doc_type: str, limit: int = 10
+    ) -> list[dict]:
+        """Filter search by document type."""
+        await self._ensure_collection()
+        filt = Filter(
+            must=[FieldCondition(key="type", match=MatchValue(value=doc_type))]
+        )
+        results, _ = await self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=filt,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [self._format_result(p, 1.0) for p in results]
+
+    async def search_by_doc_labels(
+        self, doc_labels: list[str], limit: int = 10
+    ) -> list[dict]:
+        """Filter search by document labels."""
+        labels = [lb for lb in doc_labels if lb]
+        if not labels:
+            return []
+        await self._ensure_collection()
+        m = (
+            MatchAny(any=labels)
+            if len(labels) > 1
+            else MatchValue(value=labels[0])
+        )
+        filt = Filter(must=[FieldCondition(key="doc_label", match=m)])
+        results, _ = await self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=filt,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [self._format_result(p, 1.0) for p in results]
+
+    async def search_by_status(
+        self, status: str, limit: int = 20
+    ) -> list[dict]:
+        """Filter search by status metadata field."""
+        await self._ensure_collection()
+        filt = Filter(
+            must=[FieldCondition(key="status", match=MatchValue(value=status))]
+        )
+        results, _ = await self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=filt,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [self._format_result(p, 1.0) for p in results]
+
+    async def search_by_assignee(
+        self, assignee: str, limit: int = 20
+    ) -> list[dict]:
+        """Filter search by assignee (exact match)."""
+        await self._ensure_collection()
+        filt = Filter(
+            must=[
+                FieldCondition(
+                    key="assignee", match=MatchValue(value=assignee)
+                )
+            ]
+        )
+        results, _ = await self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=filt,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [self._format_result(p, 1.0) for p in results]
+
+    async def scroll_by_title(
+        self, title_substring: str, limit: int = 5
+    ) -> list[dict]:
+        """Scroll points where title contains substring."""
+        if not title_substring or not title_substring.strip():
+            return []
+        await self._ensure_collection()
+        filt = Filter(
+            must=[
+                FieldCondition(
+                    key="title", match=MatchText(text=title_substring)
+                ),
+            ]
+        )
+        results, _ = await self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=filt,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+        return [self._format_result(p, 1.0) for p in results]
+
+    async def fetch_by_chunk_ids(
+        self, chunk_ids: list[str],
+    ) -> list[dict]:
+        """Fetch points by chunk_id payload field."""
+        if not chunk_ids:
+            return []
+        await self._ensure_collection()
+        match = (
+            MatchAny(any=chunk_ids)
+            if len(chunk_ids) > 1
+            else MatchValue(value=chunk_ids[0])
+        )
+        filt = Filter(must=[FieldCondition(key="chunk_id", match=match)])
+        try:
+            results, _ = await self.client.scroll(
+                collection_name=self.collection_name,
+                scroll_filter=filt,
+                limit=len(chunk_ids),
+                with_payload=True,
+                with_vectors=False,
+            )
+            return [self._format_result(p, 1.0) for p in results]
+        except Exception as e:
+            logger.warning(
+                "qdrant.async.fetch_by_chunk_ids.error",
+                chunk_ids=chunk_ids[:5],
+                error=str(e),
+            )
+            return []
+
+    async def delete_by_doc_labels(self, doc_labels: list[str]) -> int:
+        """Delete all points matching any of the given doc_labels.
+
+        Returns number of points deleted.
+        """
+        if not doc_labels:
+            return 0
+        await self._ensure_collection()
+        match = (
+            MatchAny(any=doc_labels)
+            if len(doc_labels) > 1
+            else MatchValue(value=doc_labels[0])
+        )
+        filt = Filter(must=[FieldCondition(key="doc_label", match=match)])
+        try:
+            existing, _ = await self.client.scroll(
+                collection_name=self.collection_name,
+                scroll_filter=filt,
+                limit=100,
+                with_payload=False,
+                with_vectors=False,
+            )
+            count = len(existing)
+            if count == 0:
+                return 0
+            await self.client.delete(
+                collection_name=self.collection_name,
+                points_selector=filt,
+            )
+            logger.info(
+                "qdrant.async.delete_by_doc_labels",
+                doc_labels=doc_labels[:5],
+                deleted=count,
+            )
+            return count
+        except Exception as e:
+            logger.error(
+                "qdrant.async.delete_by_doc_labels.error", error=str(e)
+            )
+            return 0
+
+    async def get_stats(self) -> dict:
+        """Get workspace statistics: chunk count and unique file count."""
+        await self._ensure_collection()
+        try:
+            info = await self.client.get_collection(self.collection_name)
+            chunk_count = info.points_count or 0
+            file_count = 0
+
+            if chunk_count > 0:
+                labels: set[str] = set()
+                offset = None
+                while True:
+                    results, offset = await self.client.scroll(
+                        collection_name=self.collection_name,
+                        limit=100,
+                        offset=offset,
+                        with_payload=["doc_label"],
+                        with_vectors=False,
+                    )
+                    for point in results:
+                        label = point.payload.get("doc_label")
+                        if label:
+                            labels.add(label)
+                    if offset is None:
+                        break
+                file_count = len(labels)
+
+            return {"chunk_count": chunk_count, "file_count": file_count}
+        except Exception as e:
+            logger.error(
+                "qdrant.async.stats.error",
+                workspace_id=self.workspace_id,
+                error=str(e),
+            )
+            return {"chunk_count": 0, "file_count": 0}
+
+    async def delete(self) -> None:
+        """Delete the collection permanently."""
+        try:
+            await self.client.delete_collection(self.collection_name)
+            logger.info(
+                "qdrant.async.collection.deleted_permanently",
+                collection=self.collection_name,
+            )
+        except Exception as e:
+            logger.error(
+                "qdrant.async.collection.delete_error", error=str(e)
+            )
+
+    async def close(self) -> None:
+        """Close the async client connection."""
+        await self.client.close()
+
+
 # ---------------------------------------------------------------------------
 # Module-level factory (cached singleton per workspace)
 # ---------------------------------------------------------------------------
@@ -419,6 +912,39 @@ def get_hybrid_store(workspace_id: str | None = None,
 
 
 def clear_store_cache() -> None:
-    """Clear all cached QdrantVectorStore instances."""
-    global _hybrid_stores
+    """Clear all cached QdrantVectorStore and AsyncQdrantVectorStore instances."""
+    global _hybrid_stores, _async_hybrid_stores
     _hybrid_stores = {}
+    _async_hybrid_stores = {}
+
+
+# ---------------------------------------------------------------------------
+# Async module-level factory (cached singleton per workspace)
+# ---------------------------------------------------------------------------
+_async_hybrid_stores: dict[str, AsyncQdrantVectorStore] = {}
+_async_store_lock = asyncio.Lock()
+
+
+async def get_async_hybrid_store(
+    workspace_id: str | None = None,
+    host: str | None = None,
+    port: int | None = None,
+) -> AsyncQdrantVectorStore:
+    """Get or create AsyncQdrantVectorStore for a workspace (cached singleton).
+
+    Host/port default to values from Settings (env vars) when not provided.
+    """
+    ws = _normalize_workspace_id(workspace_id)
+    if ws not in _async_hybrid_stores:
+        async with _async_store_lock:
+            if ws not in _async_hybrid_stores:
+                if host is None or port is None:
+                    from metatron.core.config import get_settings
+
+                    s = get_settings()
+                    host = host or s.qdrant_host
+                    port = port or s.qdrant_http_port
+                _async_hybrid_stores[ws] = AsyncQdrantVectorStore(
+                    workspace_id, host=host, port=port
+                )
+    return _async_hybrid_stores[ws]

--- a/tests/unit/test_qdrant_async.py
+++ b/tests/unit/test_qdrant_async.py
@@ -1,0 +1,175 @@
+"""Tests for AsyncQdrantVectorStore."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from metatron.storage.qdrant import (
+    AsyncQdrantVectorStore,
+    clear_store_cache,
+    get_async_hybrid_store,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_point(point_id="p1", payload=None, score=0.9):
+    """Create a fake Qdrant point object."""
+    return SimpleNamespace(
+        id=point_id,
+        payload=payload or {"data": "hello", "title": "T", "type": "doc"},
+        score=score,
+    )
+
+
+def _mock_collections(*names: str):
+    """Return a mock get_collections response with given collection names."""
+    cols = [SimpleNamespace(name=n) for n in names]
+    return SimpleNamespace(collections=cols)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_collection
+# ---------------------------------------------------------------------------
+
+class TestEnsureCollection:
+    async def test_creates_collection_on_first_call(self):
+        store = AsyncQdrantVectorStore(workspace_id="ws1")
+        store.client = AsyncMock()
+        store.client.get_collections.return_value = _mock_collections()
+
+        await store._ensure_collection()
+
+        store.client.create_collection.assert_awaited_once()
+        store.client.create_payload_index.assert_awaited_once()
+        assert store._collection_ensured is True
+
+    async def test_skips_creation_when_collection_exists(self):
+        store = AsyncQdrantVectorStore(workspace_id="ws1")
+        store.client = AsyncMock()
+        store.client.get_collections.return_value = _mock_collections(
+            store.collection_name
+        )
+
+        await store._ensure_collection()
+
+        store.client.create_collection.assert_not_awaited()
+        assert store._collection_ensured is True
+
+    async def test_skips_entirely_on_second_call(self):
+        store = AsyncQdrantVectorStore(workspace_id="ws1")
+        store.client = AsyncMock()
+        store._collection_ensured = True
+
+        await store._ensure_collection()
+
+        store.client.get_collections.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# add_document
+# ---------------------------------------------------------------------------
+
+class TestAddDocument:
+    @patch("metatron.storage.qdrant.get_cached_embedding_split")
+    @patch("metatron.storage.qdrant.compute_bm25_sparse_vector")
+    async def test_add_document_calls_upsert(self, mock_bm25, mock_embed):
+        mock_embed.return_value = [("chunk text", [0.1] * 768)]
+        mock_bm25.return_value = ([1, 2], [0.5, 0.6])
+
+        store = AsyncQdrantVectorStore(workspace_id="ws1")
+        store.client = AsyncMock()
+        store._collection_ensured = True
+
+        ids = await store.add_document("some text", metadata={"title": "T"})
+
+        assert len(ids) == 1
+        store.client.upsert.assert_awaited_once()
+        call_kwargs = store.client.upsert.call_args
+        points = call_kwargs.kwargs.get("points") or call_kwargs[1].get("points")
+        assert len(points) == 1
+        assert points[0].payload["workspace_id"] == "ws1"
+
+
+# ---------------------------------------------------------------------------
+# hybrid_search
+# ---------------------------------------------------------------------------
+
+class TestHybridSearch:
+    @patch("metatron.storage.qdrant.compute_query_sparse_vector")
+    @patch("metatron.storage.qdrant.get_cached_embedding")
+    async def test_hybrid_search_returns_results(self, mock_embed, mock_sparse):
+        mock_embed.return_value = [0.1] * 768
+        mock_sparse.return_value = ([1], [0.5])
+
+        store = AsyncQdrantVectorStore(workspace_id="ws1")
+        store.client = AsyncMock()
+        store._collection_ensured = True
+        store.client.query_points.return_value = SimpleNamespace(
+            points=[_make_point()]
+        )
+
+        results = await store.hybrid_search("test query", limit=5)
+
+        assert len(results) == 1
+        assert results[0]["data"] == "hello"
+        store.client.query_points.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# get_async_hybrid_store caching
+# ---------------------------------------------------------------------------
+
+class TestAsyncFactory:
+    @patch("metatron.storage.qdrant.AsyncQdrantClient")
+    async def test_caching_returns_same_instance(self, mock_client_cls):
+        clear_store_cache()
+
+        store1 = await get_async_hybrid_store(
+            workspace_id="ws1", host="localhost", port=6333
+        )
+        store2 = await get_async_hybrid_store(
+            workspace_id="ws1", host="localhost", port=6333
+        )
+
+        assert store1 is store2
+
+    @patch("metatron.storage.qdrant.AsyncQdrantClient")
+    async def test_different_workspaces_get_different_stores(self, mock_client_cls):
+        clear_store_cache()
+
+        store1 = await get_async_hybrid_store(
+            workspace_id="ws1", host="localhost", port=6333
+        )
+        store2 = await get_async_hybrid_store(
+            workspace_id="ws2", host="localhost", port=6333
+        )
+
+        assert store1 is not store2
+
+
+# ---------------------------------------------------------------------------
+# clear_store_cache
+# ---------------------------------------------------------------------------
+
+class TestClearStoreCache:
+    @patch("metatron.storage.qdrant.AsyncQdrantClient")
+    @patch("metatron.storage.qdrant.QdrantClient")
+    async def test_clears_both_caches(self, mock_sync_cls, mock_async_cls):
+        clear_store_cache()
+
+        # Populate async cache
+        await get_async_hybrid_store(
+            workspace_id="ws1", host="localhost", port=6333
+        )
+
+        # Import to check sync cache dict directly
+        from metatron.storage import qdrant
+
+        assert len(qdrant._async_hybrid_stores) == 1
+
+        clear_store_cache()
+
+        assert len(qdrant._async_hybrid_stores) == 0
+        assert len(qdrant._hybrid_stores) == 0


### PR DESCRIPTION
## Summary
Phase 1 of async migration: add `AsyncQdrantVectorStore` alongside existing sync class.

- **New class** `AsyncQdrantVectorStore` — mirrors all methods of `QdrantVectorStore` as async, uses `AsyncQdrantClient`
- **New factory** `get_async_hybrid_store()` — async cached factory with `asyncio.Lock()`
- **Updated** `clear_store_cache()` — clears both sync and async caches
- **Zero changes** to existing `QdrantVectorStore` or any callers

## Design
- Sync embedding calls wrapped in `asyncio.to_thread()` inside async methods
- Lazy `_ensure_collection()` on first operation (can't await in `__init__`)
- Same public API as sync class — future phases will swap callers incrementally

## Phase roadmap
- **Phase 1 (this PR)**: Async Qdrant store class — zero risk, no caller changes
- Phase 2: Migrate retrieval/ to use async store
- Phase 3: Migrate ingestion/ to async, remove to_thread wrappers

## Test plan
- [x] 8 new async tests pass
- [x] 1236 existing tests unaffected
- [x] Lint clean