### PR TITLE
feat(MTRNIX-213): implement persistent deduplication index

### DIFF
--- a/migrations/versions/012_dedup_fingerprints.py
+++ b/migrations/versions/012_dedup_fingerprints.py
@@ -1,0 +1,62 @@
+"""Add dedup_fingerprints table for persistent deduplication index.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-03-27
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "012"
+down_revision: str | None = "011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.has_table(conn, "dedup_fingerprints"):
+        op.drop_table("dedup_fingerprints")
+
+    op.create_table(
+        "dedup_fingerprints",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("workspace_id", sa.Text, nullable=False),
+        sa.Column("doc_label", sa.Text, nullable=False),
+        sa.Column("fingerprint", sa.BigInteger, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "fingerprint",
+            "doc_label",
+            name="uq_dedup_fp_ws_fp_doc",
+        ),
+    )
+
+    op.create_index(
+        "ix_dedup_fp_workspace",
+        "dedup_fingerprints",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_dedup_fp_doc_label",
+        "dedup_fingerprints",
+        ["workspace_id", "doc_label"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dedup_fingerprints")

--- a/src/metatron/ingestion/dedup.py
+++ b/src/metatron/ingestion/dedup.py
@@ -114,6 +114,15 @@ class DeduplicationIndex:
     def __init__(self, threshold: int = DEFAULT_THRESHOLD) -> None:
         self._hashes: dict[int, str] = {}  # simhash → doc_label
         self._threshold = threshold
+        self._new_fingerprints: list[tuple[str, int]] = []  # (doc_label, fingerprint)
+
+    def load(self, fingerprints: dict[int, str]) -> None:
+        """Bulk-load fingerprints from persistent storage into the index.
+
+        Args:
+            fingerprints: Dict mapping fingerprint (hash) to doc_label.
+        """
+        self._hashes.update(fingerprints)
 
     def check_and_add(self, text: str, doc_label: str) -> bool:
         """Check if text is a near-duplicate, then register it.
@@ -127,11 +136,19 @@ class DeduplicationIndex:
             if existing_label != doc_label and is_near_duplicate(h, existing_hash, self._threshold):
                 return True
         self._hashes[h] = doc_label
+        self._new_fingerprints.append((doc_label, h))
         return False
+
+    def get_new_fingerprints(self) -> list[tuple[str, int]]:
+        """Return fingerprints accumulated since last load/creation."""
+        return list(self._new_fingerprints)
 
     def remove_doc(self, doc_label: str) -> None:
         """Remove all hashes for a document (call before re-ingesting)."""
         self._hashes = {h: lbl for h, lbl in self._hashes.items() if lbl != doc_label}
+        self._new_fingerprints = [
+            (lbl, fp) for lbl, fp in self._new_fingerprints if lbl != doc_label
+        ]
 
     def __len__(self) -> int:
         return len(self._hashes)

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -135,6 +135,7 @@ async def ingest_documents(
     plugin_manager=None,
     source_role: str = "knowledge_base",
     skip_graph: bool = False,
+    postgres_dsn: str | None = None,
 ) -> SyncResult:
     """Ingest documents into Qdrant + Memgraph (async, uses AsyncQdrantVectorStore).
 
@@ -154,6 +155,7 @@ async def ingest_documents(
         SyncResult with ingestion statistics.
     """
     from metatron.core.config import Settings
+    from metatron.storage.postgres import PostgresStore
     from metatron.storage.qdrant import get_async_hybrid_store
 
     _settings = Settings()
