### PR TITLE
feat(MTRNIX-216): refactor SPLADE into standalone microservice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,6 @@ COPY src/ src/
 COPY migrations/ migrations/
 COPY alembic.ini .
 
-# Pre-download ML models into a shared cache dir accessible by metatron user
-ENV HF_HOME=/app/.cache/huggingface
-RUN mkdir -p /app/.cache/huggingface && \
-    python -c "from sentence_transformers import CrossEncoder; \
-    CrossEncoder('BAAI/bge-reranker-v2-m3')" \
-    || true
-
 RUN chown -R metatron:metatron /app
 USER metatron
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,7 @@ COPY alembic.ini .
 # Pre-download ML models into a shared cache dir accessible by metatron user
 ENV HF_HOME=/app/.cache/huggingface
 RUN mkdir -p /app/.cache/huggingface && \
-    python -c "from transformers import AutoModelForMaskedLM, AutoTokenizer; \
-    AutoTokenizer.from_pretrained('naver/splade-cocondenser-ensembledistil'); \
-    AutoModelForMaskedLM.from_pretrained('naver/splade-cocondenser-ensembledistil')" \
-    && python -c "from sentence_transformers import CrossEncoder; \
+    python -c "from sentence_transformers import CrossEncoder; \
     CrossEncoder('BAAI/bge-reranker-v2-m3')" \
     || true
 

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -92,6 +92,24 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
+  # SPLADE sparse vector microservice
+  # ---------------------------------------------------------------------------
+  splade:
+    build: services/splade
+    container_name: metatron-full-splade
+    ports:
+      - "8080:8080"
+    networks:
+      - metatron_full
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
   # Metatron Core API
   # ---------------------------------------------------------------------------
   metatron-core:
@@ -109,6 +127,7 @@ services:
       MEMGRAPH_HOST: memgraph
       OLLAMA_HOST: http://ollama:11434
       LLM_PROVIDER: ollama
+      SPLADE_SERVICE_URL: http://splade:8080
     volumes:
       - full_file_data:/app/data
     depends_on:
@@ -119,6 +138,8 @@ services:
       memgraph:
         condition: service_healthy
       ollama:
+        condition: service_healthy
+      splade:
         condition: service_healthy
     networks:
       - metatron_full

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -76,6 +76,22 @@ services:
       start_period: 120s
     restart: unless-stopped
 
