### PR TITLE
feat(MTRNIX-216): replace BM25 with SPLADE learned sparse representations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "pandas>=2.1,<3",
     "python-multipart>=0.0.9,<1",
     "sentence-transformers>=3.0,<4",
+    "transformers>=4.30",
     "bcrypt>=4.0",
     "mcp>=1.0,<2",
     "sse-starlette>=2.0,<4",

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -159,6 +159,11 @@ class Settings(BaseSettings):
     hyde_max_words: int = Field(4, alias="HYDE_MAX_WORDS")
     hyde_timeout: int = Field(8, alias="HYDE_TIMEOUT")
 
+    # --- SPLADE sparse representations ---
+    splade_enabled: bool = Field(True, alias="SPLADE_ENABLED")
+    splade_model: str = Field("naver/splade-cocondenser-ensembledistil", alias="SPLADE_MODEL")
+    splade_max_length: int = Field(256, alias="SPLADE_MAX_LENGTH")
+
     @property
     def cors_origins_list(self) -> list[str]:
         """Parse CORS_ORIGINS comma-separated string into a list."""

--- a/src/metatron/ingestion/splade.py
+++ b/src/metatron/ingestion/splade.py
@@ -1,0 +1,76 @@
+"""SPLADE learned sparse representations for semantic search.
+
+Replaces BM25 hash-based sparse vectors with learned term importance
+weights from a Masked Language Model. Lazy singleton pattern (same as reranker).
+"""
+
+from __future__ import annotations
+
+import threading
+
+import structlog
+
+logger = structlog.get_logger()
+
+_model = None
+_tokenizer = None
+_lock = threading.Lock()
+
+
+def _get_splade_model():
+    """Lazy-load SPLADE model (thread-safe singleton)."""
+    global _model, _tokenizer  # noqa: PLW0603
+    if _model is None:
+        with _lock:
+            if _model is None:
+                from metatron.core.config import get_settings
+
+                s = get_settings()
+                import torch  # noqa: TCH002
+                from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+                _tokenizer = AutoTokenizer.from_pretrained(s.splade_model)
+                _model = AutoModelForMaskedLM.from_pretrained(s.splade_model)
+                _model.eval()
+                if torch.cuda.is_available():
+                    _model = _model.cuda()
+                logger.info("splade.model.loaded", model=s.splade_model)
+    return _model, _tokenizer
+
+
+def compute_splade_sparse_vector(
+    text: str,
+    max_length: int = 256,
+) -> tuple[list[int], list[float]]:
+    """Compute SPLADE sparse vector for a document chunk."""
+    import torch
+
+    model, tokenizer = _get_splade_model()
+    device = next(model.parameters()).device
+    tokens = tokenizer(
+        text,
+        return_tensors="pt",
+        max_length=max_length,
+        truncation=True,
+        padding=True,
+    )
+    tokens = {k: v.to(device) for k, v in tokens.items()}
+    with torch.no_grad():
+        output = model(**tokens)
+    # SPLADE: log(1 + ReLU(logits)), max-pool over sequence length
+    logits = output.logits  # (1, seq_len, vocab_size)
+    splade_vector = torch.max(
+        torch.log1p(torch.relu(logits)), dim=1
+    ).values.squeeze()  # (vocab_size,)
+    # Extract non-zero entries
+    indices = splade_vector.nonzero(as_tuple=True)[0].tolist()
+    values = splade_vector[indices].tolist()
+    return indices, values
+
+
+def compute_splade_query_vector(
+    query: str,
+    max_length: int = 64,
+) -> tuple[list[int], list[float]]:
+    """Compute SPLADE sparse vector for a query (shorter max_length)."""
+    return compute_splade_sparse_vector(query, max_length=max_length)

--- a/src/metatron/retrieval/channels.py
+++ b/src/metatron/retrieval/channels.py
@@ -222,7 +222,13 @@ def recall_dense(ctx: RecallContext) -> list[ScoredResult]:
         adaptive_k: int | None = None
         if ctx.settings and ctx.settings.adaptive_rrf_enabled:
             dense_vec = get_cached_embedding(query)
