### PR TITLE
feat(MTRNIX-212): add transitive alias resolution via graph

### DIFF
--- a/src/metatron/retrieval/channels.py
+++ b/src/metatron/retrieval/channels.py
@@ -20,6 +20,7 @@ from metatron.storage.graph_ops import (
     get_doc_labels_by_entities,
     get_graph_entities,
     get_graph_relationships,
+    resolve_entity_aliases_batch,
 )
 from metatron.storage.qdrant import get_async_hybrid_store, get_hybrid_store
 
@@ -480,15 +481,34 @@ def recall_graph(ctx: RecallContext) -> list[ScoredResult]:
         query_for_ner = ctx.translated_query or ctx.original_query
         graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
         seeds.update(e["name"] for e in graph_ents if "name" in e)
+        # Also add 1-hop aliases returned by get_graph_entities
+        for e in graph_ents:
+            for alias in e.get("aliases", []):
+                if alias:
+                    seeds.add(alias)
 
         if not seeds:
             return []
 
-        # 3. Get direct doc_labels for seeds
+        # 3. Resolve transitive aliases for all seeds
+        try:
+            alias_map = resolve_entity_aliases_batch(
+                list(seeds), workspace_id=ctx.workspace_id,
+            )
+            for aliases in alias_map.values():
+                seeds.update(aliases)
+        except Exception:
+            logger.warning(
+                "recall_graph.alias_resolution_failed",
+                workspace=ctx.workspace_id,
+                exc_info=True,
+            )
+
+        # 4. Get direct doc_labels for seeds
         direct = get_doc_labels_by_entities(list(seeds), workspace_id=ctx.workspace_id)
         all_labels: set[str] = {r["doc_label"] for r in direct if "doc_label" in r}
 
-        # 4. Iterative BFS hop expansion
+        # 5. Iterative BFS hop expansion
         # NOTE: get_graph_relationships accepts max_depth but does NOT do multi-hop
         # internally. We always pass max_depth=1 and iterate ourselves.
         seen_entities = set(seeds)
@@ -514,7 +534,7 @@ def recall_graph(ctx: RecallContext) -> list[ScoredResult]:
         if not all_labels:
             return []
 
