### PR TITLE
feat(WS1): add Redis session cache + MemoryService skeleton (Stage 2)

### DIFF
--- a/src/metatron/agent/memory_service.py
+++ b/src/metatron/agent/memory_service.py
@@ -1,0 +1,144 @@
+"""MemoryService — orchestrates agent memory across stores (WS1).
+
+Sits at L4 (agent layer), composes L1 storage modules:
+  - RedisSessionCache  (session memory — hot cache with TTL)
+  - memory_graph.py    (Neo4j — relationships and graph queries)
+  - TODO: PostgreSQL   (source of truth — Stage 3)
+  - TODO: Qdrant       (embeddings + content — Qdrant stage)
+
+Write-through pattern for session memory:
+  cache_session() → Redis (primary) + Neo4j (best-effort)
+
+Read pattern:
+  get_session() → Redis first (fast path)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import structlog
+
+from metatron.core.models import MemoryRecord, MemoryScope
+from metatron.storage.memory_graph import save_memory_to_graph
+
+if TYPE_CHECKING:
+    from metatron.storage.memory_redis import RedisSessionCache
+
+logger = structlog.get_logger()
+
+
+class MemoryService:
+    """Orchestrates agent memory across Redis, Neo4j, (PG, Qdrant — TODO).
+
+    Session memory: Redis is the primary store with auto-TTL.
+    Neo4j receives a best-effort copy for graph traversal.
+    PG and Qdrant integration is deferred to subsequent stages.
+    """
+
+    def __init__(self, redis_cache: RedisSessionCache) -> None:
+        self._redis = redis_cache
+
+    # ------------------------------------------------------------------
+    # Session memory (Redis + Neo4j write-through)
+    # ------------------------------------------------------------------
+
+    async def cache_session(
+        self,
+        workspace_id: str,
+        session_id: str,
+        record: MemoryRecord,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> MemoryRecord:
+        """Store a session memory record. Write-through: Redis + Neo4j.
+
+        Redis is the primary store. Neo4j write is best-effort —
+        a failure is logged but does not block the cache operation.
+        """
+        result = await self._redis.cache(
+            workspace_id,
+            session_id,
+            record,
+            ttl_seconds=ttl_seconds,
+        )
+
+        # Best-effort Neo4j write (sync, via thread pool)
+        try:
+            await asyncio.to_thread(save_memory_to_graph, record)
+        except Exception:
+            logger.warning(
+                "memory_service.neo4j_write_failed",
+                record_id=record.id,
+                session_id=session_id,
+                exc_info=True,
+            )
+
+        return result
+
+    async def get_session(
+        self,
+        workspace_id: str,
+        session_id: str,
+        record_id: str,
+    ) -> MemoryRecord | None:
+        """Fetch a session record. Redis first.
+
+        TODO: fallback to Neo4j/PG when Redis misses (Stage 3).
+        """
+        return await self._redis.get(workspace_id, session_id, record_id)
+
+    async def list_session(
+        self,
+        workspace_id: str,
+        session_id: str,
+    ) -> list[MemoryRecord]:
+        """List all records for a session."""
+        return await self._redis.list(workspace_id, session_id)
+
+    async def invalidate_session(
+        self,
+        workspace_id: str,
+        session_id: str,
+    ) -> int:
+        """Drop all session records from cache."""
+        return await self._redis.invalidate(workspace_id, session_id)
+
+    async def extend_session_ttl(
+        self,
+        workspace_id: str,
+        session_id: str,
+        ttl_seconds: int,
+    ) -> bool:
+        """Extend TTL for a session."""
+        return await self._redis.extend_ttl(workspace_id, session_id, ttl_seconds)
+
+    # ------------------------------------------------------------------
+    # Persistent memory (TODO — PG + Qdrant stages)
+    # ------------------------------------------------------------------
+
+    async def save(
+        self,
+        workspace_id: str,
+        record: MemoryRecord,
+    ) -> MemoryRecord:
+        """Persist a memory record to all stores.
+
+        TODO: PG (source of truth) + Qdrant (embeddings) + Neo4j (graph).
+        """
+        raise NotImplementedError("save requires PG + Qdrant (next stages)")
+
+    async def promote(
+        self,
+        workspace_id: str,
+        session_id: str,
+        record_id: str,
+        *,
+        target_scope: MemoryScope = MemoryScope.PER_AGENT,
+    ) -> MemoryRecord:
+        """Promote a session record to persistent storage.
+
+        TODO: read from Redis → write to PG + Qdrant + Neo4j → remove from Redis.
+        """
+        raise NotImplementedError("promote requires PG + Qdrant (next stages)")

--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -143,6 +143,18 @@ Functions:
 - `get_memory_relationships(workspace_id, record_id) -> list[dict]` — all edges for a memory
 - `save_memory_to_graph(record, entity_names?, document_ids?)` — composite: node + all edges
 
+### `memory_redis.py`
+Redis session cache for Agent Memory (WS1). Wraps existing `RedisStore`.
+
+Key pattern: `mem:{workspace_id}:{session_id}:{record_id}` (records), `mem:{workspace_id}:{session_id}:_index` (ID list).
+
+Class: `RedisSessionCache(store, default_ttl=14400)`
+- `cache(workspace_id, session_id, record, ttl_seconds?) -> MemoryRecord` — store with TTL
+- `get(workspace_id, session_id, record_id) -> MemoryRecord | None` — fetch single
+- `list(workspace_id, session_id) -> list[MemoryRecord]` — all session records
+- `invalidate(workspace_id, session_id) -> int` — drop session, return count
+- `extend_ttl(workspace_id, session_id, ttl_seconds) -> bool` — refresh TTL
+
 ### `graph_ops.py`
 High-level graph query functions used by retrieval.
 

--- a/src/metatron/storage/memory_redis.py
+++ b/src/metatron/storage/memory_redis.py
@@ -1,0 +1,172 @@
+"""Redis session cache for Agent Memory (WS1).
+
+Provides TTL-bound session memory storage using the existing RedisStore.
+Each session's records are stored as individual JSON keys with an index key
+tracking all record IDs in the session.
+
+This is an L1 storage module — no business logic, no cross-store awareness.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import structlog
+
+from metatron.core.models import MemoryRecord, MemoryScope
+
+if TYPE_CHECKING:
+    from metatron.storage.redis import RedisStore
+
+logger = structlog.get_logger()
+
+# Key patterns:
+#   mem:{workspace_id}:{session_id}:{record_id}  — individual record (JSON)
+#   mem:{workspace_id}:{session_id}:_index        — list of record IDs (JSON)
+
+_PREFIX = "mem"
+
+
+def _record_key(workspace_id: str, session_id: str, record_id: str) -> str:
+    return f"{_PREFIX}:{workspace_id}:{session_id}:{record_id}"
+
+
+def _index_key(workspace_id: str, session_id: str) -> str:
+    return f"{_PREFIX}:{workspace_id}:{session_id}:_index"
+
+
+def _serialize_record(record: MemoryRecord) -> str:
+    d = asdict(record)
+    d["scope"] = record.scope.value
+    return json.dumps(d, default=str)
+
+
+def _deserialize_record(raw: str) -> MemoryRecord:
+    d = json.loads(raw)
+    d["scope"] = MemoryScope(d["scope"])
+    if d.get("ttl_expires_at"):
+        d["ttl_expires_at"] = datetime.fromisoformat(d["ttl_expires_at"])
+    else:
+        d["ttl_expires_at"] = None
+    d["created_at"] = datetime.fromisoformat(d["created_at"])
+    return MemoryRecord(**d)
+
+
+class RedisSessionCache:
+    """TTL-bound session memory cache backed by Redis.
+
+    Stores MemoryRecord objects as JSON with automatic expiration.
+    Does NOT implement SessionMemoryInterface directly — the full
+    interface (including promote) lives in MemoryService (L4).
+    """
+
+    def __init__(self, store: RedisStore, default_ttl: int = 14400) -> None:
+        self._store = store
+        self._default_ttl = default_ttl
+
+    async def cache(
+        self,
+        workspace_id: str,
+        session_id: str,
+        record: MemoryRecord,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> MemoryRecord:
+        """Store a record in session cache with TTL."""
+        ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl
+        rkey = _record_key(workspace_id, session_id, record.id)
+        ikey = _index_key(workspace_id, session_id)
+
+        # Write record
+        await self._store.set(rkey, _serialize_record(record), ttl=ttl)
+
+        # Update index — append record ID.
+        # Note: read-modify-write is not atomic. Safe for single-agent sessions;
+        # for concurrent writes, migrate to Redis SET (SADD) in the future.
+        raw_index = await self._store.get(ikey)
+        ids: list[str] = json.loads(raw_index) if raw_index else []
+        if record.id not in ids:
+            ids.append(record.id)
+        await self._store.set(ikey, json.dumps(ids), ttl=ttl)
+
+        logger.debug(
+            "memory_redis.cached",
+            record_id=record.id,
+            session_id=session_id,
+            ttl=ttl,
+        )
+        return record
+
+    async def get(
+        self,
+        workspace_id: str,
+        session_id: str,
+        record_id: str,
+    ) -> MemoryRecord | None:
+        """Fetch a single record from session cache."""
+        rkey = _record_key(workspace_id, session_id, record_id)
+        raw = await self._store.get(rkey)
+        if raw is None:
+            return None
+        return _deserialize_record(raw)
+
+    async def list(
+        self,
+        workspace_id: str,
+        session_id: str,
+    ) -> list[MemoryRecord]:
+        """List all records for a session. Skips expired (missing) records."""
+        ikey = _index_key(workspace_id, session_id)
+        raw_index = await self._store.get(ikey)
+        if raw_index is None:
+            return []
+
+        ids: list[str] = json.loads(raw_index)
+        records: list[MemoryRecord] = []
+        for record_id in ids:
+            rkey = _record_key(workspace_id, session_id, record_id)
+            raw = await self._store.get(rkey)
+            if raw is not None:
+                records.append(_deserialize_record(raw))
+        return records
+
+    async def invalidate(self, workspace_id: str, session_id: str) -> int:
+        """Drop all records for a session. Returns number of records removed."""
+        ikey = _index_key(workspace_id, session_id)
+        raw_index = await self._store.get(ikey)
+        if raw_index is None:
+            return 0
+
+        ids: list[str] = json.loads(raw_index)
+        keys_to_delete = [_record_key(workspace_id, session_id, rid) for rid in ids]
+        keys_to_delete.append(ikey)
+        await self._store.delete(*keys_to_delete)
+
+        logger.debug(
+            "memory_redis.invalidated",
+            session_id=session_id,
+            count=len(ids),
+        )
+        return len(ids)
+
+    async def extend_ttl(
+        self,
+        workspace_id: str,
+        session_id: str,
+        ttl_seconds: int,
+    ) -> bool:
+        """Extend TTL for all keys in a session. Returns True if session existed."""
+        ikey = _index_key(workspace_id, session_id)
+        raw_index = await self._store.get(ikey)
+        if raw_index is None:
+            return False
+
+        ids: list[str] = json.loads(raw_index)
+        for record_id in ids:
+            rkey = _record_key(workspace_id, session_id, record_id)
+            await self._store.expire(rkey, ttl_seconds)
+        await self._store.expire(ikey, ttl_seconds)
+        return True

--- a/tests/unit/test_memory_redis.py
+++ b/tests/unit/test_memory_redis.py
@@ -1,0 +1,231 @@
+"""Tests for RedisSessionCache (WS1 Stage 2)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from metatron.core.models import MemoryRecord, MemoryScope
+from metatron.storage.memory_redis import (
+    RedisSessionCache,
+    _deserialize_record,
+    _serialize_record,
+)
+from metatron.storage.redis import RedisStore
+
+
+def _make_cache(ttl: int = 3600) -> RedisSessionCache:
+    """Create a RedisSessionCache with a mocked RedisStore."""
+    store = RedisStore("redis://localhost:6379/0")
+    store._client = AsyncMock()
+    return RedisSessionCache(store, default_ttl=ttl)
+
+
+def _sample_record(**overrides) -> MemoryRecord:
+    defaults = {
+        "id": "mem001",
+        "workspace_id": "ws1",
+        "agent_id": "agent1",
+        "scope": MemoryScope.SESSION,
+        "source_type": "conversation",
+        "content": "hello",
+        "session_id": "sess1",
+    }
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+def _record_json(record: MemoryRecord) -> str:
+    return _serialize_record(record)
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_roundtrip(self) -> None:
+        record = _sample_record(tags=["pref"], importance_score=0.8)
+        raw = _serialize_record(record)
+        restored = _deserialize_record(raw)
+
+        assert restored.id == record.id
+        assert restored.scope == MemoryScope.SESSION
+        assert restored.tags == ["pref"]
+        assert restored.importance_score == 0.8
+        assert restored.content == "hello"
+
+    def test_none_ttl_survives_roundtrip(self) -> None:
+        record = _sample_record(ttl_expires_at=None)
+        restored = _deserialize_record(_serialize_record(record))
+        assert restored.ttl_expires_at is None
+
+
+# ---------------------------------------------------------------------------
+# Task 1: cache + get
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    async def test_stores_record_with_default_ttl(self) -> None:
+        cache = _make_cache(ttl=600)
+        record = _sample_record()
+        cache._store._client.get.return_value = None  # no existing index
+
+        result = await cache.cache("ws1", "sess1", record)
+
+        assert result.id == "mem001"
+        # Record key + index key = 2 set calls
+        assert cache._store._client.set.call_count == 2
+        # First call: record with TTL
+        rec_call = cache._store._client.set.call_args_list[0]
+        assert rec_call.args[0] == "mem:ws1:sess1:mem001"
+        assert rec_call.kwargs.get("ex") == 600
+
+    async def test_ttl_override(self) -> None:
+        cache = _make_cache(ttl=600)
+        record = _sample_record()
+        cache._store._client.get.return_value = None
+
+        await cache.cache("ws1", "sess1", record, ttl_seconds=120)
+
+        rec_call = cache._store._client.set.call_args_list[0]
+        assert rec_call.kwargs.get("ex") == 120
+
+    async def test_appends_to_existing_index(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = '["existing001"]'
+        record = _sample_record(id="mem002")
+
+        await cache.cache("ws1", "sess1", record)
+
+        # Index should now have both IDs
+        idx_call = cache._store._client.set.call_args_list[1]
+        stored_ids = json.loads(idx_call.args[1])
+        assert "existing001" in stored_ids
+        assert "mem002" in stored_ids
+
+    async def test_does_not_duplicate_in_index(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = '["mem001"]'
+        record = _sample_record(id="mem001")
+
+        await cache.cache("ws1", "sess1", record)
+
+        idx_call = cache._store._client.set.call_args_list[1]
+        stored_ids = json.loads(idx_call.args[1])
+        assert stored_ids.count("mem001") == 1
+
+
+class TestGet:
+    async def test_returns_record_when_found(self) -> None:
+        cache = _make_cache()
+        record = _sample_record()
+        cache._store._client.get.return_value = _record_json(record)
+
+        result = await cache.get("ws1", "sess1", "mem001")
+
+        assert result is not None
+        assert result.id == "mem001"
+        assert result.content == "hello"
+        cache._store._client.get.assert_called_with("mem:ws1:sess1:mem001")
+
+    async def test_returns_none_when_not_found(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = None
+
+        result = await cache.get("ws1", "sess1", "nonexistent")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Task 2: list, invalidate, extend_ttl
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    async def test_returns_all_session_records(self) -> None:
+        cache = _make_cache()
+        r1 = _sample_record(id="mem001", content="first")
+        r2 = _sample_record(id="mem002", content="second")
+        cache._store._client.get.side_effect = [
+            '["mem001", "mem002"]',  # index
+            _record_json(r1),
+            _record_json(r2),
+        ]
+
+        results = await cache.list("ws1", "sess1")
+
+        assert len(results) == 2
+        assert results[0].id == "mem001"
+        assert results[1].id == "mem002"
+
+    async def test_returns_empty_when_no_index(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = None
+
+        results = await cache.list("ws1", "sess1")
+
+        assert results == []
+
+    async def test_skips_expired_records(self) -> None:
+        cache = _make_cache()
+        r1 = _sample_record(id="mem001", content="alive")
+        cache._store._client.get.side_effect = [
+            '["mem001", "mem002"]',  # index
+            _record_json(r1),
+            None,  # mem002 expired
+        ]
+
+        results = await cache.list("ws1", "sess1")
+
+        assert len(results) == 1
+        assert results[0].id == "mem001"
+
+
+class TestInvalidate:
+    async def test_deletes_all_session_keys(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = '["mem001", "mem002"]'
+        cache._store._client.delete.return_value = 3
+
+        count = await cache.invalidate("ws1", "sess1")
+
+        assert count == 2  # number of records, not keys
+        cache._store._client.delete.assert_called_once()
+        deleted_keys = cache._store._client.delete.call_args.args
+        assert len(deleted_keys) == 3  # 2 records + 1 index
+        assert "mem:ws1:sess1:mem001" in deleted_keys
+        assert "mem:ws1:sess1:mem002" in deleted_keys
+        assert "mem:ws1:sess1:_index" in deleted_keys
+
+    async def test_returns_zero_when_no_session(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = None
+
+        count = await cache.invalidate("ws1", "sess1")
+
+        assert count == 0
+
+
+class TestExtendTtl:
+    async def test_extends_all_keys(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = '["mem001", "mem002"]'
+        cache._store._client.expire.return_value = True
+
+        result = await cache.extend_ttl("ws1", "sess1", 7200)
+
+        assert result is True
+        # 2 record keys + 1 index key = 3 expire calls
+        assert cache._store._client.expire.call_count == 3
+
+    async def test_returns_false_when_no_session(self) -> None:
+        cache = _make_cache()
+        cache._store._client.get.return_value = None
+
+        result = await cache.extend_ttl("ws1", "sess1", 7200)
+
+        assert result is False

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -1,0 +1,162 @@
+"""Tests for MemoryService (WS1 Stage 2 skeleton)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from metatron.agent.memory_service import MemoryService
+from metatron.core.models import MemoryRecord, MemoryScope
+
+
+def _make_service():
+    """Create a MemoryService with mocked dependencies."""
+    redis_cache = AsyncMock()
+    return MemoryService(redis_cache=redis_cache), redis_cache
+
+
+def _sample_record(**overrides) -> MemoryRecord:
+    defaults = {
+        "id": "mem001",
+        "workspace_id": "ws1",
+        "agent_id": "agent1",
+        "scope": MemoryScope.SESSION,
+        "session_id": "sess1",
+    }
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Session write-through
+# ---------------------------------------------------------------------------
+
+
+class TestCacheSession:
+    async def test_writes_to_redis_and_neo4j(self) -> None:
+        service, redis_cache = _make_service()
+        record = _sample_record()
+        redis_cache.cache.return_value = record
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph") as mock_graph:
+            result = await service.cache_session("ws1", "sess1", record)
+
+        assert result.id == "mem001"
+        redis_cache.cache.assert_called_once_with(
+            "ws1",
+            "sess1",
+            record,
+            ttl_seconds=None,
+        )
+        mock_graph.assert_called_once_with(record)
+
+    async def test_passes_ttl_override(self) -> None:
+        service, redis_cache = _make_service()
+        record = _sample_record()
+        redis_cache.cache.return_value = record
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            await service.cache_session("ws1", "sess1", record, ttl_seconds=120)
+
+        redis_cache.cache.assert_called_once_with(
+            "ws1",
+            "sess1",
+            record,
+            ttl_seconds=120,
+        )
+
+    async def test_neo4j_failure_does_not_block_cache(self) -> None:
+        service, redis_cache = _make_service()
+        record = _sample_record()
+        redis_cache.cache.return_value = record
+
+        with patch(
+            "metatron.agent.memory_service.save_memory_to_graph",
+            side_effect=Exception("neo4j down"),
+        ):
+            result = await service.cache_session("ws1", "sess1", record)
+
+        # Should still succeed — Neo4j is best-effort
+        assert result.id == "mem001"
+        redis_cache.cache.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Session reads
+# ---------------------------------------------------------------------------
+
+
+class TestGetSession:
+    async def test_returns_from_redis(self) -> None:
+        service, redis_cache = _make_service()
+        expected = _sample_record()
+        redis_cache.get.return_value = expected
+
+        result = await service.get_session("ws1", "sess1", "mem001")
+
+        assert result is expected
+        redis_cache.get.assert_called_once_with("ws1", "sess1", "mem001")
+
+    async def test_returns_none_when_not_cached(self) -> None:
+        service, redis_cache = _make_service()
+        redis_cache.get.return_value = None
+
+        result = await service.get_session("ws1", "sess1", "missing")
+
+        assert result is None
+
+
+class TestListSession:
+    async def test_delegates_to_redis(self) -> None:
+        service, redis_cache = _make_service()
+        records = [_sample_record(id="m1"), _sample_record(id="m2")]
+        redis_cache.list.return_value = records
+
+        result = await service.list_session("ws1", "sess1")
+
+        assert len(result) == 2
+        redis_cache.list.assert_called_once_with("ws1", "sess1")
+
+
+class TestInvalidateSession:
+    async def test_delegates_to_redis(self) -> None:
+        service, redis_cache = _make_service()
+        redis_cache.invalidate.return_value = 3
+
+        count = await service.invalidate_session("ws1", "sess1")
+
+        assert count == 3
+        redis_cache.invalidate.assert_called_once_with("ws1", "sess1")
+
+
+class TestExtendSessionTtl:
+    async def test_delegates_to_redis(self) -> None:
+        service, redis_cache = _make_service()
+        redis_cache.extend_ttl.return_value = True
+
+        result = await service.extend_session_ttl("ws1", "sess1", 7200)
+
+        assert result is True
+        redis_cache.extend_ttl.assert_called_once_with("ws1", "sess1", 7200)
+
+
+# ---------------------------------------------------------------------------
+# Persistent memory stubs
+# ---------------------------------------------------------------------------
+
+
+class TestSave:
+    async def test_raises_not_implemented(self) -> None:
+        service, _ = _make_service()
+
+        with pytest.raises(NotImplementedError):
+            await service.save("ws1", _sample_record())
+
+
+class TestPromote:
+    async def test_raises_not_implemented(self) -> None:
+        service, _ = _make_service()
+
+        with pytest.raises(NotImplementedError):
+            await service.promote("ws1", "sess1", "mem001")


### PR DESCRIPTION
- storage/memory_redis.py: RedisSessionCache with TTL-bound session CRUD
- agent/memory_service.py: MemoryService skeleton with Redis + Neo4j write-through
- promote()/save() stub as NotImplementedError (needs PG + Qdrant)
- 25 unit tests, all passing