### PR TITLE
feat(MTRNIX-262): async retrieval pipeline with parallel recall channels

### DIFF
--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -63,7 +63,7 @@ from metatron.benchmarker.services.eval_loader import (
     load_eval_testset_from_path,
 )
 from metatron.benchmarker.services.metrics.retrieval import RetrievalMetrics
-from metatron.retrieval.search import hybrid_search_and_answer
+from metatron.retrieval.search import hybrid_search_and_answer_sync
 
 RESULTS_DIR = Path(__file__).parent.parent / "eval_results"
 
@@ -107,7 +107,7 @@ def run_eval(
     if positive_queries:
         print("POSITIVE (should find relevant docs):")
     for q in positive_queries:
-        trace = hybrid_search_and_answer(
+        trace = hybrid_search_and_answer_sync(
             q.text,
             workspace,
             k,
@@ -144,7 +144,7 @@ def run_eval(
     if negative_queries:
         print("\nNEGATIVE (should NOT find relevant docs):")
     for q in negative_queries:
-        trace = hybrid_search_and_answer(
+        trace = hybrid_search_and_answer_sync(
             q.text,
             workspace,
             k,

--- a/src/metatron/agent/router.py
+++ b/src/metatron/agent/router.py
@@ -18,7 +18,7 @@ from metatron.agent.sessions import SessionManager
 from metatron.core.config import Settings
 from metatron.llm import chat_completion
 from metatron.llm.base import LLMError
-from metatron.retrieval.search import hybrid_search_and_answer
+from metatron.retrieval.search import hybrid_search_and_answer_sync
 
 try:
     from httpx import ConnectError as HttpxConnectError
@@ -199,7 +199,7 @@ class AgentRouter:
         # Call existing search pipeline
         # query = composite (with history context for richer search)
         # intent_query = text (current question only — for language detection)
-        answer = hybrid_search_and_answer(
+        answer = hybrid_search_and_answer_sync(
             query=composite,
             user_id=user_id,
             workspace_id=workspace_id,
@@ -262,7 +262,7 @@ class AgentRouter:
         lower = text.lower()
         if any(kw in lower for kw in _CONTEXT_KEYWORDS):
             try:
-                context = hybrid_search_and_answer(
+                context = hybrid_search_and_answer_sync(
                     query=text, user_id=user_id, workspace_id=workspace_id,
                     intent_query=text,
                 )

--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -48,7 +48,7 @@ class UploadResponse(BaseModel):
 
 
 @router.post("/chat", response_model=ChatResponse)
-def chat(req: ChatRequest, request: Request) -> ChatResponse:
+async def chat(req: ChatRequest, request: Request) -> ChatResponse:
     """Hybrid search with conversation history and workspace isolation."""
     from metatron.workspaces import get_workspace_manager
 
@@ -83,7 +83,7 @@ def chat(req: ChatRequest, request: Request) -> ChatResponse:
 
     try:
         from metatron.retrieval.search import hybrid_search_and_answer
-        answer = hybrid_search_and_answer(
+        answer = await hybrid_search_and_answer(
             query=composite_query,
             user_id=req.user_id,
             workspace_id=req.workspace_id,
@@ -182,25 +182,14 @@ async def chat_stream(req: ChatRequest, request: Request) -> EventSourceResponse
 
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
-            _pm = plugin_manager  # capture for closure
-            task = asyncio.get_event_loop().run_in_executor(
-                None,
-                lambda _pm=_pm: hybrid_search_and_answer(
-                    query=composite_query,
-                    user_id=req.user_id,
-                    workspace_id=workspace_id,
-                    k=req.top_k,
-                    intent_query=req.question,
-                    plugin_manager=_pm,
-                ),
+            answer: str = await hybrid_search_and_answer(
+                query=composite_query,
+                user_id=req.user_id,
+                workspace_id=workspace_id,
+                k=req.top_k,
+                intent_query=req.question,
+                plugin_manager=plugin_manager,
             )
-            # Send heartbeat every 5s while search is running
-            while not task.done():
-                try:
-                    await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
-                except TimeoutError:
-                    yield {"event": "ping", "data": "{}"}
-            answer: str = task.result()
         except Exception as exc:
             logger.error("chat.stream.error", error=str(exc), exc_info=True)
             yield {"event": "error", "data": json.dumps(

--- a/src/metatron/api/routes/openai_compat.py
+++ b/src/metatron/api/routes/openai_compat.py
@@ -351,8 +351,7 @@ async def _stream_response(
     try:
         from metatron.retrieval.search import hybrid_search_and_answer
 
-        answer = await asyncio.to_thread(
-            hybrid_search_and_answer,
+        answer = await hybrid_search_and_answer(
             query=composite_query,
             user_id=user_id,
             workspace_id=workspace_id,
@@ -437,13 +436,10 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
         )
 
     # Non-streaming path
-    import asyncio
-
     try:
         from metatron.retrieval.search import hybrid_search_and_answer
 
-        answer = await asyncio.to_thread(
-            hybrid_search_and_answer,
+        answer = await hybrid_search_and_answer(
             query=composite_query,
             user_id=user_id,
             workspace_id=workspace_id,

--- a/src/metatron/benchmarker/services/metrics/confidence.py
+++ b/src/metatron/benchmarker/services/metrics/confidence.py
@@ -20,7 +20,7 @@ import numpy as np
 import structlog
 
 from metatron.benchmarker.schemas.test_result import ConfidenceResult
-from metatron.retrieval.search import hybrid_search_and_answer
+from metatron.retrieval.search import hybrid_search_and_answer_sync
 
 logger = structlog.get_logger()
 
@@ -141,9 +141,9 @@ class ConfidenceMetric:
     def _generate_single_response(
         self, question: str, workspace_id: str,
     ) -> str:
-        """Generate one answer via hybrid_search_and_answer (sync)."""
+        """Generate one answer via hybrid_search_and_answer_sync (sync)."""
         try:
-            answer = hybrid_search_and_answer(
+            answer = hybrid_search_and_answer_sync(
                 query=question,
                 workspace_id=workspace_id,
             )

--- a/src/metatron/benchmarker/services/runner.py
+++ b/src/metatron/benchmarker/services/runner.py
@@ -85,13 +85,11 @@ class TestRunner:
         workspace_id: str,
     ) -> TestContext:
         """Run a single question through the RAG pipeline and build a TestContext."""
-        import asyncio
 
         trace: Any = None
         start = time.time()
         try:
-            trace = await asyncio.to_thread(
-                hybrid_search_and_answer,
+            trace = await hybrid_search_and_answer(
                 query=question.text,
                 workspace_id=workspace_id,
                 return_trace=True,

--- a/src/metatron/mcp/tools/search.py
+++ b/src/metatron/mcp/tools/search.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from metatron.mcp.errors import handle_tool_error
@@ -37,10 +36,9 @@ async def metatron_search(
         limit = min(max(1, limit), 100)
 
         # hybrid_search_and_answer returns str (answer with sources appended)
-        answer = await asyncio.to_thread(
-            hybrid_search_and_answer,
+        answer = await hybrid_search_and_answer(
             query,
-            workspace_id or "default",
+            workspace_id=workspace_id or "default",
         )
 
         # Return the answer directly — the search pipeline already

--- a/src/metatron/retrieval/__init__.py
+++ b/src/metatron/retrieval/__init__.py
@@ -4,10 +4,11 @@ from metatron.retrieval.context import assemble_context
 from metatron.retrieval.fallback import GracefulRetriever
 from metatron.retrieval.hybrid import rrf_fusion
 from metatron.retrieval.scoring import compute_signal_score
-from metatron.retrieval.search import hybrid_search_and_answer
+from metatron.retrieval.search import hybrid_search_and_answer, hybrid_search_and_answer_sync
 
 __all__ = [
     "hybrid_search_and_answer",
+    "hybrid_search_and_answer_sync",
     "rrf_fusion",
     "compute_signal_score",
     "assemble_context",

--- a/src/metatron/retrieval/channels.py
+++ b/src/metatron/retrieval/channels.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass
 from functools import lru_cache
@@ -17,7 +18,7 @@ from metatron.storage.graph_ops import (
     get_graph_entities,
     get_graph_relationships,
 )
-from metatron.storage.qdrant import get_hybrid_store
+from metatron.storage.qdrant import get_async_hybrid_store, get_hybrid_store
 
 logger = structlog.get_logger(__name__)
 
@@ -158,6 +159,24 @@ def recall_dense(ctx: RecallContext) -> list[ScoredResult]:
         return []
 
 
+async def recall_dense_async(ctx: RecallContext) -> list[ScoredResult]:
+    """Dense channel (async): RRF hybrid search (dense + sparse vectors)."""
+    limit = ctx.settings.recall_top_n_dense if ctx.settings else 30
+    try:
+        store = await get_async_hybrid_store(ctx.workspace_id)
+        hits = await store.hybrid_search(
+            query=ctx.translated_query or ctx.expanded_query,
+            limit=limit,
+            filter_conditions=ctx.access_filter,
+        )
+        return [_qdrant_hit_to_scored(h, channel="dense") for h in hits[:limit]]
+    except Exception:
+        logger.error(
+            "recall_dense_async failed", workspace=ctx.workspace_id, exc_info=True,
+        )
+        return []
+
+
 def recall_exact(ctx: RecallContext) -> list[ScoredResult]:
     """Exact channel: Jira key lookup + title entity search."""
     limit = ctx.settings.recall_top_n_exact if ctx.settings else 10
@@ -195,6 +214,48 @@ def recall_exact(ctx: RecallContext) -> list[ScoredResult]:
         return results[:limit]
     except Exception:
         logger.error("recall_exact failed", workspace=ctx.workspace_id, exc_info=True)
+        return []
+
+
+async def recall_exact_async(ctx: RecallContext) -> list[ScoredResult]:
+    """Exact channel (async): Jira key lookup + title entity search."""
+    limit = ctx.settings.recall_top_n_exact if ctx.settings else 10
+    if not ctx.extracted_jira_keys and not ctx.extracted_title_entities:
+        return []
+    try:
+        store = await get_async_hybrid_store(ctx.workspace_id)
+        hits: list[dict] = []
+
+        if ctx.extracted_jira_keys:
+            hits.extend(
+                _post_filter_acl(
+                    await store.search_by_doc_labels(ctx.extracted_jira_keys),
+                    ctx.access_filter,
+                )
+            )
+
+        for entity in ctx.extracted_title_entities:
+            title_hits = _post_filter_acl(
+                await store.scroll_by_title(entity, limit=5),
+                ctx.access_filter,
+            )
+            hits.extend(title_hits)
+
+        seen_ids: set[str] = set()
+        results: list[ScoredResult] = []
+        for h in hits:
+            hid = str(h.get("id", ""))
+            if hid in seen_ids:
+                continue
+            seen_ids.add(hid)
+            results.append(_qdrant_hit_to_scored(h, channel="exact"))
+
+        results.sort(key=lambda x: x["score"], reverse=True)
+        return results[:limit]
+    except Exception:
+        logger.error(
+            "recall_exact_async failed", workspace=ctx.workspace_id, exc_info=True,
+        )
         return []
 
 
@@ -247,6 +308,57 @@ def recall_metadata(ctx: RecallContext) -> list[ScoredResult]:
         return results[:limit]
     except Exception:
         logger.error("recall_metadata failed", workspace=ctx.workspace_id, exc_info=True)
+        return []
+
+
+async def recall_metadata_async(ctx: RecallContext) -> list[ScoredResult]:
+    """Metadata channel (async): date filters, person/assignee, activity status."""
+    limit = ctx.settings.recall_top_n_metadata if ctx.settings else 10
+    has_signal = ctx.extracted_dates or len(ctx.detected_person) > 0 or ctx.is_activity_query
+    if not has_signal:
+        return []
+    try:
+        store = await get_async_hybrid_store(ctx.workspace_id)
+        hits: list[dict] = []
+
+        if ctx.extracted_dates:
+            date_hits = _post_filter_acl(
+                await store.search_by_date(list(ctx.extracted_dates), limit=limit),
+                ctx.access_filter,
+            )
+            hits.extend(date_hits)
+
+        # Person-specific: search by assignee for each resolved name
+        if ctx.detected_person:
+            for name in ctx.detected_person:
+                assignee_hits = _post_filter_acl(
+                    await store.search_by_assignee(name, limit=limit),
+                    ctx.access_filter,
+                )
+                hits.extend(assignee_hits)
+        elif ctx.is_activity_query:
+            for status in _ACTIVITY_STATUSES:
+                status_hits = _post_filter_acl(
+                    await store.search_by_status(status, limit=limit),
+                    ctx.access_filter,
+                )
+                hits.extend(status_hits)
+
+        seen_ids: set[str] = set()
+        results: list[ScoredResult] = []
+        for h in hits:
+            hid = str(h.get("id", ""))
+            if hid in seen_ids:
+                continue
+            seen_ids.add(hid)
+            results.append(_qdrant_hit_to_scored(h, channel="metadata"))
+
+        results.sort(key=lambda x: x["score"], reverse=True)
+        return results[:limit]
+    except Exception:
+        logger.error(
+            "recall_metadata_async failed", workspace=ctx.workspace_id, exc_info=True,
+        )
         return []
 
 
@@ -339,4 +451,77 @@ def recall_graph(ctx: RecallContext) -> list[ScoredResult]:
         return [_qdrant_hit_to_scored(h, channel="graph") for h in hits[:limit]]
     except Exception:
         logger.error("recall_graph failed", workspace=ctx.workspace_id, exc_info=True)
+        return []
+
+
+async def recall_graph_async(ctx: RecallContext) -> list[ScoredResult]:
+    """Graph channel (async): find related documents via entity graph traversal.
+
+    Qdrant calls use async store. Memgraph calls (graph_ops) are wrapped
+    with asyncio.to_thread() since graph_ops is still sync.
+    """
+    limit = ctx.settings.recall_top_n_graph if ctx.settings else 5
+    max_depth = ctx.settings.recall_graph_max_depth if ctx.settings else 2
+    try:
+        # 1. Collect seed entity names from RecallContext
+        seeds: set[str] = set()
+        seeds.update(ctx.extracted_jira_keys)
+        seeds.update(ctx.extracted_title_entities)
+        seeds.update(ctx.detected_person)
+
+        # 2. Graph entity match on query (existing behavior)
+        query_for_ner = ctx.translated_query or ctx.original_query
+        graph_ents = list(
+            _cached_get_graph_entities((query_for_ner,), ctx.workspace_id)
+        )
+        seeds.update(e["name"] for e in graph_ents if "name" in e)
+
+        if not seeds:
+            return []
+
+        # 3. Get direct doc_labels for seeds (sync graph_ops via to_thread)
+        direct = await asyncio.to_thread(
+            get_doc_labels_by_entities, list(seeds), workspace_id=ctx.workspace_id,
+        )
+        all_labels: set[str] = {r["doc_label"] for r in direct if "doc_label" in r}
+
+        # 4. Iterative BFS hop expansion
+        seen_entities = set(seeds)
+        frontier = set(seeds)
+        for _hop in range(max_depth):
+            if not frontier:
+                break
+            rels = await asyncio.to_thread(
+                get_graph_relationships,
+                list(frontier)[:_MAX_FRONTIER],
+                workspace_id=ctx.workspace_id,
+                max_depth=1,
+            )
+            neighbor_names = {r["source"] for r in rels} | {r["target"] for r in rels}
+            frontier = neighbor_names - seen_entities
+            seen_entities.update(frontier)
+            if frontier:
+                expanded = await asyncio.to_thread(
+                    get_doc_labels_by_entities,
+                    list(frontier)[:_MAX_FRONTIER],
+                    workspace_id=ctx.workspace_id,
+                )
+                all_labels.update(
+                    r["doc_label"] for r in expanded if "doc_label" in r
+                )
+
+        if not all_labels:
+            return []
+
+        # 5. Fetch chunks via async Qdrant, apply ACL, limit
+        store = await get_async_hybrid_store(ctx.workspace_id)
+        hits = _post_filter_acl(
+            await store.search_by_doc_labels(list(all_labels), limit=limit),
+            ctx.access_filter,
+        )
+        return [_qdrant_hit_to_scored(h, channel="graph") for h in hits[:limit]]
+    except Exception:
+        logger.error(
+            "recall_graph_async failed", workspace=ctx.workspace_id, exc_info=True,
+        )
         return []

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -5,7 +5,6 @@ import asyncio
 import json
 import re
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 
 import structlog
@@ -22,10 +21,10 @@ from metatron.retrieval.aliases import resolve_person_name
 from metatron.retrieval.channels import (
     RecallContext,
     merge_channels,
-    recall_dense,
-    recall_exact,
-    recall_graph,
-    recall_metadata,
+    recall_dense_async,
+    recall_exact_async,
+    recall_graph_async,
+    recall_metadata_async,
 )
 from metatron.retrieval.prompts import (
     HYBRID_SYSTEM_PROMPT,
@@ -66,9 +65,6 @@ _MAX_TOTAL, _MAX_FRAG = _s.search_max_total_chars, _s.search_max_fragment_chars
 _GRAPH_DEPTH = int(getattr(_s, "search_graph_depth", 2))
 
 _TRANSLATE_SYS = "Translate the following query to English. Return ONLY the translation, nothing else."
-
-_recall_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="recall")
-
 
 @timed("resolve_query")
 def resolve_query(query: str) -> str:
@@ -113,21 +109,6 @@ def resolve_query(query: str) -> str:
     except Exception as e:
         logger.warning("query.resolve_failed", error=str(e))
         return query
-
-
-def _run_recall_channels(ctx: RecallContext) -> tuple[list, list, list, list]:
-    """Run 4 recall channels in parallel using thread pool.
-
-    Each channel is sync (Qdrant/Memgraph clients are sync), so we use
-    threads for true parallelism. Returns (dense, exact, metadata, graph).
-    """
-    futures = [
-        _recall_executor.submit(recall_dense, ctx),
-        _recall_executor.submit(recall_exact, ctx),
-        _recall_executor.submit(recall_metadata, ctx),
-        _recall_executor.submit(recall_graph, ctx),
-    ]
-    return tuple(f.result() for f in futures)
 
 
 def _run_hooks_sync(plugin_manager, hook_name: str, context: dict) -> dict:
@@ -636,14 +617,27 @@ def _prepend_root_context(
     return results
 
 
+async def _run_recall_channels_async(
+    ctx: RecallContext,
+) -> tuple[list, list, list, list]:
+    """Run 4 async recall channels in parallel using asyncio.gather."""
+    dense, exact, metadata, graph = await asyncio.gather(
+        recall_dense_async(ctx),
+        recall_exact_async(ctx),
+        recall_metadata_async(ctx),
+        recall_graph_async(ctx),
+    )
+    return dense, exact, metadata, graph
+
+
 @timed("hybrid_search_and_answer")
-def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
+async def hybrid_search_and_answer(  # noqa: C901
     query: str, user_id: str = "user", k: int = 25,
     workspace_id: str | None = None, intent_query: str | None = None,
     return_trace: bool = False,
     plugin_manager=None,
 ) -> str | dict:
-    """End-to-end hybrid search and answer generation."""
+    """End-to-end hybrid search and answer generation (async)."""
     import time
     start_time = time.time()
 
@@ -651,24 +645,36 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     # Resolve contextual references (relative dates, pronouns) using the full
     # composite query which contains conversation history.  When intent_query
     # is provided (OpenAI-compat), query carries the context we need.
-    rq = resolve_query(query.strip() if intent_query and query else raw_query)
+    rq = await asyncio.to_thread(
+        resolve_query, query.strip() if intent_query and query else raw_query,
+    )
     rq_original = raw_query
     use_schema = should_use_team_workflow_schema(rq)
     lang = detect_response_language(rq)
 
     # Expand query for better BM25 recall (adds status keywords, synonyms)
-    eq = expand_query(rq)
+    eq = await asyncio.to_thread(expand_query, rq)
     # Translate expanded query for vector/BM25 search if it has Cyrillic
-    sq = translate_query_to_english(eq) if _has_cyrillic(eq) else eq
+    sq = (
+        await asyncio.to_thread(translate_query_to_english, eq)
+        if _has_cyrillic(eq)
+        else eq
+    )
 
     # -- Classify query intent --
     if _s.query_classifier_enabled:
         # Reuse sq when original == expanded (avoids duplicate LLM translation)
         if _has_cyrillic(rq):
-            _translated_for_classifier = sq if rq == eq else translate_query_to_english(rq)
+            _translated_for_classifier = (
+                sq
+                if rq == eq
+                else await asyncio.to_thread(translate_query_to_english, rq)
+            )
         else:
             _translated_for_classifier = rq
-        classification = classify_query(rq, translated_query=_translated_for_classifier)
+        classification = await asyncio.to_thread(
+            classify_query, rq, translated_query=_translated_for_classifier,
+        )
     else:
         classification = {"profile": "mixed", "confidence": 1.0, "method": "disabled"}
 
@@ -677,9 +683,11 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     # -- ACL pre-filter: restrict search to user's groups --
     access_filter = None
     if plugin_manager:
-        hook_ctx = _run_hooks_sync(plugin_manager, "search_pre_filter", {
+        hook_ctx: dict = {
             "user_id": user_id, "workspace_id": workspace_id, "query": rq,
-        })
+        }
+        for hook in plugin_manager.get_pipeline_hooks("search_pre_filter"):
+            hook_ctx = await hook(hook_ctx)
         access_filter = hook_ctx.get("access_filter")
 
     # Store user_groups from pre-filter hook for graph enrichment
@@ -698,8 +706,10 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
         settings=_s,
     )
 
-    # -- Run 4 recall channels in parallel --
-    dense_results, exact_results, metadata_results, graph_results = _run_recall_channels(recall_ctx)
+    # -- Run 4 recall channels in parallel (async) --
+    dense_results, exact_results, metadata_results, graph_results = (
+        await _run_recall_channels_async(recall_ctx)
+    )
 
     # -- Merge and deduplicate across channels --
     merged = merge_channels([dense_results, exact_results, metadata_results, graph_results])
@@ -787,7 +797,7 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     _pre_rerank_count = len(base)
     if _s.reranker_enabled:
         from metatron.retrieval.reranker import rerank
-        base = rerank(query=rq, results=base, top_k=len(base))
+        base = await asyncio.to_thread(rerank, query=rq, results=base, top_k=len(base))
         normalize_rerank_scores(base)
         for r in base:
             cid = str(r.get("id", ""))
@@ -809,10 +819,12 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
 
     # -- ACL post-rerank: defense-in-depth filter --
     if plugin_manager:
-        ctx = _run_hooks_sync(plugin_manager, "search_post_rerank", {
+        post_ctx: dict = {
             "chunks": base, "user_id": user_id, "workspace_id": workspace_id,
-        })
-        base = ctx.get("chunks", base)
+        }
+        for hook in plugin_manager.get_pipeline_hooks("search_post_rerank"):
+            post_ctx = await hook(post_ctx)
+        base = post_ctx.get("chunks", base)
 
     frags, seen_h, total_c, doc_stats = _collect_frags(base, set(), 0)
     _mark_evidence_role(frags, classification["profile"])
@@ -821,30 +833,44 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     g_ents: list = []
     g_rels: list = []
     g_docs: list = []
-    try:
+
+    def _graph_enrichment_sync() -> tuple[list, list, list]:
+        """Run graph enrichment synchronously (offloaded to thread)."""
+        _g_ents: list = []
+        _g_rels: list = []
+        _g_docs: list = []
         dl = _doc_labels(base)
         frag_texts = [f["text"] for f in frags]
-        g_ents = get_entities_by_doc_labels(dl, workspace_id) if dl else get_graph_entities(frag_texts, workspace_id)
+        _g_ents = (
+            get_entities_by_doc_labels(dl, workspace_id)
+            if dl
+            else get_graph_entities(frag_texts, workspace_id)
+        )
         names: set[str] = set()
-        for e in g_ents:
+        for e in _g_ents:
             if e.get("name"):
                 names.add(e["name"])
             for a in e.get("aliases", []) or []:
                 names.add(a)
         if names:
-            date_range = extract_date_range(rq)
-            if date_range:
-                g_rels = get_relationships_at_date(
-                    list(names), target_date=date_range[0],
+            _date_range = extract_date_range(rq)
+            if _date_range:
+                _g_rels = get_relationships_at_date(
+                    list(names), target_date=_date_range[0],
                     workspace_id=workspace_id, max_depth=_GRAPH_DEPTH)
             else:
-                g_rels = get_graph_relationships(
+                _g_rels = get_graph_relationships(
                     list(names), workspace_id,
                     max_depth=_GRAPH_DEPTH, active_only=True)
-            for r in g_rels:
+            for r in _g_rels:
                 names.update(filter(None, [r.get("source"), r.get("target")]))
-            g_docs = (get_doc_labels_by_entities(list(names), workspace_id,
-                                                user_groups=user_groups) if dl else [])
+            _g_docs = (get_doc_labels_by_entities(list(names), workspace_id,
+                                                  user_groups=user_groups)
+                       if dl else [])
+        return _g_ents, _g_rels, _g_docs
+
+    try:
+        g_ents, g_rels, g_docs = await asyncio.to_thread(_graph_enrichment_sync)
         # Graph docs kept as metadata only — document chunks come from recall channels
     except Exception:
         logger.warning("search.graph_enrichment_failed", exc_info=True)
@@ -869,7 +895,8 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
     try:
         if use_schema:
             sys_prompt = TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT.format(response_language=lang)
-            c = chat_completion_with_retry(
+            c = await asyncio.to_thread(
+                chat_completion_with_retry,
                 messages=[{"role": "system", "content": sys_prompt},
                           {"role": "user", "content": ctx + TEAM_WORKFLOW_SCHEMA_SPEC}],
                 temperature=0.2, json_mode=True, timeout=60,
@@ -877,11 +904,12 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             answer = (json.loads(_extract_json_object(c)).get("answer") or "").strip()
         else:
             sys_prompt = HYBRID_SYSTEM_PROMPT.format(response_language=lang)
-            answer = chat_completion_with_retry(
+            answer = (await asyncio.to_thread(
+                chat_completion_with_retry,
                 messages=[{"role": "system", "content": sys_prompt},
                           {"role": "user", "content": ctx}],
                 temperature=0.2, timeout=60,
-            ).strip()
+            )).strip()
     except Exception:
         logger.error("search.llm_answer_failed", exc_info=True)
         n = len(base)
@@ -957,13 +985,36 @@ def hybrid_search_and_answer(  # noqa: C901  # TODO: async migration
             }
 
             from metatron.storage.pg_connection import store_query_trace_sync
-            store_query_trace_sync(workspace_id, rq, trace_data, total_ms)
+            await asyncio.to_thread(
+                store_query_trace_sync, workspace_id, rq, trace_data, total_ms,
+            )
 
             # Track per-document fetch stats for FinOps cost savings
             if doc_stats:
                 from metatron.storage.pg_connection import upsert_document_fetch_stats_sync
-                upsert_document_fetch_stats_sync(workspace_id, doc_stats)
+                await asyncio.to_thread(
+                    upsert_document_fetch_stats_sync, workspace_id, doc_stats,
+                )
         except Exception as e:
             logger.warning("search.trace_logging_failed", error=str(e))
 
     return result
+
+
+def hybrid_search_and_answer_sync(
+    query: str, user_id: str = "user", k: int = 25,
+    workspace_id: str | None = None, intent_query: str | None = None,
+    return_trace: bool = False,
+    plugin_manager=None,
+) -> str | dict:
+    """Sync wrapper around the async hybrid_search_and_answer.
+
+    For callers that run in a sync context (e.g. AgentRouter, benchmarker).
+    """
+    return asyncio.run(
+        hybrid_search_and_answer(
+            query=query, user_id=user_id, k=k,
+            workspace_id=workspace_id, intent_query=intent_query,
+            return_trace=return_trace, plugin_manager=plugin_manager,
+        )
+    )

--- a/tests/unit/test_agent_router.py
+++ b/tests/unit/test_agent_router.py
@@ -119,7 +119,7 @@ class TestRouteSmallTalk:
 
 
 class TestRouteSearch:
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_search_calls_hybrid(self, mock_search, router: AgentRouter) -> None:
         mock_search.return_value = "Found: MTRNIX-78 is about analytics."
         result = router.route("what is MTRNIX-78?", user_id="u1")
@@ -128,7 +128,7 @@ class TestRouteSearch:
         call_kwargs = mock_search.call_args
         assert call_kwargs.kwargs["workspace_id"] == "TEST_WS"
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_search_records_history(self, mock_search, router: AgentRouter) -> None:
         mock_search.return_value = "answer"
         router.route("query1", user_id="u1")
@@ -138,7 +138,7 @@ class TestRouteSearch:
         assert history[0]["content"] == "query1"
         assert history[1]["role"] == "assistant"
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_search_command_dispatches(self, mock_search, router: AgentRouter) -> None:
         mock_search.return_value = "search result"
         result = router.route("/search MTRNIX-78", user_id="u1")
@@ -149,7 +149,7 @@ class TestRouteSearch:
         result = router.route("/search", user_id="u1")
         assert "Usage" in result
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_composite_query_used(self, mock_search, router: AgentRouter) -> None:
         mock_search.return_value = "answer"
         router.route("tell me about team alpha", user_id="u1")
@@ -159,7 +159,7 @@ class TestRouteSearch:
         assert "team alpha" in second_call.kwargs["query"]
         assert second_call.kwargs["intent_query"] == "what are their deadlines?"
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_intent_query_is_current_message(self, mock_search, router: AgentRouter) -> None:
         """Bug fix: intent_query must be the current message (for language detection),
         not the composite with history. English question after Russian history
@@ -177,7 +177,7 @@ class TestRouteSearch:
         # query = independent question (no history — follow-up detection skips it)
         assert "What the team doing this week?" in fourth_call.kwargs["query"]
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_search_error_handled(self, mock_search, router: AgentRouter) -> None:
         mock_search.side_effect = RuntimeError("Qdrant down")
         result = router.route("query", user_id="u1")

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -173,7 +173,7 @@ class TestMetrics:
 
 class TestChat:
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_chat_returns_answer(
         self, mock_search, mock_mgr, client: TestClient,
     ) -> None:
@@ -189,7 +189,7 @@ class TestChat:
         assert body["workspace_id"] == "TEST_WS"
 
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_chat_with_workspace_id(
         self, mock_search, mock_mgr, client: TestClient,
     ) -> None:
@@ -208,7 +208,7 @@ class TestChat:
 
     @patch("metatron.workspaces.get_workspace_manager")
     @patch("metatron.retrieval.search.hybrid_search_and_answer",
-           side_effect=RuntimeError("LLM error"))
+           new_callable=AsyncMock, side_effect=RuntimeError("LLM error"))
     def test_chat_search_error_returns_500(
         self, mock_search, mock_mgr, client: TestClient,
     ) -> None:
@@ -226,7 +226,7 @@ class TestChat:
 
 class TestChatStream:
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_stream_returns_sse_events(
         self, mock_search, mock_mgr, client: TestClient,
     ) -> None:
@@ -258,7 +258,7 @@ class TestChatStream:
 
     @patch("metatron.workspaces.get_workspace_manager")
     @patch("metatron.retrieval.search.hybrid_search_and_answer",
-           side_effect=RuntimeError("LLM boom"))
+           new_callable=AsyncMock, side_effect=RuntimeError("LLM boom"))
     def test_stream_error_sends_error_event(
         self, mock_search, mock_mgr, client: TestClient,
     ) -> None:
@@ -277,7 +277,7 @@ class TestChatStream:
 
     @patch("metatron.workspaces.get_workspace_manager")
     @patch("metatron.retrieval.search.hybrid_search_and_answer",
-           side_effect=RuntimeError("LLM boom"))
+           new_callable=AsyncMock, side_effect=RuntimeError("LLM boom"))
     def test_stream_error_no_details(
         self, mock_search, mock_mgr, client: TestClient,
     ) -> None:

--- a/tests/unit/test_benchmarker_retrieval_integration.py
+++ b/tests/unit/test_benchmarker_retrieval_integration.py
@@ -300,7 +300,7 @@ class TestRunnerRetrievedDocLabels:
 
         with patch(
             "metatron.benchmarker.services.runner.hybrid_search_and_answer",
-            return_value=mock_trace,
+            new_callable=AsyncMock, return_value=mock_trace,
         ):
             ctx = await runner._run_single(_make_question(), "workspace1")
 
@@ -324,7 +324,7 @@ class TestRunnerRetrievedDocLabels:
 
         with patch(
             "metatron.benchmarker.services.runner.hybrid_search_and_answer",
-            return_value=mock_trace,
+            new_callable=AsyncMock, return_value=mock_trace,
         ):
             ctx = await runner._run_single(_make_question(), "workspace1")
 

--- a/tests/unit/test_benchmarker_runner.py
+++ b/tests/unit/test_benchmarker_runner.py
@@ -108,7 +108,7 @@ class TestRunSingle:
 
         with patch(
             "metatron.benchmarker.services.runner.hybrid_search_and_answer",
-            return_value=mock_trace,
+            new_callable=AsyncMock, return_value=mock_trace,
         ):
             ctx = await runner._run_single(sample_question, "workspace1")
 
@@ -128,7 +128,7 @@ class TestRunSingle:
 
         with patch(
             "metatron.benchmarker.services.runner.hybrid_search_and_answer",
-            side_effect=RuntimeError("RAG failed"),
+            new_callable=AsyncMock, side_effect=RuntimeError("RAG failed"),
         ):
             ctx = await runner._run_single(sample_question, "workspace1")
 
@@ -154,7 +154,7 @@ class TestRunSingle:
 
         with patch(
             "metatron.benchmarker.services.runner.hybrid_search_and_answer",
-            return_value=mock_trace,
+            new_callable=AsyncMock, return_value=mock_trace,
         ):
             ctx = await runner._run_single(sample_question, "workspace1")
 
@@ -184,7 +184,7 @@ class TestRunTests:
 
         with patch(
             "metatron.benchmarker.services.runner.hybrid_search_and_answer",
-            return_value=mock_trace,
+            new_callable=AsyncMock, return_value=mock_trace,
         ):
             result = await runner.run_tests(questions, "workspace1")
 
@@ -223,7 +223,7 @@ class TestRunTests:
 
         with patch(
             "metatron.benchmarker.services.runner.hybrid_search_and_answer",
-            return_value=mock_trace,
+            new_callable=AsyncMock, return_value=mock_trace,
         ):
             result = await runner.run_tests(questions, "workspace1")
 

--- a/tests/unit/test_benchmarker_search_trace.py
+++ b/tests/unit/test_benchmarker_search_trace.py
@@ -18,6 +18,10 @@ def _patch_search_internals():
     """Return a dict of patches for all internal functions of hybrid_search_and_answer."""
     patches = {
         "merge_channels": patch(f"{_SEARCH_MODULE}.merge_channels", return_value=[]),
+        "recall_dense_async": patch(f"{_SEARCH_MODULE}.recall_dense_async", return_value=[]),
+        "recall_exact_async": patch(f"{_SEARCH_MODULE}.recall_exact_async", return_value=[]),
+        "recall_metadata_async": patch(f"{_SEARCH_MODULE}.recall_metadata_async", return_value=[]),
+        "recall_graph_async": patch(f"{_SEARCH_MODULE}.recall_graph_async", return_value=[]),
         "chat_completion_with_retry": patch(f"{_SEARCH_MODULE}.chat_completion_with_retry", return_value="Test answer"),
         "get_graph_entities": patch(f"{_SEARCH_MODULE}.get_graph_entities", return_value=[]),
         "get_entities_by_doc_labels": patch(f"{_SEARCH_MODULE}.get_entities_by_doc_labels", return_value=[]),
@@ -39,7 +43,7 @@ def _patch_search_internals():
 class TestReturnTraceTrue:
     """Property 3: return_trace=True returns dict with all 6 keys."""
 
-    def test_returns_dict_with_all_keys(self):
+    async def test_returns_dict_with_all_keys(self):
         patches = _patch_search_internals()
         mocks = {}
         for name, p in patches.items():
@@ -48,7 +52,7 @@ class TestReturnTraceTrue:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="What is Metatron?",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -65,7 +69,7 @@ class TestReturnTraceTrue:
             for p in patches.values():
                 p.stop()
 
-    def test_answer_key_is_string(self):
+    async def test_answer_key_is_string(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -73,7 +77,7 @@ class TestReturnTraceTrue:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test question",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -84,7 +88,7 @@ class TestReturnTraceTrue:
             for p in patches.values():
                 p.stop()
 
-    def test_source_results_is_list(self):
+    async def test_source_results_is_list(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -92,7 +96,7 @@ class TestReturnTraceTrue:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test question",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -111,7 +115,7 @@ class TestReturnTraceTrue:
 class TestReturnTraceFalse:
     """Property 4: return_trace=False returns str."""
 
-    def test_returns_string(self):
+    async def test_returns_string(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -119,7 +123,7 @@ class TestReturnTraceFalse:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="What is Metatron?",
                 return_trace=False,
                 workspace_id="ws_test",
@@ -134,7 +138,7 @@ class TestReturnTraceFalse:
 class TestBackwardCompatibility:
     """Without return_trace parameter, function returns str (default behavior)."""
 
-    def test_default_returns_string(self):
+    async def test_default_returns_string(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -142,7 +146,7 @@ class TestBackwardCompatibility:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="What is Metatron?",
                 workspace_id="ws_test",
             )
@@ -152,7 +156,7 @@ class TestBackwardCompatibility:
             for p in patches.values():
                 p.stop()
 
-    def test_explicit_false_same_as_default(self):
+    async def test_explicit_false_same_as_default(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -160,10 +164,10 @@ class TestBackwardCompatibility:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result_default = hybrid_search_and_answer(
+            result_default = await hybrid_search_and_answer(
                 query="Test", workspace_id="ws_test",
             )
-            result_false = hybrid_search_and_answer(
+            result_false = await hybrid_search_and_answer(
                 query="Test", workspace_id="ws_test", return_trace=False,
             )
 

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -39,7 +39,7 @@ def router(settings):
 
 
 class TestRouterErrors:
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_llm_error_returns_friendly_message(
         self, mock_search: MagicMock, router: AgentRouter,
     ) -> None:
@@ -48,7 +48,7 @@ class TestRouterErrors:
         assert "AI service is temporarily unavailable" in result
         assert "provider timeout" not in result
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_qdrant_response_handling_error_returns_friendly_message(
         self, mock_search: MagicMock, router: AgentRouter,
     ) -> None:
@@ -59,7 +59,7 @@ class TestRouterErrors:
         assert "Search service is temporarily unavailable" in result
         assert "connection refused" not in result
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_generic_error_returns_friendly_message(
         self, mock_search: MagicMock, router: AgentRouter,
     ) -> None:
@@ -69,7 +69,7 @@ class TestRouterErrors:
         assert "Something went wrong" in result
         assert "something unexpected" not in result
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_unexpected_error_hides_details(
         self, mock_search: MagicMock, router: AgentRouter,
     ) -> None:
@@ -146,13 +146,13 @@ class TestLLMRetry:
 class TestSearchDegradation:
     @patch("metatron.retrieval.search.chat_completion_with_retry", return_value="answer text")
     @patch("metatron.retrieval.search.get_graph_entities", side_effect=ConnectionError("memgraph down"))
-    @patch("metatron.retrieval.search.recall_graph", return_value=[])
-    @patch("metatron.retrieval.search.recall_metadata", return_value=[])
-    @patch("metatron.retrieval.search.recall_exact", return_value=[])
-    @patch("metatron.retrieval.search.recall_dense")
+    @patch("metatron.retrieval.search.recall_graph_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_metadata_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_exact_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_dense_async")
     @patch("metatron.retrieval.search.expand_query", side_effect=lambda q: q)
     @patch("metatron.retrieval.search.should_use_team_workflow_schema", return_value=False)
-    def test_graph_failure_continues_with_empty_data(
+    async def test_graph_failure_continues_with_empty_data(
         self,
         _mock_schema: MagicMock,
         _mock_expand: MagicMock,
@@ -168,19 +168,19 @@ class TestSearchDegradation:
              "memory": {"memory": "doc1 content", "type": "confluence", "title": "Doc 1"}},
         ]
         from metatron.retrieval.search import hybrid_search_and_answer
-        result = hybrid_search_and_answer("test query")
+        result = await hybrid_search_and_answer("test query")
         assert "answer text" in result
         mock_llm.assert_called_once()
 
     @patch("metatron.retrieval.search.chat_completion_with_retry", side_effect=LLMError("all providers down"))
     @patch("metatron.retrieval.search.get_entities_by_doc_labels", return_value=[])
-    @patch("metatron.retrieval.search.recall_graph", return_value=[])
-    @patch("metatron.retrieval.search.recall_metadata", return_value=[])
-    @patch("metatron.retrieval.search.recall_exact", return_value=[])
-    @patch("metatron.retrieval.search.recall_dense")
+    @patch("metatron.retrieval.search.recall_graph_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_metadata_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_exact_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_dense_async")
     @patch("metatron.retrieval.search.expand_query", side_effect=lambda q: q)
     @patch("metatron.retrieval.search.should_use_team_workflow_schema", return_value=False)
-    def test_llm_failure_returns_document_count(
+    async def test_llm_failure_returns_document_count(
         self,
         _mock_schema: MagicMock,
         _mock_expand: MagicMock,
@@ -201,6 +201,6 @@ class TestSearchDegradation:
                          memory={"memory": "doc3", "type": "confluence", "title": "T3", "doc_label": "L3"}),
         ]
         from metatron.retrieval.search import hybrid_search_and_answer
-        result = hybrid_search_and_answer("test query")
+        result = await hybrid_search_and_answer("test query")
         assert "Found 3 relevant documents" in result
         assert "couldn't generate an answer" in result

--- a/tests/unit/test_jira_metadata.py
+++ b/tests/unit/test_jira_metadata.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from metatron.connectors.jira_processing import process_jira_issue
 from metatron.retrieval.search import _ACTIVITY_KW, _PERSON_EN, _PERSON_RU
@@ -103,14 +103,14 @@ class TestPersonExtraction:
 class TestPersonQuerySkipsGeneralInProgress:
     """Person-specific queries must NOT inject all In Progress tasks."""
 
-    @patch("metatron.retrieval.channels.get_hybrid_store")
+    @patch("metatron.retrieval.channels.get_async_hybrid_store")
     @patch("metatron.retrieval.search.expand_query", side_effect=lambda q: q)
     @patch("metatron.retrieval.search.get_graph_entities", return_value=[])
     @patch("metatron.retrieval.search.chat_completion", return_value="Answer")
-    def test_person_detected_skips_status_search(
+    async def test_person_detected_skips_status_search(
         self, mock_llm, mock_gents, mock_expand, mock_channels_store
     ) -> None:
-        store_instance = MagicMock()
+        store_instance = AsyncMock()
         store_instance.search_by_status.return_value = []
         store_instance.search_by_assignee.return_value = [
             {"memory": "Task X", "data": "Task X", "title": "MTRNIX-10",
@@ -121,7 +121,7 @@ class TestPersonQuerySkipsGeneralInProgress:
         mock_channels_store.return_value = store_instance
 
         from metatron.retrieval.search import hybrid_search_and_answer
-        hybrid_search_and_answer(
+        await hybrid_search_and_answer(
             query="Что делает Женя?", intent_query="Что делает Женя?"
         )
 
@@ -130,14 +130,14 @@ class TestPersonQuerySkipsGeneralInProgress:
         # search_by_status should NOT have been called (person takes priority)
         assert not store_instance.search_by_status.called
 
-    @patch("metatron.retrieval.channels.get_hybrid_store")
+    @patch("metatron.retrieval.channels.get_async_hybrid_store")
     @patch("metatron.retrieval.search.expand_query", side_effect=lambda q: q)
     @patch("metatron.retrieval.search.get_graph_entities", return_value=[])
     @patch("metatron.retrieval.search.chat_completion", return_value="Answer")
-    def test_no_person_uses_status_search(
+    async def test_no_person_uses_status_search(
         self, mock_llm, mock_gents, mock_expand, mock_channels_store
     ) -> None:
-        store_instance = MagicMock()
+        store_instance = AsyncMock()
         store_instance.search_by_status.return_value = [
             {"memory": "General task", "data": "General task", "title": "T-1",
              "type": "jira", "score": 1.0, "payload": {}}
@@ -147,7 +147,7 @@ class TestPersonQuerySkipsGeneralInProgress:
         mock_channels_store.return_value = store_instance
 
         from metatron.retrieval.search import hybrid_search_and_answer
-        hybrid_search_and_answer(
+        await hybrid_search_and_answer(
             query="What is the team doing?", intent_query="What is the team doing?"
         )
 

--- a/tests/unit/test_mcp_actions.py
+++ b/tests/unit/test_mcp_actions.py
@@ -395,7 +395,7 @@ class TestRouterActionIntent:
         assert router._classify("what is MTRNIX-78 about?") == Intent.SEARCH
 
     @patch("metatron.mcp.action_planner.ActionPlanner.discover_write_tools")
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_action_no_tools_falls_back_to_search(
         self, mock_search: MagicMock, mock_discover: MagicMock, router: MagicMock,
     ) -> None:
@@ -471,7 +471,7 @@ class TestRouterActionIntent:
         assert store.get_for_user("u1") is None
         mock_execute.assert_not_called()
 
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_non_confirmation_falls_through(
         self, mock_search: MagicMock, router: MagicMock,
     ) -> None:
@@ -519,7 +519,7 @@ class TestContextAwareActions:
 
     @patch("metatron.mcp.action_planner.ActionPlanner.discover_write_tools")
     @patch("metatron.mcp.action_planner.ActionPlanner.plan")
-    @patch("metatron.agent.router.hybrid_search_and_answer")
+    @patch("metatron.agent.router.hybrid_search_and_answer_sync")
     def test_summary_triggers_search_context(
         self, mock_search: MagicMock, mock_plan: MagicMock,
         mock_discover: MagicMock, router: MagicMock,
@@ -562,7 +562,7 @@ class TestContextAwareActions:
             "description": "Create bug", "preview": "Title: Bug",
         }
 
-        with patch("metatron.agent.router.hybrid_search_and_answer") as mock_search:
+        with patch("metatron.agent.router.hybrid_search_and_answer_sync") as mock_search:
             router.route("Создай баг про ошибку", user_id="u1")
             # No context keywords → search NOT called
             mock_search.assert_not_called()

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -71,6 +71,7 @@ class TestMetatronSearch:
         # Patch at the source module — lazy import resolves there
         with patch(
             "metatron.retrieval.search.hybrid_search_and_answer",
+            new_callable=AsyncMock,
             return_value="Found: document X. Sources: [1]",
         ):
             from metatron.mcp.tools.search import metatron_search
@@ -84,6 +85,7 @@ class TestMetatronSearch:
     async def test_handles_exception(self) -> None:
         with patch(
             "metatron.retrieval.search.hybrid_search_and_answer",
+            new_callable=AsyncMock,
             side_effect=RuntimeError("search failed"),
         ):
             from metatron.mcp.tools.search import metatron_search

--- a/tests/unit/test_name_aliases.py
+++ b/tests/unit/test_name_aliases.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from metatron.retrieval.aliases import NAME_ALIASES, resolve_person_name
 
@@ -56,15 +56,15 @@ class TestRussianCaseNormalization:
 
 
 class TestAliasIntegration:
-    @patch("metatron.retrieval.channels.get_hybrid_store")
+    @patch("metatron.retrieval.channels.get_async_hybrid_store")
     @patch("metatron.retrieval.search.expand_query", side_effect=lambda q: q)
     @patch("metatron.retrieval.search.get_graph_entities", return_value=[])
     @patch("metatron.retrieval.search.chat_completion", return_value="Answer about Evgeny")
-    def test_russian_nickname_triggers_assignee_search(
+    async def test_russian_nickname_triggers_assignee_search(
         self, mock_llm, mock_gents, mock_expand, mock_channels_store
     ) -> None:
         """'Что делает Женя?' should search by assignee 'Evgeny Shcherbinin'."""
-        store_instance = MagicMock()
+        store_instance = AsyncMock()
         store_instance.search_by_status.return_value = []
         store_instance.search_by_assignee.return_value = [
             {"memory": "Task X", "data": "Task X", "title": "MTRNIX-10",
@@ -75,7 +75,7 @@ class TestAliasIntegration:
         mock_channels_store.return_value = store_instance
 
         from metatron.retrieval.search import hybrid_search_and_answer
-        hybrid_search_and_answer(
+        await hybrid_search_and_answer(
             query="Что делает Женя?", intent_query="Что делает Женя?"
         )
 

--- a/tests/unit/test_openai_compat.py
+++ b/tests/unit/test_openai_compat.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -102,7 +102,7 @@ class TestChatCompletions:
     """POST /v1/chat/completions"""
 
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_non_streaming_returns_openai_format(self, mock_search, mock_mgr, client):
         mock_mgr.return_value.get_workspace.return_value = _TEST_WS
         mock_search.return_value = "The answer is 42."
@@ -161,7 +161,7 @@ class TestChatCompletions:
         assert r.status_code == 400
 
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_sources_converted_to_markdown_links(self, mock_search, mock_mgr, client):
         mock_mgr.return_value.get_workspace.return_value = _TEST_WS
         mock_search.return_value = (
@@ -183,7 +183,7 @@ class TestChatCompletions:
         assert "[\U0001f4cb JIRA-123](https://jira.example.com/JIRA-123)" in content
 
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_extra_openai_params_ignored(self, mock_search, mock_mgr, client):
         """temperature, max_tokens etc. are accepted but ignored."""
         mock_mgr.return_value.get_workspace.return_value = _TEST_WS
@@ -213,7 +213,7 @@ class TestChatCompletionsStreaming:
     """POST /v1/chat/completions with stream=true"""
 
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_streaming_returns_sse_chunks(self, mock_search, mock_mgr, client):
         mock_mgr.return_value.get_workspace.return_value = _TEST_WS
         mock_search.return_value = "The answer is 42."
@@ -245,7 +245,7 @@ class TestChatCompletionsStreaming:
         assert last_chunk["choices"][0]["finish_reason"] == "stop"
 
     @patch("metatron.workspaces.get_workspace_manager")
-    @patch("metatron.retrieval.search.hybrid_search_and_answer")
+    @patch("metatron.retrieval.search.hybrid_search_and_answer", new_callable=AsyncMock)
     def test_streaming_includes_sources_as_markdown(self, mock_search, mock_mgr, client):
         mock_mgr.return_value.get_workspace.return_value = _TEST_WS
         mock_search.return_value = (

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -395,7 +395,7 @@ class TestClassifyQuery:
 class TestSearchIntegration:
     """Verify classify_query is called in the search pipeline."""
 
-    def test_classifier_called_in_search(self) -> None:
+    async def test_classifier_called_in_search(self) -> None:
         """When enabled, classify_query is called with original query."""
         from tests.unit.test_search_trace_extended import _patch_search_internals
 
@@ -408,7 +408,7 @@ class TestSearchIntegration:
 
             with patch("metatron.retrieval.search.classify_query") as mock_cls:
                 mock_cls.return_value = {"profile": "mixed", "confidence": 1.0, "method": "rule"}
-                hybrid_search_and_answer(
+                await hybrid_search_and_answer(
                     query="What is Metatron?",
                     return_trace=True,
                     workspace_id="ws_test",
@@ -420,7 +420,7 @@ class TestSearchIntegration:
             for p in patches.values():
                 p.stop()
 
-    def test_classifier_disabled_uses_mixed(self) -> None:
+    async def test_classifier_disabled_uses_mixed(self) -> None:
         from tests.unit.test_search_trace_extended import _patch_search_internals
 
         patches = _patch_search_internals()
@@ -433,7 +433,7 @@ class TestSearchIntegration:
 
             with patch("metatron.retrieval.search.classify_query") as mock_cls, \
                  patch.object(_search_mod._s, "query_classifier_enabled", False):
-                hybrid_search_and_answer(
+                await hybrid_search_and_answer(
                     query="What is Metatron?",
                     return_trace=True,
                     workspace_id="ws_test",
@@ -443,7 +443,7 @@ class TestSearchIntegration:
             for p in patches.values():
                 p.stop()
 
-    def test_trace_includes_classifier_fields(self) -> None:
+    async def test_trace_includes_classifier_fields(self) -> None:
         from tests.unit.test_search_trace_extended import _patch_search_internals
 
         patches = _patch_search_internals()
@@ -457,7 +457,7 @@ class TestSearchIntegration:
                 mock_cls.return_value = {
                     "profile": "documentation", "confidence": 0.9, "method": "llm"
                 }
-                result = hybrid_search_and_answer(
+                result = await hybrid_search_and_answer(
                     query="What is Metatron?",
                     return_trace=True,
                     workspace_id="ws_test",

--- a/tests/unit/test_search_trace_extended.py
+++ b/tests/unit/test_search_trace_extended.py
@@ -74,6 +74,10 @@ def _patch_search_internals():
             f"{_SEARCH_MODULE}.classify_query",
             return_value={"profile": "mixed", "confidence": 1.0, "method": "rule"},
         ),
+        "recall_dense_async": patch(f"{_SEARCH_MODULE}.recall_dense_async", return_value=[]),
+        "recall_exact_async": patch(f"{_SEARCH_MODULE}.recall_exact_async", return_value=[]),
+        "recall_metadata_async": patch(f"{_SEARCH_MODULE}.recall_metadata_async", return_value=[]),
+        "recall_graph_async": patch(f"{_SEARCH_MODULE}.recall_graph_async", return_value=[]),
     }
     return patches
 
@@ -81,7 +85,7 @@ def _patch_search_internals():
 class TestPipelineStagesInTrace:
     """Verify pipeline_stages dict is present and complete in trace output."""
 
-    def test_pipeline_stages_key_exists(self):
+    async def test_pipeline_stages_key_exists(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -89,7 +93,7 @@ class TestPipelineStagesInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="What is Metatron?",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -101,7 +105,7 @@ class TestPipelineStagesInTrace:
             for p in patches.values():
                 p.stop()
 
-    def test_pipeline_stages_has_all_subkeys(self):
+    async def test_pipeline_stages_has_all_subkeys(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -109,7 +113,7 @@ class TestPipelineStagesInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="What is Metatron?",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -143,7 +147,7 @@ class TestPipelineStagesInTrace:
             for p in patches.values():
                 p.stop()
 
-    def test_pipeline_stages_query_values(self):
+    async def test_pipeline_stages_query_values(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -151,7 +155,7 @@ class TestPipelineStagesInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="What is Metatron?",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -166,7 +170,7 @@ class TestPipelineStagesInTrace:
             for p in patches.values():
                 p.stop()
 
-    def test_pipeline_stages_counts_are_ints(self):
+    async def test_pipeline_stages_counts_are_ints(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -174,7 +178,7 @@ class TestPipelineStagesInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test query",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -194,7 +198,7 @@ class TestPipelineStagesInTrace:
             for p in patches.values():
                 p.stop()
 
-    def test_fragment_count_matches_fragments(self):
+    async def test_fragment_count_matches_fragments(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -202,7 +206,7 @@ class TestPipelineStagesInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test query",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -217,7 +221,7 @@ class TestPipelineStagesInTrace:
 class TestRetrievedDocLabelsInTrace:
     """Verify retrieved_doc_labels is present and correct in trace output."""
 
-    def test_retrieved_doc_labels_key_exists(self):
+    async def test_retrieved_doc_labels_key_exists(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -225,7 +229,7 @@ class TestRetrievedDocLabelsInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test query",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -237,7 +241,7 @@ class TestRetrievedDocLabelsInTrace:
             for p in patches.values():
                 p.stop()
 
-    def test_retrieved_doc_labels_populated_from_results(self):
+    async def test_retrieved_doc_labels_populated_from_results(self):
         patches = _patch_search_internals()
         # Make merge_channels return results with doc_labels
         patches["merge_channels"] = patch(
@@ -257,7 +261,7 @@ class TestRetrievedDocLabelsInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test query",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -273,7 +277,7 @@ class TestRetrievedDocLabelsInTrace:
             for p in patches.values():
                 p.stop()
 
-    def test_retrieved_doc_labels_empty_when_no_labels(self):
+    async def test_retrieved_doc_labels_empty_when_no_labels(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -281,7 +285,7 @@ class TestRetrievedDocLabelsInTrace:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test query",
                 return_trace=True,
                 workspace_id="ws_test",
@@ -296,7 +300,7 @@ class TestRetrievedDocLabelsInTrace:
 class TestTraceNotInNonTraceMode:
     """Verify pipeline_stages and retrieved_doc_labels are NOT in non-trace output."""
 
-    def test_non_trace_returns_string(self):
+    async def test_non_trace_returns_string(self):
         patches = _patch_search_internals()
         for p in patches.values():
             p.start()
@@ -304,7 +308,7 @@ class TestTraceNotInNonTraceMode:
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
-            result = hybrid_search_and_answer(
+            result = await hybrid_search_and_answer(
                 query="Test query",
                 return_trace=False,
                 workspace_id="ws_test",

--- a/tests/unit/test_token_budget.py
+++ b/tests/unit/test_token_budget.py
@@ -227,13 +227,13 @@ class TestDefaultBudget:
 
 class TestSearchPipelineIntegration:
     @patch("metatron.retrieval.search.chat_completion_with_retry")
-    @patch("metatron.retrieval.search.recall_graph", return_value=[])
-    @patch("metatron.retrieval.search.recall_metadata", return_value=[])
-    @patch("metatron.retrieval.search.recall_exact", return_value=[])
-    @patch("metatron.retrieval.search.recall_dense")
+    @patch("metatron.retrieval.search.recall_graph_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_metadata_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_exact_async", return_value=[])
+    @patch("metatron.retrieval.search.recall_dense_async")
     @patch("metatron.retrieval.search.expand_query", side_effect=lambda q: q)
     @patch("metatron.retrieval.search.get_entities_by_doc_labels", return_value=[])
-    def test_token_budget_applied_before_llm_call(
+    async def test_token_budget_applied_before_llm_call(
         self,
         mock_graph_ents: MagicMock,
         mock_expand: MagicMock,
@@ -273,12 +273,15 @@ class TestSearchPipelineIntegration:
             mock_settings.blend_weight = 0.3
             mock_settings.rerank_pool_size = 50
 
-            hybrid_search_and_answer("test query", workspace_id="TEST")
+            await hybrid_search_and_answer("test query", workspace_id="TEST")
 
         # LLM was called
         mock_llm.assert_called_once()
         # The user content passed to LLM should be bounded
-        call_messages = mock_llm.call_args.kwargs.get("messages") or mock_llm.call_args[1].get("messages")
+        call_messages = (
+            mock_llm.call_args.kwargs.get("messages")
+            or mock_llm.call_args[1].get("messages")
+        )
         user_content = call_messages[-1]["content"]
         # With 3000 max tokens and 1500 answer reserve, ~1000 tokens for fragments
         # That's roughly ~4000 chars — far less than 20 * 8000 = 160000


### PR DESCRIPTION
## Summary
Phase 2 of async migration: convert retrieval pipeline to async-primary.

- **`hybrid_search_and_answer`** is now `async def` — parallel recall via `asyncio.gather()` (replaces ThreadPoolExecutor)
- **4 async recall channels** — `recall_dense_async`, `recall_exact_async`, `recall_metadata_async`, `recall_graph_async` using `AsyncQdrantVectorStore`
- **Sync wrapper** `hybrid_search_and_answer_sync()` for sync callers (agent/router, scripts)
- **7 callers migrated** — removed `asyncio.to_thread()` wrappers, direct `await`

## Architecture
```
Before: API → asyncio.to_thread(sync_search) → ThreadPoolExecutor(4 sync channels)
After:  API → await async_search → asyncio.gather(4 async channels)
```

Sync dependencies (LLM, reranker, graph_ops) wrapped in `asyncio.to_thread()` inside async functions.

## Files changed (24)
- `retrieval/channels.py` — 4 async recall functions
- `retrieval/search.py` — async primary + sync wrapper
- `api/routes/chat.py`, `openai_compat.py` — direct await
- `mcp/tools/search.py`, `benchmarker/runner.py` — direct await
- `agent/router.py`, `benchmarker/confidence.py` — sync wrapper
- `scripts/run_eval.py` — sync wrapper
- 14 test files — AsyncMock updates

## Test plan
- [x] 1236 tests pass (zero regressions vs develop)
- [x] 71 pre-existing failures unchanged