-        # 5. Fetch chunks, apply ACL, limit
+        # 6. Fetch chunks, apply ACL, limit
         store = get_hybrid_store(ctx.workspace_id)
         hits = _post_filter_acl(
             store.search_by_doc_labels(list(all_labels), limit=limit),
@@ -545,11 +565,32 @@ async def recall_graph_async(ctx: RecallContext) -> list[ScoredResult]:
         query_for_ner = ctx.translated_query or ctx.original_query
         graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
         seeds.update(e["name"] for e in graph_ents if "name" in e)
+        # Also add 1-hop aliases returned by get_graph_entities
+        for e in graph_ents:
+            for alias in e.get("aliases", []):
+                if alias:
+                    seeds.add(alias)
 
         if not seeds:
             return []
 
-        # 3. Get direct doc_labels for seeds (sync graph_ops via to_thread)
+        # 3. Resolve transitive aliases for all seeds
+        try:
+            alias_map = await asyncio.to_thread(
+                resolve_entity_aliases_batch,
+                list(seeds),
+                ctx.workspace_id,
+            )
+            for aliases in alias_map.values():
+                seeds.update(aliases)
+        except Exception:
+            logger.warning(
+                "recall_graph_async.alias_resolution_failed",
+                workspace=ctx.workspace_id,
+                exc_info=True,
+            )
+
+        # 4. Get direct doc_labels for seeds (sync graph_ops via to_thread)
         direct = await asyncio.to_thread(
             get_doc_labels_by_entities,
             list(seeds),
@@ -557,7 +598,7 @@ async def recall_graph_async(ctx: RecallContext) -> list[ScoredResult]:
         )
         all_labels: set[str] = {r["doc_label"] for r in direct if "doc_label" in r}
 
-        # 4. Iterative BFS hop expansion
+        # 5. Iterative BFS hop expansion
         seen_entities = set(seeds)
         frontier = set(seeds)
         for _hop in range(max_depth):
@@ -583,7 +624,7 @@ async def recall_graph_async(ctx: RecallContext) -> list[ScoredResult]:
         if not all_labels:
             return []
 
-        # 5. Fetch chunks via async Qdrant, apply ACL, limit
+        # 6. Fetch chunks via async Qdrant, apply ACL, limit
         store = await get_async_hybrid_store(ctx.workspace_id)
         hits = _post_filter_acl(
             await store.search_by_doc_labels(list(all_labels), limit=limit),

--- a/src/metatron/storage/graph_ops.py
+++ b/src/metatron/storage/graph_ops.py
@@ -58,6 +58,52 @@ def _alias_query(entity_name: str, workspace_id: str | None = None,
     )
 
 
+@memgraph_retry()
+def resolve_transitive_aliases(
+    entity_name: str,
+    workspace_id: str | None = None,
+    max_hops: int = 3,
+) -> set[str]:
+    """Resolve all aliases reachable within max_hops ALIAS edges.
+
+    BFS traversal using _alias_query() per hop.
+    Returns set of all equivalent names (including input).
+    Handles cycles (bidirectional ALIAS edges).
+    """
+    workspace_id = _normalize_workspace_id(workspace_id)
+    visited: set[str] = {entity_name}
+    frontier: set[str] = {entity_name}
+    driver = get_memgraph_driver()
+    with driver.session() as s:
+        for _ in range(max_hops):
+            if not frontier:
+                break
+            next_frontier: set[str] = set()
+            for name in frontier:
+                alias_res = s.run(_alias_query(name, workspace_id))
+                for ar in alias_res:
+                    aname = ar[0].get("name")
+                    if aname and aname not in visited:
+                        visited.add(aname)
+                        next_frontier.add(aname)
+            frontier = next_frontier
+    return visited
+
+
+def resolve_entity_aliases_batch(
+    entity_names: list[str],
+    workspace_id: str | None = None,
+    max_hops: int = 3,
+) -> dict[str, set[str]]:
+    """Resolve transitive aliases for multiple entities."""
+    if not entity_names:
+        return {}
+    return {
+        name: resolve_transitive_aliases(name, workspace_id, max_hops)
+        for name in entity_names
+    }
+
+
 def _acl_clause(user_groups: list[str] | None, node_alias: str = "d") -> str:
     """Build Cypher WHERE fragment for access_groups filtering.
 

--- a/tests/unit/test_graph_alias_resolution.py
+++ b/tests/unit/test_graph_alias_resolution.py
@@ -1,0 +1,143 @@
+"""Tests for transitive alias resolution via graph."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from metatron.storage.graph_ops import (
+    resolve_entity_aliases_batch,
+    resolve_transitive_aliases,
+)
+
+
+def _mock_alias_results(alias_graph: dict[str, list[str]]):
+    """Build a side_effect for session.run that simulates _alias_query results.
+
+    alias_graph: mapping from entity name to list of 1-hop alias names.
+    """
+    def run_side_effect(query_str: str):
+        # Extract the entity name from the Cypher query string
+        # _alias_query produces: ... e.name = 'SomeName' ...
+        for name, aliases in alias_graph.items():
+            if f"'{name}'" in query_str:
+                results = []
+                for alias in aliases:
+                    node = MagicMock()
+                    node.get.side_effect = lambda key, a=alias: a if key == "name" else None
+                    results.append((node,))
+                return results
+        return []
+    return run_side_effect
+
+
+@patch("metatron.storage.graph_ops.get_memgraph_driver")
+def test_no_aliases(mock_driver):
+    """Entity with no ALIAS edges returns just {entity_name}."""
+    session = MagicMock()
+    session.run.return_value = []
+    mock_driver.return_value.session.return_value.__enter__ = MagicMock(
+        return_value=session,
+    )
+    mock_driver.return_value.session.return_value.__exit__ = MagicMock(
+        return_value=False,
+    )
+
+    result = resolve_transitive_aliases("ProjectX", workspace_id="ws1")
+    assert result == {"ProjectX"}
+
+
+@patch("metatron.storage.graph_ops.get_memgraph_driver")
+def test_single_hop(mock_driver):
+    """A has alias B -> returns {A, B}."""
+    alias_graph = {"A": ["B"], "B": ["A"]}
+    session = MagicMock()
+    session.run.side_effect = _mock_alias_results(alias_graph)
+    mock_driver.return_value.session.return_value.__enter__ = MagicMock(
+        return_value=session,
+    )
+    mock_driver.return_value.session.return_value.__exit__ = MagicMock(
+        return_value=False,
+    )
+
+    result = resolve_transitive_aliases("A", workspace_id="ws1", max_hops=1)
+    assert result == {"A", "B"}
+
+
+@patch("metatron.storage.graph_ops.get_memgraph_driver")
+def test_multi_hop(mock_driver):
+    """A->B->C chain, max_hops=3 -> {A, B, C}."""
+    alias_graph = {"A": ["B"], "B": ["A", "C"], "C": ["B"]}
+    session = MagicMock()
+    session.run.side_effect = _mock_alias_results(alias_graph)
+    mock_driver.return_value.session.return_value.__enter__ = MagicMock(
+        return_value=session,
+    )
+    mock_driver.return_value.session.return_value.__exit__ = MagicMock(
+        return_value=False,
+    )
+
+    result = resolve_transitive_aliases("A", workspace_id="ws1", max_hops=3)
+    assert result == {"A", "B", "C"}
+
+
+@patch("metatron.storage.graph_ops.get_memgraph_driver")
+def test_cycle_handling(mock_driver):
+    """A<->B bidirectional -> no infinite loop, returns {A, B}."""
+    alias_graph = {"A": ["B"], "B": ["A"]}
+    session = MagicMock()
+    session.run.side_effect = _mock_alias_results(alias_graph)
+    mock_driver.return_value.session.return_value.__enter__ = MagicMock(
+        return_value=session,
+    )
+    mock_driver.return_value.session.return_value.__exit__ = MagicMock(
+        return_value=False,
+    )
+
+    result = resolve_transitive_aliases("A", workspace_id="ws1", max_hops=10)
+    assert result == {"A", "B"}
+
+
+@patch("metatron.storage.graph_ops.get_memgraph_driver")
+def test_max_hops_respected(mock_driver):
+    """4-hop chain A->B->C->D->E, max_hops=3 -> stops at D, misses E."""
+    alias_graph = {
+        "A": ["B"], "B": ["A", "C"], "C": ["B", "D"], "D": ["C", "E"], "E": ["D"],
+    }
+    session = MagicMock()
+    session.run.side_effect = _mock_alias_results(alias_graph)
+    mock_driver.return_value.session.return_value.__enter__ = MagicMock(
+        return_value=session,
+    )
+    mock_driver.return_value.session.return_value.__exit__ = MagicMock(
+        return_value=False,
+    )
+
+    result = resolve_transitive_aliases("A", workspace_id="ws1", max_hops=3)
+    assert result == {"A", "B", "C", "D"}
+    assert "E" not in result
+
+
+@patch("metatron.storage.graph_ops.get_memgraph_driver")
+def test_batch_resolution(mock_driver):
+    """Batch of 3 entities returns correct alias sets."""
+    alias_graph = {"X": ["Y"], "Y": ["X"], "P": ["Q"], "Q": ["P"], "M": []}
+    session = MagicMock()
+    session.run.side_effect = _mock_alias_results(alias_graph)
+    mock_driver.return_value.session.return_value.__enter__ = MagicMock(
+        return_value=session,
+    )
+    mock_driver.return_value.session.return_value.__exit__ = MagicMock(
+        return_value=False,
+    )
+
+    result = resolve_entity_aliases_batch(
+        ["X", "P", "M"], workspace_id="ws1", max_hops=2,
+    )
+    assert result["X"] == {"X", "Y"}
+    assert result["P"] == {"P", "Q"}
+    assert result["M"] == {"M"}
+
+
+def test_empty_input():
+    """Empty list returns empty dict."""
+    result = resolve_entity_aliases_batch([], workspace_id="ws1")
+    assert result == {}


### PR DESCRIPTION
## Summary
Implement graph-based transitive alias resolution using BFS over ALIAS edges in Memgraph (1..3 hops). Expands entity seed set in recall_graph before document lookup.

## Key changes
- **graph_ops.py** — `resolve_transitive_aliases()` (BFS with cycle detection), `resolve_entity_aliases_batch()`
- **channels.py** — recall_graph/recall_graph_async expand seeds with 1-hop + transitive aliases before doc lookup

## How it works
```
Query "Kostya" → seed entities → resolve_transitive_aliases("Kostya")
  → hop 1: "Konstantin Kuzmin" (direct ALIAS)
  → hop 2: "K.Kuzmin" (alias of alias)
  → seeds: {"Kostya", "Konstantin Kuzmin", "K.Kuzmin"}
  → get_doc_labels_by_entities(expanded seeds) → more relevant docs
```

## Test plan
- [x] 7 new tests (no-alias, single-hop, multi-hop, cycles, max_hops, batch, empty)
- [x] 35 recall channel tests pass (no regressions)