### PR TITLE
feat: add Neo4j indexes for Agent Memory schema (WS1 Stage 1)

### DIFF
--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -88,6 +88,43 @@ Neo4j (bolt/neo4j driver) connection and graph operations.
 `extract_graph_from_text(text, max_text_length=8000) -> dict` — LLM-based NER extraction → `{entities: [], relations: []}`.
 `write_doc_graph(doc, workspace_id)` — writes Document → Chunk → Entity nodes + relationships.
 `delete_workspace_graph(workspace_id)` — removes all nodes for workspace.
+`ensure_graph_indexes()` — creates all Neo4j indexes idempotently (see schema below).
+
+**Neo4j Graph Schema:**
+
+Node types (document ingestion):
+- `:User` — uploader (user_id, workspace_id)
+- `:Document` — ingested document (doc_id, file_name, workspace_id, doc_label)
+- `:Chunk` — document chunk (chunk_id, workspace_id, chunk_type: root|child, doc_label)
+- `:Entity` — extracted entity (name, type, workspace_id)
+- `:JiraIssue` — Jira issue node (issue_key, workspace_id)
+- `:Sprint` — Jira sprint node
+
+Node types (agent memory — WS1):
+- `:Agent` — AI agent (id, name, model, workspace_id, created_at)
+- `:Session` — agent conversation session (id, agent_id, workspace_id, started_at, ended_at)
+- `:MemoryRecord` — agent memory entry (id, workspace_id, agent_id, scope, source_type, tags, ttl_expires_at, created_at). NO content blobs — content lives in Qdrant.
+
+Relationships (document ingestion):
+- `(:User)-[:UPLOADED]->(:Document)`
+- `(:Document)-[:MENTIONS]->(:Entity)`
+- `(:Entity)-[:RELATION {type}]->(:Entity)`
+- `(:Entity)-[:ALIAS]->(:Entity)` — person name normalization
+- `(:Chunk)-[:CHILD_OF]->(:Chunk)` — root-child hierarchy
+
+Relationships (agent memory — WS1):
+- `(:Agent)-[:REMEMBERS]->(:MemoryRecord)`
+- `(:MemoryRecord)-[:ABOUT]->(:Entity)`
+- `(:MemoryRecord)-[:FROM_SESSION]->(:Session)`
+- `(:MemoryRecord)-[:DERIVED_FROM]->(:Document)`
+
+Indexes (created by `ensure_graph_indexes()`):
+- `Entity(name)`, `Entity(workspace_id)`
+- `Document(doc_label)`, `Document(workspace_id)`
+- `JiraIssue(issue_key)`, `JiraIssue(workspace_id)`
+- `Agent(workspace_id)`
+- `MemoryRecord(workspace_id, scope)` — composite, for scoped memory queries
+- `MemoryRecord(ttl_expires_at)` — for TTL cleanup jobs
 
 ### `graph_ops.py`
 High-level graph query functions used by retrieval.

--- a/src/metatron/storage/neo4j_graph.py
+++ b/src/metatron/storage/neo4j_graph.py
@@ -458,6 +458,10 @@ def ensure_graph_indexes() -> None:
             "CREATE INDEX IF NOT EXISTS FOR (d:Document) ON (d.workspace_id)",
             "CREATE INDEX IF NOT EXISTS FOR (j:JiraIssue) ON (j.issue_key)",
             "CREATE INDEX IF NOT EXISTS FOR (j:JiraIssue) ON (j.workspace_id)",
+            # Agent Memory schema indexes
+            "CREATE INDEX IF NOT EXISTS FOR (a:Agent) ON (a.workspace_id)",
+            "CREATE INDEX IF NOT EXISTS FOR (m:MemoryRecord) ON (m.workspace_id, m.scope)",
+            "CREATE INDEX IF NOT EXISTS FOR (m:MemoryRecord) ON (m.ttl_expires_at)",
         ]:
             try:
                 session.run(stmt)

--- a/tests/unit/test_graph_driver.py
+++ b/tests/unit/test_graph_driver.py
@@ -8,7 +8,7 @@ import pytest
 from neo4j.exceptions import ServiceUnavailable, SessionExpired
 
 import metatron.storage.neo4j_graph as neo4j_graph_mod
-from metatron.storage.neo4j_graph import graph_retry
+from metatron.storage.neo4j_graph import ensure_graph_indexes, graph_retry
 
 
 class TestGraphRetry:
@@ -165,3 +165,56 @@ class TestGetGraphDriverLiveness:
 
         assert result is old_driver
         mock_gdb.driver.assert_not_called()
+
+
+class TestEnsureGraphIndexes:
+    def test_creates_all_indexes(self) -> None:
+        """ensure_graph_indexes runs all 9 CREATE INDEX statements."""
+        mock_session = MagicMock()
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("metatron.storage.neo4j_graph.get_graph_driver", return_value=mock_driver):
+            ensure_graph_indexes()
+
+        stmts = [call.args[0] for call in mock_session.run.call_args_list]
+        assert len(stmts) == 9
+
+        # Original indexes
+        assert "CREATE INDEX IF NOT EXISTS FOR (e:Entity) ON (e.name)" in stmts
+        assert "CREATE INDEX IF NOT EXISTS FOR (e:Entity) ON (e.workspace_id)" in stmts
+        assert "CREATE INDEX IF NOT EXISTS FOR (d:Document) ON (d.doc_label)" in stmts
+        assert "CREATE INDEX IF NOT EXISTS FOR (d:Document) ON (d.workspace_id)" in stmts
+        assert "CREATE INDEX IF NOT EXISTS FOR (j:JiraIssue) ON (j.issue_key)" in stmts
+        assert "CREATE INDEX IF NOT EXISTS FOR (j:JiraIssue) ON (j.workspace_id)" in stmts
+
+        # Agent Memory indexes
+        assert "CREATE INDEX IF NOT EXISTS FOR (a:Agent) ON (a.workspace_id)" in stmts
+        assert (
+            "CREATE INDEX IF NOT EXISTS FOR (m:MemoryRecord) ON (m.workspace_id, m.scope)" in stmts
+        )
+        assert "CREATE INDEX IF NOT EXISTS FOR (m:MemoryRecord) ON (m.ttl_expires_at)" in stmts
+
+    def test_continues_on_index_error(self) -> None:
+        """A failing index statement does not prevent subsequent indexes."""
+        mock_session = MagicMock()
+        mock_session.run.side_effect = [
+            None,  # Entity name
+            Exception("already exists"),  # Entity workspace_id
+            None,
+            None,
+            None,
+            None,  # Document + JiraIssue
+            None,
+            None,
+            None,  # Agent Memory
+        ]
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("metatron.storage.neo4j_graph.get_graph_driver", return_value=mock_driver):
+            ensure_graph_indexes()
+
+        assert mock_session.run.call_count == 9


### PR DESCRIPTION
Add Agent, MemoryRecord, and Session node indexes to ensure_graph_indexes() for the upcoming agent memory system. Document full Neo4j graph schema (nodes, relationships, indexes) in storage/.claude/CLAUDE.md.