### PR TITLE
feat(WS1): add Qdrant memory collection + wire MemoryService save/pro…

### DIFF
--- a/src/metatron/agent/memory_service.py
+++ b/src/metatron/agent/memory_service.py
@@ -1,13 +1,16 @@
 """MemoryService — orchestrates agent memory across stores (WS1).
 
 Sits at L4 (agent layer), composes L1 storage modules:
-  - RedisSessionCache  (session memory — hot cache with TTL)
-  - memory_graph.py    (Neo4j — relationships and graph queries)
-  - TODO: PostgreSQL   (source of truth — Stage 3)
-  - TODO: Qdrant       (embeddings + content — Qdrant stage)
+  - RedisSessionCache   (session memory — hot cache with TTL)
+  - MemoryQdrantStore   (content + embeddings — vector search)
+  - memory_graph.py     (Neo4j — relationships and graph queries)
+  - TODO: PostgreSQL    (source of truth — next stage)
 
 Write-through pattern for session memory:
   cache_session() → Redis (primary) + Neo4j (best-effort)
+
+Persistent memory:
+  save() → Qdrant (content + vectors) + Neo4j (graph, best-effort)
 
 Read pattern:
   get_session() → Redis first (fast path)
@@ -20,25 +23,48 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from metatron.core.exceptions import MemoryNotFoundError
 from metatron.core.models import MemoryRecord, MemoryScope
 from metatron.storage.memory_graph import save_memory_to_graph
 
 if TYPE_CHECKING:
+    from metatron.storage.memory_qdrant import MemoryQdrantStore
     from metatron.storage.memory_redis import RedisSessionCache
 
 logger = structlog.get_logger()
 
 
 class MemoryService:
-    """Orchestrates agent memory across Redis, Neo4j, (PG, Qdrant — TODO).
+    """Orchestrates agent memory across Redis, Qdrant, Neo4j (PG — TODO).
 
     Session memory: Redis is the primary store with auto-TTL.
-    Neo4j receives a best-effort copy for graph traversal.
-    PG and Qdrant integration is deferred to subsequent stages.
+    Persistent memory: Qdrant stores content + vectors, Neo4j stores graph.
+    Neo4j writes are best-effort — failures are logged, not raised.
+    PG (source of truth) integration is deferred to next stage.
     """
 
-    def __init__(self, redis_cache: RedisSessionCache) -> None:
+    def __init__(
+        self,
+        redis_cache: RedisSessionCache,
+        qdrant_store: MemoryQdrantStore,
+    ) -> None:
         self._redis = redis_cache
+        self._qdrant = qdrant_store
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _write_graph_best_effort(self, record: MemoryRecord) -> None:
+        """Write to Neo4j graph, swallowing errors (best-effort)."""
+        try:
+            await asyncio.to_thread(save_memory_to_graph, record)
+        except Exception:
+            logger.warning(
+                "memory_service.neo4j_write_failed",
+                record_id=record.id,
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Session memory (Redis + Neo4j write-through)
@@ -64,17 +90,7 @@ class MemoryService:
             ttl_seconds=ttl_seconds,
         )
 
