### PR TITLE
feat(WS1): add Neo4j memory graph storage (Stage 2)

### DIFF
--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -126,6 +126,23 @@ Indexes (created by `ensure_graph_indexes()`):
 - `MemoryRecord(workspace_id, scope)` — composite, for scoped memory queries
 - `MemoryRecord(ttl_expires_at)` — for TTL cleanup jobs
 
+### `memory_graph.py`
+Neo4j graph operations for Agent Memory (WS1). Reuses driver from `neo4j_graph.py`.
+
+Functions:
+- `upsert_memory_node(record)` — MERGE MemoryRecord node (metadata only, no content)
+- `get_memory_node(workspace_id, record_id) -> dict | None` — fetch single node
+- `delete_memory_node(workspace_id, record_id) -> bool` — DETACH DELETE
+- `delete_agent_memories(workspace_id, agent_id, scope?) -> int` — bulk delete
+- `link_agent_memory(workspace_id, agent_id, record_id)` — MERGE Agent + REMEMBERS edge
+- `link_memory_entity(workspace_id, record_id, entity_name, relevance?)` — ABOUT edge
+- `link_memory_session(workspace_id, record_id, session_id, agent_id)` — MERGE Session + FROM_SESSION edge
+- `link_memory_document(workspace_id, record_id, doc_id)` — DERIVED_FROM edge
+- `get_agent_memories(workspace_id, agent_id, scope?, limit?) -> list[dict]` — traverse REMEMBERS
+- `get_memories_about_entity(workspace_id, entity_name, limit?) -> list[dict]` — traverse ABOUT
+- `get_memory_relationships(workspace_id, record_id) -> list[dict]` — all edges for a memory
+- `save_memory_to_graph(record, entity_names?, document_ids?)` — composite: node + all edges
+
 ### `graph_ops.py`
 High-level graph query functions used by retrieval.
 

