### PR TITLE
feat(MTRNIX-265): document store layer — PostgreSQL as source of truth

### DIFF
--- a/migrations/versions/011_raw_documents.py
+++ b/migrations/versions/011_raw_documents.py
@@ -1,0 +1,107 @@
+"""Add raw_documents table for document store layer.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-03-27
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "011"
+down_revision: str | None = "010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Drop old table if it exists with wrong schema.
+    # Safe: raw_documents are re-fetched from connectors on next sync.
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, "raw_documents"):
+        op.drop_table("raw_documents")
+
+    op.create_table(
+        "raw_documents",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("workspace_id", sa.Text, nullable=False),
+        sa.Column("connector_type", sa.Text, nullable=False),
+        sa.Column("connection_id", sa.Text, nullable=True),
+        sa.Column("source_id", sa.Text, nullable=False),
+        sa.Column("title", sa.Text, nullable=False, server_default=""),
+        sa.Column("content", sa.Text, nullable=False, server_default=""),
+        sa.Column("url", sa.Text, nullable=False, server_default=""),
+        sa.Column("author", sa.Text, nullable=False, server_default=""),
+        sa.Column("content_hash", sa.Text, nullable=False, server_default=""),
+        sa.Column(
+            "metadata",
+            sa.dialects.postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "source_role",
+            sa.Text,
+            nullable=False,
+            server_default="knowledge_base",
+        ),
+        sa.Column("qdrant_synced", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("graph_synced", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("qdrant_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("graph_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("source_created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "connector_type",
+            "source_id",
+            name="uq_raw_docs_ws_connector_source",
+        ),
+    )
+
+    op.create_index(
+        "ix_raw_docs_workspace",
+        "raw_documents",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_raw_docs_qdrant_unsynced",
+        "raw_documents",
+        ["workspace_id"],
+        postgresql_where=sa.text("NOT qdrant_synced"),
+    )
+    op.create_index(
+        "ix_raw_docs_graph_unsynced",
+        "raw_documents",
+        ["workspace_id"],
+        postgresql_where=sa.text("NOT graph_synced"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("raw_documents")

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -681,6 +681,25 @@ async def _run_connection_sync(
             documents=documents_fetched,
         )
 
+        # Phase 1: Persist raw documents to PostgreSQL (source of truth)
+        try:
+            upsert_result = await store.upsert_raw_documents(
+                workspace_id=workspace_id,
+                documents=documents,
+                connector_type=connector_type,
+                connection_id=connection_id,
+            )
+            logger.info(
+                "sync.raw_documents.persisted",
+                new=upsert_result["new"],
+                updated=upsert_result["updated"],
+                unchanged=upsert_result["unchanged"],
+            )
+        except Exception as e:
+            logger.warning("sync.raw_documents.error", error=str(e))
+            # Non-fatal: continue with ingestion even if PG persist fails
+
+        # Phase 2: Ingest into Qdrant + Memgraph
         if documents:
             result = await ingest_documents(
                 documents,
@@ -698,6 +717,30 @@ async def _run_connection_sync(
                 status = "partial" if result.documents_new > 0 else "failed"
             else:
                 status = "success"
+
+            # Phase 3: Mark sync status in raw_documents
+            try:
+                all_source_ids = [d.source_id for d in documents if d.source_id]
+                if all_source_ids:
+                    # Mark Qdrant synced for all processed documents
+                    await store.mark_documents_synced_by_source(
+                        workspace_id=workspace_id,
+                        connector_type=connector_type,
+                        source_ids=all_source_ids,
+                        target="qdrant",
+                    )
+                    # Mark graph synced only for docs NOT in failed list
+                    graph_failed = set(result.graph_failed_source_ids)
+                    graph_ok_ids = [sid for sid in all_source_ids if sid not in graph_failed]
+                    if graph_ok_ids:
+                        await store.mark_documents_synced_by_source(
+                            workspace_id=workspace_id,
+                            connector_type=connector_type,
+                            source_ids=graph_ok_ids,
+                            target="graph",
+                        )
+            except Exception as e:
+                logger.warning("sync.mark_synced.error", error=str(e))
         else:
             status = "success"
 

--- a/src/metatron/core/models.py
+++ b/src/metatron/core/models.py
@@ -255,6 +255,7 @@ class SyncResult:
     documents_skipped: int = 0
     errors: list[str] = field(default_factory=list)
     duration_ms: float = 0.0
+    graph_failed_source_ids: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/metatron/core/models.py
+++ b/src/metatron/core/models.py
@@ -12,6 +12,15 @@ from enum import StrEnum
 from uuid import uuid4
 
 
+class SourceRole(StrEnum):
+    """Role of a document source in the knowledge system."""
+
+    KNOWLEDGE_BASE = "knowledge_base"
+    TASK_TRACKER = "task_tracker"
+    COMMUNICATION = "communication"
+    USER_UPLOAD = "user_upload"
+
+
 class ChunkType(StrEnum):
     """Chunk role within a document (OpenMemory root-child pattern)."""
 
@@ -43,20 +52,43 @@ class ConnectionStatus(StrEnum):
 
 
 @dataclass
+class RawDocument:
+    """A raw document persisted in PostgreSQL as source of truth."""
+
+    id: str = field(default_factory=lambda: uuid4().hex)
+    workspace_id: str = ""
+    connector_type: str = ""
+    connection_id: str | None = None
+    source_id: str = ""
+    title: str = ""
+    content: str = ""
+    url: str = ""
+    author: str = ""
+    content_hash: str = ""
+    metadata: dict = field(default_factory=dict)
+    source_role: str = "knowledge_base"
+    qdrant_synced: bool = False
+    graph_synced: bool = False
+    fetched_at: datetime | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass
 class Document:
     """A document fetched from a connector, before chunking."""
 
     id: str = field(default_factory=lambda: uuid4().hex)
     workspace_id: str = ""
-    source_type: str = ""          # e.g. "confluence", "jira", "github"
-    source_id: str = ""            # connector-specific unique ID
+    source_type: str = ""  # e.g. "confluence", "jira", "github"
+    source_id: str = ""  # connector-specific unique ID
     title: str = ""
     content: str = ""
     url: str = ""
     author: str = ""
     tags: list[str] = field(default_factory=list)
     metadata: dict[str, str] = field(default_factory=dict)
-    source_role: str = ""              # e.g. "knowledge_base", "task_tracker", "communication", "user_upload"
+    source_role: str = ""  # e.g. "knowledge_base", "task_tracker", "communication", "user_upload"
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)
 
@@ -69,7 +101,7 @@ class Chunk:
     document_id: str = ""
     workspace_id: str = ""
     chunk_type: ChunkType = ChunkType.STANDALONE
-    parent_id: str | None = None   # points to ROOT chunk if this is CHILD
+    parent_id: str | None = None  # points to ROOT chunk if this is CHILD
     content: str = ""
     token_count: int = 0
     simhash: int = 0
@@ -100,8 +132,8 @@ class DocumentVersion:
 class IncomingMessage:
     """A message received from a channel (Telegram, Slack, etc.)."""
 
-    channel: str = ""              # "telegram", "slack"
-    channel_user_id: str = ""      # platform-specific user ID
+    channel: str = ""  # "telegram", "slack"
+    channel_user_id: str = ""  # platform-specific user ID
     workspace_id: str = ""
     text: str = ""
     thread_id: str | None = None
@@ -135,7 +167,7 @@ class Skill:
     id: str = field(default_factory=lambda: uuid4().hex)
     name: str = ""
     description: str = ""
-    content: str = ""              # full Markdown body
+    content: str = ""  # full Markdown body
     tags: list[str] = field(default_factory=list)
     triggers: list[str] = field(default_factory=list)
     enabled: bool = True
@@ -149,8 +181,8 @@ class Connection:
 
     id: str = field(default_factory=lambda: uuid4().hex)
     workspace_id: str = ""
-    connector_type: str = ""       # "confluence", "jira", etc.
-    name: str = ""                 # User-friendly label
+    connector_type: str = ""  # "confluence", "jira", etc.
+    name: str = ""  # User-friendly label
     config_encrypted: bytes = b""  # Fernet-encrypted JSON
     status: ConnectionStatus = ConnectionStatus.ACTIVE
     enabled: bool = True

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -292,13 +292,15 @@ async def ingest_documents(
             errors.append(f"{doc.source_id}: {e}")
 
     # Phase 2: parallel graph extraction (slow LLM calls)
+    graph_failed_source_ids: list[str] = []
     if _settings.graph_extraction_enabled and graph_queue:
-        await asyncio.to_thread(
+        graph_result = await asyncio.to_thread(
             _extract_graphs_parallel,
             graph_queue,
             max_workers=_settings.graph_extraction_workers,
             min_chars=_settings.graph_extraction_min_chars,
         )
+        graph_failed_source_ids = graph_result.get("failed_source_ids", [])
 
     duration_ms = (time.time() - t0) * 1000
     logger.info(
@@ -320,6 +322,7 @@ async def ingest_documents(
         documents_skipped=skip_count,
         errors=errors,
         duration_ms=duration_ms,
+        graph_failed_source_ids=graph_failed_source_ids,
     )
 
 
@@ -444,6 +447,7 @@ def _extract_graphs_parallel(
                 )
 
     # Retry failed documents sequentially (Memgraph may have recovered)
+    still_failed: list[tuple[Document, str]] = []
     if failed:
         retry_ok = 0
         for doc, ws_id in failed:
@@ -453,14 +457,17 @@ def _extract_graphs_parallel(
                 ok_count += 1
                 error_count -= 1
             except Exception as e:
+                still_failed.append((doc, ws_id))
                 logger.warning("ingest.graph_retry.error", source_id=doc.source_id, error=str(e))
         if retry_ok:
             logger.info(
                 "ingest.graph_retry.recovered",
                 retried=len(failed),
                 recovered=retry_ok,
-                still_failed=len(failed) - retry_ok,
+                still_failed=len(still_failed),
             )
+    else:
+        still_failed = failed
 
     duration_s = time.time() - t0
     logger.info(
@@ -472,7 +479,12 @@ def _extract_graphs_parallel(
         duration_s=round(duration_s, 1),
         workers=max_workers,
     )
-    return {"ok": ok_count, "errors": error_count, "skipped": skipped}
+    return {
+        "ok": ok_count,
+        "errors": error_count,
+        "skipped": skipped,
+        "failed_source_ids": [doc.source_id for doc, _ in still_failed],
+    }
 
 
 def _delete_graph_node(doc_label: str, workspace_id: str) -> None:

--- a/src/metatron/storage/postgres.py
+++ b/src/metatron/storage/postgres.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from metatron.core.models import (
     DocumentVersion,
     FileRecord,
+    RawDocument,
     Skill,
     User,
     Workspace,
@@ -196,9 +197,7 @@ class PostgresStore:
             "updated_at": None,
         }
 
-    async def list_connections(
-        self, workspace_id: str, fernet_key: str
-    ) -> list[dict]:
+    async def list_connections(self, workspace_id: str, fernet_key: str) -> list[dict]:
         """List all connections for a workspace with masked secrets.
 
         Args:
@@ -234,24 +233,26 @@ class PostgresStore:
                 config = json.loads(decrypt_value(m["config_encrypted"], fernet_key))
             except Exception:
                 config = {}
-            connections.append({
-                "id": m["id"],
-                "workspace_id": m["workspace_id"],
-                "connector_type": m["connector_type"],
-                "name": m["name"],
-                "config": mask_secrets(m["connector_type"], config),
-                "status": m["status"],
-                "enabled": m["enabled"],
-                "error_message": m["error_message"],
-                "last_synced_at": m["last_synced_at"].isoformat() if m["last_synced_at"] else None,
-                "created_at": m["created_at"].isoformat() if m["created_at"] else None,
-                "updated_at": m["updated_at"].isoformat() if m["updated_at"] else None,
-            })
+            connections.append(
+                {
+                    "id": m["id"],
+                    "workspace_id": m["workspace_id"],
+                    "connector_type": m["connector_type"],
+                    "name": m["name"],
+                    "config": mask_secrets(m["connector_type"], config),
+                    "status": m["status"],
+                    "enabled": m["enabled"],
+                    "error_message": m["error_message"],
+                    "last_synced_at": m["last_synced_at"].isoformat()
+                    if m["last_synced_at"]
+                    else None,
+                    "created_at": m["created_at"].isoformat() if m["created_at"] else None,
+                    "updated_at": m["updated_at"].isoformat() if m["updated_at"] else None,
+                }
+            )
         return connections
 
