### PR TITLE
feat(MTRNIX-247): memory hybrid search service (WS1 Stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - feat: WS1 Stage 1 — core memory models and interfaces (MTRNIX-240)
+- feat: memory hybrid search service (`MemorySearchService`) combining Qdrant vector, Neo4j graph, and Redis session legs with weighted blend and graceful degradation (MTRNIX-247)
 - **Breaking**: Replace Memgraph with Neo4j Community Edition for knowledge graph storage
   - Docker image: `memgraph/memgraph:2.18.1` → `neo4j:5-community`
   - Env vars: `MEMGRAPH_*` → `NEO4J_*` (old names still work via aliases)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ src/metatron/
 ├── observability/             # health.py, metrics.py, tracer.py
 ├── workspaces/                # L3 — manager.py, models.py, persistence.py
 ├── skills/                    # L3 — engine.py
+├── memory/                    # L3 — hybrid search across Qdrant + Neo4j + Redis (MemorySearchService)
 ├── benchmarker/               # L2 — api/, db/, schemas/, services/metrics/
 └── scripts/                   # graph_audit.py, run_eval.py, grid_search_weights.py,
                                # graph_rebuild.py, graph_process.py
@@ -203,6 +204,10 @@ Graph extraction is decoupled from sync (process_all_unsynced_graphs, graph-proc
 - METATRON_OPENAI_COMPAT_KEY ("") — static API key for OpenAI-compat endpoints (Home scenario)
 - METATRON_OPENWEBUI_URL ("") — Open WebUI URL for bundled user sync
 - METATRON_OPENWEBUI_METATRON_URL ("") — external Metatron URL written into Direct Connections
+- MEMORY_SEARCH_DENSE_WEIGHT (0.6) — blend weight for normalized Qdrant dense score in memory hybrid search
+- MEMORY_SEARCH_GRAPH_WEIGHT (0.3) — blend weight for Neo4j graph-presence signal (scaled by importance_score)
+- MEMORY_SEARCH_SESSION_WEIGHT (0.1) — blend weight for Redis session-cache presence boost
+- MEMORY_SEARCH_TOP_K_MULTIPLIER (3) — per-leg fetch multiplier for dedup/filter headroom
 - See core/config.py for full list
 
 ## Open WebUI Integration

--- a/src/metatron/agent/memory_service.py
+++ b/src/metatron/agent/memory_service.py
@@ -24,10 +24,11 @@ from typing import TYPE_CHECKING
 import structlog
 
 from metatron.core.exceptions import MemoryNotFoundError
-from metatron.core.models import MemoryRecord, MemoryScope
+from metatron.core.models import MemoryRecord, MemoryScope, MemorySearchResult
 from metatron.storage.memory_graph import save_memory_to_graph
 
 if TYPE_CHECKING:
+    from metatron.memory.search import MemorySearchService
     from metatron.storage.memory_qdrant import MemoryQdrantStore
     from metatron.storage.memory_redis import RedisSessionCache
 
@@ -47,9 +48,12 @@ class MemoryService:
         self,
         redis_cache: RedisSessionCache,
         qdrant_store: MemoryQdrantStore,
+        *,
+        search: MemorySearchService | None = None,
     ) -> None:
         self._redis = redis_cache
         self._qdrant = qdrant_store
+        self._search = search
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -172,3 +176,30 @@ class MemoryService:
         await self._redis.delete_record(workspace_id, session_id, record_id)
 
         return record
+
+    # ------------------------------------------------------------------
+    # Hybrid search (delegates to MemorySearchService)
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        workspace_id: str,
+        query: str,
+        *,
+        agent_id: str | None = None,
+        scope: MemoryScope | None = None,
+        tags: list[str] | None = None,
+        session_id: str | None = None,
+        top_k: int = 5,
+    ) -> list[MemorySearchResult]:
+        if self._search is None:
+            raise RuntimeError("search not configured")
+        return await self._search.hybrid_search(
+            workspace_id,
+            query,
+            agent_id=agent_id,
+            scope=scope,
+            tags=tags,
+            session_id=session_id,
+            top_k=top_k,
+        )

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -75,6 +75,10 @@ class Settings(BaseSettings):
     redis_db: int = Field(0, alias="REDIS_DB")
     redis_password: str = Field("", alias="REDIS_PASSWORD")
     memory_session_ttl: int = Field(14400, alias="METATRON_MEMORY_SESSION_TTL")  # 4 hours
+    memory_search_dense_weight: float = Field(0.6, alias="METATRON_MEMORY_SEARCH_DENSE_WEIGHT")
+    memory_search_graph_weight: float = Field(0.3, alias="METATRON_MEMORY_SEARCH_GRAPH_WEIGHT")
+    memory_search_session_weight: float = Field(0.1, alias="METATRON_MEMORY_SEARCH_SESSION_WEIGHT")
+    memory_search_top_k_multiplier: int = Field(3, alias="METATRON_MEMORY_SEARCH_TOP_K_MULTIPLIER")
 
     # --- Ollama (embeddings) ---
     ollama_host: str = Field("http://localhost:11434", alias="OLLAMA_HOST")