--- a/src/metatron/storage/memory_graph.py
+++ b/src/metatron/storage/memory_graph.py
@@ -1,0 +1,361 @@
+"""Neo4j graph operations for Agent Memory (WS1).
+
+Handles MemoryRecord nodes and their relationships in the knowledge graph.
+Content is NOT stored here — only metadata and edges. Content lives in Qdrant.
+
+Reuses the shared Neo4j driver from neo4j_graph.py.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from metatron.storage.neo4j_graph import get_graph_driver, graph_retry
+
+if TYPE_CHECKING:
+    from metatron.core.models import MemoryRecord
+
+logger = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Node CRUD
+# ---------------------------------------------------------------------------
+
+
+@graph_retry()
+def upsert_memory_node(record: MemoryRecord) -> None:
+    """Create or update a MemoryRecord node in Neo4j.
+
+    Stores metadata only — content lives in Qdrant.
+    Uses MERGE on (id, workspace_id) to be idempotent.
+
+    Note: ``record.content`` and ``record.metadata`` are intentionally not
+    written.  Content belongs in Qdrant; metadata is a free-form dict that
+    Neo4j cannot store as a node property (PG/Qdrant handle it).
+    """
+    driver = get_graph_driver()
+    with driver.session() as session:
+        session.run(
+            "MERGE (m:MemoryRecord {id: $id, workspace_id: $ws}) "
+            "SET m.agent_id = $agent_id, "
+            "    m.scope = $scope, "
+            "    m.source_type = $source_type, "
+            "    m.importance_score = $importance_score, "
+            "    m.tags = $tags, "
+            "    m.ttl_expires_at = $ttl_expires_at, "
+            "    m.content_hash = $content_hash, "
+            "    m.created_at = $created_at, "
+            "    m.session_id = $session_id",
+            {
+                "id": record.id,
+                "ws": record.workspace_id,
+                "agent_id": record.agent_id,
+                "scope": record.scope.value,
+                "source_type": record.source_type,
+                "importance_score": record.importance_score,
+                "tags": record.tags,
+                "ttl_expires_at": (
+                    record.ttl_expires_at.isoformat() if record.ttl_expires_at else None
+                ),
+                "content_hash": record.content_hash,
+                "created_at": record.created_at.isoformat(),
+                "session_id": record.session_id,
+            },
+        )
+    logger.debug("memory_graph.upsert", id=record.id, workspace_id=record.workspace_id)
+
+
+@graph_retry()
+def get_memory_node(workspace_id: str, record_id: str) -> dict[str, Any] | None:
+    """Fetch a single MemoryRecord node by id.
+
+    Returns node properties as a dict, or None if not found.
+    """
+    driver = get_graph_driver()
+    with driver.session() as session:
+        result = session.run(
+            "MATCH (m:MemoryRecord {id: $id, workspace_id: $ws}) RETURN m{.*} AS m",
+            {"id": record_id, "ws": workspace_id},
+        )
+        row = result.single()
+        if row is None:
+            return None
+        return dict(row["m"])
+
+
+# ---------------------------------------------------------------------------
+# Delete operations
+# ---------------------------------------------------------------------------
+
+
+@graph_retry()
+def delete_memory_node(workspace_id: str, record_id: str) -> bool:
+    """Delete a MemoryRecord node and all its edges.
+
+    Returns True if the node existed, False otherwise.
+    """
+    driver = get_graph_driver()
+    with driver.session() as session:
+        result = session.run(
+            "MATCH (m:MemoryRecord {id: $id, workspace_id: $ws}) "
+            "DETACH DELETE m "
+            "RETURN count(*) AS n",
+            {"id": record_id, "ws": workspace_id},
+        )
+        row = result.single()
+        deleted = row["n"] > 0 if row else False
+    if deleted:
+        logger.debug("memory_graph.deleted", id=record_id, workspace_id=workspace_id)
+    return deleted
+
+
+@graph_retry()
+def delete_agent_memories(
+    workspace_id: str,
+    agent_id: str,
+    scope: str | None = None,
+) -> int:
+    """Bulk-delete all MemoryRecord nodes for an agent. Returns count deleted.
+
+    If scope is provided, only deletes records matching that scope.
+    """
+    driver = get_graph_driver()
+    where = "WHERE m.scope = $scope " if scope is not None else ""
+    cypher = (
+        "MATCH (m:MemoryRecord {workspace_id: $ws, agent_id: $agent_id}) "
+        f"{where}"
+        "DETACH DELETE m "
+        "RETURN count(*) AS n"
+    )
+    params: dict[str, Any] = {"ws": workspace_id, "agent_id": agent_id}
+    if scope is not None:
+        params["scope"] = scope
+
+    with driver.session() as session:
+        result = session.run(cypher, params)
+        row = result.single()
+        count = row["n"] if row else 0
+    logger.info(
+        "memory_graph.bulk_deleted",
+        agent_id=agent_id,
+        scope=scope,
+        count=count,
+        workspace_id=workspace_id,
+    )
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Relationship edge operations
+# ---------------------------------------------------------------------------
+
+
+@graph_retry()
+def link_agent_memory(workspace_id: str, agent_id: str, record_id: str) -> None:
+    """Ensure Agent node exists and create REMEMBERS edge to MemoryRecord.
+
+    MERGE is idempotent — safe to call multiple times.
+    """
+    driver = get_graph_driver()
+    with driver.session() as session:
+        session.run(
+            "MERGE (a:Agent {id: $agent_id, workspace_id: $ws}) "
+            "WITH a "
+            "MATCH (m:MemoryRecord {id: $record_id, workspace_id: $ws}) "
+            "MERGE (a)-[:REMEMBERS {since: $since}]->(m)",
+            {
+                "agent_id": agent_id,
+                "ws": workspace_id,
+                "record_id": record_id,
+                "since": datetime.now(UTC).isoformat(),
+            },
+        )
+
+
+@graph_retry()
+def link_memory_entity(
+    workspace_id: str,
+    record_id: str,
+    entity_name: str,
+    relevance: float = 1.0,
+) -> None:
+    """Create ABOUT edge from MemoryRecord to an existing Entity."""
+    driver = get_graph_driver()
+    with driver.session() as session:
+        session.run(
+            "MATCH (m:MemoryRecord {id: $record_id, workspace_id: $ws}) "
+            "MATCH (e:Entity {name: $entity_name, workspace_id: $ws}) "
+            "MERGE (m)-[:ABOUT {relevance: $relevance}]->(e)",
+            {
+                "record_id": record_id,
+                "ws": workspace_id,
+                "entity_name": entity_name,
+                "relevance": relevance,
+            },
+        )
+
+
+@graph_retry()
+def link_memory_session(
+    workspace_id: str,
+    record_id: str,
+    session_id: str,
+    agent_id: str,
+) -> None:
+    """Ensure Session node exists and create FROM_SESSION edge."""
+    driver = get_graph_driver()
+    with driver.session() as session:
+        session.run(
+            "MERGE (s:Session {id: $session_id, workspace_id: $ws}) "
+            "ON CREATE SET s.agent_id = $agent_id "
+            "WITH s "
+            "MATCH (m:MemoryRecord {id: $record_id, workspace_id: $ws}) "
+            "MERGE (m)-[:FROM_SESSION]->(s)",
+            {
+                "session_id": session_id,
+                "ws": workspace_id,
+                "agent_id": agent_id,
+                "record_id": record_id,
+            },
+        )
+
+
+@graph_retry()
+def link_memory_document(workspace_id: str, record_id: str, doc_id: str) -> None:
+    """Create DERIVED_FROM edge from MemoryRecord to an existing Document."""
+    driver = get_graph_driver()
+    with driver.session() as session:
+        session.run(
+            "MATCH (m:MemoryRecord {id: $record_id, workspace_id: $ws}) "
+            "MATCH (d:Document {doc_id: $doc_id, workspace_id: $ws}) "
+            "MERGE (m)-[:DERIVED_FROM]->(d)",
+            {
+                "record_id": record_id,
+                "ws": workspace_id,
+                "doc_id": doc_id,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Query operations
+# ---------------------------------------------------------------------------
+
+
+@graph_retry()
+def get_agent_memories(
+    workspace_id: str,
+    agent_id: str,
+    scope: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Get all MemoryRecord nodes linked to an agent via REMEMBERS.
+
+    Returns list of node property dicts, ordered by importance_score DESC.
+    """
+    driver = get_graph_driver()
+    where = "WHERE m.scope = $scope " if scope is not None else ""
+    cypher = (
+        "MATCH (a:Agent {id: $agent_id, workspace_id: $ws})"
+        "-[:REMEMBERS]->(m:MemoryRecord) "
+        f"{where}"
+        "RETURN m{.*} AS m "
+        "ORDER BY m.importance_score DESC "
+        "LIMIT $limit"
+    )
+    params: dict[str, Any] = {"agent_id": agent_id, "ws": workspace_id, "limit": limit}
+    if scope is not None:
+        params["scope"] = scope
+
+    with driver.session() as session:
+        result = session.run(cypher, params)
+        return [dict(row["m"]) for row in result]
+
+
+@graph_retry()
+def get_memories_about_entity(
+    workspace_id: str,
+    entity_name: str,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Get MemoryRecord nodes linked to an entity via ABOUT.
+
+    Returns list of dicts with node properties + relevance score from the edge.
+    """
+    driver = get_graph_driver()
+    with driver.session() as session:
+        result = session.run(
+            "MATCH (m:MemoryRecord {workspace_id: $ws})"
+            "-[r:ABOUT]->(e:Entity {name: $entity_name, workspace_id: $ws}) "
+            "RETURN m{.*} AS m, r.relevance AS relevance "
+            "ORDER BY r.relevance DESC, m.importance_score DESC "
+            "LIMIT $limit",
+            {"ws": workspace_id, "entity_name": entity_name, "limit": limit},
+        )
+        return [{**dict(row["m"]), "relevance": row["relevance"]} for row in result]
+
+
+@graph_retry()
+def get_memory_relationships(workspace_id: str, record_id: str) -> list[dict[str, Any]]:
+    """Get all relationships (both directions) for a MemoryRecord.
+
+    Returns list of dicts with edge type and target node info (label + id).
+    Useful for provenance queries and graph scoring.
+    """
+    driver = get_graph_driver()
+    with driver.session() as session:
+        result = session.run(
+            "MATCH (m:MemoryRecord {id: $id, workspace_id: $ws})-[r]-(n) "
+            "RETURN type(r) AS type, "
+            "       labels(n)[0] AS target_label, "
+            "       coalesce(n.id, n.name, n.doc_id) AS target_id",
+            {"id": record_id, "ws": workspace_id},
+        )
+        return [dict(row) for row in result]
+
+
+# ---------------------------------------------------------------------------
+# Composite helper
+# ---------------------------------------------------------------------------
+
+
+def save_memory_to_graph(
+    record: MemoryRecord,
+    *,
+    entity_names: list[str] | None = None,
+    document_ids: list[str] | None = None,
+) -> None:
+    """Composite save: create MemoryRecord node + all relationship edges.
+
+    Always creates:
+      - MemoryRecord node (metadata only)
+      - Agent node + REMEMBERS edge
+
+    Conditionally creates:
+      - FROM_SESSION edge (if record.session_id is set)
+      - ABOUT edges (if entity_names provided)
+      - DERIVED_FROM edges (if document_ids provided)
+
+    Not transactional — a failure mid-way leaves partial state.
+    All operations are idempotent, so the caller can safely retry.
+    """
+    upsert_memory_node(record)
+    link_agent_memory(record.workspace_id, record.agent_id, record.id)
+
+    if record.session_id:
+        link_memory_session(
+            record.workspace_id,
+            record.id,
+            record.session_id,
+            record.agent_id,
+        )
+
+    for name in entity_names or []:
+        link_memory_entity(record.workspace_id, record.id, name, relevance=1.0)
+
+    for doc_id in document_ids or []:
+        link_memory_document(record.workspace_id, record.id, doc_id)

--- a/tests/unit/test_memory_graph.py
+++ b/tests/unit/test_memory_graph.py
@@ -1,0 +1,493 @@
+"""Tests for memory_graph Neo4j operations (WS1 Stage 2)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from metatron.core.models import MemoryRecord, MemoryScope
+
+
+def _mock_driver():
+    """Create a mock Neo4j driver with session context manager."""
+    mock_session = MagicMock()
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_driver, mock_session
+
+
+# ---------------------------------------------------------------------------
+# Task 1: Core node operations
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertMemoryNode:
+    def test_creates_node_with_all_metadata(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        record = MemoryRecord(
+            id="mem001",
+            workspace_id="ws1",
+            agent_id="agent1",
+            scope=MemoryScope.PER_AGENT,
+            source_type="conversation",
+            content="should not appear in cypher",
+            tags=["pref", "style"],
+            importance_score=0.8,
+            content_hash="abc123",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            session_id="sess1",
+        )
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import upsert_memory_node
+
+            upsert_memory_node(record)
+
+        mock_session.run.assert_called_once()
+        cypher = mock_session.run.call_args.args[0]
+        params = mock_session.run.call_args.args[1]
+
+        assert "MERGE (m:MemoryRecord" in cypher
+        assert params["id"] == "mem001"
+        assert params["ws"] == "ws1"
+        assert params["agent_id"] == "agent1"
+        assert params["scope"] == "per_agent"
+        assert params["source_type"] == "conversation"
+        assert params["importance_score"] == 0.8
+        assert params["tags"] == ["pref", "style"]
+        assert params["content_hash"] == "abc123"
+        assert params["session_id"] == "sess1"
+        # content must NOT be in params — it lives in Qdrant
+        assert "content" not in params
+
+    def test_handles_none_ttl(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        record = MemoryRecord(id="mem002", workspace_id="ws1", agent_id="a1")
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import upsert_memory_node
+
+            upsert_memory_node(record)
+
+        params = mock_session.run.call_args.args[1]
+        assert params["ttl_expires_at"] is None
+
+    def test_serializes_ttl_as_isoformat(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        ttl = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+        record = MemoryRecord(
+            id="mem003",
+            workspace_id="ws1",
+            agent_id="a1",
+            ttl_expires_at=ttl,
+        )
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import upsert_memory_node
+
+            upsert_memory_node(record)
+
+        params = mock_session.run.call_args.args[1]
+        assert params["ttl_expires_at"] == "2026-06-01T12:00:00+00:00"
+
+
+class TestGetMemoryNode:
+    def test_returns_dict_when_found(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.single.return_value = {
+            "m": {"id": "mem001", "workspace_id": "ws1", "agent_id": "agent1"},
+        }
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_memory_node
+
+            result = get_memory_node("ws1", "mem001")
+
+        assert result is not None
+        assert result["id"] == "mem001"
+        params = mock_session.run.call_args.args[1]
+        assert params["ws"] == "ws1"
+        assert params["id"] == "mem001"
+
+    def test_returns_none_when_not_found(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.single.return_value = None
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_memory_node
+
+            result = get_memory_node("ws1", "nonexistent")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Delete operations
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteMemoryNode:
+    def test_returns_true_when_deleted(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"n": 1}
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import delete_memory_node
+
+            assert delete_memory_node("ws1", "mem001") is True
+
+        cypher = mock_session.run.call_args.args[0]
+        assert "DETACH DELETE" in cypher
+        assert "count(*)" in cypher  # not per-row count(m)
+
+    def test_returns_false_when_not_found(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"n": 0}
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import delete_memory_node
+
+            assert delete_memory_node("ws1", "nonexistent") is False
+
+
+class TestDeleteAgentMemories:
+    def test_deletes_all_agent_memories(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"n": 5}
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import delete_agent_memories
+
+            count = delete_agent_memories("ws1", "agent1")
+
+        assert count == 5
+        cypher = mock_session.run.call_args.args[0]
+        assert "count(*)" in cypher  # not per-row count(m)
+        params = mock_session.run.call_args.args[1]
+        assert params["ws"] == "ws1"
+        assert params["agent_id"] == "agent1"
+
+    def test_deletes_scoped_memories_only(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"n": 2}
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import delete_agent_memories
+
+            count = delete_agent_memories("ws1", "agent1", scope="session")
+
+        assert count == 2
+        cypher = mock_session.run.call_args.args[0]
+        assert "m.scope = $scope" in cypher
+        params = mock_session.run.call_args.args[1]
+        assert params["scope"] == "session"
+
+    def test_returns_zero_when_no_match(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.single.return_value = None
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import delete_agent_memories
+
+            assert delete_agent_memories("ws1", "ghost") == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Relationship edge operations
+# ---------------------------------------------------------------------------
+
+
+class TestLinkAgentMemory:
+    def test_creates_agent_and_remembers_edge(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import link_agent_memory
+
+            link_agent_memory("ws1", "agent1", "mem001")
+
+        mock_session.run.assert_called_once()
+        cypher = mock_session.run.call_args.args[0]
+        params = mock_session.run.call_args.args[1]
+        assert "MERGE (a:Agent" in cypher
+        assert "MERGE (a)-[:REMEMBERS" in cypher
+        assert params["agent_id"] == "agent1"
+        assert params["record_id"] == "mem001"
+        assert "since" in params
+
+
+class TestLinkMemoryEntity:
+    def test_creates_about_edge_with_relevance(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import link_memory_entity
+
+            link_memory_entity("ws1", "mem001", "Python", relevance=0.9)
+
+        cypher = mock_session.run.call_args.args[0]
+        params = mock_session.run.call_args.args[1]
+        assert ":ABOUT" in cypher
+        assert params["entity_name"] == "Python"
+        assert params["relevance"] == 0.9
+
+    def test_default_relevance_is_one(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import link_memory_entity
+
+            link_memory_entity("ws1", "mem001", "Python")
+
+        params = mock_session.run.call_args.args[1]
+        assert params["relevance"] == 1.0
+
+
+class TestLinkMemorySession:
+    def test_creates_session_and_from_session_edge(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import link_memory_session
+
+            link_memory_session("ws1", "mem001", "sess1", "agent1")
+
+        cypher = mock_session.run.call_args.args[0]
+        params = mock_session.run.call_args.args[1]
+        assert "MERGE (s:Session" in cypher
+        assert ":FROM_SESSION" in cypher
+        assert params["session_id"] == "sess1"
+        assert params["agent_id"] == "agent1"
+
+
+class TestLinkMemoryDocument:
+    def test_creates_derived_from_edge(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import link_memory_document
+
+            link_memory_document("ws1", "mem001", "doc123")
+
+        cypher = mock_session.run.call_args.args[0]
+        params = mock_session.run.call_args.args[1]
+        assert ":DERIVED_FROM" in cypher
+        assert params["doc_id"] == "doc123"
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Query operations
+# ---------------------------------------------------------------------------
+
+
+class TestGetAgentMemories:
+    def test_returns_memories_ordered_by_importance(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(
+            return_value=iter(
+                [
+                    {"m": {"id": "m1", "importance_score": 0.9}},
+                    {"m": {"id": "m2", "importance_score": 0.5}},
+                ]
+            )
+        )
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_agent_memories
+
+            results = get_agent_memories("ws1", "agent1")
+
+        assert len(results) == 2
+        assert results[0]["id"] == "m1"
+        cypher = mock_session.run.call_args.args[0]
+        assert "REMEMBERS" in cypher
+        assert "importance_score DESC" in cypher
+
+    def test_filters_by_scope(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_agent_memories
+
+            get_agent_memories("ws1", "agent1", scope="global")
+
+        cypher = mock_session.run.call_args.args[0]
+        params = mock_session.run.call_args.args[1]
+        assert "m.scope = $scope" in cypher
+        assert params["scope"] == "global"
+
+    def test_respects_limit(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_agent_memories
+
+            get_agent_memories("ws1", "agent1", limit=10)
+
+        params = mock_session.run.call_args.args[1]
+        assert params["limit"] == 10
+
+
+class TestGetMemoriesAboutEntity:
+    def test_returns_memories_linked_to_entity(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(
+            return_value=iter([{"m": {"id": "m1"}, "relevance": 0.9}])
+        )
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_memories_about_entity
+
+            results = get_memories_about_entity("ws1", "Python")
+
+        assert len(results) == 1
+        assert results[0]["id"] == "m1"
+        assert results[0]["relevance"] == 0.9
+        cypher = mock_session.run.call_args.args[0]
+        assert "ABOUT" in cypher
+
+
+class TestGetMemoryRelationships:
+    def test_returns_all_edges(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(
+            return_value=iter(
+                [
+                    {"type": "REMEMBERS", "target_label": "Agent", "target_id": "agent1"},
+                    {"type": "ABOUT", "target_label": "Entity", "target_id": "Python"},
+                ]
+            )
+        )
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_memory_relationships
+
+            results = get_memory_relationships("ws1", "mem001")
+
+        assert len(results) == 2
+
+    def test_returns_empty_list_for_unknown_memory(self) -> None:
+        mock_driver, mock_session = _mock_driver()
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_session.run.return_value = mock_result
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            from metatron.storage.memory_graph import get_memory_relationships
+
+            results = get_memory_relationships("ws1", "nope")
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Composite save helper
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMemoryToGraph:
+    @patch("metatron.storage.memory_graph.link_memory_document")
+    @patch("metatron.storage.memory_graph.link_memory_session")
+    @patch("metatron.storage.memory_graph.link_memory_entity")
+    @patch("metatron.storage.memory_graph.link_agent_memory")
+    @patch("metatron.storage.memory_graph.upsert_memory_node")
+    def test_creates_node_and_agent_edge(
+        self,
+        mock_upsert,
+        mock_link_agent,
+        mock_link_entity,
+        mock_link_session,
+        mock_link_doc,
+    ) -> None:
+        record = MemoryRecord(id="mem001", workspace_id="ws1", agent_id="agent1")
+
+        from metatron.storage.memory_graph import save_memory_to_graph
+
+        save_memory_to_graph(record)
+
+        mock_upsert.assert_called_once_with(record)
+        mock_link_agent.assert_called_once_with("ws1", "agent1", "mem001")
+        mock_link_entity.assert_not_called()
+        mock_link_session.assert_not_called()
+        mock_link_doc.assert_not_called()
+
+    @patch("metatron.storage.memory_graph.link_memory_document")
+    @patch("metatron.storage.memory_graph.link_memory_session")
+    @patch("metatron.storage.memory_graph.link_memory_entity")
+    @patch("metatron.storage.memory_graph.link_agent_memory")
+    @patch("metatron.storage.memory_graph.upsert_memory_node")
+    def test_links_session_when_session_id_present(
+        self,
+        mock_upsert,
+        mock_link_agent,
+        mock_link_entity,
+        mock_link_session,
+        mock_link_doc,
+    ) -> None:
+        record = MemoryRecord(
+            id="mem001",
+            workspace_id="ws1",
+            agent_id="agent1",
+            session_id="sess1",
+        )
+
+        from metatron.storage.memory_graph import save_memory_to_graph
+
+        save_memory_to_graph(record)
+
+        mock_link_session.assert_called_once_with("ws1", "mem001", "sess1", "agent1")
+
+    @patch("metatron.storage.memory_graph.link_memory_document")
+    @patch("metatron.storage.memory_graph.link_memory_session")
+    @patch("metatron.storage.memory_graph.link_memory_entity")
+    @patch("metatron.storage.memory_graph.link_agent_memory")
+    @patch("metatron.storage.memory_graph.upsert_memory_node")
+    def test_links_entities_and_documents(
+        self,
+        mock_upsert,
+        mock_link_agent,
+        mock_link_entity,
+        mock_link_session,
+        mock_link_doc,
+    ) -> None:
+        record = MemoryRecord(id="mem001", workspace_id="ws1", agent_id="agent1")
+
+        from metatron.storage.memory_graph import save_memory_to_graph
+
+        save_memory_to_graph(
+            record,
+            entity_names=["Python", "FastAPI"],
+            document_ids=["doc1"],
+        )
+
+        assert mock_link_entity.call_count == 2
+        mock_link_entity.assert_any_call("ws1", "mem001", "Python", relevance=1.0)
+        mock_link_entity.assert_any_call("ws1", "mem001", "FastAPI", relevance=1.0)
+        mock_link_doc.assert_called_once_with("ws1", "mem001", "doc1")


### PR DESCRIPTION
Implement storage/memory_graph.py — Neo4j CRUD for Agent Memory:
- Node ops: upsert, get, delete (single + bulk)
- Relationship edges: REMEMBERS, ABOUT, FROM_SESSION, DERIVED_FROM
- Queries: agent memories, entity-linked memories, relationship traversal
- Composite save_memory_to_graph helper
- 24 unit tests, all passing