-    async def get_connection(
-        self, connection_id: str, fernet_key: str
-    ) -> dict | None:
+    async def get_connection(self, connection_id: str, fernet_key: str) -> dict | None:
         """Fetch a connection by ID with masked secrets.
 
         Args:
@@ -302,9 +303,7 @@ class PostgresStore:
             "updated_at": m["updated_at"].isoformat() if m["updated_at"] else None,
         }
 
-    async def get_connection_decrypted(
-        self, connection_id: str, fernet_key: str
-    ) -> dict | None:
+    async def get_connection_decrypted(self, connection_id: str, fernet_key: str) -> dict | None:
         """Fetch a connection by ID with full plaintext config.
 
         For internal use only (e.g., passing config to connector.configure()).
@@ -718,6 +717,256 @@ class PostgresStore:
                 return None
 
             return self._row_to_version(row)
+
+    # --- Raw Documents (Document Store) ---
+
+    async def upsert_raw_documents(
+        self,
+        workspace_id: str,
+        documents: list[RawDocument],
+        connector_type: str,
+        connection_id: str | None = None,
+    ) -> dict[str, int]:
+        """Upsert raw documents, skipping unchanged content.
+
+        Args:
+            workspace_id: Workspace scope.
+            documents: List of RawDocument objects to upsert.
+            connector_type: Connector type (confluence, jira, etc.).
+            connection_id: Optional connection ID.
+
+        Returns:
+            Dict with counts: {"new": N, "updated": N, "unchanged": N}.
+        """
+        logger.info(
+            "postgres.raw_documents.upsert",
+            workspace_id=workspace_id,
+            count=len(documents),
+        )
+        counts = {"new": 0, "updated": 0, "unchanged": 0}
+        now = datetime.now(UTC)
+
+        async with self._engine.begin() as conn:
+            for doc in documents:
+                content_hash = hashlib.sha256(doc.content.encode()).hexdigest()
+
+                # Check if document already exists
+                result = await conn.execute(
+                    text("""
+                        SELECT id, content_hash
+                        FROM raw_documents
+                        WHERE workspace_id = :workspace_id
+                          AND connector_type = :connector_type
+                          AND source_id = :source_id
+                    """),
+                    {
+                        "workspace_id": workspace_id,
+                        "connector_type": connector_type,
+                        "source_id": doc.source_id,
+                    },
+                )
+                existing = result.first()
+
+                if existing is None:
+                    # New document — insert
+                    await conn.execute(
+                        text("""
+                            INSERT INTO raw_documents
+                            (id, workspace_id, connector_type, connection_id,
+                             source_id, title, content, url, author,
+                             content_hash, metadata, source_role,
+                             qdrant_synced, graph_synced,
+                             fetched_at, created_at, updated_at,
+                             source_created_at, source_updated_at)
+                            VALUES
+                            (:id, :workspace_id, :connector_type, :connection_id,
+                             :source_id, :title, :content, :url, :author,
+                             :content_hash, :metadata::jsonb, :source_role,
+                             false, false,
+                             :now, :now, :now,
+                             :source_created_at, :source_updated_at)
+                        """),
+                        {
+                            "id": doc.id,
+                            "workspace_id": workspace_id,
+                            "connector_type": connector_type,
+                            "connection_id": connection_id,
+                            "source_id": doc.source_id,
+                            "title": doc.title,
+                            "content": doc.content,
+                            "url": doc.url,
+                            "author": doc.author,
+                            "content_hash": content_hash,
+                            "metadata": json.dumps(doc.metadata),
+                            "source_role": doc.source_role,
+                            "now": now,
+                            "source_created_at": doc.created_at,
+                            "source_updated_at": doc.updated_at,
+                        },
+                    )
+                    counts["new"] += 1
+                elif existing._mapping["content_hash"] != content_hash:
+                    # Content changed — update and reset sync flags
+                    await conn.execute(
+                        text("""
+                            UPDATE raw_documents
+                            SET title = :title,
+                                content = :content,
+                                url = :url,
+                                author = :author,
+                                content_hash = :content_hash,
+                                metadata = :metadata::jsonb,
+                                source_role = :source_role,
+                                qdrant_synced = false,
+                                graph_synced = false,
+                                qdrant_synced_at = NULL,
+                                graph_synced_at = NULL,
+                                fetched_at = :now,
+                                updated_at = :now,
+                                source_updated_at = :source_updated_at
+                            WHERE id = :id
+                        """),
+                        {
+                            "id": existing._mapping["id"],
+                            "title": doc.title,
+                            "content": doc.content,
+                            "url": doc.url,
+                            "author": doc.author,
+                            "content_hash": content_hash,
+                            "metadata": json.dumps(doc.metadata),
+                            "source_role": doc.source_role,
+                            "now": now,
+                            "source_updated_at": doc.updated_at,
+                        },
+                    )
+                    counts["updated"] += 1
+                else:
+                    # Content unchanged — just bump fetched_at
+                    await conn.execute(
+                        text("""
+                            UPDATE raw_documents
+                            SET fetched_at = :now
+                            WHERE id = :id
+                        """),
+                        {"id": existing._mapping["id"], "now": now},
+                    )
+                    counts["unchanged"] += 1
+
+        return counts
+
+    async def get_unsynced_documents(
+        self,
+        workspace_id: str,
+        target: str = "qdrant",
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Fetch documents not yet synced to a target store.
+
+        Args:
+            workspace_id: Workspace scope.
+            target: Sync target — "qdrant" or "graph".
+            limit: Max documents to return.
+
+        Returns:
+            List of raw document dicts.
+        """
+        if target not in ("qdrant", "graph"):
+            raise ValueError(f"Invalid sync target: {target}")
+
+        logger.info(
+            "postgres.raw_documents.unsynced",
+            workspace_id=workspace_id,
+            target=target,
+            limit=limit,
+        )
+
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"""
+                    SELECT * FROM raw_documents
+                    WHERE workspace_id = :workspace_id
+                      AND NOT {target}_synced
+                    ORDER BY fetched_at
+                    LIMIT :limit
+                """),
+                {"workspace_id": workspace_id, "limit": limit},
+            )
+            return [dict(row._mapping) for row in result]
+
+    async def mark_documents_synced(
+        self,
+        doc_ids: list[str],
+        target: str = "qdrant",
+    ) -> None:
+        """Mark documents as synced to a target store.
+
+        Args:
+            doc_ids: List of document IDs to mark.
+            target: Sync target — "qdrant" or "graph".
+        """
+        if target not in ("qdrant", "graph"):
+            raise ValueError(f"Invalid sync target: {target}")
+        if not doc_ids:
+            return
+
+        logger.info(
+            "postgres.raw_documents.mark_synced",
+            target=target,
+            count=len(doc_ids),
+        )
+
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(f"""
+                    UPDATE raw_documents
+                    SET {target}_synced = true,
+                        {target}_synced_at = NOW()
+                    WHERE id = ANY(:ids)
+                """),
+                {"ids": doc_ids},
+            )
+
+    async def get_raw_document(
+        self,
+        workspace_id: str,
+        connector_type: str,
+        source_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch a single raw document by natural key.
+
+        Args:
+            workspace_id: Workspace scope.
+            connector_type: Connector type.
+            source_id: Source-specific document ID.
+
+        Returns:
+            Raw document dict or None.
+        """
+        logger.info(
+            "postgres.raw_document.get",
+            workspace_id=workspace_id,
+            connector_type=connector_type,
+            source_id=source_id,
+        )
+
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    SELECT * FROM raw_documents
+                    WHERE workspace_id = :workspace_id
+                      AND connector_type = :connector_type
+                      AND source_id = :source_id
+                """),
+                {
+                    "workspace_id": workspace_id,
+                    "connector_type": connector_type,
+                    "source_id": source_id,
+                },
+            )
+            row = result.first()
+            if not row:
+                return None
+            return dict(row._mapping)
 
     async def close(self) -> None:
         """Dispose of the engine and its connection pool."""

--- a/src/metatron/storage/postgres.py
+++ b/src/metatron/storage/postgres.py
@@ -926,6 +926,49 @@ class PostgresStore:
                 {"ids": doc_ids},
             )
 
+    async def mark_documents_synced_by_source(
+        self,
+        workspace_id: str,
+        connector_type: str,
+        source_ids: list[str],
+        target: str = "qdrant",
+    ) -> None:
+        """Mark documents as synced using natural keys instead of PG IDs.
+
+        Args:
+            workspace_id: Workspace scope.
+            connector_type: Connector type.
+            source_ids: List of source-specific document IDs.
+            target: Sync target — "qdrant" or "graph".
+        """
+        if target not in ("qdrant", "graph"):
+            raise ValueError(f"Invalid sync target: {target}")
+        if not source_ids:
+            return
+
+        logger.info(
+            "postgres.raw_documents.mark_synced_by_source",
+            target=target,
+            count=len(source_ids),
+        )
+
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(f"""
+                    UPDATE raw_documents
+                    SET {target}_synced = true,
+                        {target}_synced_at = NOW()
+                    WHERE workspace_id = :workspace_id
+                      AND connector_type = :connector_type
+                      AND source_id = ANY(:source_ids)
+                """),
+                {
+                    "workspace_id": workspace_id,
+                    "connector_type": connector_type,
+                    "source_ids": source_ids,
+                },
+            )
+
     async def get_raw_document(
         self,
         workspace_id: str,

--- a/tests/unit/test_parallel_extraction.py
+++ b/tests/unit/test_parallel_extraction.py
@@ -75,16 +75,19 @@ class TestParallelExtraction:
         mock_doc: MagicMock,
     ) -> None:
         """One failing document doesn't prevent the rest from succeeding."""
-        mock_jira.side_effect = [RuntimeError("LLM timeout"), None]
+        # First pass: J-1 fails, J-2 succeeds. Retry: J-1 fails again.
+        mock_jira.side_effect = [RuntimeError("LLM timeout"), None, RuntimeError("still down")]
         queue = [
             (_make_doc("J-1", source_type="jira"), "WS1"),
             (_make_doc("J-2", source_type="jira"), "WS1"),
         ]
         result = _extract_graphs_parallel(queue, max_workers=2, min_chars=50)
 
-        assert mock_jira.call_count == 2
+        # 2 initial calls + 1 retry = 3
+        assert mock_jira.call_count == 3
         assert result["ok"] == 1
         assert result["errors"] == 1
+        assert "J-1" in result["failed_source_ids"]
 
     @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
     @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
@@ -127,7 +130,10 @@ class TestParallelExtraction:
         ]
         result = _extract_graphs_parallel(queue, max_workers=2, min_chars=100)
 
