### PR TITLE
feat: add memory session TTL config, fix Redis envs and docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ NEO4J_PORT=7687
 NEO4J_USER=                      # empty = no auth (NEO4J_AUTH=none in Docker)
 NEO4J_PASSWORD=
 
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_PASSWORD=
+METATRON_MEMORY_SESSION_TTL=14400  # session memory TTL in seconds (4 hours)
+
 FERNET_KEY=                      # generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 FILE_STORE_PATH=./data/files     # local path for uploaded files
 

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -149,6 +149,8 @@ services:
       OLLAMA_HOST: http://ollama:11434
       LLM_PROVIDER: ollama
       REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0
       SPLADE_SERVICE_URL: http://splade:8080
     volumes:
       - full_file_data:/app/data
@@ -239,21 +241,6 @@ services:
     networks:
       - metatron_full
     profiles: ["openwebui"]
-    restart: unless-stopped
-  embedding-proxy:
-    build: ./embedding_proxy
-    container_name: metatron-embedding-proxy
-    ports:
-      - "8001:8001"
-    environment:
-      OLLAMA_HOST: ollama
-      OLLAMA_PORT: "11434"
-      OLLAMA_MODEL: ${OLLAMA_MODEL:-nomic-embed-text}
-    depends_on:
-      - ollama
-    networks:
-      - metatron_full
-    profiles: ["benchmarker"]
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       NEO4J_HOST: neo4j
       OLLAMA_HOST: http://ollama:11434
       REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_DB: 0
       BENCHMARKER_EMBEDDING_PROXY_URL: http://embedding-proxy:8001
       # Cache HuggingFace models to persistent volume (avoids re-download on restart)
       HF_HOME: /app/data/hf_cache

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -74,6 +74,7 @@ class Settings(BaseSettings):
     redis_port: int = Field(6379, alias="REDIS_PORT")
     redis_db: int = Field(0, alias="REDIS_DB")
     redis_password: str = Field("", alias="REDIS_PASSWORD")
+    memory_session_ttl: int = Field(14400, alias="METATRON_MEMORY_SESSION_TTL")  # 4 hours
 
     # --- Ollama (embeddings) ---
     ollama_host: str = Field("http://localhost:11434", alias="OLLAMA_HOST")


### PR DESCRIPTION
- Add memory_session_ttl (METATRON_MEMORY_SESSION_TTL, default 14400s) to Settings
- Add Redis env vars to .env.example
- Add REDIS_PORT/REDIS_DB to both docker-compose environment sections
- Remove duplicate embedding-proxy service from docker-compose.full.yml