### PR TITLE
chore(MTRNIX-240): rename MemoryError, widen metadata type

### DIFF
--- a/src/metatron/core/.claude/claude.md
+++ b/src/metatron/core/.claude/claude.md
@@ -116,7 +116,7 @@ MetatronError
 ├── SecurityError
 ├── ToolDisabledError
 ├── ToolTimeoutError
-└── MemoryError  (WS1)
+└── AgentMemoryError  (WS1)
     ├── MemoryNotFoundError
     └── SnapshotCorruptError
 ```

--- a/src/metatron/core/exceptions.py
+++ b/src/metatron/core/exceptions.py
@@ -60,13 +60,13 @@ class ToolTimeoutError(MetatronError):
     """Tool execution exceeded the allowed timeout."""
 
 
-class MemoryError(MetatronError):  # noqa: A001 - intentional shadow of builtin in this namespace
+class AgentMemoryError(MetatronError):
     """Base class for memory subsystem errors (WS1)."""
 
 
-class MemoryNotFoundError(MemoryError):
+class MemoryNotFoundError(AgentMemoryError):
     """Requested memory record or snapshot does not exist."""
 
 
-class SnapshotCorruptError(MemoryError):
+class SnapshotCorruptError(AgentMemoryError):
     """Snapshot content hash mismatch or unreadable payload."""

--- a/src/metatron/core/models.py
+++ b/src/metatron/core/models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import Any
 from uuid import uuid4
 
 
@@ -307,7 +308,7 @@ class MemoryRecord:
     content_hash: str = ""
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     session_id: str | None = None
-    metadata: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/unit/core/test_memory_exceptions.py
+++ b/tests/unit/core/test_memory_exceptions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from metatron.core.exceptions import (
-    MemoryError,
+    AgentMemoryError,
     MemoryNotFoundError,
     MetatronError,
     SnapshotCorruptError,
@@ -13,13 +13,13 @@ from metatron.core.exceptions import (
 
 
 def test_exception_hierarchy() -> None:
-    assert issubclass(MemoryError, MetatronError)
-    assert issubclass(MemoryNotFoundError, MemoryError)
-    assert issubclass(SnapshotCorruptError, MemoryError)
+    assert issubclass(AgentMemoryError, MetatronError)
+    assert issubclass(MemoryNotFoundError, AgentMemoryError)
+    assert issubclass(SnapshotCorruptError, AgentMemoryError)
 
 
 def test_memory_not_found_raise_catch() -> None:
-    with pytest.raises(MemoryError):
+    with pytest.raises(AgentMemoryError):
         raise MemoryNotFoundError("missing")
     with pytest.raises(MetatronError):
         raise MemoryNotFoundError("missing")

--- a/tests/unit/core/test_memory_models.py
+++ b/tests/unit/core/test_memory_models.py
@@ -22,7 +22,6 @@ def test_memory_scope_values() -> None:
 def test_memory_record_defaults() -> None:
     record = MemoryRecord()
     assert len(record.id) == 32
-    int(record.id, 16)  # valid hex
     assert record.scope == MemoryScope.PER_AGENT
     assert record.tags == []
     assert record.metadata == {}


### PR DESCRIPTION
## Summary

Follow-up to PR #69 (MTRNIX-240) addressing review feedback:

1. **Rename `MemoryError` → `AgentMemoryError`** — avoids shadowing Python builtin `MemoryError` (which is about OOM). Removes the `noqa: A001` comment. `MemoryNotFoundError` and `SnapshotCorruptError` now inherit from `AgentMemoryError`.

2. **Widen `MemoryRecord.metadata` type** — `dict[str, str]` → `dict[str, Any]` for parity with other models (e.g. `QueryStep.metadata`). Avoids forcing callers to str-cast numeric/bool values.

3. **Minor test cleanup** — drop redundant `int(record.id, 16)` assertion since `uuid4().hex` already guarantees hex.

## Test plan

- [x] 18/18 core memory tests pass
- [x] ruff clean
- [x] mypy strict clean on touched files
- [x] No non-test source files imported `MemoryError` from exceptions — rename is safe

## Context

All three changes were flagged as non-blocking SUGGESTIONs/WARNINGs in the PR #69 review but deferred to this follow-up PR.