-        # Best-effort Neo4j write (sync, via thread pool)
-        try:
-            await asyncio.to_thread(save_memory_to_graph, record)
-        except Exception:
-            logger.warning(
-                "memory_service.neo4j_write_failed",
-                record_id=record.id,
-                session_id=session_id,
-                exc_info=True,
-            )
-
+        await self._write_graph_best_effort(record)
         return result
 
     async def get_session(
@@ -115,7 +131,7 @@ class MemoryService:
         return await self._redis.extend_ttl(workspace_id, session_id, ttl_seconds)
 
     # ------------------------------------------------------------------
-    # Persistent memory (TODO — PG + Qdrant stages)
+    # Persistent memory (Qdrant + Neo4j; PG — TODO next stage)
     # ------------------------------------------------------------------
 
     async def save(
@@ -123,11 +139,14 @@ class MemoryService:
         workspace_id: str,
         record: MemoryRecord,
     ) -> MemoryRecord:
-        """Persist a memory record to all stores.
+        """Persist a memory record: Qdrant (content + vectors) + Neo4j (graph).
 
-        TODO: PG (source of truth) + Qdrant (embeddings) + Neo4j (graph).
+        Qdrant failure propagates (primary store). Neo4j is best-effort.
+        TODO: add PG as source of truth in next stage.
         """
-        raise NotImplementedError("save requires PG + Qdrant (next stages)")
+        await self._qdrant.upsert(record)
+        await self._write_graph_best_effort(record)
+        return record
 
     async def promote(
         self,
@@ -139,6 +158,17 @@ class MemoryService:
     ) -> MemoryRecord:
         """Promote a session record to persistent storage.
 
-        TODO: read from Redis → write to PG + Qdrant + Neo4j → remove from Redis.
+        Reads from Redis → changes scope → writes to Qdrant + Neo4j →
+        deletes record from Redis (key + index).
+        TODO: add PG write in next stage.
         """
-        raise NotImplementedError("promote requires PG + Qdrant (next stages)")
+        record = await self._redis.get(workspace_id, session_id, record_id)
+        if record is None:
+            msg = f"Record {record_id} not found in session {session_id}"
+            raise MemoryNotFoundError(msg)
+
+        record.scope = target_scope
+        await self.save(workspace_id, record)
+        await self._redis.delete_record(workspace_id, session_id, record_id)
+
+        return record

--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -155,6 +155,19 @@ Class: `RedisSessionCache(store, default_ttl=14400)`
 - `invalidate(workspace_id, session_id) -> int` — drop session, return count
 - `extend_ttl(workspace_id, session_id, ttl_seconds) -> bool` — refresh TTL
 
+### `memory_qdrant.py`
+Qdrant vector store for Agent Memory (WS1). Dedicated collection per workspace.
+
+Collection: `mem_agent_memory_{workspace_id}` (dense 768-dim + sparse SPLADE/BM25).
+Payload indexes: `agent_id` (keyword), `scope` (keyword).
+
+Class: `MemoryQdrantStore(workspace_id, host?, port?)`
+- `upsert(record)` — embed content + store with vectors and payload
+- `search(workspace_id, query, agent_id?, scope?, top_k?) -> list[dict]` — hybrid RRF search
+- `delete(record_id)` — delete single point
+- `delete_by_agent(agent_id)` — delete all points for agent
+- `close()` — close client
+
 ### `graph_ops.py`
 High-level graph query functions used by retrieval.
 

--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -163,7 +163,7 @@ Payload indexes: `agent_id` (keyword), `scope` (keyword).
 
 Class: `MemoryQdrantStore(workspace_id, host?, port?)`
 - `upsert(record)` — embed content + store with vectors and payload
-- `search(workspace_id, query, agent_id?, scope?, top_k?) -> list[dict]` — hybrid RRF search
+- `search(query, agent_id?, scope?, top_k?) -> list[dict]` — hybrid RRF search (workspace scoped at init)
 - `delete(record_id)` — delete single point
 - `delete_by_agent(agent_id)` — delete all points for agent
 - `close()` — close client

--- a/src/metatron/storage/memory_qdrant.py
+++ b/src/metatron/storage/memory_qdrant.py
@@ -1,0 +1,252 @@
+"""Qdrant vector store for Agent Memory (WS1).
+
+Dedicated collection per workspace for memory records.
+Stores content text + dense/sparse embeddings for hybrid search.
+Separate from document collection (different payload schema, scoring).
+
+This is an L1 storage module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import (
+    Distance,
+    FieldCondition,
+    Filter,
+    Fusion,
+    MatchValue,
+    PayloadSchemaType,
+    PointStruct,
+    Prefetch,
+    SparseVector,
+    SparseVectorParams,
+    VectorParams,
+)
+
+from metatron.core.config import get_settings
+from metatron.llm.embeddings import get_cached_embedding
+from metatron.storage.qdrant import _compute_doc_sparse, _compute_query_sparse
+
+if TYPE_CHECKING:
+    from metatron.core.models import MemoryRecord
+
+logger = structlog.get_logger()
+
+_COLLECTION_PREFIX = "mem_agent_memory"
+_DENSE_NAME = "dense"
+_SPARSE_NAME = "bm25"
+_DENSE_DIM = 768
+
+
+def _collection_name(workspace_id: str) -> str:
+    return f"{_COLLECTION_PREFIX}_{workspace_id}"
+
+
+class MemoryQdrantStore:
+    """Async Qdrant store for agent memory records.
+
+    Each workspace gets a dedicated collection with hybrid vectors
+    (dense + sparse). Collection is lazily created on first operation.
+    """
+
+    def __init__(
+        self,
+        workspace_id: str = "MTRNIX",
+        host: str | None = None,
+        port: int | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._workspace_id = workspace_id
+        self._collection = _collection_name(workspace_id)
+        self._client = AsyncQdrantClient(
+            host=host or settings.qdrant_host,
+            port=port or settings.qdrant_http_port,
+            timeout=60,
+        )
+        self._collection_ensured = False
+
+    async def _ensure_collection(self) -> None:
+        """Create memory collection if it doesn't exist."""
+        if self._collection_ensured:
+            return
+        collections = await self._client.get_collections()
+        if any(c.name == self._collection for c in collections.collections):
+            self._collection_ensured = True
+            return
+
+        await self._client.create_collection(
+            collection_name=self._collection,
+            vectors_config={
+                _DENSE_NAME: VectorParams(size=_DENSE_DIM, distance=Distance.COSINE),
+            },
+            sparse_vectors_config={_SPARSE_NAME: SparseVectorParams()},
+        )
+        # Payload indexes for filtered search
+        for field in ("agent_id", "scope"):
+            try:
+                await self._client.create_payload_index(
+                    collection_name=self._collection,
+                    field_name=field,
+                    field_schema=PayloadSchemaType.KEYWORD,
+                )
+            except Exception:
+                logger.warning("memory_qdrant.index.failed", field=field)
+        logger.info("memory_qdrant.collection.created", collection=self._collection)
+        self._collection_ensured = True
+
+    # ------------------------------------------------------------------
+    # Upsert
+    # ------------------------------------------------------------------
+
+    async def upsert(self, record: MemoryRecord) -> None:
+        """Store a memory record with dense + sparse vectors.
+
+        Generates embeddings from record.content. Uses record.id as
+        the Qdrant point ID for deterministic updates.
+
+        Note: ``metadata``, ``session_id``, and ``content_hash`` are
+        intentionally omitted from the Qdrant payload. Qdrant is for
+        vector search, not full record storage (PG handles that).
+        """
+        await self._ensure_collection()
+
+        dense_vector = await asyncio.to_thread(get_cached_embedding, record.content)
+        sparse_indices, sparse_values = await asyncio.to_thread(
+            _compute_doc_sparse,
+            record.content,
+        )
+
+        payload: dict[str, Any] = {
+            "content": record.content,
+            "record_id": record.id,
+            "workspace_id": record.workspace_id,
+            "agent_id": record.agent_id,
+            "scope": record.scope.value,
+            "source_type": record.source_type,
+            "tags": record.tags,
+            "importance_score": record.importance_score,
+            "created_at": record.created_at.isoformat(),
+        }
+
+        point = PointStruct(
+            id=record.id,
+            vector={
+                _DENSE_NAME: dense_vector,
+                _SPARSE_NAME: SparseVector(
+                    indices=sparse_indices,
+                    values=sparse_values,
+                ),
+            },
+            payload=payload,
+        )
+
+        await self._client.upsert(
+            collection_name=self._collection,
+            points=[point],
+        )
+        logger.debug("memory_qdrant.upserted", record_id=record.id)
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        *,
+        agent_id: str | None = None,
+        scope: str | None = None,
+        top_k: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Hybrid dense+sparse search over memory records.
+
+        Uses server-side RRF fusion. Workspace is scoped at __init__ time.
+        Returns list of dicts with record payload + score.
+        """
+        await self._ensure_collection()
+
+        dense_vector = await asyncio.to_thread(get_cached_embedding, query)
+        sparse_indices, sparse_values = await asyncio.to_thread(
+            _compute_query_sparse,
+            query,
+        )
+
+        # Build optional filter
+        conditions = []
+        if agent_id:
+            conditions.append(
+                FieldCondition(key="agent_id", match=MatchValue(value=agent_id)),
+            )
+        if scope:
+            conditions.append(
+                FieldCondition(key="scope", match=MatchValue(value=scope)),
+            )
+        qfilter = Filter(must=conditions) if conditions else None  # type: ignore[arg-type]
+
+        results = await self._client.query_points(
+            collection_name=self._collection,
+            prefetch=[
+                Prefetch(
+                    query=dense_vector,
+                    using=_DENSE_NAME,
+                    limit=top_k * 3,
+                    filter=qfilter,
+                ),
+                Prefetch(
+                    query=SparseVector(indices=sparse_indices, values=sparse_values),
+                    using=_SPARSE_NAME,
+                    limit=top_k * 3,
+                    filter=qfilter,
+                ),
+            ],
+            query=Fusion.RRF,
+            limit=top_k,
+            with_payload=True,
+        )
+
+        return [
+            {
+                "record_id": (p.payload or {}).get("record_id", str(p.id)),
+                "content": (p.payload or {}).get("content", ""),
+                "score": p.score,
+                "agent_id": (p.payload or {}).get("agent_id", ""),
+                "scope": (p.payload or {}).get("scope", ""),
+                "importance_score": (p.payload or {}).get("importance_score", 0.5),
+                "tags": (p.payload or {}).get("tags", []),
+                "payload": p.payload or {},
+            }
+            for p in results.points
+        ]
+
+    # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
+
+    async def delete(self, record_id: str) -> None:
+        """Delete a single memory record by its ID."""
+        await self._ensure_collection()
+        await self._client.delete(
+            collection_name=self._collection,
+            points_selector=[record_id],
+        )
+
+    async def delete_by_agent(self, agent_id: str) -> None:
+        """Delete all memory records for an agent."""
+        await self._ensure_collection()
+        await self._client.delete(
+            collection_name=self._collection,
+            points_selector=Filter(
+                must=[
+                    FieldCondition(key="agent_id", match=MatchValue(value=agent_id)),
+                ],
+            ),
+        )
+
+    async def close(self) -> None:
+        """Close the Qdrant client."""
+        await self._client.close()

--- a/src/metatron/storage/memory_redis.py
+++ b/src/metatron/storage/memory_redis.py
@@ -152,6 +152,34 @@ class RedisSessionCache:
         )
         return len(ids)
 
+    async def delete_record(
+        self,
+        workspace_id: str,
+        session_id: str,
+        record_id: str,
+    ) -> bool:
+        """Delete a single record from session cache and remove from index.
+
+        Returns True if the record key existed.
+        """
+        rkey = _record_key(workspace_id, session_id, record_id)
+        ikey = _index_key(workspace_id, session_id)
+
+        deleted = await self._store.delete(rkey)
+
+        # Update index — remove record ID
+        raw_index = await self._store.get(ikey)
+        if raw_index is not None:
+            ids: list[str] = json.loads(raw_index)
+            if record_id in ids:
+                ids.remove(record_id)
+                if ids:
+                    await self._store.set(ikey, json.dumps(ids))
+                else:
+                    await self._store.delete(ikey)
+
+        return deleted > 0
+
     async def extend_ttl(
         self,
         workspace_id: str,

--- a/tests/unit/test_memory_qdrant.py
+++ b/tests/unit/test_memory_qdrant.py
@@ -1,0 +1,291 @@
+"""Tests for MemoryQdrantStore (WS1 Stage 2)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from metatron.core.models import MemoryRecord, MemoryScope
+from metatron.storage.memory_qdrant import MemoryQdrantStore
+
+
+def _mock_collections(*names: str):
+    """Return a mock get_collections response."""
+    cols = [SimpleNamespace(name=n) for n in names]
+    return SimpleNamespace(collections=cols)
+
+
+def _make_store(workspace_id: str = "ws1") -> MemoryQdrantStore:
+    """Create a MemoryQdrantStore with a mocked Qdrant client."""
+    store = MemoryQdrantStore(workspace_id=workspace_id)
+    store._client = AsyncMock()
+    return store
+
+
+def _sample_record(**overrides) -> MemoryRecord:
+    defaults = {
+        "id": "mem001",
+        "workspace_id": "ws1",
+        "agent_id": "agent1",
+        "scope": MemoryScope.PER_AGENT,
+        "source_type": "conversation",
+        "content": "user prefers dark mode",
+        "tags": ["preference"],
+        "importance_score": 0.8,
+    }
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_collection
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCollection:
+    async def test_creates_collection_on_first_call(self) -> None:
+        store = _make_store()
+        store._client.get_collections.return_value = _mock_collections()
+
+        await store._ensure_collection()
+
+        store._client.create_collection.assert_awaited_once()
+        # Should create payload indexes for agent_id and scope
+        assert store._client.create_payload_index.await_count == 2
+        assert store._collection_ensured is True
+
+    async def test_skips_when_exists(self) -> None:
+        store = _make_store()
+        store._client.get_collections.return_value = _mock_collections(
+            "mem_agent_memory_ws1",
+        )
+
+        await store._ensure_collection()
+
+        store._client.create_collection.assert_not_awaited()
+        assert store._collection_ensured is True
+
+    async def test_skips_on_second_call(self) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+
+        await store._ensure_collection()
+
+        store._client.get_collections.assert_not_awaited()
+
+    async def test_collection_name_includes_workspace(self) -> None:
+        store = _make_store(workspace_id="myws")
+        assert store._collection == "mem_agent_memory_myws"
+
+
+# ---------------------------------------------------------------------------
+# Upsert
+# ---------------------------------------------------------------------------
+
+
+class TestUpsert:
+    @patch(
+        "metatron.storage.memory_qdrant._compute_doc_sparse",
+        return_value=([1, 2], [0.5, 0.3]),
+    )
+    @patch(
+        "metatron.storage.memory_qdrant.get_cached_embedding",
+        return_value=[0.1] * 768,
+    )
+    async def test_upserts_record_with_vectors(self, mock_embed, mock_sparse) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+        record = _sample_record()
+
+        await store.upsert(record)
+
+        store._client.upsert.assert_awaited_once()
+        points = store._client.upsert.call_args.kwargs["points"]
+        assert len(points) == 1
+        assert points[0].id == "mem001"
+
+        payload = points[0].payload
+        assert payload["content"] == "user prefers dark mode"
+        assert payload["agent_id"] == "agent1"
+        assert payload["scope"] == "per_agent"
+        assert payload["importance_score"] == 0.8
+        assert payload["tags"] == ["preference"]
+        assert payload["record_id"] == "mem001"
+
+    @patch(
+        "metatron.storage.memory_qdrant._compute_doc_sparse",
+        return_value=([1, 2], [0.5, 0.3]),
+    )
+    @patch(
+        "metatron.storage.memory_qdrant.get_cached_embedding",
+        return_value=[0.1] * 768,
+    )
+    async def test_uses_record_id_as_point_id(self, mock_embed, mock_sparse) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+        record = _sample_record(id="custom-id-123")
+
+        await store.upsert(record)
+
+        points = store._client.upsert.call_args.kwargs["points"]
+        assert points[0].id == "custom-id-123"
+
+    @patch(
+        "metatron.storage.memory_qdrant._compute_doc_sparse",
+        return_value=([1, 2], [0.5, 0.3]),
+    )
+    @patch(
+        "metatron.storage.memory_qdrant.get_cached_embedding",
+        return_value=[0.1] * 768,
+    )
+    async def test_includes_both_dense_and_sparse_vectors(
+        self,
+        mock_embed,
+        mock_sparse,
+    ) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+        record = _sample_record()
+
+        await store.upsert(record)
+
+        point = store._client.upsert.call_args.kwargs["points"][0]
+        assert "dense" in point.vector
+        assert "bm25" in point.vector
+        assert len(point.vector["dense"]) == 768
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    @patch(
+        "metatron.storage.memory_qdrant._compute_query_sparse",
+        return_value=([1, 2], [0.5, 0.3]),
+    )
+    @patch(
+        "metatron.storage.memory_qdrant.get_cached_embedding",
+        return_value=[0.1] * 768,
+    )
+    async def test_hybrid_search_returns_results(
+        self,
+        mock_embed,
+        mock_sparse,
+    ) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+        mock_point = SimpleNamespace(
+            id="mem001",
+            payload={
+                "content": "dark mode",
+                "record_id": "mem001",
+                "agent_id": "agent1",
+                "scope": "per_agent",
+                "importance_score": 0.8,
+                "tags": ["preference"],
+            },
+            score=0.95,
+        )
+        store._client.query_points.return_value = SimpleNamespace(
+            points=[mock_point],
+        )
+
+        results = await store.search("dark mode preference", top_k=5)
+
+        assert len(results) == 1
+        assert results[0]["record_id"] == "mem001"
+        assert results[0]["score"] == 0.95
+        assert results[0]["content"] == "dark mode"
+
+    @patch(
+        "metatron.storage.memory_qdrant._compute_query_sparse",
+        return_value=([1, 2], [0.5, 0.3]),
+    )
+    @patch(
+        "metatron.storage.memory_qdrant.get_cached_embedding",
+        return_value=[0.1] * 768,
+    )
+    async def test_search_with_agent_filter(self, mock_embed, mock_sparse) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+        store._client.query_points.return_value = SimpleNamespace(points=[])
+
+        await store.search("query", agent_id="agent1")
+
+        call_kwargs = store._client.query_points.call_args.kwargs
+        prefetch_list = call_kwargs["prefetch"]
+        # Both prefetch queries should have the agent_id filter
+        assert prefetch_list[0].filter is not None
+        assert prefetch_list[1].filter is not None
+
+    @patch(
+        "metatron.storage.memory_qdrant._compute_query_sparse",
+        return_value=([1, 2], [0.5, 0.3]),
+    )
+    @patch(
+        "metatron.storage.memory_qdrant.get_cached_embedding",
+        return_value=[0.1] * 768,
+    )
+    async def test_search_without_filters(self, mock_embed, mock_sparse) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+        store._client.query_points.return_value = SimpleNamespace(points=[])
+
+        await store.search("query")
+
+        call_kwargs = store._client.query_points.call_args.kwargs
+        prefetch_list = call_kwargs["prefetch"]
+        # No filter when no agent_id/scope provided
+        assert prefetch_list[0].filter is None
+
+    @patch(
+        "metatron.storage.memory_qdrant._compute_query_sparse",
+        return_value=([1, 2], [0.5, 0.3]),
+    )
+    @patch(
+        "metatron.storage.memory_qdrant.get_cached_embedding",
+        return_value=[0.1] * 768,
+    )
+    async def test_search_returns_empty_on_no_results(
+        self,
+        mock_embed,
+        mock_sparse,
+    ) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+        store._client.query_points.return_value = SimpleNamespace(points=[])
+
+        results = await store.search("nothing matches")
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    async def test_delete_by_record_id(self) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+
+        await store.delete("mem001")
+
+        store._client.delete.assert_awaited_once()
+        call_kwargs = store._client.delete.call_args.kwargs
+        assert call_kwargs["points_selector"] == ["mem001"]
+
+    async def test_delete_by_agent(self) -> None:
+        store = _make_store()
+        store._collection_ensured = True
+
+        await store.delete_by_agent("agent1")
+
+        store._client.delete.assert_awaited_once()
+        call_kwargs = store._client.delete.call_args.kwargs
+        # Should use a Filter, not a list of IDs
+        selector = call_kwargs["points_selector"]
+        assert hasattr(selector, "must")  # It's a Filter object

--- a/tests/unit/test_memory_redis.py
+++ b/tests/unit/test_memory_redis.py
@@ -210,6 +210,50 @@ class TestInvalidate:
         assert count == 0
 
 
+class TestDeleteRecord:
+    async def test_deletes_key_and_updates_index(self) -> None:
+        cache = _make_cache()
+        cache._store._client.delete.return_value = 1
+        cache._store._client.get.return_value = '["mem001", "mem002"]'
+
+        result = await cache.delete_record("ws1", "sess1", "mem001")
+
+        assert result is True
+        # Should delete the record key
+        cache._store._client.delete.assert_any_call("mem:ws1:sess1:mem001")
+        # Should update the index without mem001
+        set_calls = [
+            c for c in cache._store._client.set.call_args_list if "mem:ws1:sess1:_index" in c.args
+        ]
+        assert len(set_calls) == 1
+        import json
+
+        updated_ids = json.loads(set_calls[0].args[1])
+        assert "mem001" not in updated_ids
+        assert "mem002" in updated_ids
+
+    async def test_deletes_index_when_last_record(self) -> None:
+        cache = _make_cache()
+        cache._store._client.delete.return_value = 1
+        cache._store._client.get.return_value = '["mem001"]'
+
+        await cache.delete_record("ws1", "sess1", "mem001")
+
+        # Index should be deleted entirely (empty list)
+        delete_calls = cache._store._client.delete.call_args_list
+        deleted_keys = [c.args[0] for c in delete_calls]
+        assert "mem:ws1:sess1:_index" in deleted_keys
+
+    async def test_returns_false_when_key_missing(self) -> None:
+        cache = _make_cache()
+        cache._store._client.delete.return_value = 0
+        cache._store._client.get.return_value = None
+
+        result = await cache.delete_record("ws1", "sess1", "nonexistent")
+
+        assert result is False
+
+
 class TestExtendTtl:
     async def test_extends_all_keys(self) -> None:
         cache = _make_cache()

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -1,4 +1,4 @@
-"""Tests for MemoryService (WS1 Stage 2 skeleton)."""
+"""Tests for MemoryService (WS1 Stage 2)."""
 
 from __future__ import annotations
 
@@ -7,13 +7,16 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from metatron.agent.memory_service import MemoryService
+from metatron.core.exceptions import MemoryNotFoundError
 from metatron.core.models import MemoryRecord, MemoryScope
 
 
 def _make_service():
     """Create a MemoryService with mocked dependencies."""
     redis_cache = AsyncMock()
-    return MemoryService(redis_cache=redis_cache), redis_cache
+    qdrant_store = AsyncMock()
+    service = MemoryService(redis_cache=redis_cache, qdrant_store=qdrant_store)
+    return service, redis_cache, qdrant_store
 
 
 def _sample_record(**overrides) -> MemoryRecord:
@@ -35,7 +38,7 @@ def _sample_record(**overrides) -> MemoryRecord:
 
 class TestCacheSession:
     async def test_writes_to_redis_and_neo4j(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         record = _sample_record()
         redis_cache.cache.return_value = record
 
@@ -52,7 +55,7 @@ class TestCacheSession:
         mock_graph.assert_called_once_with(record)
 
     async def test_passes_ttl_override(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         record = _sample_record()
         redis_cache.cache.return_value = record
 
@@ -67,7 +70,7 @@ class TestCacheSession:
         )
 
     async def test_neo4j_failure_does_not_block_cache(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         record = _sample_record()
         redis_cache.cache.return_value = record
 
@@ -77,7 +80,6 @@ class TestCacheSession:
         ):
             result = await service.cache_session("ws1", "sess1", record)
 
-        # Should still succeed — Neo4j is best-effort
         assert result.id == "mem001"
         redis_cache.cache.assert_called_once()
 
@@ -89,7 +91,7 @@ class TestCacheSession:
 
 class TestGetSession:
     async def test_returns_from_redis(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         expected = _sample_record()
         redis_cache.get.return_value = expected
 
@@ -99,7 +101,7 @@ class TestGetSession:
         redis_cache.get.assert_called_once_with("ws1", "sess1", "mem001")
 
     async def test_returns_none_when_not_cached(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         redis_cache.get.return_value = None
 
         result = await service.get_session("ws1", "sess1", "missing")
@@ -109,7 +111,7 @@ class TestGetSession:
 
 class TestListSession:
     async def test_delegates_to_redis(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         records = [_sample_record(id="m1"), _sample_record(id="m2")]
         redis_cache.list.return_value = records
 
@@ -121,7 +123,7 @@ class TestListSession:
 
 class TestInvalidateSession:
     async def test_delegates_to_redis(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         redis_cache.invalidate.return_value = 3
 
         count = await service.invalidate_session("ws1", "sess1")
@@ -132,7 +134,7 @@ class TestInvalidateSession:
 
 class TestExtendSessionTtl:
     async def test_delegates_to_redis(self) -> None:
-        service, redis_cache = _make_service()
+        service, redis_cache, _ = _make_service()
         redis_cache.extend_ttl.return_value = True
 
         result = await service.extend_session_ttl("ws1", "sess1", 7200)
@@ -142,21 +144,80 @@ class TestExtendSessionTtl:
 
 
 # ---------------------------------------------------------------------------
-# Persistent memory stubs
+# Persistent memory (Qdrant + Neo4j)
 # ---------------------------------------------------------------------------
 
 
 class TestSave:
-    async def test_raises_not_implemented(self) -> None:
-        service, _ = _make_service()
+    async def test_writes_to_qdrant_and_neo4j(self) -> None:
+        service, _, qdrant_store = _make_service()
+        record = _sample_record(scope=MemoryScope.PER_AGENT)
 
-        with pytest.raises(NotImplementedError):
-            await service.save("ws1", _sample_record())
+        with patch("metatron.agent.memory_service.save_memory_to_graph") as mock_graph:
+            result = await service.save("ws1", record)
+
+        assert result.id == "mem001"
+        qdrant_store.upsert.assert_awaited_once_with(record)
+        mock_graph.assert_called_once_with(record)
+
+    async def test_neo4j_failure_does_not_block_save(self) -> None:
+        service, _, qdrant_store = _make_service()
+        record = _sample_record(scope=MemoryScope.PER_AGENT)
+
+        with patch(
+            "metatron.agent.memory_service.save_memory_to_graph",
+            side_effect=Exception("neo4j down"),
+        ):
+            result = await service.save("ws1", record)
+
+        assert result.id == "mem001"
+        qdrant_store.upsert.assert_awaited_once()
+
+    async def test_qdrant_failure_propagates(self) -> None:
+        service, _, qdrant_store = _make_service()
+        record = _sample_record(scope=MemoryScope.PER_AGENT)
+        qdrant_store.upsert.side_effect = Exception("qdrant down")
+
+        with pytest.raises(Exception, match="qdrant down"):
+            await service.save("ws1", record)
+
+
+# ---------------------------------------------------------------------------
+# Promote
+# ---------------------------------------------------------------------------
 
 
 class TestPromote:
-    async def test_raises_not_implemented(self) -> None:
-        service, _ = _make_service()
+    async def test_promotes_session_record(self) -> None:
+        service, redis_cache, qdrant_store = _make_service()
+        record = _sample_record(scope=MemoryScope.SESSION, session_id="sess1")
+        redis_cache.get.return_value = record
 
-        with pytest.raises(NotImplementedError):
-            await service.promote("ws1", "sess1", "mem001")
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            result = await service.promote("ws1", "sess1", "mem001")
+
+        assert result.scope == MemoryScope.PER_AGENT
+        qdrant_store.upsert.assert_awaited_once()
+        redis_cache.delete_record.assert_awaited_once_with("ws1", "sess1", "mem001")
+
+    async def test_promote_with_custom_scope(self) -> None:
+        service, redis_cache, _ = _make_service()
+        record = _sample_record(scope=MemoryScope.SESSION)
+        redis_cache.get.return_value = record
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            result = await service.promote(
+                "ws1",
+                "sess1",
+                "mem001",
+                target_scope=MemoryScope.GLOBAL,
+            )
+
+        assert result.scope == MemoryScope.GLOBAL
+
+    async def test_promote_raises_when_not_found(self) -> None:
+        service, redis_cache, _ = _make_service()
+        redis_cache.get.return_value = None
+
+        with pytest.raises(MemoryNotFoundError):
+            await service.promote("ws1", "sess1", "missing")


### PR DESCRIPTION
…mote (Stage 2)

- storage/memory_qdrant.py: MemoryQdrantStore with hybrid search (dense+SPLADE) dedicated collection mem_agent_memory_{workspace_id}, payload indexes
- storage/memory_redis.py: add delete_record() for clean index management
- agent/memory_service.py: save() writes Qdrant + Neo4j, promote() moves session records to persistent storage, DRY _write_graph_best_effort()
- 87 memory-related tests, all passing