### PR TITLE
feat(MTRNIX-214): push temporal filtering into Cypher queries

### DIFF
--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -74,6 +74,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception as exc:
         logger.error("migrations.failed", error=str(exc))
 
+    # Ensure Memgraph property indexes exist (idempotent, non-fatal)
+    try:
+        import asyncio as _asyncio
+
+        from metatron.storage.memgraph import ensure_memgraph_indexes
+
+        await _asyncio.to_thread(ensure_memgraph_indexes)
+    except Exception as exc:
+        logger.warning("memgraph.indexes.failed", error=str(exc))
+
     # One-time migration: env-var credentials → DB connections (idempotent)
     try:
         from metatron.storage.migrate_env_connections import migrate_env_to_db

--- a/src/metatron/storage/graph_ops.py
+++ b/src/metatron/storage/graph_ops.py
@@ -262,21 +262,43 @@ def get_all_workspace_entities(workspace_id: str | None = None,
 
 
 @memgraph_retry()
-def get_graph_relationships(entity_names: list[str],
-                            workspace_id: str | None = None,
-                            max_depth: int = 5,
-                            active_only: bool = False) -> list[dict]:
+def get_graph_relationships(
+    entity_names: list[str],
+    workspace_id: str | None = None,
+    max_depth: int = 5,
+    active_only: bool = False,
+    valid_after: str | None = None,
+    valid_before: str | None = None,
+) -> list[dict]:
     """Get relationships for entities (variable depth traversal).
 
     Args:
         active_only: When True, only return relationships where valid_to IS NULL
                      (i.e. currently active / not closed).
+        valid_after: ISO date string — only return relationships with
+                     valid_from >= this value (NULL valid_from included).
+        valid_before: ISO date string — only return relationships with
+                      valid_from <= this value (NULL valid_from included).
     """
     workspace_id = _normalize_workspace_id(workspace_id)
     depth = max(1, min(max_depth, 5))
     driver = get_memgraph_driver()
     results: list[dict] = []
     seen: set[tuple] = set()
+
+    # Build optional temporal WHERE fragments
+    temporal = ""
+    if active_only:
+        temporal += " AND r.valid_to IS NULL"
+    if valid_after is not None:
+        temporal += (
+            f" AND (r.valid_from IS NULL OR r.valid_from >= {_esc(valid_after)})"
+        )
+    if valid_before is not None:
+        temporal += (
+            f" AND (r.valid_from IS NULL OR r.valid_from <= {_esc(valid_before)})"
+        )
+
     with driver.session() as s:
         # For each entity, get RELATION edges (both directions)
         for name in entity_names:
@@ -284,11 +306,13 @@ def get_graph_relationships(entity_names: list[str],
             if workspace_id == DEFAULT_WORKSPACE_ID:
                 _all_rels.extend(s.run(
                     f"MATCH (e:Entity)-[r]->(b:Entity) "
-                    f"WHERE e.name = {_esc(name)} RETURN r",
+                    f"WHERE e.name = {_esc(name)}"
+                    f"{temporal} RETURN r",
                 ))
                 _all_rels.extend(s.run(
                     f"MATCH (e:Entity)<-[r]-(b:Entity) "
-                    f"WHERE e.name = {_esc(name)} RETURN r",
+                    f"WHERE e.name = {_esc(name)}"
+                    f"{temporal} RETURN r",
                 ))
             else:
                 _ws = _esc(workspace_id)
@@ -296,13 +320,15 @@ def get_graph_relationships(entity_names: list[str],
                     f"MATCH (e:Entity)-[r]->(b:Entity) "
                     f"WHERE e.name = {_esc(name)} "
                     f"AND e.workspace_id = {_ws} "
-                    f"AND b.workspace_id = {_ws} RETURN r",
+                    f"AND b.workspace_id = {_ws}"
+                    f"{temporal} RETURN r",
                 ))
                 _all_rels.extend(s.run(
                     f"MATCH (e:Entity)<-[r]-(b:Entity) "
                     f"WHERE e.name = {_esc(name)} "
                     f"AND e.workspace_id = {_ws} "
-                    f"AND b.workspace_id = {_ws} RETURN r",
+                    f"AND b.workspace_id = {_ws}"
+                    f"{temporal} RETURN r",
                 ))
             for rr in _all_rels:
                 rel = rr[0]
@@ -313,8 +339,6 @@ def get_graph_relationships(entity_names: list[str],
                 rel_type = rel.get("type")
                 vf = rel.get("valid_from")
                 vt = rel.get("valid_to")
-                if active_only and vt is not None:
-                    continue
                 key = (src_name, tgt_name, rel_type)
                 if key in seen:
                     continue
@@ -338,6 +362,9 @@ def get_relationships_at_date(entity_names: list[str],
                               max_depth: int = 5) -> list[dict]:
     """Get relationships valid at a specific date (ISO format YYYY-MM-DD).
 
+    Temporal filtering is pushed into Cypher WHERE clauses so Memgraph
+    can prune early instead of returning all edges for Python post-filter.
+
     Returns relationships where:
     - valid_from is NULL or <= target_date
     - valid_to is NULL or >= target_date
@@ -346,17 +373,24 @@ def get_relationships_at_date(entity_names: list[str],
     driver = get_memgraph_driver()
     results: list[dict] = []
     seen: set[tuple] = set()
+    _td = _esc(target_date)
+    temporal = (
+        f" AND (r.valid_from IS NULL OR r.valid_from <= {_td})"
+        f" AND (r.valid_to IS NULL OR r.valid_to >= {_td})"
+    )
     with driver.session() as s:
         for name in entity_names:
             _all_rels = []
             if workspace_id == DEFAULT_WORKSPACE_ID:
                 _all_rels.extend(s.run(
                     f"MATCH (e:Entity)-[r]->(b:Entity) "
-                    f"WHERE e.name = {_esc(name)} RETURN r",
+                    f"WHERE e.name = {_esc(name)}"
+                    f"{temporal} RETURN r",
                 ))
                 _all_rels.extend(s.run(
                     f"MATCH (e:Entity)<-[r]-(b:Entity) "
-                    f"WHERE e.name = {_esc(name)} RETURN r",
+                    f"WHERE e.name = {_esc(name)}"
+                    f"{temporal} RETURN r",
                 ))
             else:
                 _ws = _esc(workspace_id)
@@ -364,26 +398,23 @@ def get_relationships_at_date(entity_names: list[str],
                     f"MATCH (e:Entity)-[r]->(b:Entity) "
                     f"WHERE e.name = {_esc(name)} "
                     f"AND e.workspace_id = {_ws} "
-                    f"AND b.workspace_id = {_ws} RETURN r",
+                    f"AND b.workspace_id = {_ws}"
+                    f"{temporal} RETURN r",
                 ))
                 _all_rels.extend(s.run(
                     f"MATCH (e:Entity)<-[r]-(b:Entity) "
                     f"WHERE e.name = {_esc(name)} "
                     f"AND e.workspace_id = {_ws} "
-                    f"AND b.workspace_id = {_ws} RETURN r",
+                    f"AND b.workspace_id = {_ws}"
+                    f"{temporal} RETURN r",
                 ))
             for rr in _all_rels:
                 rel = rr[0]
-                vf = rel.get("valid_from")
-                vt = rel.get("valid_to")
-                # Date filter in Python
-                if vf is not None and vf > target_date:
-                    continue
-                if vt is not None and vt < target_date:
-                    continue
                 src_name = rel.start_node.get("name", "")
                 tgt_name = rel.end_node.get("name", "")
                 rel_type = rel.get("type")
+                vf = rel.get("valid_from")
+                vt = rel.get("valid_to")
                 key = (src_name, tgt_name, rel_type)
                 if key in seen:
                     continue

--- a/src/metatron/storage/memgraph.py
+++ b/src/metatron/storage/memgraph.py
@@ -462,6 +462,26 @@ def write_chunk_hierarchy(
 
 
 @memgraph_retry()
+def ensure_memgraph_indexes() -> None:
+    """Create node property indexes for frequently queried fields."""
+    driver = get_memgraph_driver()
+    with driver.session() as session:
+        for stmt in [
+            "CREATE INDEX ON :Entity(name)",
+            "CREATE INDEX ON :Entity(workspace_id)",
+            "CREATE INDEX ON :Document(doc_label)",
+            "CREATE INDEX ON :Document(workspace_id)",
+            "CREATE INDEX ON :JiraIssue(issue_key)",
+            "CREATE INDEX ON :JiraIssue(workspace_id)",
+        ]:
+            try:
+                session.run(stmt)
+            except Exception:
+                pass  # Index may already exist
+    logger.info("memgraph.indexes.ensured")
+
+
+@memgraph_retry()
 def delete_workspace_graph(workspace_id: str) -> None:
     """Delete all graph data for a specific workspace. WARNING: permanent."""
     driver = get_memgraph_driver()

--- a/tests/unit/test_temporal_cypher.py
+++ b/tests/unit/test_temporal_cypher.py
@@ -1,0 +1,159 @@
+"""Tests for Cypher-level temporal filtering in graph_ops.
+
+Verifies that temporal WHERE clauses are pushed into Cypher queries
+instead of being applied as Python post-filters.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _mock_driver():
+    """Create a mock Memgraph driver + session."""
+    mock_session = MagicMock()
+    mock_session.run.return_value = []
+    mock_drv = MagicMock()
+    mock_drv.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_drv.session.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_drv, mock_session
+
+
+# --- 1. get_relationships_at_date includes temporal WHERE ---
+
+class TestRelationshipsAtDateCypher:
+    @patch("metatron.storage.graph_ops.get_memgraph_driver")
+    def test_relationships_at_date_cypher_has_temporal_where(
+        self, mock_get_driver: MagicMock,
+    ) -> None:
+        drv, session = _mock_driver()
+        mock_get_driver.return_value = drv
+
+        from metatron.storage.graph_ops import get_relationships_at_date
+
+        get_relationships_at_date(["Alice"], target_date="2025-06-15", workspace_id="ws1")
+
+        # Collect all Cypher strings passed to session.run()
+        queries = [call[0][0] for call in session.run.call_args_list]
+        assert len(queries) >= 2  # forward + reverse
+
+        for q in queries:
+            assert "r.valid_from IS NULL OR r.valid_from <=" in q
+            assert "r.valid_to IS NULL OR r.valid_to >=" in q
+            assert "'2025-06-15'" in q
+
+    @patch("metatron.storage.graph_ops.get_memgraph_driver")
+    def test_null_dates_included(self, mock_get_driver: MagicMock) -> None:
+        """NULL valid_from/valid_to treated as 'always valid' via IS NULL checks."""
+        drv, session = _mock_driver()
+        mock_get_driver.return_value = drv
+
+        from metatron.storage.graph_ops import get_relationships_at_date
+
+        get_relationships_at_date(["X"], target_date="2025-01-01", workspace_id="ws1")
+
+        queries = [call[0][0] for call in session.run.call_args_list]
+        for q in queries:
+            # IS NULL OR ensures rows with NULL dates pass through
+            assert "r.valid_from IS NULL" in q
+            assert "r.valid_to IS NULL" in q
+
+
+# --- 2. active_only adds valid_to IS NULL in Cypher ---
+
+class TestActiveOnlyCypher:
+    @patch("metatron.storage.graph_ops.get_memgraph_driver")
+    def test_active_only_cypher_has_valid_to_null(
+        self, mock_get_driver: MagicMock,
+    ) -> None:
+        drv, session = _mock_driver()
+        mock_get_driver.return_value = drv
+
+        from metatron.storage.graph_ops import get_graph_relationships
+
+        get_graph_relationships(["Alice"], workspace_id="ws1", active_only=True)
+
+        queries = [call[0][0] for call in session.run.call_args_list]
+        for q in queries:
+            assert "r.valid_to IS NULL" in q
+
+    @patch("metatron.storage.graph_ops.get_memgraph_driver")
+    def test_active_only_false_no_valid_to_clause(
+        self, mock_get_driver: MagicMock,
+    ) -> None:
+        drv, session = _mock_driver()
+        mock_get_driver.return_value = drv
+
+        from metatron.storage.graph_ops import get_graph_relationships
+
+        get_graph_relationships(["Alice"], workspace_id="ws1", active_only=False)
+
+        queries = [call[0][0] for call in session.run.call_args_list]
+        for q in queries:
+            assert "r.valid_to IS NULL" not in q
+
+
+# --- 3. valid_after param in Cypher ---
+
+class TestValidAfterCypher:
+    @patch("metatron.storage.graph_ops.get_memgraph_driver")
+    def test_valid_after_param_in_cypher(
+        self, mock_get_driver: MagicMock,
+    ) -> None:
+        drv, session = _mock_driver()
+        mock_get_driver.return_value = drv
+
+        from metatron.storage.graph_ops import get_graph_relationships
+
+        get_graph_relationships(
+            ["Alice"], workspace_id="ws1", valid_after="2025-01-01",
+        )
+
+        queries = [call[0][0] for call in session.run.call_args_list]
+        for q in queries:
+            assert "r.valid_from IS NULL OR r.valid_from >= '2025-01-01'" in q
+
+
+# --- 4. valid_before param in Cypher ---
+
+class TestValidBeforeCypher:
+    @patch("metatron.storage.graph_ops.get_memgraph_driver")
+    def test_valid_before_param_in_cypher(
+        self, mock_get_driver: MagicMock,
+    ) -> None:
+        drv, session = _mock_driver()
+        mock_get_driver.return_value = drv
+
+        from metatron.storage.graph_ops import get_graph_relationships
+
+        get_graph_relationships(
+            ["Alice"], workspace_id="ws1", valid_before="2025-12-31",
+        )
+
+        queries = [call[0][0] for call in session.run.call_args_list]
+        for q in queries:
+            assert "r.valid_from IS NULL OR r.valid_from <= '2025-12-31'" in q
+
+
+# --- 5. ensure_memgraph_indexes idempotent ---
+
+class TestEnsureIndexes:
+    @patch("metatron.storage.memgraph.get_memgraph_driver")
+    def test_ensure_indexes_idempotent(
+        self, mock_get_driver: MagicMock,
+    ) -> None:
+        drv, session = _mock_driver()
+        mock_get_driver.return_value = drv
+
+        from metatron.storage.memgraph import ensure_memgraph_indexes
+
+        # First call
+        ensure_memgraph_indexes()
+        first_count = session.run.call_count
+
+        # Second call — no error even if indexes exist
+        session.run.side_effect = Exception("Index already exists")
+        ensure_memgraph_indexes()
+
+        # Both calls completed without raising
+        assert session.run.call_count > first_count

--- a/tests/unit/test_temporal_facts.py
+++ b/tests/unit/test_temporal_facts.py
@@ -180,26 +180,24 @@ class TestDocumentEdgesTemporal:
 
 class TestGraphRelationshipsTemporal:
     @patch("metatron.storage.graph_ops.get_memgraph_driver")
-    def test_active_only_filters_closed_relationships(self, mock_driver: MagicMock) -> None:
-        # Build mock relationship with valid_to set (closed)
-        mock_rel = MagicMock()
-        mock_rel.get = lambda k, d=None: {
-            "type": "works_on", "valid_from": "2025-06-01", "valid_to": "2025-06-20",
-        }.get(k, d)
-        mock_rel.start_node.get = lambda k, d=None: {"name": "Alice"}.get(k, d)
-        mock_rel.end_node.get = lambda k, d=None: {"name": "TEST-1"}.get(k, d)
-        mock_record = MagicMock()
-        mock_record.__getitem__ = lambda self, k: mock_rel
-
+    def test_active_only_filters_via_cypher(self, mock_driver: MagicMock) -> None:
+        """active_only=True pushes r.valid_to IS NULL into Cypher WHERE clause."""
         mock_session = MagicMock()
-        mock_session.run.return_value = [mock_record]
-        mock_driver.return_value.session.return_value.__enter__ = MagicMock(return_value=mock_session)
-        mock_driver.return_value.session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.run.return_value = []
+        mock_driver.return_value.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session,
+        )
+        mock_driver.return_value.session.return_value.__exit__ = MagicMock(
+            return_value=False,
+        )
 
         from metatron.storage.graph_ops import get_graph_relationships
-        # active_only=True should filter out relationships with valid_to set
-        results = get_graph_relationships(["Alice"], workspace_id="ws1", active_only=True)
-        assert len(results) == 0
+
+        get_graph_relationships(["Alice"], workspace_id="ws1", active_only=True)
+
+        queries = [call[0][0] for call in mock_session.run.call_args_list]
+        for q in queries:
+            assert "r.valid_to IS NULL" in q
 
     @patch("metatron.storage.graph_ops.get_memgraph_driver")
     def test_default_includes_closed_relationships(self, mock_driver: MagicMock) -> None:


### PR DESCRIPTION
## Summary
Move date-range filtering from Python post-processing into Cypher WHERE clauses. Add Memgraph node property indexes.

## Key changes
- **graph_ops.py** — `get_relationships_at_date()` and `get_graph_relationships()` now filter temporally in Cypher, not Python. New `valid_after`/`valid_before` params.
- **memgraph.py** — `ensure_memgraph_indexes()` creates indexes on Entity, Document, JiraIssue nodes
- **api/app.py** — indexes created at startup

## Test plan
- [x] 7 new temporal Cypher tests
- [x] 11 temporal facts tests pass (no regressions)