@@ -161,6 +163,23 @@ async def ingest_documents(
     store = await get_async_hybrid_store(workspace_id)
     await store._ensure_collection()
     dedup_index = DeduplicationIndex()
+
+    # Persistent dedup: load existing fingerprints from PostgreSQL
+    _pg_dsn = postgres_dsn or _settings.postgres_dsn
+    pg_store: PostgresStore | None = None
+    try:
+        pg_store = PostgresStore(_pg_dsn)
+        existing_fps = await pg_store.batch_load_fingerprints(workspace_id)
+        if existing_fps:
+            dedup_index.load(existing_fps)
+            logger.info(
+                "ingest.dedup.loaded",
+                workspace_id=workspace_id,
+                fingerprints=len(existing_fps),
+            )
+    except Exception as e:
+        logger.warning("ingest.dedup.load_error", error=str(e))
+
     new_count = 0
     updated_count = 0
     skip_count = 0
@@ -189,6 +208,17 @@ async def ingest_documents(
                 if deleted > 0:
                     was_updated = True
                     dedup_index.remove_doc(doc.source_id)
+                    if pg_store:
+                        try:
+                            await pg_store.delete_fingerprints_by_doc(
+                                workspace_id, doc.source_id
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "ingest.dedup.delete_error",
+                                doc_label=doc.source_id,
+                                error=str(e),
+                            )
                     await asyncio.to_thread(
                         _delete_graph_node,
                         doc.source_id,
@@ -292,6 +322,21 @@ async def ingest_documents(
             logger.warning("ingest.document.error", source_id=doc.source_id, error=str(e))
             errors.append(f"{doc.source_id}: {e}")
 
+    # Persist new fingerprints to PostgreSQL
+    if pg_store:
+        try:
+            new_fps = dedup_index.get_new_fingerprints()
+            if new_fps:
+                saved = await pg_store.save_fingerprints(workspace_id, new_fps)
+                logger.info(
+                    "ingest.dedup.saved",
+                    workspace_id=workspace_id,
+                    new_fingerprints=len(new_fps),
+                    inserted=saved,
+                )
+        except Exception as e:
+            logger.warning("ingest.dedup.save_error", error=str(e))
+
     # Phase 2: parallel graph extraction (slow LLM calls)
     graph_failed_source_ids: list[str] = []
     if not skip_graph and _settings.graph_extraction_enabled and graph_queue:
@@ -302,6 +347,9 @@ async def ingest_documents(
             min_chars=_settings.graph_extraction_min_chars,
         )
         graph_failed_source_ids = graph_result.get("failed_source_ids", [])
+
+    if pg_store:
+        await pg_store.close()
 
     duration_ms = (time.time() - t0) * 1000
     logger.info(

--- a/src/metatron/storage/postgres.py
+++ b/src/metatron/storage/postgres.py
@@ -29,6 +29,16 @@ from metatron.core.models import (
 logger = structlog.get_logger()
 
 
+def _to_pg_bigint(h: int) -> int:
+    """Convert unsigned 64-bit hash to signed PG BIGINT range."""
+    return h if h < (1 << 63) else h - (1 << 64)
+
+
+def _from_pg_bigint(v: int) -> int:
+    """Convert signed PG BIGINT back to unsigned 64-bit hash."""
+    return v if v >= 0 else v + (1 << 64)
+
+
 class PostgresStore:
     """Async PostgreSQL data store for metadata, skills, auth, and traces.
 
@@ -1012,6 +1022,103 @@ class PostgresStore:
             if not row:
                 return None
             return dict(row._mapping)
+
+    # --- Dedup Fingerprints ---
+
+    async def batch_load_fingerprints(self, workspace_id: str) -> dict[int, str]:
+        """Load all fingerprints for a workspace.
+
+        Returns:
+            Dict mapping fingerprint (unsigned 64-bit) to doc_label.
+        """
+        logger.info("postgres.fingerprints.load", workspace_id=workspace_id)
+
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    SELECT fingerprint, doc_label
+                    FROM dedup_fingerprints
+                    WHERE workspace_id = :workspace_id
+                """),
+                {"workspace_id": workspace_id},
+            )
+            return {
+                _from_pg_bigint(row._mapping["fingerprint"]): row._mapping["doc_label"]
+                for row in result
+            }
+
+    async def save_fingerprints(
+        self,
+        workspace_id: str,
+        fingerprints: list[tuple[str, int]],
+    ) -> int:
+        """Batch-insert new fingerprints, skipping duplicates.
+
+        Args:
+            workspace_id: Workspace scope.
+            fingerprints: List of (doc_label, fingerprint) tuples.
+
+        Returns:
+            Number of rows actually inserted.
+        """
+        if not fingerprints:
+            return 0
+
+        logger.info(
+            "postgres.fingerprints.save",
+            workspace_id=workspace_id,
+            count=len(fingerprints),
+        )
+
+        inserted = 0
+        async with self._engine.begin() as conn:
+            for doc_label, fp in fingerprints:
+                result = await conn.execute(
+                    text("""
+                        INSERT INTO dedup_fingerprints
+                        (id, workspace_id, doc_label, fingerprint)
+                        VALUES (:id, :workspace_id, :doc_label, :fingerprint)
+                        ON CONFLICT DO NOTHING
+                    """),
+                    {
+                        "id": uuid4().hex,
+                        "workspace_id": workspace_id,
+                        "doc_label": doc_label,
+                        "fingerprint": _to_pg_bigint(fp),
+                    },
+                )
+                inserted += result.rowcount  # type: ignore[operator]
+
+        return inserted
+
+    async def delete_fingerprints_by_doc(
+        self, workspace_id: str, doc_label: str
+    ) -> int:
+        """Delete all fingerprints for a document.
+
+        Args:
+            workspace_id: Workspace scope.
+            doc_label: Document label to delete fingerprints for.
+
+        Returns:
+            Number of rows deleted.
+        """
+        logger.info(
+            "postgres.fingerprints.delete",
+            workspace_id=workspace_id,
+            doc_label=doc_label,
+        )
+
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    DELETE FROM dedup_fingerprints
+                    WHERE workspace_id = :workspace_id
+                      AND doc_label = :doc_label
+                """),
+                {"workspace_id": workspace_id, "doc_label": doc_label},
+            )
+            return result.rowcount  # type: ignore[return-value]
 
     async def close(self) -> None:
         """Dispose of the engine and its connection pool."""

--- a/tests/unit/test_dedup_persistent.py
+++ b/tests/unit/test_dedup_persistent.py
@@ -1,0 +1,223 @@
+"""Tests for persistent deduplication index (MTRNIX-213)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.ingestion.dedup import DeduplicationIndex, simhash
+from metatron.storage.postgres import (
+    PostgresStore,
+    _from_pg_bigint,
+    _to_pg_bigint,
+)
+
+# ---------------------------------------------------------------------------
+# SQLite compatibility
+# ---------------------------------------------------------------------------
+
+_original_text = text
+
+
+def _sqlite_text(sql, *args, **kwargs):
+    """Wrap sqlalchemy.text to strip PG-specific casts for SQLite."""
+    return _original_text(sql.replace("::jsonb", ""), *args, **kwargs)
+
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS dedup_fingerprints (
+    id              TEXT PRIMARY KEY,
+    workspace_id    TEXT NOT NULL,
+    doc_label       TEXT NOT NULL,
+    fingerprint     INTEGER NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(workspace_id, fingerprint, doc_label)
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def engine():
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with eng.begin() as conn:
+        await conn.execute(text(_CREATE_TABLE))
+    yield eng
+    await eng.dispose()
+
+
+@pytest.fixture
+async def store(engine):
+    """PostgresStore wired to in-memory SQLite."""
+    s = PostgresStore.__new__(PostgresStore)
+    s._engine = engine
+    with patch("metatron.storage.postgres.text", _sqlite_text):
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Tests: DeduplicationIndex persistence features
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPreloadsFingerprints:
+    def test_load_preloads_fingerprints(self):
+        """load() makes check_and_add detect cross-doc dups."""
+        idx = DeduplicationIndex()
+        text_a = "the quick brown fox jumps over the lazy dog near the river"
+        fp = simhash(text_a)
+
+        # Pre-load fingerprint from "doc_A"
+        idx.load({fp: "doc_A"})
+
+        # Same text from "doc_B" should be detected as duplicate
+        is_dup = idx.check_and_add(text_a, "doc_B")
+        assert is_dup is True
+
+    def test_load_same_doc_not_flagged(self):
+        """load() does not flag same-doc chunks as dups."""
+        idx = DeduplicationIndex()
+        text_a = "the quick brown fox jumps over the lazy dog near the river"
+        fp = simhash(text_a)
+
+        idx.load({fp: "doc_A"})
+
+        # Same doc re-ingest should not be flagged
+        is_dup = idx.check_and_add(text_a, "doc_A")
+        assert is_dup is False
+
+
+class TestGetNewFingerprints:
+    def test_get_new_fingerprints(self):
+        """Only new additions (not loaded) are returned."""
+        idx = DeduplicationIndex()
+        existing_text = "existing content that was already indexed before"
+        fp = simhash(existing_text)
+        idx.load({fp: "old_doc"})
+
+        # Add new content
+        new_text = "brand new unique content for testing dedup persistence"
+        idx.check_and_add(new_text, "new_doc")
+
+        new_fps = idx.get_new_fingerprints()
+        assert len(new_fps) == 1
+        assert new_fps[0][0] == "new_doc"
+        assert new_fps[0][1] == simhash(new_text)
+
+    def test_loaded_not_in_new(self):
+        """Loaded fingerprints are not returned as new."""
+        idx = DeduplicationIndex()
+        idx.load({12345: "doc_A"})
+
+        new_fps = idx.get_new_fingerprints()
+        assert len(new_fps) == 0
+
+
+class TestRemoveDocClearsNew:
+    def test_remove_doc_clears_new(self):
+        """remove_doc() cleans both _hashes and _new_fingerprints."""
+        idx = DeduplicationIndex()
+        text_a = "some unique text for document alpha testing"
+        text_b = "another unique text for document beta testing"
+
+        idx.check_and_add(text_a, "doc_A")
+        idx.check_and_add(text_b, "doc_B")
+        assert len(idx.get_new_fingerprints()) == 2
+
+        idx.remove_doc("doc_A")
+
+        assert len(idx) == 1
+        new_fps = idx.get_new_fingerprints()
+        assert len(new_fps) == 1
+        assert new_fps[0][0] == "doc_B"
+
+
+# ---------------------------------------------------------------------------
+# Tests: BIGINT conversion
+# ---------------------------------------------------------------------------
+
+
+class TestBigintConversion:
+    def test_roundtrip_small_value(self):
+        """Small values round-trip correctly."""
+        assert _from_pg_bigint(_to_pg_bigint(42)) == 42
+
+    def test_roundtrip_near_boundary(self):
+        """Values near 2^63 boundary round-trip correctly."""
+        boundary = (1 << 63) - 1  # max signed positive
+        assert _from_pg_bigint(_to_pg_bigint(boundary)) == boundary
+
+        over = 1 << 63  # exactly at boundary
+        assert _to_pg_bigint(over) < 0
+        assert _from_pg_bigint(_to_pg_bigint(over)) == over
+
+    def test_roundtrip_large_value(self):
+        """Large unsigned values (above 2^63) round-trip correctly."""
+        large = (1 << 64) - 1  # max unsigned 64-bit
+        pg_val = _to_pg_bigint(large)
+        assert pg_val == -1  # wraps to -1 in signed space
+        assert _from_pg_bigint(pg_val) == large
+
+    def test_roundtrip_zero(self):
+        """Zero round-trips correctly."""
+        assert _from_pg_bigint(_to_pg_bigint(0)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: PostgresStore batch_load / save (SQLite-backed)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchLoadAndSave:
+    async def test_save_and_load_roundtrip(self, store):
+        """save_fingerprints → batch_load_fingerprints returns same data."""
+        fps = [("doc_1", 100), ("doc_1", 200), ("doc_2", 300)]
+        inserted = await store.save_fingerprints("ws_test", fps)
+        assert inserted == 3
+
+        loaded = await store.batch_load_fingerprints("ws_test")
+        assert loaded == {100: "doc_1", 200: "doc_1", 300: "doc_2"}
+
+    async def test_save_dedup_on_conflict(self, store):
+        """Duplicate (workspace, fingerprint, doc_label) is skipped."""
+        fps = [("doc_1", 100)]
+        await store.save_fingerprints("ws_test", fps)
+        inserted = await store.save_fingerprints("ws_test", fps)
+        assert inserted == 0
+
+    async def test_delete_by_doc(self, store):
+        """delete_fingerprints_by_doc removes only that doc's FPs."""
+        fps = [("doc_1", 100), ("doc_1", 200), ("doc_2", 300)]
+        await store.save_fingerprints("ws_test", fps)
+
+        deleted = await store.delete_fingerprints_by_doc("ws_test", "doc_1")
+        assert deleted == 2
+
+        loaded = await store.batch_load_fingerprints("ws_test")
+        assert loaded == {300: "doc_2"}
+
+    async def test_workspace_isolation(self, store):
+        """Fingerprints from different workspaces don't mix."""
+        await store.save_fingerprints("ws_a", [("doc_1", 100)])
+        await store.save_fingerprints("ws_b", [("doc_2", 200)])
+
+        loaded_a = await store.batch_load_fingerprints("ws_a")
+        loaded_b = await store.batch_load_fingerprints("ws_b")
+
+        assert loaded_a == {100: "doc_1"}
+        assert loaded_b == {200: "doc_2"}
+
+    async def test_save_empty_list(self, store):
+        """Saving empty list returns 0, no error."""
+        inserted = await store.save_fingerprints("ws_test", [])
+        assert inserted == 0


### PR DESCRIPTION
## Summary
Move deduplication index from in-memory-only to PostgreSQL-backed persistent store. SimHash fingerprints survive process restarts — duplicates detected across sync runs.

## Key changes
- **Migration 012** — `dedup_fingerprints` table (workspace_id, doc_label, fingerprint BIGINT)
- **PostgresStore** — `batch_load_fingerprints()`, `save_fingerprints()`, `delete_fingerprints_by_doc()` + BIGINT conversion helpers
- **DeduplicationIndex** — `load()` for bulk pre-loading, `get_new_fingerprints()` for batch save
- **pipeline.py** — loads FPs at sync start, saves new FPs at end, deletes on incremental re-ingest

## How it works
```
Sync start → batch_load_fingerprints(workspace) → DeduplicationIndex.load()
Per chunk  → check_and_add() → track new fingerprint
Sync end   → save_fingerprints(new_fps) → persist to PG
Next sync  → loads all FPs including previous run → cross-restart dedup works
```

## Test plan
- [x] 14 new tests (load, track, remove, BIGINT conversion, PG save/load/delete/isolation)
- [x] 9 ingestion tests pass (no regressions)