-            sp_indices, sp_values = compute_query_sparse_vector(query)
+            if ctx.settings.splade_enabled:
+                from metatron.ingestion.splade import compute_splade_query_vector
+
+                sparse_fn = compute_splade_query_vector
+            else:
+                sparse_fn = compute_query_sparse_vector
+            sp_indices, sp_values = sparse_fn(query)
             dense_raw = store.dense_search_raw(
                 dense_vec,
                 limit=20,
@@ -279,10 +285,13 @@ async def recall_dense_async(ctx: RecallContext) -> list[ScoredResult]:
         adaptive_k: int | None = None
         if ctx.settings and ctx.settings.adaptive_rrf_enabled:
             dense_vec = await asyncio.to_thread(get_cached_embedding, query)
-            sp_indices, sp_values = await asyncio.to_thread(
-                compute_query_sparse_vector,
-                query,
-            )
+            if ctx.settings.splade_enabled:
+                from metatron.ingestion.splade import compute_splade_query_vector
+
+                sparse_fn = compute_splade_query_vector
+            else:
+                sparse_fn = compute_query_sparse_vector
+            sp_indices, sp_values = await asyncio.to_thread(sparse_fn, query)
             dense_raw = await store.dense_search_raw(
                 dense_vec,
                 limit=20,

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -31,11 +31,13 @@ from qdrant_client.models import (
     VectorParams,
 )
 
+from metatron.core.config import get_settings
 from metatron.ingestion.bm25 import compute_bm25_sparse_vector, compute_query_sparse_vector
 from metatron.llm.embeddings import (  # TODO: async migration
     get_cached_embedding,
     get_cached_embedding_split,
 )
+
 # Lazy import to avoid circular: qdrant → hybrid → retrieval → channels → qdrant
 # from metatron.retrieval.hybrid import rrf_fusion  # imported in methods that need it
 
@@ -62,6 +64,24 @@ def get_collection_name(workspace_id: str | None = None) -> str:
     if workspace_id == DEFAULT_WORKSPACE_ID:
         return BASE_COLLECTION_NAME
     return f"{BASE_COLLECTION_NAME}_{workspace_id}"
+
+
+def _compute_doc_sparse(text: str) -> tuple[list[int], list[float]]:
+    """Dispatch document sparse vector computation to SPLADE or BM25."""
+    if get_settings().splade_enabled:
+        from metatron.ingestion.splade import compute_splade_sparse_vector
+
+        return compute_splade_sparse_vector(text)
+    return compute_bm25_sparse_vector(text)
+
+
+def _compute_query_sparse(query: str) -> tuple[list[int], list[float]]:
+    """Dispatch query sparse vector computation to SPLADE or BM25."""
+    if get_settings().splade_enabled:
+        from metatron.ingestion.splade import compute_splade_query_vector
+
+        return compute_splade_query_vector(query)
+    return compute_query_sparse_vector(query)
 
 
 class QdrantVectorStore:
@@ -156,7 +176,7 @@ class QdrantVectorStore:
             qdrant_ids.append(qdrant_id)
 
             bm25_text = f"{title} {title} {chunk_text}" if title else chunk_text
-            sparse_indices, sparse_values = compute_bm25_sparse_vector(bm25_text)
+            sparse_indices, sparse_values = _compute_doc_sparse(bm25_text)
 
             payload = {**metadata}
             payload["data"] = chunk_text
@@ -239,7 +259,7 @@ class QdrantVectorStore:
         fusion is used (backward compatible).
         """
         dense_query = get_cached_embedding(query)
-        sparse_indices, sparse_values = compute_query_sparse_vector(query)
+        sparse_indices, sparse_values = _compute_query_sparse(query)
         try:
             if rrf_k is not None:
                 dense_raw = self.dense_search_raw(
@@ -316,8 +336,8 @@ class QdrantVectorStore:
     def keyword_search(
         self, query: str, limit: int = 10, filter_conditions: Filter | None = None
     ) -> list[dict]:
-        """Sparse-only (keyword/BM25) search."""
-        sparse_indices, sparse_values = compute_query_sparse_vector(query)
+        """Sparse-only (keyword) search."""
+        sparse_indices, sparse_values = _compute_query_sparse(query)
         if not sparse_indices:
             return []
         results = self.client.query_points(
@@ -609,9 +629,9 @@ class AsyncQdrantVectorStore:
         text: str,
         title: str = "",
     ) -> tuple[list[int], list[float]]:
-        """Build BM25 sparse vector (sync helper)."""
+        """Build sparse vector (sync helper). Uses SPLADE or BM25."""
         bm25_text = f"{title} {title} {text}" if title else text
-        return compute_bm25_sparse_vector(bm25_text)
+        return _compute_doc_sparse(bm25_text)
 
     async def add_document(
         self,
@@ -729,7 +749,7 @@ class AsyncQdrantVectorStore:
         """
         await self._ensure_collection()
         dense_query = await asyncio.to_thread(get_cached_embedding, query)
-        sparse_indices, sparse_values = await asyncio.to_thread(compute_query_sparse_vector, query)
+        sparse_indices, sparse_values = await asyncio.to_thread(_compute_query_sparse, query)
         try:
             if rrf_k is not None:
                 dense_raw = await self.dense_search_raw(
@@ -815,9 +835,9 @@ class AsyncQdrantVectorStore:
         limit: int = 10,
         filter_conditions: Filter | None = None,
     ) -> list[dict]:
-        """Sparse-only (keyword/BM25) search."""
+        """Sparse-only (keyword) search."""
         await self._ensure_collection()
-        sparse_indices, sparse_values = await asyncio.to_thread(compute_query_sparse_vector, query)
+        sparse_indices, sparse_values = await asyncio.to_thread(_compute_query_sparse, query)
         if not sparse_indices:
             return []
         results = await self.client.query_points(

--- a/tests/unit/test_splade.py
+++ b/tests/unit/test_splade.py
@@ -1,0 +1,161 @@
+"""Tests for SPLADE sparse vector computation and dispatch logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+@pytest.fixture()
+def _mock_splade_model():
+    """Mock _get_splade_model to return a fake model + tokenizer."""
+    import metatron.ingestion.splade as splade_mod
+
+    # Reset global singleton state
+    splade_mod._model = None
+    splade_mod._tokenizer = None
+
+    # Build a fake model that returns controlled logits
+    vocab_size = 200
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.return_value = {
+        "input_ids": torch.ones(1, 5, dtype=torch.long),
+        "attention_mask": torch.ones(1, 5, dtype=torch.long),
+    }
+
+    mock_model = MagicMock()
+    # Simulate logits: (1, seq_len=5, vocab_size=200)
+    # Set specific positions to have positive values after ReLU
+    fake_logits = torch.zeros(1, 5, vocab_size)
+    fake_logits[0, 0, 10] = 2.0
+    fake_logits[0, 1, 42] = 3.0
+    fake_logits[0, 2, 100] = 1.0
+    mock_output = MagicMock()
+    mock_output.logits = fake_logits
+    mock_model.return_value = mock_output
+    mock_model.parameters.return_value = iter([torch.nn.Parameter(torch.zeros(1))])
+
+    with patch.object(splade_mod, "_get_splade_model", return_value=(mock_model, mock_tokenizer)):
+        yield {
+            "model": mock_model,
+            "tokenizer": mock_tokenizer,
+        }
+
+    # Clean up singleton
+    splade_mod._model = None
+    splade_mod._tokenizer = None
+
+
+class TestSpladeComputation:
+    """Test SPLADE sparse vector computation."""
+
+    def test_compute_splade_sparse_vector(self, _mock_splade_model):
+        """Mock model output produces correct (indices, values) tuple."""
+        from metatron.ingestion.splade import compute_splade_sparse_vector
+
+        indices, values = compute_splade_sparse_vector("test document text")
+        assert isinstance(indices, list)
+        assert isinstance(values, list)
+        assert len(indices) == len(values)
+        assert len(indices) > 0
+        # Verify known non-zero positions
+        assert 10 in indices
+        assert 42 in indices
+        assert 100 in indices
+        # Values should be log1p of the logit values
+        for v in values:
+            assert v > 0.0
+
+    def test_compute_splade_query_vector(self, _mock_splade_model):
+        """Query vector uses shorter max_length but same model."""
+        from metatron.ingestion.splade import compute_splade_query_vector
+
+        indices, values = compute_splade_query_vector("test query")
+        assert isinstance(indices, list)
+        assert isinstance(values, list)
+        assert len(indices) == len(values)
+        assert len(indices) > 0
+
+    def test_lazy_model_loading(self):
+        """Model is loaded only on first call, not on import."""
+        import metatron.ingestion.splade as splade_mod
+
+        splade_mod._model = None
+        splade_mod._tokenizer = None
+
+        # Before any call, model should be None
+        assert splade_mod._model is None
+
+        fake_param = torch.nn.Parameter(torch.zeros(1))
+        fake_model = MagicMock()
+        fake_model.parameters.side_effect = lambda: iter([fake_param])
+        fake_tokenizer = MagicMock()
+
+        with patch.object(
+            splade_mod,
+            "_get_splade_model",
+            return_value=(fake_model, fake_tokenizer),
+        ) as mock_get:
+            fake_output = MagicMock()
+            fake_output.logits = torch.zeros(1, 5, 100)
+            fake_model.return_value = fake_output
+            fake_tokenizer.return_value = {
+                "input_ids": torch.ones(1, 5, dtype=torch.long),
+                "attention_mask": torch.ones(1, 5, dtype=torch.long),
+            }
+
+            splade_mod.compute_splade_sparse_vector("first call")
+            assert mock_get.call_count == 1
+
+            splade_mod.compute_splade_sparse_vector("second call")
+            assert mock_get.call_count == 2  # called each time (singleton is in _get)
+
+
+class TestSpladeDispatch:
+    """Test SPLADE/BM25 dispatch logic in qdrant.py."""
+
+    def test_splade_disabled_uses_bm25(self, settings):
+        """When splade_enabled=False, BM25 path is used."""
+        settings.splade_enabled = False
+        with patch("metatron.storage.qdrant.get_settings", return_value=settings):
+            from metatron.storage.qdrant import _compute_doc_sparse, _compute_query_sparse
+
+            with patch(
+                "metatron.storage.qdrant.compute_bm25_sparse_vector",
+                return_value=([1, 2], [0.5, 0.6]),
+            ) as mock_bm25:
+                result = _compute_doc_sparse("test text")
+                mock_bm25.assert_called_once_with("test text")
+                assert result == ([1, 2], [0.5, 0.6])
+
+            with patch(
+                "metatron.storage.qdrant.compute_query_sparse_vector",
+                return_value=([3], [1.0]),
+            ) as mock_bm25_q:
+                result = _compute_query_sparse("test query")
+                mock_bm25_q.assert_called_once_with("test query")
+                assert result == ([3], [1.0])
+
+    def test_splade_enabled_uses_splade(self, settings):
+        """When splade_enabled=True, SPLADE path is used."""
+        settings.splade_enabled = True
+        with patch("metatron.storage.qdrant.get_settings", return_value=settings):
+            from metatron.storage.qdrant import _compute_doc_sparse, _compute_query_sparse
+
+            with patch(
+                "metatron.ingestion.splade.compute_splade_sparse_vector",
+                return_value=([10, 42], [0.5, 1.2]),
+            ) as mock_splade:
+                result = _compute_doc_sparse("test text")
+                mock_splade.assert_called_once_with("test text")
+                assert result == ([10, 42], [0.5, 1.2])
+
+            with patch(
+                "metatron.ingestion.splade.compute_splade_query_vector",
+                return_value=([10], [0.8]),
+            ) as mock_splade_q:
+                result = _compute_query_sparse("test query")
+                mock_splade_q.assert_called_once_with("test query")
+                assert result == ([10], [0.8])


### PR DESCRIPTION
## Summary
Replace BM25 hash-based sparse vectors with SPLADE learned sparse representations. Semantic expansion improves recall beyond exact term matching.

## Key changes
- **splade.py** (new) — lazy singleton model loading, `compute_splade_sparse_vector()`, `compute_splade_query_vector()`
- **config.py** — `SPLADE_ENABLED` (default true), `SPLADE_MODEL`, `SPLADE_MAX_LENGTH`
- **qdrant.py** — dispatcher for SPLADE/BM25 in all sparse vector paths
- **channels.py** — adaptive RRF uses SPLADE when enabled
- **pyproject.toml** — `transformers>=4.30` dependency

## Feature flag
`SPLADE_ENABLED=false` falls back to BM25 (zero behavior change). Full reindex required after enabling.

## Test plan
- [x] 5 new tests (sparse vector computation, dispatch, lazy loading)
- [ ] Full reindex + eval comparison after merge