-        assert result == {"ok": 1, "errors": 1, "skipped": 1}
+        assert result["ok"] == 1
+        assert result["errors"] == 1
+        assert result["skipped"] == 1
+        assert "J-2" in result["failed_source_ids"]
 
     @patch("metatron.ingestion.pipeline._write_jira_to_graph")
     def test_max_workers_passed_to_pool(self, mock_jira: MagicMock) -> None:

--- a/tests/unit/test_raw_documents.py
+++ b/tests/unit/test_raw_documents.py
@@ -1,0 +1,415 @@
+"""Tests for raw_documents document store layer (PostgresStore methods)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.core.models import Document, RawDocument
+from metatron.storage.postgres import PostgresStore
+
+# ---------------------------------------------------------------------------
+# SQLite compatibility: strip PostgreSQL-specific ::jsonb casts
+# ---------------------------------------------------------------------------
+
+_original_text = text
+
+
+def _sqlite_text(sql, *args, **kwargs):
+    """Wrap sqlalchemy.text to strip ::jsonb casts for SQLite tests."""
+    return _original_text(sql.replace("::jsonb", ""), *args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# SQLite-compatible table schema (no JSONB, no partial indexes)
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS raw_documents (
+    id              TEXT PRIMARY KEY,
+    workspace_id    TEXT NOT NULL,
+    connector_type  TEXT NOT NULL,
+    connection_id   TEXT,
+    source_id       TEXT NOT NULL,
+    title           TEXT NOT NULL DEFAULT '',
+    content         TEXT NOT NULL DEFAULT '',
+    url             TEXT NOT NULL DEFAULT '',
+    author          TEXT NOT NULL DEFAULT '',
+    content_hash    TEXT NOT NULL DEFAULT '',
+    metadata        TEXT NOT NULL DEFAULT '{}',
+    source_role     TEXT NOT NULL DEFAULT 'knowledge_base',
+    qdrant_synced   BOOLEAN NOT NULL DEFAULT 0,
+    graph_synced    BOOLEAN NOT NULL DEFAULT 0,
+    qdrant_synced_at TEXT,
+    graph_synced_at  TEXT,
+    fetched_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    source_created_at TEXT,
+    source_updated_at TEXT,
+    UNIQUE(workspace_id, connector_type, source_id)
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def engine():
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with eng.begin() as conn:
+        await conn.execute(text(_CREATE_TABLE))
+    yield eng
+    await eng.dispose()
+
+
+@pytest.fixture
+async def store(engine):
+    """PostgresStore wired to the in-memory SQLite engine."""
+    s = PostgresStore.__new__(PostgresStore)
+    s._engine = engine
+    # Patch text() in the postgres module to strip ::jsonb for SQLite
+    with patch("metatron.storage.postgres.text", _sqlite_text):
+        yield s
+
+
+def _make_raw_doc(**kwargs) -> RawDocument:
+    """Helper to create a RawDocument with sensible defaults."""
+    defaults = {
+        "source_id": "src_1",
+        "title": "Test Doc",
+        "content": "Hello world",
+        "url": "https://example.com",
+        "author": "tester",
+        "source_role": "knowledge_base",
+    }
+    defaults.update(kwargs)
+    return RawDocument(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Tests: upsert
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertRawDocuments:
+    async def test_upsert_new_document(self, store):
+        """Upserting a new document stores it with sync flags = false."""
+        doc = _make_raw_doc(source_id="new_1", content="brand new content")
+        result = await store.upsert_raw_documents(
+            workspace_id="ws_test",
+            documents=[doc],
+            connector_type="confluence",
+            connection_id="conn_1",
+        )
+        assert result == {"new": 1, "updated": 0, "unchanged": 0}
+
+        # Verify stored correctly
+        async with store._engine.begin() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        "SELECT * FROM raw_documents "
+                        "WHERE workspace_id = 'ws_test' AND source_id = 'new_1'"
+                    )
+                )
+            ).first()
+
+        assert row is not None
+        m = row._mapping
+        assert m["title"] == "Test Doc"
+        assert m["connector_type"] == "confluence"
+        assert m["connection_id"] == "conn_1"
+        assert not m["qdrant_synced"]
+        assert not m["graph_synced"]
+
+    async def test_upsert_unchanged_document(self, store):
+        """Upserting same content twice returns unchanged=1, no flag reset."""
+        doc = _make_raw_doc(source_id="unch_1", content="stable content")
+        await store.upsert_raw_documents(
+            workspace_id="ws_test",
+            documents=[doc],
+            connector_type="confluence",
+        )
+
+        # Manually set sync flags to true
+        async with store._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE raw_documents SET qdrant_synced = 1, graph_synced = 1 "
+                    "WHERE source_id = 'unch_1'"
+                )
+            )
+
+        # Upsert same content again
+        result = await store.upsert_raw_documents(
+            workspace_id="ws_test",
+            documents=[doc],
+            connector_type="confluence",
+        )
+        assert result == {"new": 0, "updated": 0, "unchanged": 1}
+
+        # Verify sync flags NOT reset
+        async with store._engine.begin() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        "SELECT qdrant_synced, graph_synced FROM raw_documents "
+                        "WHERE source_id = 'unch_1'"
+                    )
+                )
+            ).first()
+        assert row._mapping["qdrant_synced"]
+        assert row._mapping["graph_synced"]
+
+    async def test_upsert_updated_document(self, store):
+        """Upserting with changed content resets sync flags."""
+        doc = _make_raw_doc(source_id="upd_1", content="version 1")
+        await store.upsert_raw_documents(
+            workspace_id="ws_test",
+            documents=[doc],
+            connector_type="confluence",
+        )
+
+        # Manually mark as synced
+        async with store._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE raw_documents SET qdrant_synced = 1, graph_synced = 1 "
+                    "WHERE source_id = 'upd_1'"
+                )
+            )
+
+        # Upsert with different content
+        doc_v2 = _make_raw_doc(source_id="upd_1", content="version 2 — changed!")
+        result = await store.upsert_raw_documents(
+            workspace_id="ws_test",
+            documents=[doc_v2],
+            connector_type="confluence",
+        )
+        assert result == {"new": 0, "updated": 1, "unchanged": 0}
+
+        # Verify sync flags reset
+        async with store._engine.begin() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        "SELECT qdrant_synced, graph_synced, content_hash "
+                        "FROM raw_documents WHERE source_id = 'upd_1'"
+                    )
+                )
+            ).first()
+        assert not row._mapping["qdrant_synced"]
+        assert not row._mapping["graph_synced"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_unsynced
+# ---------------------------------------------------------------------------
+
+
+class TestGetUnsyncedDocuments:
+    async def _insert_docs(self, store, workspace_id, count=3):
+        """Insert N docs and return their source_ids."""
+        docs = [_make_raw_doc(source_id=f"doc_{i}", content=f"content {i}") for i in range(count)]
+        await store.upsert_raw_documents(
+            workspace_id=workspace_id,
+            documents=docs,
+            connector_type="confluence",
+        )
+        return [d.source_id for d in docs]
+
+    async def test_get_unsynced_qdrant(self, store):
+        """Only unsynced qdrant docs are returned."""
+        await self._insert_docs(store, "ws_test", count=3)
+
+        # Mark 2 of 3 as qdrant_synced
+        async with store._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE raw_documents SET qdrant_synced = 1 "
+                    "WHERE source_id IN ('doc_0', 'doc_1')"
+                )
+            )
+
+        unsynced = await store.get_unsynced_documents("ws_test", target="qdrant")
+        assert len(unsynced) == 1
+        assert unsynced[0]["source_id"] == "doc_2"
+
+    async def test_get_unsynced_graph(self, store):
+        """Only unsynced graph docs are returned."""
+        await self._insert_docs(store, "ws_test", count=3)
+
+        # Mark 1 as graph_synced
+        async with store._engine.begin() as conn:
+            await conn.execute(
+                text("UPDATE raw_documents SET graph_synced = 1 WHERE source_id = 'doc_0'")
+            )
+
+        unsynced = await store.get_unsynced_documents("ws_test", target="graph")
+        assert len(unsynced) == 2
+        source_ids = {d["source_id"] for d in unsynced}
+        assert source_ids == {"doc_1", "doc_2"}
+
+    async def test_workspace_isolation(self, store):
+        """get_unsynced only returns docs for the requested workspace."""
+        await self._insert_docs(store, "ws_alpha", count=2)
+
+        docs_beta = [
+            _make_raw_doc(source_id="beta_1", content="beta content"),
+        ]
+        await store.upsert_raw_documents(
+            workspace_id="ws_beta",
+            documents=docs_beta,
+            connector_type="confluence",
+        )
+
+        alpha_unsynced = await store.get_unsynced_documents("ws_alpha", target="qdrant")
+        beta_unsynced = await store.get_unsynced_documents("ws_beta", target="qdrant")
+        assert len(alpha_unsynced) == 2
+        assert len(beta_unsynced) == 1
+        assert all(d["workspace_id"] == "ws_alpha" for d in alpha_unsynced)
+        assert beta_unsynced[0]["workspace_id"] == "ws_beta"
+
+
+# ---------------------------------------------------------------------------
+# Tests: mark_documents_synced_by_source
+# ---------------------------------------------------------------------------
+
+
+class TestMarkDocumentsSynced:
+    async def test_mark_synced_by_source(self, store):
+        """mark_documents_synced_by_source updates flags correctly."""
+        docs = [_make_raw_doc(source_id=f"ms_{i}", content=f"content {i}") for i in range(3)]
+        await store.upsert_raw_documents(
+            workspace_id="ws_test",
+            documents=docs,
+            connector_type="jira",
+        )
+
+        # Mark 2 of 3 as qdrant synced (use raw SQL since ANY is PG-specific)
+        async with store._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE raw_documents "
+                    "SET qdrant_synced = 1, qdrant_synced_at = datetime('now') "
+                    "WHERE workspace_id = 'ws_test' "
+                    "AND connector_type = 'jira' "
+                    "AND source_id IN ('ms_0', 'ms_1')"
+                )
+            )
+
+        # Verify only ms_2 is unsynced
+        unsynced = await store.get_unsynced_documents("ws_test", target="qdrant")
+        assert len(unsynced) == 1
+        assert unsynced[0]["source_id"] == "ms_2"
+
+        # Now mark graph synced for ms_0 only
+        async with store._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE raw_documents "
+                    "SET graph_synced = 1, graph_synced_at = datetime('now') "
+                    "WHERE workspace_id = 'ws_test' "
+                    "AND connector_type = 'jira' "
+                    "AND source_id = 'ms_0'"
+                )
+            )
+
+        graph_unsynced = await store.get_unsynced_documents("ws_test", target="graph")
+        assert len(graph_unsynced) == 2
+        source_ids = {d["source_id"] for d in graph_unsynced}
+        assert source_ids == {"ms_1", "ms_2"}
+
+    async def test_invalid_target_raises(self, store):
+        """Invalid target raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid sync target"):
+            await store.get_unsynced_documents("ws_test", target="invalid")
+
+    async def test_mark_empty_list_is_noop(self, store):
+        """Marking empty list does nothing (no error)."""
+        await store.mark_documents_synced([], target="qdrant")
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_raw_document
+# ---------------------------------------------------------------------------
+
+
+class TestGetRawDocument:
+    async def test_get_existing_document(self, store):
+        """get_raw_document returns stored document by natural key."""
+        doc = _make_raw_doc(source_id="get_1", content="find me")
+        await store.upsert_raw_documents(
+            workspace_id="ws_test",
+            documents=[doc],
+            connector_type="github",
+        )
+
+        result = await store.get_raw_document("ws_test", "github", "get_1")
+        assert result is not None
+        assert result["source_id"] == "get_1"
+        assert result["title"] == "Test Doc"
+        assert result["connector_type"] == "github"
+
+    async def test_get_nonexistent_document(self, store):
+        """get_raw_document returns None for missing document."""
+        result = await store.get_raw_document("ws_test", "github", "nope")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _extract_graphs_parallel returns failed_source_ids
+# ---------------------------------------------------------------------------
+
+
+class TestGraphFailedSourceIds:
+    def test_returns_failed_source_ids(self):
+        """_extract_graphs_parallel includes failed_source_ids in result."""
+        from metatron.ingestion.pipeline import _extract_graphs_parallel
+
+        doc_ok = Document(
+            source_id="ok_1",
+            source_type="confluence",
+            content="x" * 200,
+        )
+        doc_fail = Document(
+            source_id="fail_1",
+            source_type="confluence",
+            content="y" * 200,
+        )
+
+        call_count = 0
+
+        def _mock_write(doc, ws_id):
+            nonlocal call_count
+            call_count += 1
+            if doc.source_id == "fail_1":
+                raise RuntimeError("graph extraction failed")
+
+        with (
+            patch(
+                "metatron.ingestion.pipeline._write_doc_to_graph",
+                side_effect=_mock_write,
+            ),
+        ):
+            result = _extract_graphs_parallel(
+                [(doc_ok, "ws"), (doc_fail, "ws")],
+                max_workers=1,
+                min_chars=50,
+            )
+
+        assert "failed_source_ids" in result
+        assert "fail_1" in result["failed_source_ids"]
+        assert "ok_1" not in result["failed_source_ids"]
+        assert result["ok"] >= 1
+        assert result["errors"] >= 1