+  splade:
+    image: ghcr.io/aisec-co-il/metatroncore:splade-develop
+    pull_policy: always
+    container_name: metatron-full-splade
+    ports:
+      - "8080:8080"
+    networks:
+      - metatron_full
+    healthcheck:
+      test: ["CMD", "python", "-c", "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
   metatron-core:
     image: ghcr.io/aisec-co-il/metatroncore:metatroncore-develop
     pull_policy: always
@@ -93,6 +109,7 @@ services:
       MEMGRAPH_HOST: memgraph
       OLLAMA_HOST: http://ollama:11434
       BENCHMARKER_EMBEDDING_PROXY_URL: http://embedding-proxy:8001
+      SPLADE_SERVICE_URL: http://splade:8080
     volumes:
       - full_file_data:/app/data
     depends_on:
@@ -103,6 +120,8 @@ services:
       memgraph:
         condition: service_healthy
       ollama:
+        condition: service_healthy
+      splade:
         condition: service_healthy
     networks:
       - metatron_full

--- a/services/splade/Dockerfile
+++ b/services/splade/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt
+
+COPY main.py .
+
+# Pre-download model at build time
+RUN python -c "from transformers import AutoModelForMaskedLM, AutoTokenizer; \
+    AutoTokenizer.from_pretrained('naver/splade-cocondenser-ensembledistil'); \
+    AutoModelForMaskedLM.from_pretrained('naver/splade-cocondenser-ensembledistil')"
+
+EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 --start-period=30s \
+    CMD python -c "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/splade/main.py
+++ b/services/splade/main.py
@@ -1,0 +1,75 @@
+"""SPLADE sparse vector microservice."""
+
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+
+import torch
+from fastapi import FastAPI
+from pydantic import BaseModel
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+SPLADE_MODEL = os.getenv("SPLADE_MODEL", "naver/splade-cocondenser-ensembledistil")
+MAX_LENGTH = int(os.getenv("SPLADE_MAX_LENGTH", "256"))
+QUERY_MAX_LENGTH = int(os.getenv("SPLADE_QUERY_MAX_LENGTH", "64"))
+
+_model = None
+_tokenizer = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _model, _tokenizer  # noqa: PLW0603
+    _tokenizer = AutoTokenizer.from_pretrained(SPLADE_MODEL)
+    _model = AutoModelForMaskedLM.from_pretrained(SPLADE_MODEL)
+    _model.eval()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+class SparseRequest(BaseModel):
+    text: str
+    max_length: int | None = None
+
+
+class SparseResponse(BaseModel):
+    indices: list[int]
+    values: list[float]
+
+
+def _compute(text: str, max_length: int) -> tuple[list[int], list[float]]:
+    tokens = _tokenizer(
+        text,
+        return_tensors="pt",
+        max_length=max_length,
+        truncation=True,
+        padding=True,
+    )
+    with torch.no_grad():
+        output = _model(**tokens)
+    splade_vector = torch.max(
+        torch.log1p(torch.relu(output.logits)), dim=1
+    ).values.squeeze()
+    indices = splade_vector.nonzero(as_tuple=True)[0].tolist()
+    values = splade_vector[indices].tolist()
+    return indices, values
+
+
+@app.post("/sparse/document", response_model=SparseResponse)
+def sparse_document(req: SparseRequest):
+    indices, values = _compute(req.text, req.max_length or MAX_LENGTH)
+    return SparseResponse(indices=indices, values=values)
+
+
+@app.post("/sparse/query", response_model=SparseResponse)
+def sparse_query(req: SparseRequest):
+    indices, values = _compute(req.text, req.max_length or QUERY_MAX_LENGTH)
+    return SparseResponse(indices=indices, values=values)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "model": SPLADE_MODEL, "device": "cpu"}

--- a/services/splade/requirements.txt
+++ b/services/splade/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.100
+uvicorn>=0.20
+pydantic>=2.0
+torch>=2.0
+transformers>=4.30

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -163,6 +163,7 @@ class Settings(BaseSettings):
     splade_enabled: bool = Field(True, alias="SPLADE_ENABLED")
     splade_model: str = Field("naver/splade-cocondenser-ensembledistil", alias="SPLADE_MODEL")
     splade_max_length: int = Field(256, alias="SPLADE_MAX_LENGTH")
+    splade_service_url: str = Field("", alias="SPLADE_SERVICE_URL")
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -66,31 +66,79 @@ def get_collection_name(workspace_id: str | None = None) -> str:
     return f"{BASE_COLLECTION_NAME}_{workspace_id}"
 
 