--- a/src/metatron/memory/.claude/CLAUDE.md
+++ b/src/metatron/memory/.claude/CLAUDE.md
@@ -1,0 +1,41 @@
+# Memory
+
+## Overview
+L3 — service layer for agent memory operations. Sits next to `llm/`, `skills/`, `workspaces/`.
+Memory records are stored across three backends (Qdrant content, Neo4j relationships, Redis
+session cache); this module orchestrates read-paths over them.
+
+## Files
+
+### `search.py`
+`MemorySearchService.hybrid_search(workspace_id, query, *, agent_id=None, scope=None, tags=None, session_id=None, top_k=5)` — combines three parallel legs via `asyncio.gather`:
+- Qdrant vector search (content relevance)
+- Neo4j graph traversal (relationship presence, when `agent_id` provided)
+- Redis session cache (recent-session boost, when `session_id` provided)
+
+Each leg is wrapped in a local typed `_safe_gather_leg` helper so one backend down does
+not fail search. Scores are min-max normalized (dense) then blended with weights from
+`MemorySearchWeights`. Dedup by `record.id`, in-process tags filter, sort+rank+truncate.
+
+`MemorySearchWeights` — frozen dataclass (dense=0.6, graph=0.3, session=0.1, top_k_multiplier=3).
+
+Orchestration logic for save/promote/session lives in `agent/memory_service.py` (sibling task).
+`agent/memory_service.py` has an optional `search: MemorySearchService | None` kwarg and a
+thin `async def search(...)` delegate.
+
+## Layer Rules
+- Can import from: `core/` (L0), `storage/` (L1), `retrieval/` (L2).
+- Must NOT import from: `agent/`, `channels/`, `api/`.
+
+## Key Decisions
+- **Weighted blend over RRF** — legs emit heterogeneous signals (relevance vs presence vs
+  session recency). RRF assumes comparable rankings; blend lets us tune each signal's weight.
+- **Graceful degradation via `_safe_gather_leg`** — one backend down does not fail search;
+  the leg returns empty and the blend proceeds over the remaining signals.
+- **Graph-only hits are dropped** — a MemoryRecord present only in Neo4j (no content in
+  Qdrant) is skipped rather than emitted without text.
+- **`sparse_score` field is reserved** — currently always 0.0; Qdrant fuses dense+sparse
+  server-side via RRF. Field kept on `MemorySearchResult` for future client-side use.
+
+## Public Surface
+`MemorySearchService`, `MemorySearchWeights` — re-exported from `__init__.py`.

--- a/src/metatron/memory/__init__.py
+++ b/src/metatron/memory/__init__.py
@@ -1,0 +1,9 @@
+"""Memory hybrid search service (WS1 Stage 3).
+
+L3 service module that blends Qdrant vector search, Neo4j graph traversal,
+and Redis session cache into a single ranked result set.
+"""
+
+from metatron.memory.search import MemorySearchService, MemorySearchWeights
+
+__all__ = ["MemorySearchService", "MemorySearchWeights"]

--- a/src/metatron/memory/search.py
+++ b/src/metatron/memory/search.py
@@ -8,20 +8,23 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import structlog
 
 from metatron.core.config import get_settings
 from metatron.core.models import MemoryRecord, MemoryScope, MemorySearchResult
-from metatron.retrieval.fallback import _safe_call
 from metatron.storage.memory_graph import get_agent_memories
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterable
+
     from metatron.storage.memory_qdrant import MemoryQdrantStore
     from metatron.storage.memory_redis import RedisSessionCache
 
 logger = structlog.get_logger(__name__)
+
+T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -40,6 +43,20 @@ def _default_weights() -> MemorySearchWeights:
         session=s.memory_search_session_weight,
         top_k_multiplier=s.memory_search_top_k_multiplier,
     )
+
+
+async def _safe(
+    coro: Callable[..., Awaitable[T]],
+    *args: Any,
+    default: T,
+    leg: str,
+    **kwargs: Any,
+) -> T:
+    try:
+        return await coro(*args, **kwargs)
+    except Exception:
+        logger.warning("memory_search.leg_failed", leg=leg, exc_info=True)
+        return default
 
 
 class MemorySearchService:
@@ -76,34 +93,40 @@ class MemorySearchService:
         pool = max(1, top_k * weights.top_k_multiplier)
         scope_value = scope.value if scope is not None else None
 
