### PR TITLE
feat(MTRNIX-266): decouple graph extraction from sync — process from PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev test lint migrate docker-up docker-down clean test-installer verify-checksum update-checksum prepare-release eval eval-all eval-save eval-compare eval-history grid-search graph-rebuild graph-rebuild-dry
+.PHONY: setup dev test lint migrate docker-up docker-down clean test-installer verify-checksum update-checksum prepare-release eval eval-all eval-save eval-compare eval-history grid-search graph-rebuild graph-rebuild-dry graph-process
 
 setup:
 	python -m venv .venv
@@ -78,6 +78,9 @@ graph-rebuild:
 
 graph-rebuild-dry:
 	.venv/bin/python scripts/graph_rebuild.py --workspace $(or $(WORKSPACE),MTRNIX) --dry-run
+
+graph-process:
+	.venv/bin/python scripts/graph_process.py --workspace $(or $(WORKSPACE),MTRNIX)
 
 # ============================================================================
 # Installer Distribution Targets

--- a/scripts/graph_process.py
+++ b/scripts/graph_process.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Process unsynced documents for graph extraction from PostgreSQL."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+sys.path.insert(0, "src")
+
+from metatron.core.config import Settings
+from metatron.ingestion.pipeline import process_unsynced_graphs
+from metatron.storage.postgres import PostgresStore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Process unsynced documents for graph extraction")
+    parser.add_argument("--workspace", default="MTRNIX", help="Workspace ID (default: MTRNIX)")
+    parser.add_argument("--batch-size", type=int, default=50, help="Batch size (default: 50)")
+    args = parser.parse_args()
+
+    s = Settings()
+    store = PostgresStore(s.postgres_dsn)
+    result = asyncio.run(process_unsynced_graphs(args.workspace, store, args.batch_size))
+    print(
+        f"Graph processing: {result['ok']} ok, "
+        f"{result['errors']} errors, "
+        f"{result['skipped']} skipped"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/graph_rebuild.py
+++ b/scripts/graph_rebuild.py
@@ -1,154 +1,106 @@
 #!/usr/bin/env python3
-"""Rebuild Memgraph knowledge graph from Qdrant stored documents.
+"""Rebuild Memgraph knowledge graph from PostgreSQL raw_documents.
 
-Scrolls all unique documents from Qdrant, reconstructs minimal Document
-objects from payload metadata, and replays graph extraction. Useful after
+Reads documents from raw_documents table (source of truth), reconstructs
+minimal Document objects, and replays graph extraction. Useful after
 Memgraph data loss or cleanup.
 
 Usage:
     python scripts/graph_rebuild.py --workspace MTRNIX
     python scripts/graph_rebuild.py --workspace MTRNIX --dry-run
     python scripts/graph_rebuild.py --workspace MTRNIX --source-type jira
+    python scripts/graph_rebuild.py --workspace MTRNIX --force
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 import time
 
 import structlog
+from sqlalchemy import text as sa_text
 
 sys.path.insert(0, "src")
 
 from metatron.core.models import Document
 from metatron.ingestion.pipeline import _extract_graphs_parallel
-from metatron.storage.qdrant import get_hybrid_store
+from metatron.storage.pg_connection import get_session
 
 logger = structlog.get_logger(__name__)
 
 
-def _scroll_unique_documents(
+def _query_documents(
     workspace_id: str,
     source_type: str | None = None,
+    force: bool = False,
 ) -> list[dict]:
-    """Scroll Qdrant and collect one representative chunk per unique doc_label."""
-    store = get_hybrid_store(workspace_id)
-    seen_labels: set[str] = set()
-    documents: list[dict] = []
-    offset = None
+    """Query raw_documents from PostgreSQL for graph rebuild."""
+    with get_session() as session:
+        query = """
+            SELECT * FROM raw_documents
+            WHERE workspace_id = :ws AND (NOT graph_synced OR :force)
+            ORDER BY fetched_at
+        """
+        params: dict = {"ws": workspace_id, "force": force}
 
-    payload_fields = [
-        "doc_label",
-        "title",
-        "type",
-        "source_id",
-        "author",
-        "date",
-        "url",
-        "workspace_id",
-        "data",
-        "memory",
-        "source_role",
-        "status",
-        "assignee",
-        "reporter",
-        "issuetype",
-        "priority",
-        "created_at_str",
-        "updated_at_str",
-        "resolved_at_str",
-    ]
+        if source_type:
+            query = """
+                SELECT * FROM raw_documents
+                WHERE workspace_id = :ws
+                  AND connector_type = :source_type
+                  AND (NOT graph_synced OR :force)
+                ORDER BY fetched_at
+            """
+            params["source_type"] = source_type
 
-    while True:
-        results, offset = store.client.scroll(
-            collection_name=store.collection_name,
-            limit=100,
-            offset=offset,
-            with_payload=payload_fields,
-            with_vectors=False,
-        )
-        for point in results:
-            p = point.payload or {}
-            label = p.get("doc_label", "")
-            if not label or label in seen_labels:
-                continue
-            if source_type and p.get("type", "") != source_type:
-                continue
-            seen_labels.add(label)
-            documents.append(p)
-
-        if offset is None:
-            break
-
-    return documents
+        result = session.execute(sa_text(query), params)
+        return [dict(row._mapping) for row in result]
 
 
-def _collect_full_content(workspace_id: str, doc_label: str) -> str:
-    """Collect and concatenate all chunk texts for a document."""
-    store = get_hybrid_store(workspace_id)
-    from qdrant_client.models import FieldCondition, Filter, MatchValue
-
-    chunks_text: list[str] = []
-    offset = None
-    while True:
-        results, offset = store.client.scroll(
-            collection_name=store.collection_name,
-            scroll_filter=Filter(
-                must=[
-                    FieldCondition(key="doc_label", match=MatchValue(value=doc_label)),
-                ]
-            ),
-            limit=100,
-            offset=offset,
-            with_payload=["data", "memory"],
-            with_vectors=False,
-        )
-        for point in results:
-            p = point.payload or {}
-            text = p.get("data") or p.get("memory") or ""
-            if text:
-                chunks_text.append(text)
-        if offset is None:
-            break
-
-    return "\n\n".join(chunks_text)
-
-
-def _reconstruct_document(payload: dict) -> Document:
-    """Reconstruct a minimal Document from Qdrant payload metadata."""
-    content = payload.get("data") or payload.get("memory") or ""
-
-    metadata: dict[str, str] = {}
-    for key in (
-        "status",
-        "assignee",
-        "reporter",
-        "issuetype",
-        "priority",
-        "created_at_str",
-        "updated_at_str",
-        "resolved_at_str",
-    ):
-        val = payload.get(key)
-        if val:
-            metadata[key] = str(val)
+def _reconstruct_document(row: dict) -> Document:
+    """Reconstruct a Document from a PostgreSQL raw_documents row."""
+    metadata = row.get("metadata") or {}
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except (json.JSONDecodeError, TypeError):
+            metadata = {}
 
     return Document(
-        source_type=payload.get("type", ""),
-        source_id=payload.get("source_id") or payload.get("doc_label", ""),
-        title=payload.get("title", ""),
-        content=content,
-        url=payload.get("url", ""),
-        author=payload.get("author", ""),
-        source_role=payload.get("source_role", ""),
+        source_type=row.get("connector_type", ""),
+        source_id=row.get("source_id", ""),
+        title=row.get("title") or "",
+        content=row.get("content") or "",
+        url=row.get("url") or "",
+        author=row.get("author") or "",
+        source_role=row.get("source_role") or "",
         metadata=metadata,
-        workspace_id=payload.get("workspace_id", ""),
+        created_at=row.get("source_created_at") or row.get("created_at"),
+        updated_at=row.get("source_updated_at") or row.get("updated_at"),
     )
 
 
+def _mark_graph_synced(workspace_id: str, source_ids: list[str]) -> None:
+    """Mark documents as graph_synced in PostgreSQL."""
+    if not source_ids:
+        return
+    with get_session() as session:
+        session.execute(
+            sa_text("""
+                UPDATE raw_documents
+                SET graph_synced = true, graph_synced_at = NOW()
+                WHERE workspace_id = :ws AND source_id = ANY(:ids)
+            """),
+            {"ws": workspace_id, "ids": source_ids},
+        )
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Rebuild Memgraph graph from Qdrant data")
+    parser = argparse.ArgumentParser(
+        description="Rebuild Memgraph graph from PostgreSQL raw_documents"
+    )
     parser.add_argument("--workspace", default="MTRNIX", help="Workspace ID (default: MTRNIX)")
     parser.add_argument(
         "--source-type",
@@ -159,6 +111,11 @@ def main() -> None:
         "--dry-run",
         action="store_true",
         help="Show what would be rebuilt without writing",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rebuild ALL docs (ignore graph_synced flag)",
     )
     parser.add_argument(
         "--workers",
@@ -173,41 +130,48 @@ def main() -> None:
         "graph_rebuild.start",
         workspace=args.workspace,
         source_type=args.source_type,
+        force=args.force,
     )
 
-    docs_payload = _scroll_unique_documents(args.workspace, args.source_type)
-    logger.info("graph_rebuild.documents_found", count=len(docs_payload))
+    rows = _query_documents(args.workspace, args.source_type, args.force)
+    logger.info("graph_rebuild.documents_found", count=len(rows))
 
-    if not docs_payload:
+    if not rows:
         logger.info("graph_rebuild.nothing_to_rebuild")
         return
 
     if args.dry_run:
-        for p in docs_payload:
+        for row in rows:
             print(
-                f"  {p.get('type', '?'):12s}  {p.get('doc_label', '?'):20s}"
-                f"  {p.get('title', '')[:60]}"
+                f"  {row.get('connector_type', '?'):12s}"
+                f"  {row.get('source_id', '?'):20s}"
+                f"  {(row.get('title') or '')[:60]}"
             )
-        print(f"\nTotal: {len(docs_payload)} documents would be rebuilt")
+        print(f"\nTotal: {len(rows)} documents would be rebuilt")
         return
 
     graph_queue: list[tuple[Document, str]] = []
-    for i, payload in enumerate(docs_payload):
-        doc = _reconstruct_document(payload)
-        full_content = _collect_full_content(args.workspace, doc.source_id)
-        if full_content:
-            doc.content = full_content
-        graph_queue.append((doc, args.workspace))
+    for i, row in enumerate(rows):
+        doc = _reconstruct_document(row)
+        if doc.content and doc.content.strip():
+            graph_queue.append((doc, args.workspace))
         if (i + 1) % 50 == 0:
             logger.info(
                 "graph_rebuild.progress",
                 reconstructed=i + 1,
-                total=len(docs_payload),
+                total=len(rows),
             )
 
     logger.info("graph_rebuild.reconstructed", count=len(graph_queue))
 
     result = _extract_graphs_parallel(graph_queue, max_workers=args.workers)
+
+    # Mark successfully processed documents as graph_synced
+    failed_ids = set(result.get("failed_source_ids", []))
+    ok_ids = [doc.source_id for doc, _ in graph_queue if doc.source_id not in failed_ids]
+    if ok_ids:
+        _mark_graph_synced(args.workspace, ok_ids)
+        logger.info("graph_rebuild.marked_synced", count=len(ok_ids))
 
     elapsed = time.time() - t0
     logger.info(

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -706,6 +706,7 @@ async def _run_connection_sync(
                 workspace_id,
                 connector_type,
                 source_role=connector.source_role,
+                skip_graph=True,
             )
             documents_new = result.documents_new
             documents_updated = result.documents_updated
@@ -718,29 +719,31 @@ async def _run_connection_sync(
             else:
                 status = "success"
 
-            # Phase 3: Mark sync status in raw_documents
+            # Phase 3: Mark Qdrant sync status in raw_documents
             try:
                 all_source_ids = [d.source_id for d in documents if d.source_id]
                 if all_source_ids:
-                    # Mark Qdrant synced for all processed documents
                     await store.mark_documents_synced_by_source(
                         workspace_id=workspace_id,
                         connector_type=connector_type,
                         source_ids=all_source_ids,
                         target="qdrant",
                     )
-                    # Mark graph synced only for docs NOT in failed list
-                    graph_failed = set(result.graph_failed_source_ids)
-                    graph_ok_ids = [sid for sid in all_source_ids if sid not in graph_failed]
-                    if graph_ok_ids:
-                        await store.mark_documents_synced_by_source(
-                            workspace_id=workspace_id,
-                            connector_type=connector_type,
-                            source_ids=graph_ok_ids,
-                            target="graph",
-                        )
             except Exception as e:
                 logger.warning("sync.mark_synced.error", error=str(e))
+
+            # Phase 4: Graph extraction from PG (separate, fresh connections)
+            try:
+                from metatron.ingestion.pipeline import process_unsynced_graphs
+
+                graph_result = await process_unsynced_graphs(workspace_id, store)
+                logger.info(
+                    "sync.graph_processing.done",
+                    ok=graph_result["ok"],
+                    errors=graph_result["errors"],
+                )
+            except Exception as e:
+                logger.warning("sync.graph_processing.error", error=str(e))
         else:
             status = "success"
 

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -134,6 +134,7 @@ async def ingest_documents(
     incremental: bool = False,
     plugin_manager=None,
     source_role: str = "knowledge_base",
+    skip_graph: bool = False,
 ) -> SyncResult:
     """Ingest documents into Qdrant + Memgraph (async, uses AsyncQdrantVectorStore).
 
@@ -293,7 +294,7 @@ async def ingest_documents(
 
     # Phase 2: parallel graph extraction (slow LLM calls)
     graph_failed_source_ids: list[str] = []
-    if _settings.graph_extraction_enabled and graph_queue:
+    if not skip_graph and _settings.graph_extraction_enabled and graph_queue:
         graph_result = await asyncio.to_thread(
             _extract_graphs_parallel,
             graph_queue,
@@ -359,6 +360,102 @@ def _write_chunk_hierarchy(
             doc_label=doc_label,
             error=str(e),
         )
+
+
+async def process_unsynced_graphs(
+    workspace_id: str,
+    store,  # PostgresStore
+    batch_size: int = 50,
+) -> dict[str, int]:
+    """Process graph extraction for documents not yet synced to Memgraph.
+
+    Reads raw documents from PostgreSQL and processes them one at a time
+    through graph extraction. Designed to run independently from the main
+    ingestion pipeline (decoupled graph sync).
+
+    Args:
+        workspace_id: Workspace scope.
+        store: PostgresStore instance.
+        batch_size: Max documents to process per call.
+
+    Returns:
+        Dict with counts: {"ok": N, "errors": N, "skipped": N}.
+    """
+    import json
+
+    ok_count = 0
+    error_count = 0
+    skipped = 0
+
+    rows = await store.get_unsynced_documents(workspace_id, target="graph", limit=batch_size)
+
+    if not rows:
+        return {"ok": 0, "errors": 0, "skipped": 0}
+
+    logger.info(
+        "process_unsynced_graphs.start",
+        workspace_id=workspace_id,
+        batch_size=len(rows),
+    )
+
+    for row in rows:
+        try:
+            # Handle metadata that might be JSON string or dict
+            metadata = row.get("metadata") or {}
+            if isinstance(metadata, str):
+                try:
+                    metadata = json.loads(metadata)
+                except (json.JSONDecodeError, TypeError):
+                    metadata = {}
+
+            doc = Document(
+                source_type=row["connector_type"],
+                source_id=row["source_id"],
+                title=row.get("title") or "",
+                content=row.get("content") or "",
+                url=row.get("url") or "",
+                author=row.get("author") or "",
+                metadata=metadata,
+                created_at=row.get("source_created_at") or row.get("created_at"),
+                updated_at=row.get("source_updated_at") or row.get("updated_at"),
+            )
+
+            if not doc.content or not doc.content.strip():
+                skipped += 1
+                continue
+
+            # Process one document at a time (sequential)
+            if doc.source_type == "jira":
+                await asyncio.to_thread(_write_jira_to_graph, doc, workspace_id)
+            else:
+                await asyncio.to_thread(_write_doc_to_graph, doc, workspace_id)
+
+            # Mark as synced on success
+            await store.mark_documents_synced_by_source(
+                workspace_id=workspace_id,
+                connector_type=row["connector_type"],
+                source_ids=[row["source_id"]],
+                target="graph",
+            )
+            ok_count += 1
+
+        except Exception as e:
+            error_count += 1
+            logger.warning(
+                "process_unsynced_graphs.doc_error",
+                source_id=row.get("source_id"),
+                error=str(e),
+            )
+
+    logger.info(
+        "process_unsynced_graphs.done",
+        workspace_id=workspace_id,
+        ok=ok_count,
+        errors=error_count,
+        skipped=skipped,
+    )
+
+    return {"ok": ok_count, "errors": error_count, "skipped": skipped}
 
 
 def _extract_graphs_parallel(

--- a/tests/unit/test_hierarchical_ingestion.py
+++ b/tests/unit/test_hierarchical_ingestion.py
@@ -226,6 +226,63 @@ class TestGracefulDegradation:
         assert mock_store.add_document.call_count >= 1
 
 
+class TestSkipGraph:
+    """skip_graph parameter controls whether graph extraction runs."""
+
+    @patch("metatron.ingestion.pipeline._register_persons")
+    @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_skip_graph_skips_extraction(
+        self,
+        mock_store_fn,
+        mock_graph,
+        mock_persons,
+    ) -> None:
+        from metatron.ingestion.pipeline import ingest_documents
+
+        mock_store = AsyncMock()
+        mock_store_fn.return_value = mock_store
+
+        doc = _make_doc("some content for graph test")
+
+        with patch("metatron.core.config.Settings") as mock_settings_cls:
+            s = mock_settings_cls.return_value
+            s.hierarchical_chunking_enabled = False
+            s.graph_extraction_enabled = True
+
+            await ingest_documents([doc], workspace_id="ws_test", skip_graph=True)
+
+        mock_graph.assert_not_called()
+
+    @patch("metatron.ingestion.pipeline._register_persons")
+    @patch("metatron.ingestion.pipeline._extract_graphs_parallel")
+    @patch("metatron.storage.qdrant.get_async_hybrid_store", new_callable=AsyncMock)
+    async def test_skip_graph_false_runs_extraction(
+        self,
+        mock_store_fn,
+        mock_graph,
+        mock_persons,
+    ) -> None:
+        from metatron.ingestion.pipeline import ingest_documents
+
+        mock_store = AsyncMock()
+        mock_store_fn.return_value = mock_store
+        mock_graph.return_value = {"ok": 1, "errors": 0, "skipped": 0, "failed_source_ids": []}
+
+        doc = _make_doc("some content for graph test")
+
+        with patch("metatron.core.config.Settings") as mock_settings_cls:
+            s = mock_settings_cls.return_value
+            s.hierarchical_chunking_enabled = False
+            s.graph_extraction_enabled = True
+            s.graph_extraction_workers = 2
+            s.graph_extraction_min_chars = 10
+
+            await ingest_documents([doc], workspace_id="ws_test", skip_graph=False)
+
+        mock_graph.assert_called_once()
+
+
 class TestGraphRetry:
     """Failed graph writes are retried sequentially after parallel extraction."""
 

--- a/tests/unit/test_raw_documents.py
+++ b/tests/unit/test_raw_documents.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -413,3 +414,147 @@ class TestGraphFailedSourceIds:
         assert "ok_1" not in result["failed_source_ids"]
         assert result["ok"] >= 1
         assert result["errors"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: process_unsynced_graphs
+# ---------------------------------------------------------------------------
+
+
+def _make_pg_row(
+    source_id: str,
+    connector_type: str,
+    title: str = "Test",
+    content: str = "Some content for graph extraction",
+) -> dict:
+    """Build a fake raw_documents row as returned by PostgresStore."""
+    return {
+        "id": f"pg_{source_id}",
+        "workspace_id": "ws_test",
+        "connector_type": connector_type,
+        "source_id": source_id,
+        "title": title,
+        "content": content,
+        "url": f"https://example.com/{source_id}",
+        "author": "test_user",
+        "metadata": {"status": "Done"},
+        "source_role": "knowledge_base",
+        "source_created_at": datetime(2026, 1, 1),
+        "source_updated_at": datetime(2026, 1, 2),
+        "created_at": datetime(2026, 1, 1),
+        "updated_at": datetime(2026, 1, 2),
+    }
+
+
+class TestProcessUnsyncedGraphs:
+    """process_unsynced_graphs reads from PG and writes graphs per doc."""
+
+    @patch("metatron.ingestion.pipeline._write_doc_to_graph")
+    @patch("metatron.ingestion.pipeline._write_jira_to_graph")
+    async def test_process_unsynced_graphs(
+        self,
+        mock_jira_graph,
+        mock_doc_graph,
+    ) -> None:
+        from metatron.ingestion.pipeline import process_unsynced_graphs
+
+        jira_row = _make_pg_row("PROJ-1", "jira", title="Bug fix")
+        confluence_row = _make_pg_row("page-123", "confluence", title="Design doc")
+
+        mock_store = AsyncMock()
+        mock_store.get_unsynced_documents = AsyncMock(return_value=[jira_row, confluence_row])
+        mock_store.mark_documents_synced_by_source = AsyncMock()
+
+        result = await process_unsynced_graphs("ws_test", mock_store, batch_size=50)
+
+        assert result["ok"] == 2
+        assert result["errors"] == 0
+        assert result["skipped"] == 0
+
+        # Jira doc should use _write_jira_to_graph
+        mock_jira_graph.assert_called_once()
+        jira_call_doc = mock_jira_graph.call_args[0][0]
+        assert jira_call_doc.source_id == "PROJ-1"
+        assert jira_call_doc.source_type == "jira"
+
+        # Confluence doc should use _write_doc_to_graph
+        mock_doc_graph.assert_called_once()
+        doc_call_doc = mock_doc_graph.call_args[0][0]
+        assert doc_call_doc.source_id == "page-123"
+        assert doc_call_doc.source_type == "confluence"
+
+        # mark_documents_synced_by_source called for each doc
+        assert mock_store.mark_documents_synced_by_source.call_count == 2
+
+    @patch("metatron.ingestion.pipeline._write_doc_to_graph")
+    @patch("metatron.ingestion.pipeline._write_jira_to_graph")
+    async def test_process_unsynced_graphs_handles_errors(
+        self,
+        mock_jira_graph,
+        mock_doc_graph,
+    ) -> None:
+        from metatron.ingestion.pipeline import process_unsynced_graphs
+
+        jira_row = _make_pg_row("PROJ-1", "jira")
+        confluence_row = _make_pg_row("page-123", "confluence")
+
+        mock_jira_graph.side_effect = ConnectionError("Memgraph down")
+
+        mock_store = AsyncMock()
+        mock_store.get_unsynced_documents = AsyncMock(return_value=[jira_row, confluence_row])
+        mock_store.mark_documents_synced_by_source = AsyncMock()
+
+        result = await process_unsynced_graphs("ws_test", mock_store)
+
+        # Jira failed, confluence succeeded
+        assert result["ok"] == 1
+        assert result["errors"] == 1
+
+        # Only confluence should be marked synced
+        assert mock_store.mark_documents_synced_by_source.call_count == 1
+        call_kwargs = mock_store.mark_documents_synced_by_source.call_args[1]
+        assert call_kwargs["source_ids"] == ["page-123"]
+
+    @patch("metatron.ingestion.pipeline._write_doc_to_graph")
+    @patch("metatron.ingestion.pipeline._write_jira_to_graph")
+    async def test_process_unsynced_graphs_skips_empty_content(
+        self,
+        mock_jira_graph,
+        mock_doc_graph,
+    ) -> None:
+        from metatron.ingestion.pipeline import process_unsynced_graphs
+
+        empty_row = _make_pg_row("empty-1", "confluence", content="   ")
+
+        mock_store = AsyncMock()
+        mock_store.get_unsynced_documents = AsyncMock(return_value=[empty_row])
+        mock_store.mark_documents_synced_by_source = AsyncMock()
+
+        result = await process_unsynced_graphs("ws_test", mock_store)
+
+        assert result["ok"] == 0
+        assert result["skipped"] == 1
+        mock_doc_graph.assert_not_called()
+        mock_jira_graph.assert_not_called()
+
+    @patch("metatron.ingestion.pipeline._write_doc_to_graph")
+    @patch("metatron.ingestion.pipeline._write_jira_to_graph")
+    async def test_process_unsynced_graphs_handles_string_metadata(
+        self,
+        mock_jira_graph,
+        mock_doc_graph,
+    ) -> None:
+        from metatron.ingestion.pipeline import process_unsynced_graphs
+
+        row = _make_pg_row("page-1", "confluence")
+        row["metadata"] = '{"status": "Published"}'  # JSON string, not dict
+
+        mock_store = AsyncMock()
+        mock_store.get_unsynced_documents = AsyncMock(return_value=[row])
+        mock_store.mark_documents_synced_by_source = AsyncMock()
+
+        result = await process_unsynced_graphs("ws_test", mock_store)
+
+        assert result["ok"] == 1
+        doc_arg = mock_doc_graph.call_args[0][0]
+        assert doc_arg.metadata == {"status": "Published"}


### PR DESCRIPTION
## Summary
Graph extraction no longer runs during sync. Sync writes PG + Qdrant only (fast). Graph extraction runs separately from `raw_documents` with fresh Memgraph connections per document.

## Architecture
```
Before: Sync → PG → Qdrant + Memgraph (parallel, Memgraph crashes)
After:  Sync → PG → Qdrant (fast) → graph_process (sequential, fresh connections, retryable)
```

## Key changes
- **pipeline.py** — `skip_graph=True` param, new `process_unsynced_graphs()` function
- **connections.py** — sync passes `skip_graph=True`, calls `process_unsynced_graphs()` after Qdrant phase
- **graph_rebuild.py** — rewritten to read from PG `raw_documents` instead of Qdrant chunks
- **graph_process.py** — new CLI script for `process_unsynced_graphs()`
- **Makefile** — `make graph-process` target

## Why this fixes Memgraph crashes
- Sync no longer opens Memgraph connections that sit idle for 30-70 sec during LLM extraction
- Graph processing opens connection right before each write — fresh, short-lived
- If Memgraph fails, doc stays `graph_synced=false` → retry via `make graph-process`

## Test plan
- [x] 6 new tests (skip_graph, process_unsynced_graphs with errors/empty/string metadata)
- [x] 25 related tests pass
- [x] Zero regressions