### PR TITLE
fix: CustomProvider URL handling and error logging

### DIFF
--- a/src/metatron/llm/provider.py
+++ b/src/metatron/llm/provider.py
@@ -31,7 +31,11 @@ def _settings_for_provider(name: str, settings: Settings) -> dict:
     if name == "ollama":
         return {"model": settings.ollama_llm_model}
     if name == "custom":
-        return {"api_key": settings.custom_llm_api_key, "model": settings.custom_llm_model}
+        return {
+            "api_key": settings.custom_llm_api_key,
+            "model": settings.custom_llm_model,
+            "api_url": settings.custom_llm_url,
+        }
     return {}
 
 

--- a/src/metatron/llm/providers/custom.py
+++ b/src/metatron/llm/providers/custom.py
@@ -42,7 +42,12 @@ class CustomProvider(LLMProvider):
             api_key: Optional API key for authentication.
         """
         super().__init__(model, **kwargs)
-        self.api_url = api_url or os.getenv("CUSTOM_LLM_URL", "")
+        base_url = api_url or os.getenv("CUSTOM_LLM_URL", "")
+        # Ensure URL points to chat completions endpoint
+        self.api_url = (
+            base_url if base_url.endswith("/chat/completions")
+            else f"{base_url.rstrip('/')}/chat/completions"
+        )
         self.api_key = api_key or os.getenv("CUSTOM_LLM_API_KEY", "")
 
     @property
@@ -96,6 +101,14 @@ class CustomProvider(LLMProvider):
 
             if resp.status_code == 401:
                 raise LLMAuthenticationError("Custom API authentication failed")
+
+            if resp.status_code >= 400:
+                logger.error(
+                    "custom_api.error_response",
+                    status=resp.status_code,
+                    body=resp.text[:500],
+                    model=self.model,
+                )
 
             resp.raise_for_status()
             data = resp.json()


### PR DESCRIPTION
## Summary

- Fix CustomProvider not receiving `custom_llm_url` from Settings (was falling back to `os.getenv` which doesn't see `.env` file values)
- Auto-append `/chat/completions` to base URL when user provides `http://host:port/v1` format
- Log response body on 4xx/5xx errors for debugging (previously showed only "400 Bad Request" with no details)

## Context

Discovered during on-prem LLM evaluation with LM Studio. Custom provider (`LLM_PROVIDER=custom`) was broken when configured via `.env` file — URL never reached the provider constructor.

## Test plan

- [x] Verified with LM Studio (phi-3.5-mini-instruct) over LAN
- [x] Ollama, DeepSeek, OpenRouter providers not affected (different code paths)
- [ ] `make test` — unit tests