+_splade_http_client = None
+
+
+def _get_splade_client():
+    global _splade_http_client  # noqa: PLW0603
+    if _splade_http_client is None:
+        import httpx
+
+        _splade_http_client = httpx.Client(timeout=10.0)
+    return _splade_http_client
+
+
+def _call_splade_service(
+    base_url: str,
+    endpoint: str,
+    text: str,
+    max_length: int | None = None,
+) -> tuple[list[int], list[float]]:
+    client = _get_splade_client()
+    payload: dict = {"text": text}
+    if max_length:
+        payload["max_length"] = max_length
+    resp = client.post(f"{base_url}{endpoint}", json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["indices"], data["values"]
+
+
 def _compute_doc_sparse(text: str) -> tuple[list[int], list[float]]:
     """Dispatch document sparse vector computation to SPLADE or BM25."""
-    splade_on = get_settings().splade_enabled
-    logger.info("sparse.dispatch", splade_enabled=splade_on, text_len=len(text))
-    if splade_on:
+    settings = get_settings()
+    if not settings.splade_enabled:
+        return compute_bm25_sparse_vector(text)
+    # Prefer remote service
+    if settings.splade_service_url:
         try:
-            from metatron.ingestion.splade import compute_splade_sparse_vector
-
-            result = compute_splade_sparse_vector(text)
-            logger.debug("sparse.splade.ok", indices=len(result[0]))
-            return result
+            return _call_splade_service(
+                settings.splade_service_url, "/sparse/document", text
+            )
         except Exception as e:
-            logger.warning("splade.doc.fallback_to_bm25", error=str(e)[:200])
+            logger.warning("splade.service.fallback_to_bm25", error=str(e)[:200])
+            return compute_bm25_sparse_vector(text)
+    # Fallback: local model
+    try:
+        from metatron.ingestion.splade import compute_splade_sparse_vector
+
+        return compute_splade_sparse_vector(text)
+    except Exception as e:
+        logger.warning("splade.local.fallback_to_bm25", error=str(e)[:200])
     return compute_bm25_sparse_vector(text)
 
 
 def _compute_query_sparse(query: str) -> tuple[list[int], list[float]]:
     """Dispatch query sparse vector computation to SPLADE or BM25."""
-    if get_settings().splade_enabled:
+    settings = get_settings()
+    if not settings.splade_enabled:
+        return compute_query_sparse_vector(query)
+    # Prefer remote service
+    if settings.splade_service_url:
         try:
-            from metatron.ingestion.splade import compute_splade_query_vector
-
-            return compute_splade_query_vector(query)
+            return _call_splade_service(
+                settings.splade_service_url, "/sparse/query", query
+            )
         except Exception as e:
-            logger.warning("splade.query.fallback_to_bm25", error=str(e)[:200])
+            logger.warning("splade.service.fallback_to_bm25", error=str(e)[:200])
+            return compute_query_sparse_vector(query)
+    # Fallback: local model
+    try:
+        from metatron.ingestion.splade import compute_splade_query_vector
+
+        return compute_splade_query_vector(query)
+    except Exception as e:
+        logger.warning("splade.query.fallback_to_bm25", error=str(e)[:200])
     return compute_query_sparse_vector(query)
 
 

--- a/tests/unit/test_splade_service.py
+++ b/tests/unit/test_splade_service.py
@@ -1,0 +1,163 @@
+"""Tests for SPLADE microservice client and dispatch logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCallSpladeService:
+    """Test the _call_splade_service HTTP client helper."""
+
+    def test_call_splade_service_success(self):
+        """Mock httpx, verify returns indices/values."""
+        import metatron.storage.qdrant as qdrant_mod
+
+        # Reset singleton
+        qdrant_mod._splade_http_client = None
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "indices": [10, 42, 100],
+            "values": [0.5, 1.2, 0.3],
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            indices, values = qdrant_mod._call_splade_service(
+                "http://splade:8080", "/sparse/document", "test text"
+            )
+
+        assert indices == [10, 42, 100]
+        assert values == [0.5, 1.2, 0.3]
+        mock_client.post.assert_called_once_with(
+            "http://splade:8080/sparse/document",
+            json={"text": "test text"},
+        )
+        mock_response.raise_for_status.assert_called_once()
+
+        # Cleanup singleton
+        qdrant_mod._splade_http_client = None
+
+    def test_call_splade_service_with_max_length(self):
+        """When max_length is provided, it is included in payload."""
+        import metatron.storage.qdrant as qdrant_mod
+
+        qdrant_mod._splade_http_client = None
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"indices": [1], "values": [0.5]}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            qdrant_mod._call_splade_service(
+                "http://splade:8080", "/sparse/query", "q", max_length=64
+            )
+
+        mock_client.post.assert_called_once_with(
+            "http://splade:8080/sparse/query",
+            json={"text": "q", "max_length": 64},
+        )
+
+        qdrant_mod._splade_http_client = None
+
+    def test_call_splade_service_failure_raises(self):
+        """When httpx raises, error propagates (caller handles fallback)."""
+        import httpx
+
+        import metatron.storage.qdrant as qdrant_mod
+
+        qdrant_mod._splade_http_client = None
+
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.ConnectError("connection refused")
+
+        with patch("httpx.Client", return_value=mock_client):
+            with pytest.raises(httpx.ConnectError):
+                qdrant_mod._call_splade_service(
+                    "http://splade:8080", "/sparse/document", "text"
+                )
+
+        qdrant_mod._splade_http_client = None
+
+
+class TestDispatchWithService:
+    """Test SPLADE dispatch prefers service URL over local model."""
+
+    def test_dispatch_prefers_service_url(self, settings):
+        """When splade_service_url is set, calls service not local model."""
+        settings.splade_enabled = True
+        settings.splade_service_url = "http://splade:8080"
+
+        with patch("metatron.storage.qdrant.get_settings", return_value=settings), patch(
+            "metatron.storage.qdrant._call_splade_service",
+            return_value=([10, 42], [0.5, 1.2]),
+        ) as mock_service:
+            from metatron.storage.qdrant import _compute_doc_sparse
+
+            result = _compute_doc_sparse("test text")
+
+        mock_service.assert_called_once_with(
+            "http://splade:8080", "/sparse/document", "test text"
+        )
+        assert result == ([10, 42], [0.5, 1.2])
+
+    def test_dispatch_query_prefers_service_url(self, settings):
+        """Query dispatch also prefers service URL."""
+        settings.splade_enabled = True
+        settings.splade_service_url = "http://splade:8080"
+
+        with patch("metatron.storage.qdrant.get_settings", return_value=settings), patch(
+            "metatron.storage.qdrant._call_splade_service",
+            return_value=([10], [0.8]),
+        ) as mock_service:
+            from metatron.storage.qdrant import _compute_query_sparse
+
+            result = _compute_query_sparse("test query")
+
+        mock_service.assert_called_once_with(
+            "http://splade:8080", "/sparse/query", "test query"
+        )
+        assert result == ([10], [0.8])
+
+    def test_dispatch_service_failure_fallback_to_bm25(self, settings):
+        """When service call fails, falls back to BM25."""
+        settings.splade_enabled = True
+        settings.splade_service_url = "http://splade:8080"
+
+        with patch("metatron.storage.qdrant.get_settings", return_value=settings), patch(
+            "metatron.storage.qdrant._call_splade_service",
+            side_effect=Exception("connection refused"),
+        ), patch(
+            "metatron.storage.qdrant.compute_bm25_sparse_vector",
+            return_value=([1, 2], [0.5, 0.6]),
+        ) as mock_bm25:
+            from metatron.storage.qdrant import _compute_doc_sparse
+
+            result = _compute_doc_sparse("test text")
+
+        mock_bm25.assert_called_once_with("test text")
+        assert result == ([1, 2], [0.5, 0.6])
+
+    def test_dispatch_no_url_uses_local(self, settings):
+        """When splade_service_url is empty, uses local model."""
+        settings.splade_enabled = True
+        settings.splade_service_url = ""
+
+        with patch("metatron.storage.qdrant.get_settings", return_value=settings), patch(
+            "metatron.ingestion.splade.compute_splade_sparse_vector",
+            return_value=([10, 42], [0.5, 1.2]),
+        ) as mock_local:
+            from metatron.storage.qdrant import _compute_doc_sparse
+
+            result = _compute_doc_sparse("test text")
+
+        mock_local.assert_called_once_with("test text")
+        assert result == ([10, 42], [0.5, 1.2])


### PR DESCRIPTION
## Summary
Refactor SPLADE from in-process model to standalone microservice. Solves Docker permission issue (model cached under root, runtime as metatron user).

## Architecture
```
Before: metatron-api → local transformers model (fails in Docker)
After:  metatron-api → HTTP → metatron-splade-service:8080 → sparse vector
```

## New service: `services/splade/`
- FastAPI app: `POST /sparse/document`, `POST /sparse/query`, `GET /health`
- Own Dockerfile with model pre-download
- ~440MB isolated container

## API client changes
- 3-tier dispatch: remote service > local model > BM25 fallback
- Config: `SPLADE_SERVICE_URL` (empty = local mode)

## Docker Compose
- New `splade` service in both install/ and full docker-compose
- metatron-core depends on splade service health

## Test plan
- [x] 12 tests pass (5 existing + 7 new service client tests)
- [ ] Build splade-service image + docker compose up