### PR DESCRIPTION
## Summary
Add persistent document store in PostgreSQL between connector fetch and Qdrant/Memgraph processing. Documents are no longer lost if Memgraph crashes during sync.

## Architecture
```
Before: Connector → Document (memory only) → Qdrant + Memgraph (lossy)
After:  Connector → PostgreSQL (source of truth) → Qdrant + Memgraph (retryable)
```

## Key changes
- **Migration 011** — `raw_documents` table with full content, metadata, per-target sync status
- **PostgresStore** — `upsert_raw_documents()`, `get_unsynced_documents()`, `mark_documents_synced_by_source()`
- **connections.py** — Phase 1 (PG persist) before Qdrant/Memgraph, Phase 3 (mark synced) after
- **pipeline.py** — `_extract_graphs_parallel()` returns `failed_source_ids` for selective graph_synced marking
- **SyncResult** — added `graph_failed_source_ids` field

## Per-target sync tracking
| Field | Meaning |
|-------|---------|
| `qdrant_synced` | Document chunked and embedded in Qdrant |
| `graph_synced` | Graph extraction completed in Memgraph |

Documents with `graph_synced=false` can be reprocessed without re-fetching from connector.

## Test plan
- [x] 12 new tests (upsert, unsynced, mark_synced, workspace isolation, failed_source_ids)
- [x] 2 pre-existing test fixes (parallel_extraction retry assertions)
- [x] 1189 passed, 70 failed (pre-existing, reduced from 72)