### PR TITLE
feat(MTRNIX-262): async ingestion pipeline with AsyncQdrantVectorStore

### DIFF
--- a/src/metatron/agent/router.py
+++ b/src/metatron/agent/router.py
@@ -39,41 +39,116 @@ except ImportError:  # pragma: no cover
 
 logger = structlog.get_logger()
 
-_GREETING_WORDS = frozenset({
-    "hi", "hello", "hey", "привет", "здравствуйте", "добрый день",
-    "добрый вечер", "доброе утро", "хай", "хей", "yo", "sup",
-    "good morning", "good evening", "good afternoon",
-})
+_GREETING_WORDS = frozenset(
+    {
+        "hi",
+        "hello",
+        "hey",
+        "привет",
+        "здравствуйте",
+        "добрый день",
+        "добрый вечер",
+        "доброе утро",
+        "хай",
+        "хей",
+        "yo",
+        "sup",
+        "good morning",
+        "good evening",
+        "good afternoon",
+    }
+)
 
-_SMALLTALK_PATTERNS = frozenset({
-    "how are you", "как дела", "что нового", "what's up",
-    "who are you", "кто ты", "what can you do", "что ты умеешь",
-    "thanks", "спасибо", "thank you", "благодарю",
-})
+_SMALLTALK_PATTERNS = frozenset(
+    {
+        "how are you",
+        "как дела",
+        "что нового",
+        "what's up",
+        "who are you",
+        "кто ты",
+        "what can you do",
+        "что ты умеешь",
+        "thanks",
+        "спасибо",
+        "thank you",
+        "благодарю",
+    }
+)
 
 
-_ACTION_KEYWORDS_EN = frozenset({
-    "create", "make", "file", "open", "send", "post",
-    "update", "add comment", "write", "submit", "publish",
-})
+_ACTION_KEYWORDS_EN = frozenset(
+    {
+        "create",
+        "make",
+        "file",
+        "open",
+        "send",
+        "post",
+        "update",
+        "add comment",
+        "write",
+        "submit",
+        "publish",
+    }
+)
 
-_ACTION_KEYWORDS_RU = frozenset({
-    "создай", "создать", "заведи", "завести", "добавь", "добавить",
-    "отправь", "отправить", "напиши", "написать", "обнови", "обновить",
-    "прокомментируй", "опубликуй", "опубликовать",
-})
+_ACTION_KEYWORDS_RU = frozenset(
+    {
+        "создай",
+        "создать",
+        "заведи",
+        "завести",
+        "добавь",
+        "добавить",
+        "отправь",
+        "отправить",
+        "напиши",
+        "написать",
+        "обнови",
+        "обновить",
+        "прокомментируй",
+        "опубликуй",
+        "опубликовать",
+    }
+)
 
-_CONFIRMATION_YES = frozenset({
-    "да", "yes", "y", "д", "ок", "ok", "подтверждаю", "confirm",
-})
-_CONFIRMATION_NO = frozenset({
-    "нет", "no", "n", "отмена", "cancel", "отменить",
-})
+_CONFIRMATION_YES = frozenset(
+    {
+        "да",
+        "yes",
+        "y",
+        "д",
+        "ок",
+        "ok",
+        "подтверждаю",
+        "confirm",
+    }
+)
+_CONFIRMATION_NO = frozenset(
+    {
+        "нет",
+        "no",
+        "n",
+        "отмена",
+        "cancel",
+        "отменить",
+    }
+)
 
-_CONTEXT_KEYWORDS = frozenset({
-    "итоги", "summary", "отчёт", "отчет", "report",
-    "результаты", "results", "обзор", "overview",
-})
+_CONTEXT_KEYWORDS = frozenset(
+    {
+        "итоги",
+        "summary",
+        "отчёт",
+        "отчет",
+        "report",
+        "результаты",
+        "results",
+        "обзор",
+        "overview",
+    }
+)
 
 
 class Intent(StrEnum):
@@ -152,9 +227,12 @@ class AgentRouter:
             logger.error("router.error.llm", intent=intent, error=str(e), exc_info=True)
             return "AI service is temporarily unavailable. Please try again later."
         except Exception as e:
-            if (HttpxConnectError and isinstance(e, HttpxConnectError)) or \
-               (QdrantResponseHandlingException and isinstance(e, QdrantResponseHandlingException)):
-                logger.error("router.error.search_service", intent=intent, error=str(e), exc_info=True)
+            if (HttpxConnectError and isinstance(e, HttpxConnectError)) or (
+                QdrantResponseHandlingException and isinstance(e, QdrantResponseHandlingException)
+            ):
+                logger.error(
+                    "router.error.search_service", intent=intent, error=str(e), exc_info=True
+                )
                 return "Search service is temporarily unavailable. Please try again later."
             if Neo4jServiceUnavailable and isinstance(e, Neo4jServiceUnavailable):
                 logger.error("router.error.graph", intent=intent, error=str(e), exc_info=True)
@@ -212,7 +290,10 @@ class AgentRouter:
         return answer
 
     def _check_confirmation(
-        self, text: str, user_id: str, workspace_id: str,
+        self,
+        text: str,
+        user_id: str,
+        workspace_id: str,
     ) -> str | None:
         """Check if user is confirming/cancelling a pending action.
 
@@ -229,6 +310,7 @@ class AgentRouter:
 
         if text_lower in _CONFIRMATION_YES:
             from metatron.mcp.action_executor import ActionExecutor
+
             executor = ActionExecutor()
             result = executor.execute(pending)
             store.remove(pending.action_id)
@@ -263,7 +345,9 @@ class AgentRouter:
         if any(kw in lower for kw in _CONTEXT_KEYWORDS):
             try:
                 context = hybrid_search_and_answer_sync(
-                    query=text, user_id=user_id, workspace_id=workspace_id,
+                    query=text,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
                     intent_query=text,
                 )
             except Exception as e:
@@ -293,16 +377,21 @@ class AgentRouter:
 
         # Return confirmation prompt
         preview = action.preview or "(no preview)"
-        return (
-            f"**{action.description}**\n\n"
-            f"{preview}\n\n"
-            f"Confirm? (Yes/No)"
-        )
+        return f"**{action.description}**\n\n{preview}\n\nConfirm? (Yes/No)"
 
     # -- Supported upload formats --
-    SUPPORTED_UPLOAD_EXTENSIONS: frozenset[str] = frozenset({
-        ".txt", ".md", ".html", ".htm", ".csv", ".xlsx", ".xls", ".pdf",
-    })
+    SUPPORTED_UPLOAD_EXTENSIONS: frozenset[str] = frozenset(
+        {
+            ".txt",
+            ".md",
+            ".html",
+            ".htm",
+            ".csv",
+            ".xlsx",
+            ".xls",
+            ".pdf",
+        }
+    )
     _MAX_UPLOAD_BYTES: int = 20 * 1024 * 1024  # 20 MB
 
     def handle_file_upload(
@@ -364,11 +453,18 @@ class AgentRouter:
         )
 
         try:
-            result = ingest_documents(
-                [doc], ws, connector_type="upload", incremental=True,
+            result = asyncio.run(
+                ingest_documents(
+                    [doc],
+                    ws,
+                    connector_type="upload",
+                    incremental=True,
+                )
             )
         except Exception as e:
-            logger.error("router.upload.ingest_error", filename=filename, error=str(e), exc_info=True)
+            logger.error(
+                "router.upload.ingest_error", filename=filename, error=str(e), exc_info=True
+            )
             return f"Error processing {filename}. The error has been logged."
 
         parts = []
@@ -385,6 +481,7 @@ class AgentRouter:
         """Parse uploaded file bytes into text based on extension."""
         if ext == ".pdf":
             from metatron.ingestion.processors.pdf import extract_text_from_pdf
+
             return extract_text_from_pdf(content, filename)
 
         if ext in (".txt", ".md"):
@@ -395,10 +492,12 @@ class AgentRouter:
 
         if ext in (".html", ".htm"):
             from metatron.ingestion.processors.html import process_html
+
             return process_html(content)
 
         if ext in (".csv", ".xlsx", ".xls"):
             from metatron.ingestion.processors.tabular import process_tabular_file
+
             text, _meta = process_tabular_file(content, filename)
             return text
 
@@ -432,10 +531,13 @@ class AgentRouter:
         try:
             answer = chat_completion(
                 messages=[
-                    {"role": "system", "content": (
-                        "You are Metatron, a helpful AI knowledge assistant for teams. "
-                        "Reply briefly and friendly. Keep answers to 1-2 sentences."
-                    )},
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are Metatron, a helpful AI knowledge assistant for teams. "
+                            "Reply briefly and friendly. Keep answers to 1-2 sentences."
+                        ),
+                    },
                     {"role": "user", "content": text},
                 ],
                 temperature=0.7,
@@ -575,7 +677,10 @@ class AgentRouter:
         return f"Unknown /mcp subcommand: {subcmd}. Try /mcp list"
 
     def _run_mcp_sync(
-        self, config: MCPServerConfig, workspace_id: str, force_full: bool,
+        self,
+        config: MCPServerConfig,
+        workspace_id: str,
+        force_full: bool,
     ) -> str:
         """Run sync for a single MCP server (sync wrapper)."""
         from metatron.mcp.sync import MCPSyncManager
@@ -583,9 +688,7 @@ class AgentRouter:
         manager = MCPSyncManager()
         loop = asyncio.new_event_loop()
         try:
-            result = loop.run_until_complete(
-                manager.sync_server(config, workspace_id, force_full)
-            )
+            result = loop.run_until_complete(manager.sync_server(config, workspace_id, force_full))
         except Exception as e:
             logger.error("router.mcp_sync.error", server=config.name, error=str(e), exc_info=True)
             return f"MCP sync error for **{config.name}**: {e}"
@@ -605,7 +708,10 @@ class AgentRouter:
         return f"**{config.name}** ({mode}): {', '.join(parts_msg) or 'no documents'}"
 
     def _run_mcp_sync_all(
-        self, workspace_id: str, force_full: bool, registry: MCPServerRegistry,
+        self,
+        workspace_id: str,
+        force_full: bool,
+        registry: MCPServerRegistry,
     ) -> str:
         """Run sync for all enabled MCP servers (sync wrapper)."""
         from metatron.mcp.sync import MCPSyncManager
@@ -613,9 +719,7 @@ class AgentRouter:
         manager = MCPSyncManager(registry)
         loop = asyncio.new_event_loop()
         try:
-            results = loop.run_until_complete(
-                manager.sync_all(workspace_id, force_full)
-            )
+            results = loop.run_until_complete(manager.sync_all(workspace_id, force_full))
         except Exception as e:
             logger.error("router.mcp_sync_all.error", error=str(e), exc_info=True)
             return f"MCP sync-all error: {e}"
@@ -646,6 +750,7 @@ class AgentRouter:
 
         loop = asyncio.new_event_loop()
         try:
+
             async def _list() -> list[dict]:
                 async with MCPClient(config) as client:
                     return await client.list_tools()
@@ -676,8 +781,7 @@ class AgentRouter:
             /sync confluence full — full sync (ignores last sync time)
         """
         return (
-            "Sync via chat is no longer supported. "
-            "Use the API: POST /api/v1/connections/{id}/sync"
+            "Sync via chat is no longer supported. Use the API: POST /api/v1/connections/{id}/sync"
         )
 
     def _cmd_status(self, workspace_id: str) -> str:
@@ -687,16 +791,14 @@ class AgentRouter:
         # Qdrant stats
         try:
             from metatron.storage.qdrant import get_hybrid_store
+
             store = get_hybrid_store(workspace_id)
             count = store.client.count(collection_name=store.collection_name).count
             lines.append(f"**Qdrant points:** {count}")
         except Exception as e:
             lines.append(f"**Qdrant:** unavailable ({e})")
 
-        lines.append(
-            "**Connectors:** managed via API "
-            "(GET /api/v1/connections)"
-        )
+        lines.append("**Connectors:** managed via API (GET /api/v1/connections)")
 
         # LLM provider
         lines.append(f"**LLM provider:** {self._settings.llm_provider}")
@@ -723,9 +825,4 @@ class AgentRouter:
             logger.error("router.rebuild_aliases.error", error=str(e), exc_info=True)
             return "Failed to scan Qdrant: the error has been logged."
 
-        return (
-            f"Alias registry rebuilt: {added} new persons found, "
-            f"{registry.person_count} total."
-        )
-
-
+        return f"Alias registry rebuilt: {added} new persons found, {registry.person_count} total."

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -176,7 +176,9 @@ async def _try_start_channel(
 
     try:
         await channel_manager.start_channel(
-            connection_id, connector_type, config,
+            connection_id,
+            connector_type,
+            config,
             workspace_id=workspace_id,
         )
         logger.info(
@@ -267,7 +269,11 @@ async def create_connection(
     schema = CONNECTOR_SCHEMAS.get(body.connector_type)
     if schema and schema.category == "channel":
         await _try_start_channel(
-            request, result["id"], body.connector_type, body.config, ws_id,
+            request,
+            result["id"],
+            body.connector_type,
+            body.config,
+            ws_id,
         )
 
     return ConnectionResponse(**result)
@@ -297,7 +303,8 @@ async def list_connections(
                 detail="category must be 'connector' or 'channel'",
             )
         connections = [
-            c for c in connections
+            c
+            for c in connections
             if CONNECTOR_SCHEMAS.get(c["connector_type"], None)
             and CONNECTOR_SCHEMAS[c["connector_type"]].category == category
         ]
@@ -390,10 +397,12 @@ async def update_connection(
         updates["enabled"] = body.enabled
     if body.config is not None:
         errors = validate_config(
-            existing["connector_type"], body.config,
+            existing["connector_type"],
+            body.config,
         )
         # Allow masked secrets through validation (they'll be merged)
         from metatron.connectors.schemas import SECRET_MASK
+
         if errors:
             # Re-check: are all errors for fields that are masked?
             real_errors = []
@@ -414,18 +423,22 @@ async def update_connection(
                     real_errors.append(err)
             if real_errors:
                 raise HTTPException(
-                    status_code=422, detail="; ".join(real_errors),
+                    status_code=422,
+                    detail="; ".join(real_errors),
                 )
         updates["config"] = body.config
 
     if not updates:
         raise HTTPException(
-            status_code=422, detail="No fields to update",
+            status_code=422,
+            detail="No fields to update",
         )
 
     try:
         result = await store.update_connection(
-            connection_id, updates, fernet_key,
+            connection_id,
+            updates,
+            fernet_key,
         )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from None
@@ -485,20 +498,14 @@ async def test_connection(
         # Channels don't have a testable configure() flow
         return TestConnectionResponse(
             success=True,
-            message=(
-                "Connection saved "
-                "(test not available for this type)"
-            ),
+            message=("Connection saved (test not available for this type)"),
         )
 
     registry = _get_registry()
     if not registry.is_registered(connector_type):
         return TestConnectionResponse(
             success=True,
-            message=(
-                "Connection saved "
-                "(test not available for this type)"
-            ),
+            message=("Connection saved (test not available for this type)"),
         )
 
     try:
@@ -512,7 +519,9 @@ async def test_connection(
 
         # Clear error on success
         await store.update_connection_status(
-            connection_id, status="active", error_message=None,
+            connection_id,
+            status="active",
+            error_message=None,
         )
         return TestConnectionResponse(success=True)
 
@@ -561,12 +570,14 @@ async def trigger_sync(
 
     if not conn.get("enabled", True):
         raise HTTPException(
-            status_code=400, detail="Connection is disabled",
+            status_code=400,
+            detail="Connection is disabled",
         )
 
     # Mark as syncing
     await store.update_connection_status(
-        connection_id, status="syncing",
+        connection_id,
+        status="syncing",
     )
 
     # Extract event bus for post-sync notification (graceful if unavailable)
@@ -671,26 +682,20 @@ async def _run_connection_sync(
         )
 
         if documents:
-            # ingest_documents is sync — run in thread pool
-            result = await asyncio.to_thread(
-                ingest_documents, documents, workspace_id, connector_type,
+            result = await ingest_documents(
+                documents,
+                workspace_id,
+                connector_type,
                 source_role=connector.source_role,
             )
             documents_new = result.documents_new
             documents_updated = result.documents_updated
             documents_skipped = result.documents_skipped
-            qdrant_chunks = (
-                result.documents_new + result.documents_updated
-            )
+            qdrant_chunks = result.documents_new + result.documents_updated
 
             if result.errors:
-                errors_list = [
-                    _sanitize_error(str(e))
-                    for e in result.errors[:10]
-                ]
-                status = (
-                    "partial" if result.documents_new > 0 else "failed"
-                )
+                errors_list = [_sanitize_error(str(e)) for e in result.errors[:10]]
+                status = "partial" if result.documents_new > 0 else "failed"
             else:
                 status = "success"
         else:
@@ -710,12 +715,8 @@ async def _run_connection_sync(
         duration_ms = (time.perf_counter() - start_time) * 1000
 
         # Update connection status
-        final_status = (
-            "active" if status == "success" else "error"
-        )
-        error_msg = (
-            "; ".join(errors_list) if errors_list else None
-        )
+        final_status = "active" if status == "success" else "error"
+        error_msg = "; ".join(errors_list) if errors_list else None
         try:
             await store.update_connection_status(
                 connection_id,
@@ -732,6 +733,7 @@ async def _run_connection_sync(
 
         # Log sync result (sync ORM — run in thread pool)
         try:
+
             def _write_sync_log() -> None:
                 with get_session() as session:
                     sync_log = SyncLogRow(
@@ -746,9 +748,7 @@ async def _run_connection_sync(
                         documents_skipped=documents_skipped,
                         errors=errors_list,
                         duration_ms=duration_ms,
-                        source_title=(
-                            f"{connector_type.capitalize()} Sync"
-                        ),
+                        source_title=(f"{connector_type.capitalize()} Sync"),
                         qdrant_chunks=qdrant_chunks,
                         created_at=datetime.now(UTC),
                     )
@@ -763,19 +763,24 @@ async def _run_connection_sync(
             )
         except Exception as e:
             logger.warning(
-                "sync.log_failed", sync_id=sync_id, error=str(e),
+                "sync.log_failed",
+                sync_id=sync_id,
+                error=str(e),
             )
 
         # Emit SYNC_COMPLETED for cache invalidation and plugin hooks
         if event_bus is not None:
             try:
-                await event_bus.emit(SYNC_COMPLETED, {
-                    "workspace_id": workspace_id,
-                    "connection_id": connection_id,
-                    "connector_type": connector_type,
-                    "sync_id": sync_id,
-                    "status": status,
-                })
+                await event_bus.emit(
+                    SYNC_COMPLETED,
+                    {
+                        "workspace_id": workspace_id,
+                        "connection_id": connection_id,
+                        "connector_type": connector_type,
+                        "sync_id": sync_id,
+                        "status": status,
+                    },
+                )
             except Exception as e:
                 logger.warning(
                     "sync.event_emit.error",

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -43,8 +43,10 @@ def extract_document_date(
     Returns: YYYY-MM-DD string, or "" if no date found.
     """
     fallback_year = (
-        updated_at.year if updated_at and isinstance(updated_at, datetime)
-        else created_at.year if created_at and isinstance(created_at, datetime)
+        updated_at.year
+        if updated_at and isinstance(updated_at, datetime)
+        else created_at.year
+        if created_at and isinstance(created_at, datetime)
         else None
     )
 
@@ -125,7 +127,7 @@ class IngestionPipeline:
         raise NotImplementedError("Ingestion pipeline not yet implemented")
 
 
-def ingest_documents(
+async def ingest_documents(
     documents: list[Document],
     workspace_id: str,
     connector_type: str = "",
@@ -133,9 +135,9 @@ def ingest_documents(
     plugin_manager=None,
     source_role: str = "knowledge_base",
 ) -> SyncResult:
-    """Ingest documents into Qdrant + Memgraph (sync, uses existing stores).
+    """Ingest documents into Qdrant + Memgraph (async, uses AsyncQdrantVectorStore).
 
-    Simplified pipeline that works with the current sync code:
+    Pipeline stages:
     1. (Incremental) Delete old chunks for each document being re-ingested
     2. Chunk each document's content
     3. Store each chunk in Qdrant (embedding happens inside add_document)
@@ -151,12 +153,12 @@ def ingest_documents(
         SyncResult with ingestion statistics.
     """
     from metatron.core.config import Settings
-    from metatron.storage.qdrant import get_hybrid_store
+    from metatron.storage.qdrant import get_async_hybrid_store
 
     _settings = Settings()
     t0 = time.time()
-    store = get_hybrid_store(workspace_id)
-    store._ensure_collection()
+    store = await get_async_hybrid_store(workspace_id)
+    await store._ensure_collection()
     dedup_index = DeduplicationIndex()
     new_count = 0
     updated_count = 0
@@ -169,19 +171,28 @@ def ingest_documents(
     for doc in documents:
         try:
             if not doc.content or not doc.content.strip():
-                logger.info("ingest.skipped", title=doc.title, source_id=doc.source_id,
-                            source_type=doc.source_type, reason="empty body")
+                logger.info(
+                    "ingest.skipped",
+                    title=doc.title,
+                    source_id=doc.source_id,
+                    source_type=doc.source_type,
+                    reason="empty body",
+                )
                 skip_count += 1
                 continue
 
             # Incremental: delete old chunks before re-ingesting
             was_updated = False
             if incremental and doc.source_id:
-                deleted = store.delete_by_doc_labels([doc.source_id])
+                deleted = await store.delete_by_doc_labels([doc.source_id])
                 if deleted > 0:
                     was_updated = True
                     dedup_index.remove_doc(doc.source_id)
-                    _delete_graph_node(doc.source_id, workspace_id)
+                    await asyncio.to_thread(
+                        _delete_graph_node,
+                        doc.source_id,
+                        workspace_id,
+                    )
 
             if _settings.hierarchical_chunking_enabled:
                 chunk_objs = root_child_chunk(
@@ -208,8 +219,9 @@ def ingest_documents(
                 # Dedup: skip near-duplicate chunks from different documents
                 if dedup_index.check_and_add(chunk, doc.source_id):
                     dedup_count += 1
-                    logger.debug("ingest.chunk.duplicate", title=doc.title,
-                                 source_id=doc.source_id)
+                    logger.debug(
+                        "ingest.chunk.duplicate", title=doc.title, source_id=doc.source_id
+                    )
                     continue
 
                 chunk_hash = simhash(chunk)
@@ -232,13 +244,20 @@ def ingest_documents(
                 # -- ACL: run pre_index hooks to enrich metadata --
                 if plugin_manager:
                     for hook in plugin_manager.get_pipeline_hooks("pre_index"):
-                        hook_ctx = asyncio.run(hook({
-                            "document": doc, "metadata": metadata,
-                            "workspace_id": workspace_id,
-                        }))
+                        hook_ctx = await hook(
+                            {
+                                "document": doc,
+                                "metadata": metadata,
+                                "workspace_id": workspace_id,
+                            }
+                        )
                         metadata = hook_ctx.get("metadata", metadata)
 
-                store.add_document(chunk, metadata=metadata, doc_id=doc.source_id)
+                await store.add_document(
+                    chunk,
+                    metadata=metadata,
+                    doc_id=doc.source_id,
+                )
 
             if was_updated:
                 updated_count += 1
@@ -247,35 +266,50 @@ def ingest_documents(
 
             # Write chunk hierarchy to Memgraph (graceful degradation)
             if _settings.hierarchical_chunking_enabled:
-                _write_chunk_hierarchy(chunk_objs, workspace_id, doc.source_id)
+                await asyncio.to_thread(
+                    _write_chunk_hierarchy,
+                    chunk_objs,
+                    workspace_id,
+                    doc.source_id,
+                )
 
             # Register people from any source into alias registry
-            _register_persons(doc)
+            await asyncio.to_thread(_register_persons, doc)
 
             # Collect for Phase 2 graph extraction
             graph_queue.append((doc, workspace_id))
 
             if (new_count + updated_count) % 50 == 0:
-                logger.info("ingest.progress", new=new_count, updated=updated_count,
-                            total=len(documents))
+                logger.info(
+                    "ingest.progress", new=new_count, updated=updated_count, total=len(documents)
+                )
 
         except Exception as e:
-            logger.debug("ingest.skipped", title=doc.title, source_id=doc.source_id, reason=f"error: {e}")
+            logger.debug(
+                "ingest.skipped", title=doc.title, source_id=doc.source_id, reason=f"error: {e}"
+            )
             logger.warning("ingest.document.error", source_id=doc.source_id, error=str(e))
             errors.append(f"{doc.source_id}: {e}")
 
     # Phase 2: parallel graph extraction (slow LLM calls)
     if _settings.graph_extraction_enabled and graph_queue:
-        _extract_graphs_parallel(
+        await asyncio.to_thread(
+            _extract_graphs_parallel,
             graph_queue,
             max_workers=_settings.graph_extraction_workers,
             min_chars=_settings.graph_extraction_min_chars,
         )
 
     duration_ms = (time.time() - t0) * 1000
-    logger.info("ingest.done", new=new_count, updated=updated_count,
-                skipped=skip_count, duplicates=dedup_count,
-                errors=len(errors), duration_ms=round(duration_ms))
+    logger.info(
+        "ingest.done",
+        new=new_count,
+        updated=updated_count,
+        skipped=skip_count,
+        duplicates=dedup_count,
+        errors=len(errors),
+        duration_ms=round(duration_ms),
+    )
 
     return SyncResult(
         connector_type=connector_type,
@@ -305,7 +339,8 @@ def _write_chunk_hierarchy(
 
         for root_id in root_ids:
             child_ids = [
-                c.id for c in chunk_objs
+                c.id
+                for c in chunk_objs
                 if c.chunk_type == ChunkType.CHILD and c.parent_id == root_id
             ]
             if child_ids:
@@ -356,8 +391,12 @@ def _extract_graphs_parallel(
                 jira_struct_only.append((doc, ws_id))
             else:
                 skipped += 1
-                logger.debug("ingest.graph.skipped_short", source_id=doc.source_id,
-                             content_len=content_len, min_chars=min_chars)
+                logger.debug(
+                    "ingest.graph.skipped_short",
+                    source_id=doc.source_id,
+                    content_len=content_len,
+                    min_chars=min_chars,
+                )
         else:
             eligible.append((doc, ws_id))
 
@@ -368,12 +407,14 @@ def _extract_graphs_parallel(
             ok_count += 1
         except Exception as e:
             error_count += 1
-            logger.warning("ingest.jira_struct.error",
-                           source_id=doc.source_id, error=str(e))
+            logger.warning("ingest.jira_struct.error", source_id=doc.source_id, error=str(e))
 
     if not eligible:
-        logger.info("ingest.graph_parallel.skip_all", skipped=skipped,
-                     jira_struct_only=len(jira_struct_only))
+        logger.info(
+            "ingest.graph_parallel.skip_all",
+            skipped=skipped,
+            jira_struct_only=len(jira_struct_only),
+        )
         return {"ok": ok_count, "errors": error_count, "skipped": skipped}
 
     def _write_graph(doc: Document, ws_id: str) -> str:
@@ -388,8 +429,7 @@ def _extract_graphs_parallel(
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         future_to_item = {
-            pool.submit(_write_graph, doc, ws_id): (doc, ws_id)
-            for doc, ws_id in eligible
+            pool.submit(_write_graph, doc, ws_id): (doc, ws_id) for doc, ws_id in eligible
         }
         for future in as_completed(future_to_item):
             doc, ws_id = future_to_item[future]
@@ -399,8 +439,9 @@ def _extract_graphs_parallel(
             except Exception as e:
                 error_count += 1
                 failed.append((doc, ws_id))
-                logger.warning("ingest.graph_parallel.error",
-                               source_id=doc.source_id, error=str(e))
+                logger.warning(
+                    "ingest.graph_parallel.error", source_id=doc.source_id, error=str(e)
+                )
 
     # Retry failed documents sequentially (Memgraph may have recovered)
     if failed:
@@ -412,17 +453,25 @@ def _extract_graphs_parallel(
                 ok_count += 1
                 error_count -= 1
             except Exception as e:
-                logger.warning("ingest.graph_retry.error",
-                               source_id=doc.source_id, error=str(e))
+                logger.warning("ingest.graph_retry.error", source_id=doc.source_id, error=str(e))
         if retry_ok:
-            logger.info("ingest.graph_retry.recovered", retried=len(failed),
-                        recovered=retry_ok, still_failed=len(failed) - retry_ok)
+            logger.info(
+                "ingest.graph_retry.recovered",
+                retried=len(failed),
+                recovered=retry_ok,
+                still_failed=len(failed) - retry_ok,
+            )
 
     duration_s = time.time() - t0
-    logger.info("ingest.graph_parallel.done",
-                ok=ok_count, errors=error_count, skipped=skipped,
-                total=len(graph_queue), duration_s=round(duration_s, 1),
-                workers=max_workers)
+    logger.info(
+        "ingest.graph_parallel.done",
+        ok=ok_count,
+        errors=error_count,
+        skipped=skipped,
+        total=len(graph_queue),
+        duration_s=round(duration_s, 1),
+        workers=max_workers,
+    )
     return {"ok": ok_count, "errors": error_count, "skipped": skipped}
 
 
@@ -430,17 +479,18 @@ def _delete_graph_node(doc_label: str, workspace_id: str) -> None:
     """Delete graph node for a document (best-effort, non-fatal)."""
     try:
         from metatron.storage.graph_ops import delete_document_node
+
         delete_document_node(doc_label, workspace_id)
     except Exception as e:
         logger.warning("ingest.graph_delete.error", doc_label=doc_label, error=str(e))
 
 
 _PERSON_FIELDS = [
-    ("assignee", "assignee_email"),       # Jira
-    ("reporter", "reporter_email"),       # Jira
-    ("author", "author_email"),           # Confluence, generic
+    ("assignee", "assignee_email"),  # Jira
+    ("reporter", "reporter_email"),  # Jira
+    ("author", "author_email"),  # Confluence, generic
     ("last_modified_by", "last_modified_by_email"),  # Confluence
-    ("creator", "creator_email"),         # Generic / future connectors
+    ("creator", "creator_email"),  # Generic / future connectors
 ]
 
 
@@ -466,8 +516,9 @@ def _register_persons(doc: Document) -> None:
         logger.warning("ingest.alias_register.error", source_id=doc.source_id, error=str(e))
 
 
-def _write_jira_to_graph(doc: Document, workspace_id: str,
-                         skip_llm_extraction: bool = False) -> None:
+def _write_jira_to_graph(
+    doc: Document, workspace_id: str, skip_llm_extraction: bool = False
+) -> None:
     """Write a Jira document to Memgraph knowledge graph."""
     try:
         from metatron.storage.graph_jira import write_jira_graph_to_memgraph
@@ -482,14 +533,15 @@ def _write_jira_to_graph(doc: Document, workspace_id: str,
             "issuetype": doc.metadata.get("issuetype"),
             "priority": doc.metadata.get("priority"),
             "description": doc.content[:2000],
-            "created": doc.metadata.get("created_at_str") or (
-                doc.created_at.isoformat() if doc.created_at else None),
-            "updated": doc.metadata.get("updated_at_str") or (
-                doc.updated_at.isoformat() if doc.updated_at else None),
+            "created": doc.metadata.get("created_at_str")
+            or (doc.created_at.isoformat() if doc.created_at else None),
+            "updated": doc.metadata.get("updated_at_str")
+            or (doc.updated_at.isoformat() if doc.updated_at else None),
             "resolved_at": doc.metadata.get("resolved_at_str") or None,
         }
         write_jira_graph_to_memgraph(
-            jira_data, doc.content,
+            jira_data,
+            doc.content,
             workspace_id=workspace_id,
             doc_label=doc.source_id,
             skip_llm_extraction=skip_llm_extraction,
@@ -504,8 +556,13 @@ def _write_doc_to_graph(doc: Document, workspace_id: str) -> None:
     try:
         from metatron.storage.memgraph import write_doc_graph_to_memgraph
 
-        doc_date = (doc.updated_at.isoformat() if doc.updated_at
-                    else doc.created_at.isoformat() if doc.created_at else None)
+        doc_date = (
+            doc.updated_at.isoformat()
+            if doc.updated_at
+            else doc.created_at.isoformat()
+            if doc.created_at
+            else None
+        )
         write_doc_graph_to_memgraph(
             text=doc.content[:8000],
             file_name=doc.title or doc.source_id or "untitled",

--- a/src/metatron/mcp/sync.py
+++ b/src/metatron/mcp/sync.py
@@ -138,7 +138,7 @@ class MCPSyncManager:
                 documents_skipped=len(all_docs),
             )
 
-        result = ingest_documents(
+        result = await ingest_documents(
             docs_to_ingest,
             workspace_id,
             connector_type=f"mcp:{config.name}",
@@ -186,13 +186,15 @@ class MCPSyncManager:
                     error=str(e),
                     exc_info=True,
                 )
-                results.append((
-                    config.name,
-                    SyncResult(
-                        connector_type=f"mcp:{config.name}",
-                        workspace_id=workspace_id,
-                        errors=[str(e)],
-                    ),
-                ))
+                results.append(
+                    (
+                        config.name,
+                        SyncResult(
+                            connector_type=f"mcp:{config.name}",
+                            workspace_id=workspace_id,
+                            errors=[str(e)],
+                        ),
+                    )
+                )
 
         return results

--- a/src/metatron/mcp/tools/store.py
+++ b/src/metatron/mcp/tools/store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import uuid
 from typing import Any
 
@@ -51,8 +50,7 @@ async def metatron_store(
         )
 
         # ingest_documents returns SyncResult (not .success / .new_chunks)
-        result = await asyncio.to_thread(
-            ingest_documents,
+        result = await ingest_documents(
             [doc],
             workspace_id or "default",
             connector_type="memory",

--- a/tests/unit/test_date_metadata.py
+++ b/tests/unit/test_date_metadata.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from metatron.connectors.confluence import ConfluenceConnector
 from metatron.connectors.jira import JiraConnector
@@ -59,8 +59,11 @@ class TestConfluenceDateMetadata:
 
 
 class TestJiraDateMetadata:
-    def _make_raw_issue(self, created: str = "2026-01-20T08:00:00.000+0000",
-                        updated: str = "2026-02-10T15:30:00.000+0000") -> dict:
+    def _make_raw_issue(
+        self,
+        created: str = "2026-01-20T08:00:00.000+0000",
+        updated: str = "2026-02-10T15:30:00.000+0000",
+    ) -> dict:
         return {
             "key": "TEST-1",
             "fields": {
@@ -72,9 +75,12 @@ class TestJiraDateMetadata:
                 "updated": updated,
                 "priority": {"name": "Medium"},
                 "issuetype": {"name": "Task"},
-                "description": {"type": "doc", "content": [
-                    {"type": "paragraph", "content": [{"type": "text", "text": "Description"}]}
-                ]},
+                "description": {
+                    "type": "doc",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "Description"}]}
+                    ],
+                },
             },
         }
 
@@ -101,11 +107,11 @@ class TestJiraDateMetadata:
 
 
 class TestPipelineDateExtraction:
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_date_in_metadata(self, mock_store_fn: MagicMock) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_date_in_metadata(self, mock_store_fn: AsyncMock) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         doc = Document(
@@ -116,7 +122,7 @@ class TestPipelineDateExtraction:
             updated_at=datetime(2026, 2, 9, 7, 46, 41),
             created_at=datetime(2026, 1, 15, 10, 0, 0),
         )
-        ingest_documents([doc], workspace_id="ws1", connector_type="confluence")
+        await ingest_documents([doc], workspace_id="ws1", connector_type="confluence")
 
         # Verify add_document was called with date in metadata
         assert mock_store.add_document.called
@@ -124,11 +130,11 @@ class TestPipelineDateExtraction:
         metadata = call_kwargs.kwargs.get("metadata") or call_kwargs[1].get("metadata")
         assert metadata["date"] == "2026-02-09"
 
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_date_from_created_at_fallback(self, mock_store_fn: MagicMock) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_date_from_created_at_fallback(self, mock_store_fn: AsyncMock) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         # Document with only created_at (updated_at defaults to utcnow but
@@ -140,7 +146,7 @@ class TestPipelineDateExtraction:
             content="Issue content.",
             created_at=datetime(2026, 1, 20, 8, 0, 0),
         )
-        ingest_documents([doc], workspace_id="ws1", connector_type="jira")
+        await ingest_documents([doc], workspace_id="ws1", connector_type="jira")
 
         assert mock_store.add_document.called
         call_kwargs = mock_store.add_document.call_args
@@ -148,11 +154,14 @@ class TestPipelineDateExtraction:
         # Should have a date (from updated_at default or created_at)
         assert metadata["date"] != ""
 
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_date_prefers_updated_over_created(self, mock_store_fn: MagicMock) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_date_prefers_updated_over_created(
+        self,
+        mock_store_fn: AsyncMock,
+    ) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         doc = Document(
@@ -163,7 +172,7 @@ class TestPipelineDateExtraction:
             updated_at=datetime(2026, 2, 10, 12, 0, 0),
             created_at=datetime(2026, 1, 1, 12, 0, 0),
         )
-        ingest_documents([doc], workspace_id="ws1", connector_type="confluence")
+        await ingest_documents([doc], workspace_id="ws1", connector_type="confluence")
 
         call_kwargs = mock_store.add_document.call_args
         metadata = call_kwargs.kwargs.get("metadata") or call_kwargs[1].get("metadata")

--- a/tests/unit/test_file_upload.py
+++ b/tests/unit/test_file_upload.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -34,9 +34,14 @@ def router(settings):
 
 def _sync_result(**kwargs) -> SyncResult:
     defaults = dict(
-        connector_type="upload", workspace_id="TEST_WS",
-        documents_fetched=1, documents_new=1, documents_updated=0,
-        documents_skipped=0, errors=[], duration_ms=10.0,
+        connector_type="upload",
+        workspace_id="TEST_WS",
+        documents_fetched=1,
+        documents_new=1,
+        documents_updated=0,
+        documents_skipped=0,
+        errors=[],
+        duration_ms=10.0,
     )
     defaults.update(kwargs)
     return SyncResult(**defaults)
@@ -57,7 +62,9 @@ class TestExtensionValidation:
     def test_unsupported_extension_rejected(self, router: AgentRouter) -> None:
         for ext in (".docx", ".jpg", ".zip", ".py"):
             result = router.handle_file_upload(
-                b"data", f"file{ext}", user_id="u1",
+                b"data",
+                f"file{ext}",
+                user_id="u1",
             )
             assert "Unsupported file type" in result
             assert ext in result
@@ -77,7 +84,11 @@ class TestSizeValidation:
 
     def test_file_within_limit_accepted(self, router: AgentRouter) -> None:
         small = b"x" * 100
-        with patch("metatron.ingestion.pipeline.ingest_documents", return_value=_sync_result()):
+        with patch(
+            "metatron.ingestion.pipeline.ingest_documents",
+            new_callable=AsyncMock,
+            return_value=_sync_result(),
+        ):
             result = router.handle_file_upload(small, "ok.txt", user_id="u1")
         assert "Indexed" in result
 
@@ -120,9 +131,11 @@ class TestFileParsing:
 
 
 class TestDocumentMetadata:
-    @patch("metatron.ingestion.pipeline.ingest_documents")
+    @patch("metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock)
     def test_document_has_correct_metadata(
-        self, mock_ingest: MagicMock, router: AgentRouter,
+        self,
+        mock_ingest: MagicMock,
+        router: AgentRouter,
     ) -> None:
         mock_ingest.return_value = _sync_result()
         router.handle_file_upload(
@@ -141,29 +154,38 @@ class TestDocumentMetadata:
         assert doc.metadata["filename"] == "report.txt"
         assert doc.author == "u1"
 
-    @patch("metatron.ingestion.pipeline.ingest_documents")
+    @patch("metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock)
     def test_incremental_mode_enabled(
-        self, mock_ingest: MagicMock, router: AgentRouter,
+        self,
+        mock_ingest: MagicMock,
+        router: AgentRouter,
     ) -> None:
         mock_ingest.return_value = _sync_result()
         router.handle_file_upload(b"Content for incremental test", "f.txt", user_id="u1")
         call_kwargs = mock_ingest.call_args
-        assert call_kwargs.kwargs.get("incremental") is True or call_kwargs[1].get("incremental") is True
+        assert (
+            call_kwargs.kwargs.get("incremental") is True
+            or call_kwargs[1].get("incremental") is True
+        )
 
 
 class TestPipelineIntegration:
-    @patch("metatron.ingestion.pipeline.ingest_documents")
+    @patch("metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock)
     def test_successful_upload_reports_new(
-        self, mock_ingest: MagicMock, router: AgentRouter,
+        self,
+        mock_ingest: MagicMock,
+        router: AgentRouter,
     ) -> None:
         mock_ingest.return_value = _sync_result(documents_new=1)
         result = router.handle_file_upload(b"Content here!", "doc.txt", user_id="u1")
         assert "Indexed doc.txt" in result
         assert "1 new" in result
 
-    @patch("metatron.ingestion.pipeline.ingest_documents")
+    @patch("metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock)
     def test_re_upload_reports_updated(
-        self, mock_ingest: MagicMock, router: AgentRouter,
+        self,
+        mock_ingest: MagicMock,
+        router: AgentRouter,
     ) -> None:
         mock_ingest.return_value = _sync_result(documents_new=0, documents_updated=1)
         result = router.handle_file_upload(b"Updated content!", "doc.txt", user_id="u1")
@@ -180,9 +202,11 @@ class TestErrorHandling:
         )
         assert "Could not parse" in result or "empty" in result.lower()
 
-    @patch("metatron.ingestion.pipeline.ingest_documents")
+    @patch("metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock)
     def test_pipeline_error_returns_friendly_message(
-        self, mock_ingest: MagicMock, router: AgentRouter,
+        self,
+        mock_ingest: MagicMock,
+        router: AgentRouter,
     ) -> None:
         mock_ingest.side_effect = RuntimeError("Qdrant down")
         result = router.handle_file_upload(b"Good content here", "doc.txt", user_id="u1")
@@ -192,29 +216,49 @@ class TestErrorHandling:
 
 class TestTitleExtraction:
     def test_markdown_heading(self, router: AgentRouter) -> None:
-        assert router._extract_title_from_content(
-            "# Deployment Guide\n\nSome body text here.", "file.md",
-        ) == "Deployment Guide"
+        assert (
+            router._extract_title_from_content(
+                "# Deployment Guide\n\nSome body text here.",
+                "file.md",
+            )
+            == "Deployment Guide"
+        )
 
     def test_markdown_h2(self, router: AgentRouter) -> None:
-        assert router._extract_title_from_content(
-            "## Architecture Overview\n\nDetails.", "file.md",
-        ) == "Architecture Overview"
+        assert (
+            router._extract_title_from_content(
+                "## Architecture Overview\n\nDetails.",
+                "file.md",
+            )
+            == "Architecture Overview"
+        )
 
     def test_first_line_fallback(self, router: AgentRouter) -> None:
-        assert router._extract_title_from_content(
-            "Project Aurora Status Report\n\nThis is the body.", "report.txt",
-        ) == "Project Aurora Status Report"
+        assert (
+            router._extract_title_from_content(
+                "Project Aurora Status Report\n\nThis is the body.",
+                "report.txt",
+            )
+            == "Project Aurora Status Report"
+        )
 
     def test_skips_short_lines(self, router: AgentRouter) -> None:
-        assert router._extract_title_from_content(
-            "Hi\n\nThis is the actual meaningful title line\nMore content.", "f.txt",
-        ) == "This is the actual meaningful title line"
+        assert (
+            router._extract_title_from_content(
+                "Hi\n\nThis is the actual meaningful title line\nMore content.",
+                "f.txt",
+            )
+            == "This is the actual meaningful title line"
+        )
 
     def test_skips_empty_lines(self, router: AgentRouter) -> None:
-        assert router._extract_title_from_content(
-            "\n\n\nReal Title of the Document\nBody.", "f.txt",
-        ) == "Real Title of the Document"
+        assert (
+            router._extract_title_from_content(
+                "\n\n\nReal Title of the Document\nBody.",
+                "f.txt",
+            )
+            == "Real Title of the Document"
+        )
 
     def test_falls_back_to_filename(self, router: AgentRouter) -> None:
         assert router._extract_title_from_content("", "notes.txt") == "notes.txt"
@@ -224,18 +268,25 @@ class TestTitleExtraction:
 
     def test_heading_only_hashes_skipped(self, router: AgentRouter) -> None:
         """A line like '###' with no text should be skipped."""
-        assert router._extract_title_from_content(
-            "###\nActual title of the document\nBody.", "f.md",
-        ) == "Actual title of the document"
+        assert (
+            router._extract_title_from_content(
+                "###\nActual title of the document\nBody.",
+                "f.md",
+            )
+            == "Actual title of the document"
+        )
 
-    @patch("metatron.ingestion.pipeline.ingest_documents")
+    @patch("metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock)
     def test_extracted_title_used_in_document(
-        self, mock_ingest: MagicMock, router: AgentRouter,
+        self,
+        mock_ingest: MagicMock,
+        router: AgentRouter,
     ) -> None:
         mock_ingest.return_value = _sync_result()
         router.handle_file_upload(
             b"# My Important Report\n\nBody text goes here.",
-            "report.md", user_id="u1",
+            "report.md",
+            user_id="u1",
         )
         doc = mock_ingest.call_args.args[0][0]
         assert doc.title == "My Important Report"

--- a/tests/unit/test_hierarchical_ingestion.py
+++ b/tests/unit/test_hierarchical_ingestion.py
@@ -1,7 +1,8 @@
 """Tests for hierarchical chunking in the ingestion pipeline."""
+
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 from metatron.core.models import ChunkType, Document
 
@@ -42,14 +43,17 @@ class TestHierarchicalIngestionEnabled:
     @patch("metatron.ingestion.pipeline._register_persons")
     @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
     @patch("metatron.ingestion.pipeline._write_chunk_hierarchy")
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_stores_chunk_type_and_parent_id(
-        self, mock_store_fn, mock_hierarchy, mock_graph, mock_persons,
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_stores_chunk_type_and_parent_id(
+        self,
+        mock_store_fn,
+        mock_hierarchy,
+        mock_graph,
+        mock_persons,
     ) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
-        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         content = _long_content()
@@ -60,7 +64,7 @@ class TestHierarchicalIngestionEnabled:
             s.hierarchical_chunking_enabled = True
             s.graph_extraction_enabled = False
 
-            ingest_documents([doc], workspace_id="ws_test")
+            await ingest_documents([doc], workspace_id="ws_test")
 
         # Verify add_document was called with chunk_type/parent_id in metadata
         assert mock_store.add_document.call_count >= 2
@@ -80,14 +84,17 @@ class TestHierarchicalIngestionEnabled:
     @patch("metatron.ingestion.pipeline._register_persons")
     @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
     @patch("metatron.ingestion.pipeline._write_chunk_hierarchy")
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_writes_chunk_hierarchy_to_memgraph(
-        self, mock_store_fn, mock_hierarchy, mock_graph, mock_persons,
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_writes_chunk_hierarchy_to_memgraph(
+        self,
+        mock_store_fn,
+        mock_hierarchy,
+        mock_graph,
+        mock_persons,
     ) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
-        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         content = _long_content()
@@ -98,7 +105,7 @@ class TestHierarchicalIngestionEnabled:
             s.hierarchical_chunking_enabled = True
             s.graph_extraction_enabled = False
 
-            ingest_documents([doc], workspace_id="ws_test")
+            await ingest_documents([doc], workspace_id="ws_test")
 
         mock_hierarchy.assert_called_once()
         call_args = mock_hierarchy.call_args
@@ -113,14 +120,17 @@ class TestHierarchicalIngestionDisabled:
     @patch("metatron.ingestion.pipeline._register_persons")
     @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
     @patch("metatron.ingestion.pipeline._write_chunk_hierarchy")
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_uses_simple_chunk_when_disabled(
-        self, mock_store_fn, mock_hierarchy, mock_graph, mock_persons,
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_uses_simple_chunk_when_disabled(
+        self,
+        mock_store_fn,
+        mock_hierarchy,
+        mock_graph,
+        mock_persons,
     ) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
-        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         content = _long_content()
@@ -131,7 +141,7 @@ class TestHierarchicalIngestionDisabled:
             s.hierarchical_chunking_enabled = False
             s.graph_extraction_enabled = False
 
-            ingest_documents([doc], workspace_id="ws_test")
+            await ingest_documents([doc], workspace_id="ws_test")
 
         # All chunks should be standalone (simple_chunk)
         calls = mock_store.add_document.call_args_list
@@ -144,19 +154,22 @@ class TestHierarchicalIngestionDisabled:
 
 
 class TestEnsureCollection:
-    """_ensure_collection() is called after get_hybrid_store() in ingest_documents()."""
+    """_ensure_collection() is called after get_async_hybrid_store() in ingest_documents()."""
 
     @patch("metatron.ingestion.pipeline._register_persons")
     @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
     @patch("metatron.ingestion.pipeline._write_chunk_hierarchy")
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_ensure_collection_called_after_get_hybrid_store(
-        self, mock_store_fn, mock_hierarchy, mock_graph, mock_persons,
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_ensure_collection_called_after_get_hybrid_store(
+        self,
+        mock_store_fn,
+        mock_hierarchy,
+        mock_graph,
+        mock_persons,
     ) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
-        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         doc = _make_doc("some content")
@@ -166,7 +179,7 @@ class TestEnsureCollection:
             s.hierarchical_chunking_enabled = False
             s.graph_extraction_enabled = False
 
-            ingest_documents([doc], workspace_id="ws_test")
+            await ingest_documents([doc], workspace_id="ws_test")
 
         mock_store._ensure_collection.assert_called_once()
 
@@ -176,14 +189,16 @@ class TestGracefulDegradation:
 
     @patch("metatron.ingestion.pipeline._register_persons")
     @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_continues_when_memgraph_unavailable(
-        self, mock_store_fn, mock_graph, mock_persons,
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_continues_when_memgraph_unavailable(
+        self,
+        mock_store_fn,
+        mock_graph,
+        mock_persons,
     ) -> None:
         from metatron.ingestion.pipeline import ingest_documents
 
-        mock_store = MagicMock()
-        mock_store.delete_by_doc_labels.return_value = 0
+        mock_store = AsyncMock()
         mock_store_fn.return_value = mock_store
 
         content = _long_content()
@@ -200,7 +215,7 @@ class TestGracefulDegradation:
             s.hierarchical_chunking_enabled = True
             s.graph_extraction_enabled = False
 
-            result = ingest_documents([doc], workspace_id="ws_test")
+            result = await ingest_documents([doc], workspace_id="ws_test")
 
         # Ingestion should succeed despite Memgraph failure
         # _write_chunk_hierarchy is called after store.add_document calls,
@@ -229,9 +244,12 @@ class TestGraphRetry:
             if doc.source_id == "doc1" and call_count["doc1"] == 1:
                 raise ConnectionError("Memgraph down")
 
-        with patch("metatron.ingestion.pipeline._write_jira_to_graph"), patch(
-            "metatron.ingestion.pipeline._write_doc_to_graph",
-            side_effect=flaky_write,
+        with (
+            patch("metatron.ingestion.pipeline._write_jira_to_graph"),
+            patch(
+                "metatron.ingestion.pipeline._write_doc_to_graph",
+                side_effect=flaky_write,
+            ),
         ):
             result = _extract_graphs_parallel(queue, max_workers=1)
 
@@ -244,9 +262,12 @@ class TestGraphRetry:
         doc = _make_doc("A" * 200, source_id="doc1")
         queue = [(doc, "ws")]
 
-        with patch("metatron.ingestion.pipeline._write_jira_to_graph"), patch(
-            "metatron.ingestion.pipeline._write_doc_to_graph",
-            side_effect=ConnectionError("Memgraph permanently down"),
+        with (
+            patch("metatron.ingestion.pipeline._write_jira_to_graph"),
+            patch(
+                "metatron.ingestion.pipeline._write_doc_to_graph",
+                side_effect=ConnectionError("Memgraph permanently down"),
+            ),
         ):
             result = _extract_graphs_parallel(queue, max_workers=1)
 

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from metatron.connectors.sync_state import SyncState
 
@@ -135,6 +135,7 @@ class TestConnectorSinceParameter:
         import inspect
 
         from metatron.connectors.confluence import ConfluenceConnector
+
         sig = inspect.signature(ConfluenceConnector.fetch)
         assert "since" in sig.parameters
 
@@ -142,6 +143,7 @@ class TestConnectorSinceParameter:
         import inspect
 
         from metatron.connectors.jira import JiraConnector
+
         sig = inspect.signature(JiraConnector.fetch)
         assert "since" in sig.parameters
 
@@ -152,22 +154,30 @@ class TestConnectorSinceParameter:
 
 
 class TestPipelineDedup:
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_duplicate_chunks_across_docs_skipped(self, mock_get_store) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_duplicate_chunks_across_docs_skipped(self, mock_get_store) -> None:
         """When two docs produce identical chunks, the second is skipped."""
         from metatron.core.models import Document
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         mock_get_store.return_value = store
 
         # Two docs with identical content → same chunks
-        doc1 = Document(source_type="confluence", source_id="PAGE-1",
-                        title="Doc A", content="The quick brown fox jumps over the lazy dog in the park every single morning")
-        doc2 = Document(source_type="confluence", source_id="PAGE-2",
-                        title="Doc B", content="The quick brown fox jumps over the lazy dog in the park every single morning")
+        doc1 = Document(
+            source_type="confluence",
+            source_id="PAGE-1",
+            title="Doc A",
+            content="The quick brown fox jumps over the lazy dog in the park every single morning",
+        )
+        doc2 = Document(
+            source_type="confluence",
+            source_id="PAGE-2",
+            title="Doc B",
+            content="The quick brown fox jumps over the lazy dog in the park every single morning",
+        )
 
-        result = ingest_documents([doc1, doc2], "WS1", "confluence")
+        result = await ingest_documents([doc1, doc2], "WS1", "confluence")
 
         # Both docs should count as new (document-level), but doc2's chunks
         # should be skipped at the chunk level (dedup)
@@ -177,19 +187,23 @@ class TestPipelineDedup:
         # doc1 should have stored at least 1 chunk
         assert calls_count >= 1
 
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_simhash_stored_in_metadata(self, mock_get_store) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_simhash_stored_in_metadata(self, mock_get_store) -> None:
         """Chunk metadata includes simhash value."""
         from metatron.core.models import Document
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         mock_get_store.return_value = store
 
-        doc = Document(source_type="confluence", source_id="PAGE-1",
-                       title="Test", content="Unique content that should be indexed normally here")
+        doc = Document(
+            source_type="confluence",
+            source_id="PAGE-1",
+            title="Test",
+            content="Unique content that should be indexed normally here",
+        )
 
-        ingest_documents([doc], "WS1", "confluence")
+        await ingest_documents([doc], "WS1", "confluence")
 
         assert store.add_document.call_count >= 1
         # Check metadata of first call
@@ -198,102 +212,138 @@ class TestPipelineDedup:
         assert "simhash" in metadata
         assert isinstance(metadata["simhash"], int)
 
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_same_doc_chunks_not_deduped(self, mock_get_store) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_same_doc_chunks_not_deduped(self, mock_get_store) -> None:
         """Chunks from the same document are NOT flagged as duplicates."""
         from metatron.core.models import Document
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         mock_get_store.return_value = store
 
-        doc = Document(source_type="confluence", source_id="PAGE-1",
-                       title="Test", content="Repeated content. " * 50)
+        doc = Document(
+            source_type="confluence",
+            source_id="PAGE-1",
+            title="Test",
+            content="Repeated content. " * 50,
+        )
 
-        result = ingest_documents([doc], "WS1", "confluence")
+        result = await ingest_documents([doc], "WS1", "confluence")
         assert result.documents_new == 1
         # All chunks from same doc should be stored (not deduped against each other)
         assert store.add_document.call_count >= 1
 
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_incremental_removes_doc_from_dedup_index(self, mock_get_store) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_incremental_removes_doc_from_dedup_index(
+        self,
+        mock_get_store,
+    ) -> None:
         """Incremental reingest calls dedup_index.remove_doc before processing."""
         from metatron.core.models import Document
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         store.delete_by_doc_labels.return_value = 2  # had old chunks
         mock_get_store.return_value = store
 
-        doc1 = Document(source_type="confluence", source_id="PAGE-1",
-                        title="Original", content="The quick brown fox jumps over the lazy dog in the park every morning")
-        doc2 = Document(source_type="confluence", source_id="PAGE-1",
-                        title="Updated", content="The quick brown fox jumps over the lazy dog in the park every morning")
+        doc1 = Document(
+            source_type="confluence",
+            source_id="PAGE-1",
+            title="Original",
+            content="The quick brown fox jumps over the lazy dog in the park every morning",
+        )
+        doc2 = Document(
+            source_type="confluence",
+            source_id="PAGE-1",
+            title="Updated",
+            content="The quick brown fox jumps over the lazy dog in the park every morning",
+        )
 
         with patch("metatron.ingestion.pipeline._delete_graph_node"):
-            result = ingest_documents([doc1, doc2], "WS1", "confluence", incremental=True)
+            result = await ingest_documents(
+                [doc1, doc2],
+                "WS1",
+                "confluence",
+                incremental=True,
+            )
 
         # Both should be updated (incremental delete found old chunks)
         assert result.documents_updated == 2
 
 
 class TestPipelineIncremental:
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_incremental_deletes_old_chunks(self, mock_get_store) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_incremental_deletes_old_chunks(self, mock_get_store) -> None:
         from metatron.core.models import Document
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         store.delete_by_doc_labels.return_value = 3
         mock_get_store.return_value = store
 
         doc = Document(
-            source_type="confluence", source_id="PAGE-1",
-            title="Test", content="Some content for chunking.",
+            source_type="confluence",
+            source_id="PAGE-1",
+            title="Test",
+            content="Some content for chunking.",
         )
 
         with patch("metatron.ingestion.pipeline._delete_graph_node") as mock_gd:
-            result = ingest_documents([doc], "WS1", "confluence", incremental=True)
+            result = await ingest_documents(
+                [doc],
+                "WS1",
+                "confluence",
+                incremental=True,
+            )
 
             store.delete_by_doc_labels.assert_called_once_with(["PAGE-1"])
             mock_gd.assert_called_once_with("PAGE-1", "WS1")
             assert result.documents_updated == 1
             assert result.documents_new == 0
 
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_incremental_new_doc_counted_as_new(self, mock_get_store) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_incremental_new_doc_counted_as_new(self, mock_get_store) -> None:
         from metatron.core.models import Document
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         store.delete_by_doc_labels.return_value = 0
         mock_get_store.return_value = store
 
         doc = Document(
-            source_type="confluence", source_id="PAGE-NEW",
-            title="New Page", content="Brand new content.",
+            source_type="confluence",
+            source_id="PAGE-NEW",
+            title="New Page",
+            content="Brand new content.",
         )
 
         with patch("metatron.ingestion.pipeline._delete_graph_node") as mock_gd:
-            result = ingest_documents([doc], "WS1", "confluence", incremental=True)
+            result = await ingest_documents(
+                [doc],
+                "WS1",
+                "confluence",
+                incremental=True,
+            )
 
             assert result.documents_new == 1
             assert result.documents_updated == 0
             mock_gd.assert_not_called()
 
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_non_incremental_skips_delete(self, mock_get_store) -> None:
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_non_incremental_skips_delete(self, mock_get_store) -> None:
         from metatron.core.models import Document
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         mock_get_store.return_value = store
 
         doc = Document(
-            source_type="confluence", source_id="PAGE-1",
-            title="Test", content="Content.",
+            source_type="confluence",
+            source_id="PAGE-1",
+            title="Test",
+            content="Content.",
         )
-        ingest_documents([doc], "WS1", "confluence", incremental=False)
+        await ingest_documents([doc], "WS1", "confluence", incremental=False)
 
         store.delete_by_doc_labels.assert_not_called()
 

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -395,13 +395,18 @@ class TestMCPSyncManager:
 
         docs = [Document(source_id="d1", content="hello world", source_type="mcp")]
 
-        with patch("metatron.mcp.sync.get_adapter") as mock_adapter, \
-             patch("metatron.ingestion.pipeline.ingest_documents") as mock_ingest:
+        with (
+            patch("metatron.mcp.sync.get_adapter") as mock_adapter,
+            patch(
+                "metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock
+            ) as mock_ingest,
+        ):
             adapter = AsyncMock()
             adapter.fetch_documents = AsyncMock(return_value=docs)
             mock_adapter.return_value = adapter
 
             from metatron.core.models import SyncResult
+
             mock_ingest.return_value = SyncResult(
                 connector_type="mcp:test-srv",
                 workspace_id="WS1",
@@ -426,8 +431,12 @@ class TestMCPSyncManager:
         # Pre-seed same hash
         mgr._hashes["d1"] = mgr._content_hash("hello")
 
-        with patch("metatron.mcp.sync.get_adapter") as mock_adapter, \
-             patch("metatron.ingestion.pipeline.ingest_documents") as mock_ingest:
+        with (
+            patch("metatron.mcp.sync.get_adapter") as mock_adapter,
+            patch(
+                "metatron.ingestion.pipeline.ingest_documents", new_callable=AsyncMock
+            ) as mock_ingest,
+        ):
             adapter = AsyncMock()
             adapter.fetch_documents = AsyncMock(return_value=docs)
             mock_adapter.return_value = adapter
@@ -524,15 +533,18 @@ class TestMCPClient:
         mocks = self._mock_mcp_sdk()
         cfg = MCPServerConfig(name="test", command="echo")
 
-        with patch.object(client_mod, "_ClientSession", return_value=mocks["session"]), \
-             patch.object(client_mod, "_StdioServerParameters", return_value=MagicMock()), \
-             patch.object(client_mod, "_stdio_client", return_value=mocks["stdio_ctx"]):
+        with (
+            patch.object(client_mod, "_ClientSession", return_value=mocks["session"]),
+            patch.object(client_mod, "_StdioServerParameters", return_value=MagicMock()),
+            patch.object(client_mod, "_stdio_client", return_value=mocks["stdio_ctx"]),
+        ):
             # Mark as already imported
             client_mod._ClientSession = MagicMock(return_value=mocks["session"])
             client_mod._StdioServerParameters = MagicMock()
             client_mod._stdio_client = MagicMock(return_value=mocks["stdio_ctx"])
 
             from metatron.mcp.client import MCPClient
+
             client = MCPClient(cfg)
             await client.connect()
             tools = await client.list_tools()
@@ -554,6 +566,7 @@ class TestMCPClient:
         client_mod._stdio_client = MagicMock(return_value=mocks["stdio_ctx"])
 
         from metatron.mcp.client import MCPClient
+
         client = MCPClient(cfg)
         await client.connect()
         result = await client.call_tool("read_file", {"path": "/test"})
@@ -659,11 +672,7 @@ class TestAdapterTwoPhase:
         """Bug fix: macOS /private/tmp paths should be preserved."""
         from metatron.mcp.adapter import GenericMCPAdapter
 
-        text = (
-            "Allowed directories:\n"
-            "/private/tmp/project-a\n"
-            "/private/tmp/project-b\n"
-        )
+        text = "Allowed directories:\n/private/tmp/project-a\n/private/tmp/project-b\n"
         dirs = GenericMCPAdapter._parse_directories(text)
         assert dirs == ["/private/tmp/project-a", "/private/tmp/project-b"]
 
@@ -702,7 +711,8 @@ class TestAdapterTwoPhase:
 
         text = "[FILE] bug-report.md\n[FILE] notes.md\n[FILE] image.png"
         files = GenericMCPAdapter._parse_directory_listing(
-            text, "/private/tmp/test-docs",
+            text,
+            "/private/tmp/test-docs",
         )
         assert "/private/tmp/test-docs/bug-report.md" in files
         assert "/private/tmp/test-docs/notes.md" in files
@@ -714,7 +724,8 @@ class TestAdapterTwoPhase:
 
         text = "[FILE] /abs/path/file.py"
         files = GenericMCPAdapter._parse_directory_listing(
-            text, "/some/parent",
+            text,
+            "/some/parent",
         )
         assert files == ["/abs/path/file.py"]
 
@@ -744,7 +755,9 @@ class TestAdapterTwoPhase:
         from metatron.mcp.adapter import GenericMCPAdapter
 
         cfg = MCPServerConfig(
-            name="test", command="echo", get_tool="custom_read",
+            name="test",
+            command="echo",
+            get_tool="custom_read",
         )
         adapter = GenericMCPAdapter(cfg)
         tools = [
@@ -788,18 +801,22 @@ class TestAdapterTwoPhase:
         adapter = GenericMCPAdapter(cfg)
 
         mock_client = AsyncMock()
-        mock_client.list_tools = AsyncMock(return_value=[
-            {"name": "list_directory", "description": "List directory"},
-            {"name": "read_text_file", "description": "Read text file"},
-        ])
+        mock_client.list_tools = AsyncMock(
+            return_value=[
+                {"name": "list_directory", "description": "List directory"},
+                {"name": "read_text_file", "description": "Read text file"},
+            ]
+        )
 
         # list_directory returns file listing (relative names)
-        listing_blocks = [{"type": "text", "text": (
-            "[FILE] src/main.py\n"
-            "[FILE] docs/readme.md\n"
-            "[DIR] build/\n"
-            "[FILE] logo.png\n"
-        )}]
+        listing_blocks = [
+            {
+                "type": "text",
+                "text": (
+                    "[FILE] src/main.py\n[FILE] docs/readme.md\n[DIR] build/\n[FILE] logo.png\n"
+                ),
+            }
+        ]
         file1_blocks = [{"type": "text", "text": "print('hello')"}]
         file2_blocks = [{"type": "text", "text": "# README"}]
 
@@ -840,9 +857,11 @@ class TestAdapterTwoPhase:
         adapter = GenericMCPAdapter(cfg)
 
         mock_client = AsyncMock()
-        mock_client.list_tools = AsyncMock(return_value=[
-            {"name": "create_issue", "description": "Create issue"},
-        ])
+        mock_client.list_tools = AsyncMock(
+            return_value=[
+                {"name": "create_issue", "description": "Create issue"},
+            ]
+        )
 
         with patch("metatron.mcp.adapter.MCPClient") as MockClient:
             MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -861,22 +880,22 @@ class TestAdapterTwoPhase:
         adapter = GenericMCPAdapter(cfg)
 
         mock_client = AsyncMock()
-        mock_client.list_tools = AsyncMock(return_value=[
-            {"name": "list_allowed_directories", "description": "Allowed dirs"},
-            {"name": "list_directory", "description": "List directory"},
-            {"name": "read_text_file", "description": "Read text file"},
-        ])
+        mock_client.list_tools = AsyncMock(
+            return_value=[
+                {"name": "list_allowed_directories", "description": "Allowed dirs"},
+                {"name": "list_directory", "description": "List directory"},
+                {"name": "read_text_file", "description": "Read text file"},
+            ]
+        )
 
         calls_log: list[tuple[str, dict | None]] = []
 
         def call_tool_side_effect(name: str, args: dict | None = None) -> list:
             calls_log.append((name, args))
             if name == "list_allowed_directories":
-                return [{"type": "text", "text":
-                    "Allowed directories:\n/private/tmp/test-docs"}]
+                return [{"type": "text", "text": "Allowed directories:\n/private/tmp/test-docs"}]
             if name == "list_directory":
-                return [{"type": "text", "text":
-                    "[FILE] notes.md\n[FILE] pic.jpg"}]
+                return [{"type": "text", "text": "[FILE] notes.md\n[FILE] pic.jpg"}]
             if name == "read_text_file":
                 return [{"type": "text", "text": "Some notes content"}]
             return []
@@ -909,10 +928,12 @@ class TestAdapterTwoPhase:
         adapter = GenericMCPAdapter(cfg)
 
         mock_client = AsyncMock()
-        mock_client.list_tools = AsyncMock(return_value=[
-            {"name": "list_directory", "description": "List directory"},
-            {"name": "read_text_file", "description": "Read text file"},
-        ])
+        mock_client.list_tools = AsyncMock(
+            return_value=[
+                {"name": "list_directory", "description": "List directory"},
+                {"name": "read_text_file", "description": "Read text file"},
+            ]
+        )
 
         read_count = 0
 
@@ -947,10 +968,12 @@ class TestAdapterTwoPhase:
         adapter = GenericMCPAdapter(cfg)
 
         mock_client = AsyncMock()
-        mock_client.list_tools = AsyncMock(return_value=[
-            {"name": "search_files", "description": "Search files"},
-            {"name": "read_text_file", "description": "Read text file"},
-        ])
+        mock_client.list_tools = AsyncMock(
+            return_value=[
+                {"name": "search_files", "description": "Search files"},
+                {"name": "read_text_file", "description": "Read text file"},
+            ]
+        )
 
         def call_tool_side_effect(name: str, args: dict | None = None) -> list:
             if name == "search_files":
@@ -1021,4 +1044,3 @@ class TestAdapterTwoPhase:
         sdk_result = MagicMock()
         sdk_result.content = []
         assert _extract_text(sdk_result) == ""
-

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -152,11 +152,14 @@ class TestMetatronGet:
 class TestMetatronStore:
     @pytest.mark.asyncio
     async def test_stores_document(self) -> None:
+        from unittest.mock import AsyncMock
+
         mock_result = MagicMock()
         mock_result.errors = []
         mock_result.documents_new = 2
         with patch(
             "metatron.ingestion.pipeline.ingest_documents",
+            new_callable=AsyncMock,
             return_value=mock_result,
         ):
             from metatron.mcp.tools.store import metatron_store
@@ -168,11 +171,14 @@ class TestMetatronStore:
 
     @pytest.mark.asyncio
     async def test_custom_doc_label(self) -> None:
+        from unittest.mock import AsyncMock
+
         mock_result = MagicMock()
         mock_result.errors = []
         mock_result.documents_new = 1
         with patch(
             "metatron.ingestion.pipeline.ingest_documents",
+            new_callable=AsyncMock,
             return_value=mock_result,
         ):
             from metatron.mcp.tools.store import metatron_store

--- a/tests/unit/test_parallel_extraction.py
+++ b/tests/unit/test_parallel_extraction.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from metatron.core.models import Document
 from metatron.ingestion.pipeline import _extract_graphs_parallel
@@ -31,7 +31,9 @@ class TestParallelExtraction:
     @patch("metatron.ingestion.pipeline._write_doc_to_graph")
     @patch("metatron.ingestion.pipeline._write_jira_to_graph")
     def test_calls_graph_writer_for_each_document(
-        self, mock_jira: MagicMock, mock_doc: MagicMock,
+        self,
+        mock_jira: MagicMock,
+        mock_doc: MagicMock,
     ) -> None:
         """3 documents → 3 graph writer calls."""
         queue = [
@@ -50,7 +52,9 @@ class TestParallelExtraction:
     @patch("metatron.ingestion.pipeline._write_doc_to_graph")
     @patch("metatron.ingestion.pipeline._write_jira_to_graph")
     def test_short_non_jira_documents_skipped(
-        self, mock_jira: MagicMock, mock_doc: MagicMock,
+        self,
+        mock_jira: MagicMock,
+        mock_doc: MagicMock,
     ) -> None:
         """Non-Jira documents with content shorter than min_chars are skipped."""
         queue = [
@@ -66,7 +70,9 @@ class TestParallelExtraction:
     @patch("metatron.ingestion.pipeline._write_doc_to_graph")
     @patch("metatron.ingestion.pipeline._write_jira_to_graph")
     def test_error_in_one_does_not_stop_others(
-        self, mock_jira: MagicMock, mock_doc: MagicMock,
+        self,
+        mock_jira: MagicMock,
+        mock_doc: MagicMock,
     ) -> None:
         """One failing document doesn't prevent the rest from succeeding."""
         mock_jira.side_effect = [RuntimeError("LLM timeout"), None]
@@ -81,14 +87,16 @@ class TestParallelExtraction:
         assert result["errors"] == 1
 
     @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
-    @patch("metatron.storage.qdrant.get_hybrid_store")
-    def test_disabled_skips_all_graph_extraction(
-        self, mock_get_store: MagicMock, mock_parallel: MagicMock,
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_disabled_skips_all_graph_extraction(
+        self,
+        mock_get_store: AsyncMock,
+        mock_parallel: MagicMock,
     ) -> None:
         """graph_extraction_enabled=False means no parallel extraction."""
         from metatron.ingestion.pipeline import ingest_documents
 
-        store = MagicMock()
+        store = AsyncMock()
         mock_get_store.return_value = store
 
         doc = _make_doc("J-1", content="Some real content for testing graph extraction")
@@ -99,14 +107,16 @@ class TestParallelExtraction:
             mock_settings.graph_extraction_workers = 4
             mock_settings.graph_extraction_min_chars = 100
 
-            ingest_documents([doc], "WS1", "jira")
+            await ingest_documents([doc], "WS1", "jira")
 
         mock_parallel.assert_not_called()
 
     @patch("metatron.ingestion.pipeline._write_doc_to_graph")
     @patch("metatron.ingestion.pipeline._write_jira_to_graph")
     def test_result_counters(
-        self, mock_jira: MagicMock, mock_doc: MagicMock,
+        self,
+        mock_jira: MagicMock,
+        mock_doc: MagicMock,
     ) -> None:
         """Result dict tracks ok, errors, and skipped correctly."""
         mock_jira.side_effect = [None, ValueError("bad data")]
@@ -126,7 +136,9 @@ class TestParallelExtraction:
 
         with patch(
             "metatron.ingestion.pipeline.ThreadPoolExecutor",
-            wraps=__import__("concurrent.futures", fromlist=["ThreadPoolExecutor"]).ThreadPoolExecutor,
+            wraps=__import__(
+                "concurrent.futures", fromlist=["ThreadPoolExecutor"]
+            ).ThreadPoolExecutor,
         ) as mock_pool_cls:
             _extract_graphs_parallel(queue, max_workers=7, min_chars=50)
             mock_pool_cls.assert_called_once_with(max_workers=7)
@@ -134,7 +146,9 @@ class TestParallelExtraction:
     @patch("metatron.ingestion.pipeline._write_doc_to_graph")
     @patch("metatron.ingestion.pipeline._write_jira_to_graph")
     def test_short_jira_still_creates_node(
-        self, mock_jira: MagicMock, mock_doc: MagicMock,
+        self,
+        mock_jira: MagicMock,
+        mock_doc: MagicMock,
     ) -> None:
         """Short Jira docs still get JiraIssue node (skip_llm_extraction=True)."""
         queue = [
@@ -157,7 +171,9 @@ class TestParallelExtraction:
     @patch("metatron.ingestion.pipeline._write_doc_to_graph")
     @patch("metatron.ingestion.pipeline._write_jira_to_graph")
     def test_short_jira_error_counted(
-        self, mock_jira: MagicMock, mock_doc: MagicMock,
+        self,
+        mock_jira: MagicMock,
+        mock_doc: MagicMock,
     ) -> None:
         """Error in short Jira struct-only write is counted."""
         mock_jira.side_effect = RuntimeError("Memgraph down")


### PR DESCRIPTION
## Summary
Phase 3 of async migration: convert ingestion pipeline to async.

- **`ingest_documents()`** is now `async def` — uses `AsyncQdrantVectorStore` directly
- Sync Memgraph calls wrapped in `asyncio.to_thread()` (graph extraction, hierarchy write)
- Plugin hook antipattern fixed — native `await` instead of `asyncio.run()`
- 4 callers migrated: connections.py, mcp/sync.py, mcp/tools/store.py (direct await), agent/router.py (asyncio.run wrapper)

## Architecture
```
Before: async caller → asyncio.to_thread(ingest_documents) → sync Qdrant
After:  async caller → await ingest_documents() → await AsyncQdrant + to_thread(Memgraph)
```

## MTRNIX-262 Complete
- Phase 1: AsyncQdrantVectorStore ✅
- Phase 2: Async retrieval pipeline ✅
- Phase 3: Async ingestion pipeline ✅ (this PR)

## Test plan
- [x] 1206 tests pass (zero regressions)
- [x] 71 pre-existing failures unchanged