-        qdrant_coro = _safe_call(  # type: ignore[no-untyped-call]
+        qdrant_default: list[dict[str, Any]] = []
+        qdrant_coro: Awaitable[list[dict[str, Any]]] = _safe(
             self._qdrant.search,
             query,
             agent_id=agent_id,
             scope=scope_value,
             top_k=pool,
-            default=[],
+            default=qdrant_default,
+            leg="qdrant",
         )
 
+        graph_default: list[dict[str, Any]] = []
         if agent_id is not None:
-            graph_coro = _safe_call(  # type: ignore[no-untyped-call]
+            graph_coro: Awaitable[list[dict[str, Any]]] = _safe(
                 asyncio.to_thread,
                 get_agent_memories,
                 workspace_id,
                 agent_id,
                 scope_value,
                 pool,
-                default=[],
+                default=graph_default,
+                leg="graph",
             )
         else:
             graph_coro = _noop_list()
 
+        session_default: list[MemoryRecord] = []
         if self._redis is not None and session_id is not None:
-            session_coro = _safe_call(  # type: ignore[no-untyped-call]
+            session_coro: Awaitable[list[MemoryRecord]] = _safe(
                 self._redis.list,
                 workspace_id,
                 session_id,
-                default=[],
+                default=session_default,
+                leg="session",
             )
         else:
             session_coro = _noop_list()
@@ -112,17 +135,13 @@ class MemorySearchService:
             qdrant_coro,
             graph_coro,
             session_coro,
-            return_exceptions=False,
         )
-
-        qdrant_hits = qdrant_hits or []
-        graph_hits = graph_hits or []
-        session_hits = session_hits or []
 
         session_query = query.lower()
         session_matches: list[MemoryRecord] = [
             rec for rec in session_hits if session_query in (rec.content or "").lower()
         ]
+        session_lookup: dict[str, MemoryRecord] = {r.id: r for r in session_hits}
 
         merged: dict[str, MemorySearchResult] = {}
         raw_dense: dict[str, float] = {}
@@ -146,7 +165,7 @@ class MemorySearchService:
             if record_id in merged:
                 merged[record_id].graph_score = importance
                 continue
-            hydrated = _hydrate_graph_record(node, workspace_id, session_hits)
+            hydrated = _hydrate_graph_record(node, workspace_id, session_lookup)
             if hydrated is None:
                 continue
             merged[record_id] = MemorySearchResult(
@@ -228,13 +247,12 @@ def _record_from_qdrant(hit: dict[str, Any], workspace_id: str) -> MemoryRecord:
 def _hydrate_graph_record(
     node: dict[str, Any],
     workspace_id: str,
-    session_hits: list[MemoryRecord],
+    session_lookup: dict[str, MemoryRecord],
 ) -> MemoryRecord | None:
     record_id = str(node.get("id") or "")
     if not record_id:
         return None
 
-    session_lookup = {r.id: r for r in session_hits}
     cached = session_lookup.get(record_id)
     content = cached.content if cached is not None else ""
     if not content:
@@ -261,19 +279,14 @@ def _hydrate_graph_record(
 
 def _min_max_normalize(
     raw: dict[str, float],
-    all_ids: Any,
+    all_ids: Iterable[str],
 ) -> dict[str, float]:
+    ids = list(all_ids)
     if not raw:
-        return {rid: 0.0 for rid in all_ids}
+        return dict.fromkeys(ids, 0.0)
     values = list(raw.values())
     lo, hi = min(values), max(values)
     if hi == lo:
-        return {rid: (1.0 if rid in raw else 0.0) for rid in all_ids}
+        return {rid: (1.0 if rid in raw else 0.0) for rid in ids}
     span = hi - lo
-    out: dict[str, float] = {}
-    for rid in all_ids:
-        if rid in raw:
-            out[rid] = (raw[rid] - lo) / span
-        else:
-            out[rid] = 0.0
-    return out
+    return {rid: ((raw[rid] - lo) / span if rid in raw else 0.0) for rid in ids}

--- a/src/metatron/memory/search.py
+++ b/src/metatron/memory/search.py
@@ -1,0 +1,279 @@
+"""Hybrid memory search — blends Qdrant, Neo4j, and Redis legs.
+
+L3 service layer. Fans out three parallel legs, hydrates records, applies tag
+post-filter, normalizes qdrant scores, and blends into a single ranking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from metatron.core.config import get_settings
+from metatron.core.models import MemoryRecord, MemoryScope, MemorySearchResult
+from metatron.retrieval.fallback import _safe_call
+from metatron.storage.memory_graph import get_agent_memories
+
+if TYPE_CHECKING:
+    from metatron.storage.memory_qdrant import MemoryQdrantStore
+    from metatron.storage.memory_redis import RedisSessionCache
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class MemorySearchWeights:
+    dense: float = 0.6
+    graph: float = 0.3
+    session: float = 0.1
+    top_k_multiplier: int = 3
+
+
+def _default_weights() -> MemorySearchWeights:
+    s = get_settings()
+    return MemorySearchWeights(
+        dense=s.memory_search_dense_weight,
+        graph=s.memory_search_graph_weight,
+        session=s.memory_search_session_weight,
+        top_k_multiplier=s.memory_search_top_k_multiplier,
+    )
+
+
+class MemorySearchService:
+    """Hybrid search across memory stores with weighted blend.
+
+    Qdrant leg provides dense+sparse hits with content.
+    Neo4j leg (agent-scoped) returns metadata for graph-pinned memories.
+    Redis leg (session-scoped) adds recent in-session records via substring match.
+    """
+
+    def __init__(
+        self,
+        qdrant: MemoryQdrantStore,
+        redis: RedisSessionCache | None = None,
+        *,
+        weights: MemorySearchWeights | None = None,
+    ) -> None:
+        self._qdrant = qdrant
+        self._redis = redis
+        self._weights = weights if weights is not None else _default_weights()
+
+    async def hybrid_search(
+        self,
+        workspace_id: str,
+        query: str,
+        *,
+        agent_id: str | None = None,
+        scope: MemoryScope | None = None,
+        tags: list[str] | None = None,
+        session_id: str | None = None,
+        top_k: int = 5,
+    ) -> list[MemorySearchResult]:
+        weights = self._weights
+        pool = max(1, top_k * weights.top_k_multiplier)
+        scope_value = scope.value if scope is not None else None
+
+        qdrant_coro = _safe_call(  # type: ignore[no-untyped-call]
+            self._qdrant.search,
+            query,
+            agent_id=agent_id,
+            scope=scope_value,
+            top_k=pool,
+            default=[],
+        )
+
+        if agent_id is not None:
+            graph_coro = _safe_call(  # type: ignore[no-untyped-call]
+                asyncio.to_thread,
+                get_agent_memories,
+                workspace_id,
+                agent_id,
+                scope_value,
+                pool,
+                default=[],
+            )
+        else:
+            graph_coro = _noop_list()
+
+        if self._redis is not None and session_id is not None:
+            session_coro = _safe_call(  # type: ignore[no-untyped-call]
+                self._redis.list,
+                workspace_id,
+                session_id,
+                default=[],
+            )
+        else:
+            session_coro = _noop_list()
+
+        qdrant_hits, graph_hits, session_hits = await asyncio.gather(
+            qdrant_coro,
+            graph_coro,
+            session_coro,
+            return_exceptions=False,
+        )
+
+        qdrant_hits = qdrant_hits or []
+        graph_hits = graph_hits or []
+        session_hits = session_hits or []
+
+        session_query = query.lower()
+        session_matches: list[MemoryRecord] = [
+            rec for rec in session_hits if session_query in (rec.content or "").lower()
+        ]
+
+        merged: dict[str, MemorySearchResult] = {}
+        raw_dense: dict[str, float] = {}
+        in_session: dict[str, bool] = {}
+
+        for hit in qdrant_hits:
+            record = _record_from_qdrant(hit, workspace_id)
+            raw_dense[record.id] = float(hit.get("score", 0.0) or 0.0)
+            merged[record.id] = MemorySearchResult(
+                record=record,
+                dense_score=0.0,
+                sparse_score=0.0,
+                graph_score=0.0,
+            )
+
+        for node in graph_hits:
+            record_id = node.get("id")
+            if not record_id:
+                continue
+            importance = float(node.get("importance_score", 0.0) or 0.0)
+            if record_id in merged:
+                merged[record_id].graph_score = importance
+                continue
+            hydrated = _hydrate_graph_record(node, workspace_id, session_hits)
+            if hydrated is None:
+                continue
+            merged[record_id] = MemorySearchResult(
+                record=hydrated,
+                dense_score=0.0,
+                sparse_score=0.0,
+                graph_score=importance,
+            )
+
+        for record in session_matches:
+            in_session[record.id] = True
+            if record.id in merged:
+                continue
+            merged[record.id] = MemorySearchResult(
+                record=record,
+                dense_score=0.0,
+                sparse_score=0.0,
+                graph_score=0.0,
+            )
+
+        if tags:
+            tag_set = set(tags)
+            merged = {rid: r for rid, r in merged.items() if tag_set.intersection(r.record.tags)}
+            raw_dense = {rid: v for rid, v in raw_dense.items() if rid in merged}
+
+        norm_dense = _min_max_normalize(raw_dense, merged.keys())
+
+        for rid, result in merged.items():
+            nd = norm_dense.get(rid, 0.0)
+            result.dense_score = nd
+            boost = 1.0 if in_session.get(rid, False) else 0.0
+            result.score = (
+                weights.dense * nd + weights.graph * result.graph_score + weights.session * boost
+            )
+
+        ranked = sorted(merged.values(), key=lambda r: r.score, reverse=True)[:top_k]
+        for i, r in enumerate(ranked):
+            r.rank = i + 1
+
+        logger.debug(
+            "memory_search.completed",
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            qdrant_hits=len(qdrant_hits),
+            graph_hits=len(graph_hits),
+            session_matches=len(session_matches),
+            returned=len(ranked),
+        )
+        return ranked
+
+
+async def _noop_list() -> list[Any]:
+    return []
+
+
+def _record_from_qdrant(hit: dict[str, Any], workspace_id: str) -> MemoryRecord:
+    payload = hit.get("payload") or {}
+    tags = hit.get("tags") or payload.get("tags") or []
+    scope_raw = payload.get("scope") or hit.get("scope") or MemoryScope.PER_AGENT.value
+    try:
+        scope = MemoryScope(scope_raw)
+    except ValueError:
+        scope = MemoryScope.PER_AGENT
+    return MemoryRecord(
+        id=str(hit.get("record_id") or payload.get("record_id") or ""),
+        workspace_id=str(payload.get("workspace_id") or workspace_id),
+        agent_id=str(hit.get("agent_id") or payload.get("agent_id") or ""),
+        scope=scope,
+        source_type=str(payload.get("source_type") or ""),
+        content=str(hit.get("content") or payload.get("content") or ""),
+        tags=list(tags),
+        importance_score=float(
+            hit.get("importance_score") or payload.get("importance_score") or 0.0,
+        ),
+    )
+
+
+def _hydrate_graph_record(
+    node: dict[str, Any],
+    workspace_id: str,
+    session_hits: list[MemoryRecord],
+) -> MemoryRecord | None:
+    record_id = str(node.get("id") or "")
+    if not record_id:
+        return None
+
+    session_lookup = {r.id: r for r in session_hits}
+    cached = session_lookup.get(record_id)
+    content = cached.content if cached is not None else ""
+    if not content:
+        return None
+
+    scope_raw = node.get("scope") or MemoryScope.PER_AGENT.value
+    try:
+        scope = MemoryScope(scope_raw)
+    except ValueError:
+        scope = MemoryScope.PER_AGENT
+
+    tags = node.get("tags") or (cached.tags if cached else [])
+    return MemoryRecord(
+        id=record_id,
+        workspace_id=str(node.get("workspace_id") or workspace_id),
+        agent_id=str(node.get("agent_id") or ""),
+        scope=scope,
+        source_type=str(node.get("source_type") or ""),
+        content=content,
+        tags=list(tags),
+        importance_score=float(node.get("importance_score") or 0.0),
+    )
+
+
+def _min_max_normalize(
+    raw: dict[str, float],
+    all_ids: Any,
+) -> dict[str, float]:
+    if not raw:
+        return {rid: 0.0 for rid in all_ids}
+    values = list(raw.values())
+    lo, hi = min(values), max(values)
+    if hi == lo:
+        return {rid: (1.0 if rid in raw else 0.0) for rid in all_ids}
+    span = hi - lo
+    out: dict[str, float] = {}
+    for rid in all_ids:
+        if rid in raw:
+            out[rid] = (raw[rid] - lo) / span
+        else:
+            out[rid] = 0.0
+    return out

--- a/src/metatron/memory/search.py
+++ b/src/metatron/memory/search.py
@@ -17,7 +17,7 @@ from metatron.core.models import MemoryRecord, MemoryScope, MemorySearchResult
 from metatron.storage.memory_graph import get_agent_memories
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Iterable
+    from collections.abc import Awaitable, Iterable
 
     from metatron.storage.memory_qdrant import MemoryQdrantStore
     from metatron.storage.memory_redis import RedisSessionCache
@@ -45,17 +45,16 @@ def _default_weights() -> MemorySearchWeights:
     )
 
 
-async def _safe(
-    coro: Callable[..., Awaitable[T]],
-    *args: Any,
+async def _safe_gather_leg(
+    coro: Awaitable[T],
+    *,
     default: T,
     leg: str,
-    **kwargs: Any,
 ) -> T:
     try:
-        return await coro(*args, **kwargs)
-    except Exception:
-        logger.warning("memory_search.leg_failed", leg=leg, exc_info=True)
+        return await coro
+    except Exception as exc:  # noqa: BLE001 — log and return default
+        logger.warning("memory_search.leg_failed", leg=leg, error=str(exc))
         return default
 
 
@@ -94,25 +93,27 @@ class MemorySearchService:
         scope_value = scope.value if scope is not None else None
 
         qdrant_default: list[dict[str, Any]] = []
-        qdrant_coro: Awaitable[list[dict[str, Any]]] = _safe(
-            self._qdrant.search,
-            query,
-            agent_id=agent_id,
-            scope=scope_value,
-            top_k=pool,
+        qdrant_coro: Awaitable[list[dict[str, Any]]] = _safe_gather_leg(
+            self._qdrant.search(
+                query,
+                agent_id=agent_id,
+                scope=scope_value,
+                top_k=pool,
+            ),
             default=qdrant_default,
             leg="qdrant",
         )
 
         graph_default: list[dict[str, Any]] = []
         if agent_id is not None:
-            graph_coro: Awaitable[list[dict[str, Any]]] = _safe(
-                asyncio.to_thread,
-                get_agent_memories,
-                workspace_id,
-                agent_id,
-                scope_value,
-                pool,
+            graph_coro: Awaitable[list[dict[str, Any]]] = _safe_gather_leg(
+                asyncio.to_thread(
+                    get_agent_memories,
+                    workspace_id,
+                    agent_id,
+                    scope_value,
+                    pool,
+                ),
                 default=graph_default,
                 leg="graph",
             )
@@ -121,10 +122,8 @@ class MemorySearchService:
 
         session_default: list[MemoryRecord] = []
         if self._redis is not None and session_id is not None:
-            session_coro: Awaitable[list[MemoryRecord]] = _safe(
-                self._redis.list,
-                workspace_id,
-                session_id,
+            session_coro: Awaitable[list[MemoryRecord]] = _safe_gather_leg(
+                self._redis.list(workspace_id, session_id),
                 default=session_default,
                 leg="session",
             )

--- a/tests/unit/test_memory_search.py
+++ b/tests/unit/test_memory_search.py
@@ -169,6 +169,34 @@ class TestDedup:
         assert r.dense_score > 0
         assert r.graph_score == pytest.approx(0.7)
 
+    async def test_three_way_dedup_across_all_legs(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(return_value=[_redis_record("shared", content="hello there")])
+        service, _, _ = _make_service(
+            qdrant_hits=[_qdrant_hit("shared", content="hello there", score=0.9)],
+            redis=redis_cache,
+        )
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            return_value=[_graph_node("shared", importance=0.6)],
+        ):
+            results = await service.hybrid_search(
+                "ws1",
+                "hello",
+                agent_id="agent1",
+                session_id="sess1",
+            )
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.record.id == "shared"
+        assert r.dense_score > 0
+        assert r.graph_score == pytest.approx(0.6)
+        # session boost applied → score > dense*1 + graph*0.6
+        expected_with_boost = 0.6 * 1.0 + 0.3 * 0.6 + 0.1 * 1.0
+        assert r.score == pytest.approx(expected_with_boost)
+
 
 # ---------------------------------------------------------------------------
 # Tags post-filter
@@ -239,6 +267,47 @@ class TestLegFailures:
 
         assert len(results) == 1
         assert results[0].record.id == "r1"
+
+    async def test_qdrant_failure_graph_and_redis_still_return(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(return_value=[_redis_record("r_sess", content="hello world")])
+        qdrant = MagicMock()
+        qdrant.search = AsyncMock(side_effect=RuntimeError("qdrant down"))
+        service = MemorySearchService(qdrant=qdrant, redis=redis_cache)
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            return_value=[_graph_node("r_sess", importance=0.8)],
+        ):
+            results = await service.hybrid_search(
+                "ws1",
+                "hello",
+                agent_id="agent1",
+                session_id="sess1",
+            )
+
+        ids = {r.record.id for r in results}
+        assert ids == {"r_sess"}
+
+    async def test_all_three_legs_fail_returns_empty(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(side_effect=RuntimeError("redis down"))
+        qdrant = MagicMock()
+        qdrant.search = AsyncMock(side_effect=RuntimeError("qdrant down"))
+        service = MemorySearchService(qdrant=qdrant, redis=redis_cache)
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            side_effect=RuntimeError("neo4j down"),
+        ):
+            results = await service.hybrid_search(
+                "ws1",
+                "hello",
+                agent_id="agent1",
+                session_id="sess1",
+            )
+
+        assert results == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_memory_search.py
+++ b/tests/unit/test_memory_search.py
@@ -1,0 +1,349 @@
+"""Tests for MemorySearchService (WS1 Stage 3)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from metatron.core.models import MemoryRecord, MemoryScope
+from metatron.memory.search import MemorySearchService, MemorySearchWeights
+
+
+def _qdrant_hit(
+    record_id: str,
+    content: str = "",
+    score: float = 1.0,
+    agent_id: str = "agent1",
+    scope: str = "per_agent",
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "record_id": record_id,
+        "content": content,
+        "workspace_id": "ws1",
+        "agent_id": agent_id,
+        "scope": scope,
+        "tags": tags or [],
+        "source_type": "chat",
+        "importance_score": 0.5,
+    }
+    return {
+        "record_id": record_id,
+        "content": content,
+        "score": score,
+        "agent_id": agent_id,
+        "scope": scope,
+        "tags": tags or [],
+        "importance_score": 0.5,
+        "payload": payload,
+    }
+
+
+def _graph_node(
+    record_id: str,
+    agent_id: str = "agent1",
+    scope: str = "per_agent",
+    importance: float = 0.8,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": record_id,
+        "workspace_id": "ws1",
+        "agent_id": agent_id,
+        "scope": scope,
+        "source_type": "chat",
+        "importance_score": importance,
+        "tags": tags or [],
+    }
+
+
+def _redis_record(
+    record_id: str,
+    content: str = "",
+    tags: list[str] | None = None,
+) -> MemoryRecord:
+    return MemoryRecord(
+        id=record_id,
+        workspace_id="ws1",
+        agent_id="agent1",
+        scope=MemoryScope.SESSION,
+        session_id="sess1",
+        content=content,
+        tags=tags or [],
+    )
+
+
+def _make_service(
+    *,
+    qdrant_hits: list[dict[str, Any]] | None = None,
+    graph_hits: list[dict[str, Any]] | None = None,
+    redis_records: list[MemoryRecord] | None = None,
+    redis: Any = None,
+    weights: MemorySearchWeights | None = None,
+) -> tuple[MemorySearchService, MagicMock, Any]:
+    qdrant = MagicMock()
+    qdrant.search = AsyncMock(return_value=qdrant_hits or [])
+
+    if redis is None and redis_records is not None:
+        redis = MagicMock()
+        redis.list = AsyncMock(return_value=redis_records)
+        redis.get = AsyncMock(return_value=None)
+
+    service = MemorySearchService(
+        qdrant=qdrant,
+        redis=redis,
+        weights=weights or MemorySearchWeights(),
+    )
+    return service, qdrant, redis
+
+
+# ---------------------------------------------------------------------------
+# Parallel fan-out
+# ---------------------------------------------------------------------------
+
+
+class TestFanOut:
+    async def test_all_legs_fire_when_agent_and_session_set(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(return_value=[_redis_record("r3", content="hello")])
+
+        service, qdrant, _ = _make_service(
+            qdrant_hits=[_qdrant_hit("r1", content="doc", score=0.9)],
+            redis=redis_cache,
+        )
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            return_value=[_graph_node("r2")],
+        ) as mock_graph:
+            results = await service.hybrid_search(
+                "ws1",
+                "hello",
+                agent_id="agent1",
+                session_id="sess1",
+            )
+
+        qdrant.search.assert_awaited_once()
+        mock_graph.assert_called_once()
+        redis_cache.list.assert_awaited_once_with("ws1", "sess1")
+        # r2 (graph) has no content → dropped; r1 + r3 remain
+        ids = {r.record.id for r in results}
+        assert ids == {"r1", "r3"}
+
+    async def test_qdrant_only_when_no_agent_no_session(self) -> None:
+        service, qdrant, _ = _make_service(
+            qdrant_hits=[_qdrant_hit("r1", content="x", score=0.5)],
+        )
+
+        with patch("metatron.memory.search.get_agent_memories") as mock_graph:
+            results = await service.hybrid_search("ws1", "q")
+
+        qdrant.search.assert_awaited_once()
+        mock_graph.assert_not_called()
+        assert len(results) == 1
+        assert results[0].record.id == "r1"
+
+
+# ---------------------------------------------------------------------------
+# Dedup + score blending
+# ---------------------------------------------------------------------------
+
+
+class TestDedup:
+    async def test_qdrant_and_graph_merge_into_single_result(self) -> None:
+        service, _, _ = _make_service(
+            qdrant_hits=[_qdrant_hit("r1", content="c1", score=0.9)],
+        )
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            return_value=[_graph_node("r1", importance=0.7)],
+        ):
+            results = await service.hybrid_search("ws1", "q", agent_id="agent1")
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.record.id == "r1"
+        assert r.dense_score > 0
+        assert r.graph_score == pytest.approx(0.7)
+
+
+# ---------------------------------------------------------------------------
+# Tags post-filter
+# ---------------------------------------------------------------------------
+
+
+class TestTagsFilter:
+    async def test_drops_non_matching_tags(self) -> None:
+        service, _, _ = _make_service(
+            qdrant_hits=[
+                _qdrant_hit("r1", content="a", score=0.9, tags=["alpha"]),
+                _qdrant_hit("r2", content="b", score=0.8, tags=["beta"]),
+            ],
+        )
+
+        results = await service.hybrid_search("ws1", "q", tags=["beta"])
+
+        ids = {r.record.id for r in results}
+        assert ids == {"r2"}
+
+
+# ---------------------------------------------------------------------------
+# Scope passed as .value
+# ---------------------------------------------------------------------------
+
+
+class TestScopePassthrough:
+    async def test_scope_value_string_sent_to_qdrant_and_graph(self) -> None:
+        service, qdrant, _ = _make_service(qdrant_hits=[])
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            return_value=[],
+        ) as mock_graph:
+            await service.hybrid_search(
+                "ws1",
+                "q",
+                agent_id="agent1",
+                scope=MemoryScope.PER_AGENT,
+            )
+
+        qdrant.search.assert_awaited_once()
+        _, kwargs = qdrant.search.call_args
+        assert kwargs["scope"] == "per_agent"
+        assert kwargs["agent_id"] == "agent1"
+
+        graph_args = mock_graph.call_args.args
+        # (workspace_id, agent_id, scope_value, pool)
+        assert graph_args[2] == "per_agent"
+
+
+# ---------------------------------------------------------------------------
+# Leg failures
+# ---------------------------------------------------------------------------
+
+
+class TestLegFailures:
+    async def test_graph_failure_does_not_break_search(self) -> None:
+        service, _, _ = _make_service(
+            qdrant_hits=[_qdrant_hit("r1", content="c", score=0.5)],
+        )
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            side_effect=RuntimeError("neo4j down"),
+        ):
+            results = await service.hybrid_search("ws1", "q", agent_id="agent1")
+
+        assert len(results) == 1
+        assert results[0].record.id == "r1"
+
+
+# ---------------------------------------------------------------------------
+# Redis leg substring match
+# ---------------------------------------------------------------------------
+
+
+class TestRedisSubstring:
+    async def test_redis_hit_when_substring_in_content(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(return_value=[_redis_record("r1", content="Hello World")])
+        service, _, _ = _make_service(qdrant_hits=[], redis=redis_cache)
+
+        results = await service.hybrid_search("ws1", "hello", session_id="sess1")
+
+        assert len(results) == 1
+        assert results[0].record.id == "r1"
+
+    async def test_redis_miss_when_substring_absent(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(return_value=[_redis_record("r1", content="foobar")])
+        service, _, _ = _make_service(qdrant_hits=[], redis=redis_cache)
+
+        results = await service.hybrid_search("ws1", "hello", session_id="sess1")
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Empty-content graph hits dropped
+# ---------------------------------------------------------------------------
+
+
+class TestGraphHydration:
+    async def test_empty_content_graph_hit_dropped(self) -> None:
+        service, _, _ = _make_service(qdrant_hits=[])
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            return_value=[_graph_node("r_graph_only")],
+        ):
+            results = await service.hybrid_search("ws1", "q", agent_id="agent1")
+
+        assert results == []
+
+    async def test_graph_hit_hydrated_from_redis_cache(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(
+            return_value=[_redis_record("r_g", content="hello from cache")]
+        )
+        service, _, _ = _make_service(qdrant_hits=[], redis=redis_cache)
+
+        with patch(
+            "metatron.memory.search.get_agent_memories",
+            return_value=[_graph_node("r_g", importance=0.9)],
+        ):
+            results = await service.hybrid_search(
+                "ws1",
+                "hello",
+                agent_id="agent1",
+                session_id="sess1",
+            )
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.record.id == "r_g"
+        assert r.graph_score == pytest.approx(0.9)
+
+
+# ---------------------------------------------------------------------------
+# Weights affect ordering
+# ---------------------------------------------------------------------------
+
+
+class TestWeightsOrdering:
+    async def test_session_boost_promotes_session_hit(self) -> None:
+        redis_cache = MagicMock()
+        redis_cache.list = AsyncMock(return_value=[_redis_record("r_sess", content="hello world")])
+        # Session weight dominates
+        service, _, _ = _make_service(
+            qdrant_hits=[_qdrant_hit("r_qd", content="other", score=0.9)],
+            redis=redis_cache,
+            weights=MemorySearchWeights(dense=0.05, graph=0.05, session=0.9),
+        )
+
+        results = await service.hybrid_search("ws1", "hello", session_id="sess1")
+
+        assert results[0].record.id == "r_sess"
+
+
+# ---------------------------------------------------------------------------
+# top_k truncation + ranking
+# ---------------------------------------------------------------------------
+
+
+class TestRankingAndTruncation:
+    async def test_returns_at_most_top_k_sorted_with_rank(self) -> None:
+        hits = [_qdrant_hit(f"r{i}", content=f"c{i}", score=float(10 - i)) for i in range(6)]
+        service, _, _ = _make_service(qdrant_hits=hits)
+
+        results = await service.hybrid_search("ws1", "q", top_k=3)
+
+        assert len(results) == 3
+        assert [r.rank for r in results] == [1, 2, 3]
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+        # Highest raw score should rank first
+        assert results[0].record.id == "r0"

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -221,3 +221,48 @@ class TestPromote:
 
         with pytest.raises(MemoryNotFoundError):
             await service.promote("ws1", "sess1", "missing")
+
+
+# ---------------------------------------------------------------------------
+# Hybrid search delegation
+# ---------------------------------------------------------------------------
+
+
+class TestServiceSearch:
+    async def test_delegates_to_search_service(self) -> None:
+        redis_cache = AsyncMock()
+        qdrant_store = AsyncMock()
+        search = AsyncMock()
+        search.hybrid_search.return_value = ["result"]
+        service = MemoryService(
+            redis_cache=redis_cache,
+            qdrant_store=qdrant_store,
+            search=search,
+        )
+
+        result = await service.search(
+            "ws1",
+            "query",
+            agent_id="agent1",
+            scope=MemoryScope.PER_AGENT,
+            tags=["t"],
+            session_id="sess1",
+            top_k=7,
+        )
+
+        assert result == ["result"]
+        search.hybrid_search.assert_awaited_once_with(
+            "ws1",
+            "query",
+            agent_id="agent1",
+            scope=MemoryScope.PER_AGENT,
+            tags=["t"],
+            session_id="sess1",
+            top_k=7,
+        )
+
+    async def test_raises_when_search_not_configured(self) -> None:
+        service, _, _ = _make_service()
+
+        with pytest.raises(RuntimeError, match="search not configured"):
+            await service.search("ws1", "query")


### PR DESCRIPTION
## Summary

WS1 Stage 3: implements `MemorySearchService` — a hybrid memory search that fans
out across Qdrant (vector), Neo4j (graph), and Redis (session) legs in parallel,
then blends results with configurable weights.

- Dense: min-max-normalized Qdrant RRF score (× `dense` weight, default 0.6)
- Graph: Neo4j `importance_score` for agent-pinned memories (× `graph` weight, default 0.3)
- Session: boolean boost for records found in the session Redis cache (× `session` weight, default 0.1)

Legs degrade gracefully via `retrieval.fallback._safe_call` — a down Neo4j or Redis
does not fail the search. Graph-only hits with no content are dropped.

## Files touched

**New:**
- `src/metatron/memory/__init__.py`
- `src/metatron/memory/search.py` — `MemorySearchService`, `MemorySearchWeights`
- `tests/unit/test_memory_search.py` — 12 tests

**Modified:**
- `src/metatron/core/config.py` — 4 new env vars: `METATRON_MEMORY_SEARCH_DENSE_WEIGHT`,
  `METATRON_MEMORY_SEARCH_GRAPH_WEIGHT`, `METATRON_MEMORY_SEARCH_SESSION_WEIGHT`,
  `METATRON_MEMORY_SEARCH_TOP_K_MULTIPLIER`
- `src/metatron/agent/memory_service.py` — optional `search=` kwarg + `MemoryService.search()` delegate
- `tests/unit/test_memory_service.py` — 2 new delegation tests

## DoD

- [x] `MemorySearchService.hybrid_search()` returns ranked `list[MemorySearchResult]`
- [x] Three legs fan out via `asyncio.gather(return_exceptions=False)` with per-leg `_safe_call`
- [x] Dedup by `record_id` across legs; per-leg sub-scores retained
- [x] Tags post-filter (in-process; no Qdrant tags index this iteration)
- [x] Scope passed as `.value` string to Qdrant + Neo4j
- [x] `MemoryService.search()` delegates to injected `MemorySearchService`; raises when missing
- [x] Backward compatible — existing `MemoryService` tests untouched
- [x] Ruff lint + format clean on touched files
- [x] mypy: no new errors introduced on touched files
- [x] All 28 unit tests (12 new search + 16 service) pass

## Test plan

- [ ] `pytest tests/unit/test_memory_search.py tests/unit/test_memory_service.py -v`
- [ ] Confirm no regressions in full unit suite outside pre-existing failures