### PR TITLE
feat(MTRNIX-248): memory PostgreSQL store + MemoryService orchestrati…

### DIFF
--- a/migrations/versions/013_memory_system.py
+++ b/migrations/versions/013_memory_system.py
@@ -1,0 +1,117 @@
+"""Add memory_records and memory_snapshots tables for WS1.
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-04-14
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "013"
+down_revision: str | None = "012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memory_records",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("workspace_id", sa.Text, nullable=False),
+        sa.Column("agent_id", sa.Text, nullable=False),
+        sa.Column("scope", sa.Text, nullable=False),
+        sa.Column("source_type", sa.Text, nullable=False, server_default=""),
+        sa.Column("content", sa.Text, nullable=False, server_default=""),
+        sa.Column(
+            "tags",
+            sa.dialects.postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "importance_score",
+            sa.Float,
+            nullable=False,
+            server_default=sa.text("0.5"),
+        ),
+        sa.Column("ttl_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("content_hash", sa.Text, nullable=False, server_default=""),
+        sa.Column("session_id", sa.Text, nullable=True),
+        sa.Column(
+            "metadata",
+            sa.dialects.postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+
+    op.create_index("ix_memory_records_workspace", "memory_records", ["workspace_id"])
+    op.create_index("ix_memory_records_agent", "memory_records", ["workspace_id", "agent_id"])
+    op.create_index("ix_memory_records_scope", "memory_records", ["workspace_id", "scope"])
+    op.create_index(
+        "ix_memory_records_ttl",
+        "memory_records",
+        ["workspace_id", "ttl_expires_at"],
+        postgresql_where=sa.text("ttl_expires_at IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_memory_records_content_hash",
+        "memory_records",
+        ["workspace_id", "agent_id", "content_hash"],
+    )
+    op.create_index(
+        "ix_memory_records_tags",
+        "memory_records",
+        ["tags"],
+        postgresql_using="gin",
+    )
+
+    op.create_table(
+        "memory_snapshots",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("workspace_id", sa.Text, nullable=False),
+        sa.Column("agent_id", sa.Text, nullable=False),
+        sa.Column("label", sa.Text, nullable=False, server_default=""),
+        sa.Column("trigger", sa.Text, nullable=False, server_default="manual"),
+        sa.Column("record_count", sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("content_hash", sa.Text, nullable=False, server_default=""),
+        sa.Column("size_bytes", sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.Column("storage_path", sa.Text, nullable=False, server_default=""),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+
+    op.create_index(
+        "ix_memory_snapshots_agent",
+        "memory_snapshots",
+        ["workspace_id", "agent_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("memory_snapshots")
+    op.drop_table("memory_records")

--- a/src/metatron/agent/.claude/claude.md
+++ b/src/metatron/agent/.claude/claude.md
@@ -49,6 +49,28 @@ Defines JSON schemas passed to LLM for structured tool invocation:
 - `sync_connector` — trigger connector sync
 - `get_document` — fetch specific document
 
+### `memory_service.py`
+`MemoryService` — orchestrates agent memory across stores (WS1).
+Bound to a single `workspace_id` at construction. Composes L1 storage:
+`MemoryPostgresStore` (source of truth) + `MemoryQdrantStore` + `RedisSessionCache` + `memory_graph.py`.
+All public methods assert `workspace_id` matches the bound value.
+
+Session methods (Redis + Neo4j write-through):
+- `cache_session(ws, session_id, record, ttl?) -> MemoryRecord` — Redis primary, Neo4j best-effort
+- `get_session(ws, session_id, record_id) -> MemoryRecord | None` — Redis first, PG fallback
+- `list_session(ws, session_id) -> list[MemoryRecord]`
+- `invalidate_session(ws, session_id) -> int`
+- `extend_session_ttl(ws, session_id, ttl) -> bool`
+
+Persistent methods (PG + Qdrant + Neo4j):
+- `save(ws, record) -> MemoryRecord` — content dedup via exact-match hash, then PG → Qdrant → Neo4j (best-effort). Non-atomic.
+- `get(ws, record_id) -> MemoryRecord | None` — PG (source of truth)
+- `delete(ws, record_id) -> bool` — PG → Qdrant → Neo4j (best-effort)
+- `list_records(ws, agent_id?, scope?, limit?, offset?) -> list[MemoryRecord]` — PG with filters
+- `reset(ws, agent_id?, scope?) -> int` — DELETE RETURNING id from PG + per-id Qdrant + Neo4j cleanup
+- `promote(ws, session_id, record_id, target_scope?) -> MemoryRecord` — Redis/PG → save to all stores; dedup-aware scope upgrade
+- `search(ws, query, agent_id?, scope?, tags?, session_id?, top_k?) -> list[MemorySearchResult]` — delegates to MemorySearchService
+
 ### `commands.py`
 Legacy stub — slash-command handlers (`/help`, `/sync`, `/clear`).
 Not currently used by `AgentRouter` (commands handled inline in router).

--- a/src/metatron/agent/memory_service.py
+++ b/src/metatron/agent/memory_service.py
@@ -1,34 +1,36 @@
 """MemoryService — orchestrates agent memory across stores (WS1).
 
 Sits at L4 (agent layer), composes L1 storage modules:
-  - RedisSessionCache   (session memory — hot cache with TTL)
+  - MemoryPostgresStore (source of truth — errors propagate)
   - MemoryQdrantStore   (content + embeddings — vector search)
+  - RedisSessionCache   (session memory — hot cache with TTL)
   - memory_graph.py     (Neo4j — relationships and graph queries)
-  - TODO: PostgreSQL    (source of truth — next stage)
 
-Write-through pattern for session memory:
+Write order for persistent memory:
+  save() → dedup check (PG) → PG → Qdrant → Neo4j (best-effort)
+
+Write-through for session memory:
   cache_session() → Redis (primary) + Neo4j (best-effort)
-
-Persistent memory:
-  save() → Qdrant (content + vectors) + Neo4j (graph, best-effort)
-
-Read pattern:
-  get_session() → Redis first (fast path)
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from typing import TYPE_CHECKING
 
 import structlog
 
 from metatron.core.exceptions import MemoryNotFoundError
 from metatron.core.models import MemoryRecord, MemoryScope, MemorySearchResult
-from metatron.storage.memory_graph import save_memory_to_graph
+from metatron.storage.memory_graph import (
+    delete_memory_node,
+    save_memory_to_graph,
+)
 
 if TYPE_CHECKING:
     from metatron.memory.search import MemorySearchService
+    from metatron.storage.memory_postgres import MemoryPostgresStore
     from metatron.storage.memory_qdrant import MemoryQdrantStore
     from metatron.storage.memory_redis import RedisSessionCache
 
@@ -36,28 +38,40 @@ logger = structlog.get_logger()
 
 
 class MemoryService:
-    """Orchestrates agent memory across Redis, Qdrant, Neo4j (PG — TODO).
+    """Orchestrates agent memory across PG, Qdrant, Redis, Neo4j.
 
-    Session memory: Redis is the primary store with auto-TTL.
-    Persistent memory: Qdrant stores content + vectors, Neo4j stores graph.
-    Neo4j writes are best-effort — failures are logged, not raised.
-    PG (source of truth) integration is deferred to next stage.
+    PG is source of truth — failures propagate.
+    Qdrant stores content + vectors — failures propagate.
+    Neo4j stores graph edges — best-effort (failures logged, not raised).
+    Redis caches session records with TTL.
     """
 
     def __init__(
         self,
         redis_cache: RedisSessionCache,
         qdrant_store: MemoryQdrantStore,
+        pg_store: MemoryPostgresStore,
         *,
+        workspace_id: str,
         search: MemorySearchService | None = None,
     ) -> None:
         self._redis = redis_cache
         self._qdrant = qdrant_store
+        self._pg = pg_store
+        self._workspace_id = workspace_id
         self._search = search
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _check_workspace(self, workspace_id: str) -> None:
+        if workspace_id != self._workspace_id:
+            msg = (
+                f"workspace_id mismatch: service bound to {self._workspace_id!r}, "
+                f"got {workspace_id!r}"
+            )
+            raise ValueError(msg)
 
     async def _write_graph_best_effort(self, record: MemoryRecord) -> None:
         """Write to Neo4j graph, swallowing errors (best-effort)."""
@@ -69,6 +83,21 @@ class MemoryService:
                 record_id=record.id,
                 exc_info=True,
             )
+
+    async def _delete_graph_best_effort(self, workspace_id: str, record_id: str) -> None:
+        """Delete from Neo4j graph, swallowing errors."""
+        try:
+            await asyncio.to_thread(delete_memory_node, workspace_id, record_id)
+        except Exception:
+            logger.warning(
+                "memory_service.neo4j_delete_failed",
+                record_id=record_id,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _compute_content_hash(content: str) -> str:
+        return hashlib.sha256(content.encode()).hexdigest()
 
     # ------------------------------------------------------------------
     # Session memory (Redis + Neo4j write-through)
@@ -87,6 +116,7 @@ class MemoryService:
         Redis is the primary store. Neo4j write is best-effort —
         a failure is logged but does not block the cache operation.
         """
+        self._check_workspace(workspace_id)
         result = await self._redis.cache(
             workspace_id,
             session_id,
@@ -103,11 +133,12 @@ class MemoryService:
         session_id: str,
         record_id: str,
     ) -> MemoryRecord | None:
-        """Fetch a session record. Redis first.
-
-        TODO: fallback to Neo4j/PG when Redis misses (Stage 3).
-        """
-        return await self._redis.get(workspace_id, session_id, record_id)
+        """Fetch a session record. Redis first, PG fallback."""
+        self._check_workspace(workspace_id)
+        record = await self._redis.get(workspace_id, session_id, record_id)
+        if record is not None:
+            return record
+        return await self._pg.get(workspace_id, record_id)
 
     async def list_session(
         self,
@@ -115,6 +146,7 @@ class MemoryService:
         session_id: str,
     ) -> list[MemoryRecord]:
         """List all records for a session."""
+        self._check_workspace(workspace_id)
         return await self._redis.list(workspace_id, session_id)
 
     async def invalidate_session(
@@ -123,6 +155,7 @@ class MemoryService:
         session_id: str,
     ) -> int:
         """Drop all session records from cache."""
+        self._check_workspace(workspace_id)
         return await self._redis.invalidate(workspace_id, session_id)
 
     async def extend_session_ttl(
@@ -132,10 +165,11 @@ class MemoryService:
         ttl_seconds: int,
     ) -> bool:
         """Extend TTL for a session."""
+        self._check_workspace(workspace_id)
         return await self._redis.extend_ttl(workspace_id, session_id, ttl_seconds)
 
     # ------------------------------------------------------------------
-    # Persistent memory (Qdrant + Neo4j; PG — TODO next stage)
+    # Persistent memory (PG + Qdrant + Neo4j)
     # ------------------------------------------------------------------
 
     async def save(
@@ -143,14 +177,121 @@ class MemoryService:
         workspace_id: str,
         record: MemoryRecord,
     ) -> MemoryRecord:
-        """Persist a memory record: Qdrant (content + vectors) + Neo4j (graph).
+        """Persist a memory record with content dedup.
 
-        Qdrant failure propagates (primary store). Neo4j is best-effort.
-        TODO: add PG as source of truth in next stage.
+        1. Compute content hash
+        2. Check PG for existing record with same hash (dedup)
+        3. If duplicate — return existing, skip writes
+        4. PG write first (source of truth, errors propagate)
+        5. Qdrant write (content + vectors, errors propagate)
+        6. Neo4j write (graph edges, best-effort)
+
+        Note: writes across PG, Qdrant and Neo4j are NOT atomic. A failure
+        between steps (e.g. Qdrant down after PG commits) leaves the system
+        in a transient inconsistent state — PG is the source of truth and
+        derived stores are reconciled lazily (re-save / reset).
+
+        Content hash is computed on the raw content string (exact-match
+        semantics). Whitespace-only differences are distinct records.
         """
+        self._check_workspace(workspace_id)
+        record.content_hash = self._compute_content_hash(record.content)
+
+        existing = await self._pg.get_by_hash(workspace_id, record.agent_id, record.content_hash)
+        if existing is not None:
+            logger.debug(
+                "memory_service.dedup_hit",
+                existing_id=existing.id,
+                new_id=record.id,
+            )
+            return existing
+
+        await self._pg.save(record)
         await self._qdrant.upsert(record)
         await self._write_graph_best_effort(record)
         return record
+
+    async def get(
+        self,
+        workspace_id: str,
+        record_id: str,
+    ) -> MemoryRecord | None:
+        """Fetch a persistent record from PG (source of truth)."""
+        self._check_workspace(workspace_id)
+        return await self._pg.get(workspace_id, record_id)
+
+    async def delete(
+        self,
+        workspace_id: str,
+        record_id: str,
+    ) -> bool:
+        """Delete a record from all stores. Returns True if PG had it."""
+        self._check_workspace(workspace_id)
+        deleted = await self._pg.delete(workspace_id, record_id)
+        if not deleted:
+            return False
+
+        try:
+            await self._qdrant.delete(record_id)
+        except Exception:
+            logger.warning(
+                "memory_service.qdrant_delete_failed",
+                record_id=record_id,
+                exc_info=True,
+            )
+
+        await self._delete_graph_best_effort(workspace_id, record_id)
+        return True
+
+    async def list_records(
+        self,
+        workspace_id: str,
+        *,
+        agent_id: str | None = None,
+        scope: MemoryScope | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[MemoryRecord]:
+        """List records from PG with optional filters."""
+        self._check_workspace(workspace_id)
+        return await self._pg.list_records(
+            workspace_id,
+            agent_id=agent_id,
+            scope=scope,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def reset(
+        self,
+        workspace_id: str,
+        *,
+        agent_id: str | None = None,
+        scope: MemoryScope | None = None,
+    ) -> int:
+        """Bulk-delete matching records from all stores.
+
+        Uses DELETE ... RETURNING id in PG so the deleted-id set is
+        authoritative (no race with concurrent inserts). Per-id deletes
+        in Qdrant + Neo4j avoid the over-delete bug of `delete_by_agent`.
+        """
+        self._check_workspace(workspace_id)
+        count, ids = await self._pg.reset(workspace_id, agent_id=agent_id, scope=scope)
+        if not ids:
+            return 0
+
+        for record_id in ids:
+            try:
+                await self._qdrant.delete(record_id)
+            except Exception:
+                logger.warning(
+                    "memory_service.qdrant_reset_failed",
+                    record_id=record_id,
+                    exc_info=True,
+                )
+            await self._delete_graph_best_effort(workspace_id, record_id)
+
+        return count
 
     async def promote(
         self,
@@ -162,20 +303,48 @@ class MemoryService:
     ) -> MemoryRecord:
         """Promote a session record to persistent storage.
 
-        Reads from Redis → changes scope → writes to Qdrant + Neo4j →
-        deletes record from Redis (key + index).
-        TODO: add PG write in next stage.
+        Reads from Redis (fallback PG) -> changes scope -> saves to
+        PG + Qdrant + Neo4j -> deletes record from Redis.
+
+        Dedup edge case: if another record with identical content already
+        exists for this agent, its scope is upgraded to target_scope (in PG
+        + Qdrant) so the promotion intent is honoured even on a dedup hit.
         """
+        self._check_workspace(workspace_id)
         record = await self._redis.get(workspace_id, session_id, record_id)
+        if record is None:
+            record = await self._pg.get(workspace_id, record_id)
         if record is None:
             msg = f"Record {record_id} not found in session {session_id}"
             raise MemoryNotFoundError(msg)
 
         record.scope = target_scope
-        await self.save(workspace_id, record)
-        await self._redis.delete_record(workspace_id, session_id, record_id)
+        record.content_hash = self._compute_content_hash(record.content)
 
-        return record
+        existing = await self._pg.get_by_hash(workspace_id, record.agent_id, record.content_hash)
+        if existing is not None:
+            if existing.scope != target_scope:
+                existing.scope = target_scope
+                await self._pg.save(existing)
+                await self._qdrant.upsert(existing)
+                await self._write_graph_best_effort(existing)
+            result = existing
+        else:
+            await self._pg.save(record)
+            await self._qdrant.upsert(record)
+            await self._write_graph_best_effort(record)
+            result = record
+
+        try:
+            await self._redis.delete_record(workspace_id, session_id, record_id)
+        except Exception:
+            logger.warning(
+                "memory_service.redis_cleanup_failed",
+                record_id=record_id,
+                session_id=session_id,
+                exc_info=True,
+            )
+        return result
 
     # ------------------------------------------------------------------
     # Hybrid search (delegates to MemorySearchService)
@@ -192,6 +361,7 @@ class MemoryService:
         session_id: str | None = None,
         top_k: int = 5,
     ) -> list[MemorySearchResult]:
+        self._check_workspace(workspace_id)
         if self._search is None:
             raise RuntimeError("search not configured")
         return await self._search.hybrid_search(

--- a/src/metatron/core/.claude/claude.md
+++ b/src/metatron/core/.claude/claude.md
@@ -49,11 +49,11 @@ Pure dataclasses — no ORM, no Pydantic, no business logic. These shapes flow b
 - `SyncResult` — connector sync outcome with counts and errors
 - `QueryStep` — single step in 7-step query trace for benchmarker
 
-Enums: `ChunkType` (ROOT, CHILD, STANDALONE), `Role` (VIEWER, EDITOR, ADMIN), `ConnectionStatus` (ACTIVE, SYNCING, ERROR, DISABLED), `MemoryScope` (SESSION, USER, WORKSPACE, GLOBAL)
+Enums: `ChunkType` (ROOT, CHILD, STANDALONE), `Role` (VIEWER, EDITOR, ADMIN), `ConnectionStatus` (ACTIVE, SYNCING, ERROR, DISABLED), `MemoryScope` (GLOBAL, PER_AGENT, SESSION)
 
 WS1 memory shapes (MTRNIX-240):
-- `MemoryRecord` — single memory entry (id, scope, workspace_id, user_id, session_id, key, value, metadata, created_at, updated_at)
-- `MemorySnapshot` — point-in-time serialized memory state for restore/rollback
+- `MemoryRecord` — single memory entry (id, workspace_id, agent_id, scope, source_type, content, tags, importance_score, ttl_expires_at, content_hash, session_id, metadata, created_at)
+- `MemorySnapshot` — snapshot metadata pointing at an external JSONL+gzip dump (id, workspace_id, agent_id, label, trigger, record_count, content_hash, size_bytes, storage_path, created_at)
 - `MemorySearchResult` — memory query hit with score and record
 
 ### `interfaces.py`
@@ -68,8 +68,8 @@ ABCs:
 - `ProcessorInterface` — `supported_types()`, `extract_text(content, filename)`
 - `AuthBackendInterface` — `authenticate(token) -> User | None`, `create_token(user)`
 - `RetrieverInterface` — `retrieve(workspace_id, query, top_k)`
-- `MemoryStoreInterface` (WS1) — 8 async methods: `store`, `get`, `search`, `delete`, `list_by_scope`, `reset`, `snapshot`, `restore`
-- `SessionMemoryInterface` (WS1) — 6 async methods for per-session conversational memory: `append`, `get_history`, `clear`, `summarize`, `snapshot`, `restore`
+- `MemoryStoreInterface` (WS1) — 8 async methods: `save`, `get`, `search`, `delete`, `list`, `reset`, `create_snapshot`, `restore_snapshot`
+- `SessionMemoryInterface` (WS1) — 6 async methods for per-session conversational memory: `cache`, `get`, `list`, `invalidate`, `extend_ttl`, `promote`
 
 Protocols (`@runtime_checkable`):
 - `EventHandler` — `async __call__(event_name, payload)` — for event bus subscribers

--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -168,6 +168,24 @@ Class: `MemoryQdrantStore(workspace_id, host?, port?)`
 - `delete_by_agent(agent_id)` — delete all points for agent
 - `close()` — close client
 
+### `memory_postgres.py`
+PostgreSQL store for Agent Memory (WS1). Source of truth for all memory records and snapshots.
+
+Tables: `memory_records` (migration 013), `memory_snapshots` (migration 013).
+
+Class: `MemoryPostgresStore(engine: AsyncEngine)`
+- `save(record) -> MemoryRecord` — upsert by id, sets updated_at
+- `get(workspace_id, record_id) -> MemoryRecord | None` — fetch by id
+- `delete(workspace_id, record_id) -> bool` — delete, returns True if existed
+- `list_records(workspace_id, agent_id?, scope?, limit?, offset?) -> list[MemoryRecord]` — filtered list
+- `reset(workspace_id, agent_id?, scope?) -> tuple[int, list[str]]` — DELETE RETURNING id, returns (count, deleted_ids)
+- `get_by_hash(workspace_id, agent_id, content_hash) -> MemoryRecord | None` — dedup lookup (ORDER BY created_at DESC)
+- `delete_expired(workspace_id) -> int` — TTL cleanup (not yet wired to a periodic trigger)
+- `save_snapshot(snapshot) -> MemorySnapshot` — insert snapshot metadata
+- `delete_snapshot(workspace_id, snapshot_id) -> bool` — delete, returns True if existed
+- `get_snapshot(workspace_id, snapshot_id) -> MemorySnapshot | None`
+- `list_snapshots(workspace_id, agent_id) -> list[MemorySnapshot]`
+
 ### `graph_ops.py`
 High-level graph query functions used by retrieval.
 

--- a/src/metatron/storage/memory_postgres.py
+++ b/src/metatron/storage/memory_postgres.py
@@ -1,0 +1,354 @@
+"""PostgreSQL store for Agent Memory (WS1).
+
+Source of truth for memory records and snapshots. Stores all fields
+including content (unlike Neo4j which is metadata-only).
+
+Uses raw SQL via SQLAlchemy async engine — same pattern as postgres.py.
+This is an L1 storage module — no business logic.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from sqlalchemy import text
+
+from metatron.core.models import MemoryRecord, MemoryScope, MemorySnapshot
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+logger = structlog.get_logger()
+
+# ------------------------------------------------------------------
+# Row → dataclass helpers
+# ------------------------------------------------------------------
+
+_RECORD_COLUMNS = (
+    "id, workspace_id, agent_id, scope, source_type, content, "
+    "tags, importance_score, ttl_expires_at, content_hash, "
+    "session_id, metadata, created_at, updated_at"
+)
+
+_SNAPSHOT_COLUMNS = (
+    "id, workspace_id, agent_id, label, trigger, record_count, "
+    "content_hash, size_bytes, storage_path, created_at"
+)
+
+
+def _row_to_record(m: Any) -> MemoryRecord:
+    """Convert a DB row mapping to MemoryRecord."""
+    ttl = m["ttl_expires_at"]
+    if ttl and not getattr(ttl, "tzinfo", None):
+        ttl = ttl.replace(tzinfo=UTC)
+    created = m["created_at"]
+    if created and not getattr(created, "tzinfo", None):
+        created = created.replace(tzinfo=UTC)
+    return MemoryRecord(
+        id=m["id"],
+        workspace_id=m["workspace_id"],
+        agent_id=m["agent_id"],
+        scope=MemoryScope(m["scope"]),
+        source_type=m["source_type"],
+        content=m["content"],
+        tags=m["tags"] if isinstance(m["tags"], list) else json.loads(m["tags"]),
+        importance_score=m["importance_score"],
+        ttl_expires_at=ttl,
+        content_hash=m["content_hash"],
+        session_id=m["session_id"],
+        metadata=(m["metadata"] if isinstance(m["metadata"], dict) else json.loads(m["metadata"])),
+        created_at=created or datetime.now(UTC),
+    )
+
+
+def _row_to_snapshot(m: Any) -> MemorySnapshot:
+    """Convert a DB row mapping to MemorySnapshot."""
+    created = m["created_at"]
+    if created and not getattr(created, "tzinfo", None):
+        created = created.replace(tzinfo=UTC)
+    return MemorySnapshot(
+        id=m["id"],
+        workspace_id=m["workspace_id"],
+        agent_id=m["agent_id"],
+        label=m["label"],
+        trigger=m["trigger"],
+        record_count=m["record_count"],
+        content_hash=m["content_hash"],
+        size_bytes=m["size_bytes"],
+        storage_path=m["storage_path"],
+        created_at=created or datetime.now(UTC),
+    )
+
+
+class MemoryPostgresStore:
+    """Async PostgreSQL store for agent memory records and snapshots.
+
+    Source of truth — all other stores (Qdrant, Neo4j, Redis) are derived.
+    """
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    # ------------------------------------------------------------------
+    # Records — CRUD
+    # ------------------------------------------------------------------
+
+    async def save(self, record: MemoryRecord) -> MemoryRecord:
+        """Insert or update a memory record (upsert by id).
+
+        Sets updated_at to current time on every call.
+        """
+        now = datetime.now(UTC)
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(f"""
+                    INSERT INTO memory_records ({_RECORD_COLUMNS})
+                    VALUES (:id, :workspace_id, :agent_id, :scope, :source_type,
+                            :content, :tags::jsonb, :importance_score, :ttl_expires_at,
+                            :content_hash, :session_id, :metadata::jsonb,
+                            :created_at, :updated_at)
+                    ON CONFLICT (id) DO UPDATE SET
+                        scope = EXCLUDED.scope,
+                        source_type = EXCLUDED.source_type,
+                        content = EXCLUDED.content,
+                        tags = EXCLUDED.tags,
+                        importance_score = EXCLUDED.importance_score,
+                        ttl_expires_at = EXCLUDED.ttl_expires_at,
+                        content_hash = EXCLUDED.content_hash,
+                        session_id = EXCLUDED.session_id,
+                        metadata = EXCLUDED.metadata,
+                        updated_at = EXCLUDED.updated_at
+                """),
+                {
+                    "id": record.id,
+                    "workspace_id": record.workspace_id,
+                    "agent_id": record.agent_id,
+                    "scope": record.scope.value,
+                    "source_type": record.source_type,
+                    "content": record.content,
+                    "tags": json.dumps(record.tags),
+                    "importance_score": record.importance_score,
+                    "ttl_expires_at": record.ttl_expires_at,
+                    "content_hash": record.content_hash,
+                    "session_id": record.session_id,
+                    "metadata": json.dumps(record.metadata),
+                    "created_at": record.created_at,
+                    "updated_at": now,
+                },
+            )
+        logger.debug("memory_pg.saved", record_id=record.id)
+        return record
+
+    async def get(self, workspace_id: str, record_id: str) -> MemoryRecord | None:
+        """Fetch a single record by id within the workspace."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"""
+                    SELECT {_RECORD_COLUMNS}
+                    FROM memory_records
+                    WHERE id = :id AND workspace_id = :ws
+                """),
+                {"id": record_id, "ws": workspace_id},
+            )
+            row = result.first()
+        if row is None:
+            return None
+        return _row_to_record(row._mapping)
+
+    async def delete(self, workspace_id: str, record_id: str) -> bool:
+        """Delete a record. Returns True if it existed."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("DELETE FROM memory_records WHERE id = :id AND workspace_id = :ws"),
+                {"id": record_id, "ws": workspace_id},
+            )
+            deleted = result.rowcount > 0
+        if deleted:
+            logger.debug("memory_pg.deleted", record_id=record_id)
+        return deleted
+
+    async def list_records(
+        self,
+        workspace_id: str,
+        *,
+        agent_id: str | None = None,
+        scope: MemoryScope | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[MemoryRecord]:
+        """List records with optional filters and pagination."""
+        where_parts = ["workspace_id = :ws"]
+        params: dict[str, Any] = {"ws": workspace_id, "limit": limit, "offset": offset}
+
+        if agent_id is not None:
+            where_parts.append("agent_id = :agent_id")
+            params["agent_id"] = agent_id
+        if scope is not None:
+            where_parts.append("scope = :scope")
+            params["scope"] = scope.value
+
+        where_clause = " AND ".join(where_parts)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"""
+                    SELECT {_RECORD_COLUMNS}
+                    FROM memory_records
+                    WHERE {where_clause}
+                    ORDER BY created_at DESC
+                    LIMIT :limit OFFSET :offset
+                """),
+                params,
+            )
+            rows = result.fetchall()
+        return [_row_to_record(r._mapping) for r in rows]
+
+    async def reset(
+        self,
+        workspace_id: str,
+        *,
+        agent_id: str | None = None,
+        scope: MemoryScope | None = None,
+    ) -> tuple[int, list[str]]:
+        """Bulk-delete matching records. Returns (count, deleted_ids).
+
+        Uses DELETE ... RETURNING id inside a single transaction so the
+        deleted-id set is authoritative (no race with concurrent inserts).
+        """
+        where_parts = ["workspace_id = :ws"]
+        params: dict[str, Any] = {"ws": workspace_id}
+
+        if agent_id is not None:
+            where_parts.append("agent_id = :agent_id")
+            params["agent_id"] = agent_id
+        if scope is not None:
+            where_parts.append("scope = :scope")
+            params["scope"] = scope.value
+
+        where_clause = " AND ".join(where_parts)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"DELETE FROM memory_records WHERE {where_clause} RETURNING id"),
+                params,
+            )
+            rows = result.fetchall()
+        ids = [r[0] for r in rows]
+        count = len(ids)
+        logger.info("memory_pg.reset", workspace_id=workspace_id, count=count)
+        return count, ids
+
+    # ------------------------------------------------------------------
+    # Dedup + TTL
+    # ------------------------------------------------------------------
+
+    async def get_by_hash(
+        self, workspace_id: str, agent_id: str, content_hash: str
+    ) -> MemoryRecord | None:
+        """Find a record by content hash within the same agent. Used for dedup."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"""
+                    SELECT {_RECORD_COLUMNS}
+                    FROM memory_records
+                    WHERE workspace_id = :ws AND agent_id = :agent_id
+                      AND content_hash = :hash
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                """),
+                {"ws": workspace_id, "agent_id": agent_id, "hash": content_hash},
+            )
+            row = result.first()
+        if row is None:
+            return None
+        return _row_to_record(row._mapping)
+
+    async def delete_expired(self, workspace_id: str) -> int:
+        """Delete records whose TTL has passed. Returns number removed."""
+        now = datetime.now(UTC)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    DELETE FROM memory_records
+                    WHERE workspace_id = :ws AND ttl_expires_at < :now
+                """),
+                {"ws": workspace_id, "now": now},
+            )
+            count = result.rowcount
+        if count:
+            logger.info("memory_pg.expired_deleted", workspace_id=workspace_id, count=count)
+        return count
+
+    # ------------------------------------------------------------------
+    # Snapshots
+    # ------------------------------------------------------------------
+
+    async def save_snapshot(self, snapshot: MemorySnapshot) -> MemorySnapshot:
+        """Insert a snapshot metadata row."""
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(f"""
+                    INSERT INTO memory_snapshots ({_SNAPSHOT_COLUMNS})
+                    VALUES (:id, :workspace_id, :agent_id, :label, :trigger,
+                            :record_count, :content_hash, :size_bytes,
+                            :storage_path, :created_at)
+                """),
+                {
+                    "id": snapshot.id,
+                    "workspace_id": snapshot.workspace_id,
+                    "agent_id": snapshot.agent_id,
+                    "label": snapshot.label,
+                    "trigger": snapshot.trigger,
+                    "record_count": snapshot.record_count,
+                    "content_hash": snapshot.content_hash,
+                    "size_bytes": snapshot.size_bytes,
+                    "storage_path": snapshot.storage_path,
+                    "created_at": snapshot.created_at,
+                },
+            )
+        logger.debug("memory_pg.snapshot_saved", snapshot_id=snapshot.id)
+        return snapshot
+
+    async def delete_snapshot(self, workspace_id: str, snapshot_id: str) -> bool:
+        """Delete a snapshot. Returns True if it existed."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("DELETE FROM memory_snapshots WHERE id = :id AND workspace_id = :ws"),
+                {"id": snapshot_id, "ws": workspace_id},
+            )
+            deleted = result.rowcount > 0
+        if deleted:
+            logger.debug("memory_pg.snapshot_deleted", snapshot_id=snapshot_id)
+        return deleted
+
+    async def get_snapshot(self, workspace_id: str, snapshot_id: str) -> MemorySnapshot | None:
+        """Fetch a snapshot by id."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"""
+                    SELECT {_SNAPSHOT_COLUMNS}
+                    FROM memory_snapshots
+                    WHERE id = :id AND workspace_id = :ws
+                """),
+                {"id": snapshot_id, "ws": workspace_id},
+            )
+            row = result.first()
+        if row is None:
+            return None
+        return _row_to_snapshot(row._mapping)
+
+    async def list_snapshots(self, workspace_id: str, agent_id: str) -> list[MemorySnapshot]:
+        """List snapshots for an agent, newest first."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"""
+                    SELECT {_SNAPSHOT_COLUMNS}
+                    FROM memory_snapshots
+                    WHERE workspace_id = :ws AND agent_id = :agent_id
+                    ORDER BY created_at DESC
+                """),
+                {"ws": workspace_id, "agent_id": agent_id},
+            )
+            rows = result.fetchall()
+        return [_row_to_snapshot(r._mapping) for r in rows]

--- a/tests/unit/test_memory_postgres.py
+++ b/tests/unit/test_memory_postgres.py
@@ -1,0 +1,419 @@
+"""Tests for MemoryPostgresStore (WS1)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from metatron.core.models import MemoryRecord, MemoryScope, MemorySnapshot
+from metatron.storage.memory_postgres import MemoryPostgresStore
+
+
+def _make_store() -> tuple[MemoryPostgresStore, MagicMock]:
+    """Create store with a mocked engine."""
+    engine = MagicMock()
+    store = MemoryPostgresStore(engine)
+    return store, engine
+
+
+def _sample_record(**overrides) -> MemoryRecord:
+    defaults = {
+        "id": "mem001",
+        "workspace_id": "ws1",
+        "agent_id": "agent1",
+        "scope": MemoryScope.PER_AGENT,
+        "source_type": "conversation",
+        "content": "user prefers dark mode",
+        "tags": ["preference"],
+        "importance_score": 0.8,
+        "content_hash": "abc123",
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+def _sample_snapshot(**overrides) -> MemorySnapshot:
+    defaults = {
+        "id": "snap001",
+        "workspace_id": "ws1",
+        "agent_id": "agent1",
+        "label": "before refactor",
+        "trigger": "manual",
+        "record_count": 10,
+        "content_hash": "snapabc",
+        "size_bytes": 4096,
+        "storage_path": "/snapshots/snap001.jsonl.gz",
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return MemorySnapshot(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to set up async engine mock
+# ---------------------------------------------------------------------------
+
+_RECORD_ROW = {
+    "id": "mem001",
+    "workspace_id": "ws1",
+    "agent_id": "agent1",
+    "scope": "per_agent",
+    "source_type": "conversation",
+    "content": "user prefers dark mode",
+    "tags": ["preference"],
+    "importance_score": 0.8,
+    "ttl_expires_at": None,
+    "content_hash": "abc123",
+    "session_id": None,
+    "metadata": {},
+    "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    "updated_at": datetime(2026, 1, 1, tzinfo=UTC),
+}
+
+_SNAPSHOT_ROW = {
+    "id": "snap001",
+    "workspace_id": "ws1",
+    "agent_id": "agent1",
+    "label": "before refactor",
+    "trigger": "manual",
+    "record_count": 10,
+    "content_hash": "snapabc",
+    "size_bytes": 4096,
+    "storage_path": "/snapshots/snap001.jsonl.gz",
+    "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+}
+
+
+def _mock_row(row_data: dict) -> MagicMock:
+    mapping = MagicMock()
+    mapping.__getitem__ = lambda self, k: row_data[k]
+    mapping.get = lambda k, default=None: row_data.get(k, default)
+    row = MagicMock()
+    row._mapping = mapping
+    return row
+
+
+class _FakeCtx:
+    """Async context manager that yields a fixed connection mock."""
+
+    def __init__(self, conn: AsyncMock) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> AsyncMock:
+        return self._conn
+
+    async def __aexit__(self, *exc: object) -> None:
+        pass
+
+
+def _conn_with_row(engine: MagicMock, row_data: dict | None, rowcount: int = 1):
+    """Set up engine.begin() context returning a conn mock.
+
+    If row_data is None, .first() returns None and .fetchall() returns [].
+    """
+    conn = AsyncMock()
+
+    result = MagicMock()
+    result.rowcount = rowcount
+    if row_data is not None:
+        row = _mock_row(row_data)
+        result.first.return_value = row
+        result.fetchall.return_value = [row]
+    else:
+        result.first.return_value = None
+        result.fetchall.return_value = []
+
+    conn.execute.return_value = result
+    engine.begin.return_value = _FakeCtx(conn)
+    return conn
+
+
+# ===========================================================================
+# save
+# ===========================================================================
+
+
+class TestSave:
+    async def test_inserts_record(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None)
+        record = _sample_record()
+
+        result = await store.save(record)
+
+        assert result.id == "mem001"
+        conn.execute.assert_called_once()
+        params = conn.execute.call_args.args[1]
+        assert params["workspace_id"] == "ws1"
+        assert params["content"] == "user prefers dark mode"
+
+    async def test_sets_updated_at(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None)
+        record = _sample_record()
+        before = datetime.now(UTC)
+
+        await store.save(record)
+
+        params = conn.execute.call_args.args[1]
+        assert params["updated_at"] >= before
+
+    async def test_serialises_tags_as_json(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None)
+        record = _sample_record(tags=["a", "b"])
+
+        await store.save(record)
+
+        params = conn.execute.call_args.args[1]
+        assert params["tags"] == '["a", "b"]'
+
+    async def test_serialises_metadata_as_json(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None)
+        record = _sample_record(metadata={"key": "val"})
+
+        await store.save(record)
+
+        params = conn.execute.call_args.args[1]
+        assert params["metadata"] == '{"key": "val"}'
+
+
+# ===========================================================================
+# get
+# ===========================================================================
+
+
+class TestGet:
+    async def test_returns_record_when_found(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, _RECORD_ROW)
+
+        result = await store.get("ws1", "mem001")
+
+        assert result is not None
+        assert result.id == "mem001"
+        assert result.scope == MemoryScope.PER_AGENT
+        assert result.content == "user prefers dark mode"
+        assert result.tags == ["preference"]
+
+    async def test_returns_none_when_not_found(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None)
+
+        result = await store.get("ws1", "missing")
+
+        assert result is None
+
+
+# ===========================================================================
+# delete
+# ===========================================================================
+
+
+class TestDelete:
+    async def test_returns_true_when_deleted(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None, rowcount=1)
+
+        assert await store.delete("ws1", "mem001") is True
+
+    async def test_returns_false_when_not_found(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None, rowcount=0)
+
+        assert await store.delete("ws1", "nonexistent") is False
+
+
+# ===========================================================================
+# list
+# ===========================================================================
+
+
+class TestList:
+    async def test_returns_records(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, _RECORD_ROW)
+
+        records = await store.list_records("ws1")
+
+        assert len(records) == 1
+        assert records[0].id == "mem001"
+
+    async def test_filters_by_agent_and_scope(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None)
+
+        await store.list_records("ws1", agent_id="agent1", scope=MemoryScope.GLOBAL)
+
+        sql_text = str(conn.execute.call_args.args[0])
+        assert "agent_id" in sql_text
+        assert "scope" in sql_text
+
+    async def test_empty_result(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None)
+
+        records = await store.list_records("ws1")
+
+        assert records == []
+
+    async def test_pagination_params(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None)
+
+        await store.list_records("ws1", limit=10, offset=20)
+
+        params = conn.execute.call_args.args[1]
+        assert params["limit"] == 10
+        assert params["offset"] == 20
+
+
+# ===========================================================================
+# reset
+# ===========================================================================
+
+
+class TestReset:
+    async def test_returns_count_and_ids(self) -> None:
+        store, engine = _make_store()
+        conn = AsyncMock()
+        result = MagicMock()
+        row1 = MagicMock()
+        row1.__getitem__ = lambda self, i: "id1"
+        row2 = MagicMock()
+        row2.__getitem__ = lambda self, i: "id2"
+        result.fetchall.return_value = [row1, row2]
+        conn.execute.return_value = result
+        engine.begin.return_value = _FakeCtx(conn)
+
+        count, ids = await store.reset("ws1", agent_id="agent1")
+
+        assert count == 2
+        assert ids == ["id1", "id2"]
+
+    async def test_with_scope_filter(self) -> None:
+        store, engine = _make_store()
+        conn = AsyncMock()
+        result = MagicMock()
+        result.fetchall.return_value = []
+        conn.execute.return_value = result
+        engine.begin.return_value = _FakeCtx(conn)
+
+        count, ids = await store.reset("ws1", scope=MemoryScope.SESSION)
+
+        assert count == 0
+        assert ids == []
+        sql_text = str(conn.execute.call_args.args[0])
+        assert "scope" in sql_text
+        assert "RETURNING id" in sql_text
+
+
+# ===========================================================================
+# get_by_hash
+# ===========================================================================
+
+
+class TestGetByHash:
+    async def test_returns_record_when_hash_matches(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, _RECORD_ROW)
+
+        result = await store.get_by_hash("ws1", "agent1", "abc123")
+
+        assert result is not None
+        assert result.id == "mem001"
+
+    async def test_returns_none_when_no_match(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None)
+
+        result = await store.get_by_hash("ws1", "agent1", "nonexistent")
+
+        assert result is None
+
+
+# ===========================================================================
+# delete_expired
+# ===========================================================================
+
+
+class TestDeleteExpired:
+    async def test_returns_count(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None, rowcount=3)
+
+        count = await store.delete_expired("ws1")
+
+        assert count == 3
+        sql_text = str(conn.execute.call_args.args[0])
+        assert "ttl_expires_at" in sql_text
+        params = conn.execute.call_args.args[1]
+        assert params["ws"] == "ws1"
+        assert "now" in params
+
+
+# ===========================================================================
+# Snapshots
+# ===========================================================================
+
+
+class TestSaveSnapshot:
+    async def test_inserts_snapshot(self) -> None:
+        store, engine = _make_store()
+        conn = _conn_with_row(engine, None)
+        snap = _sample_snapshot()
+
+        result = await store.save_snapshot(snap)
+
+        assert result.id == "snap001"
+        conn.execute.assert_called_once()
+        params = conn.execute.call_args.args[1]
+        assert params["id"] == "snap001"
+        assert params["record_count"] == 10
+
+
+class TestGetSnapshot:
+    async def test_returns_snapshot_when_found(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, _SNAPSHOT_ROW)
+
+        result = await store.get_snapshot("ws1", "snap001")
+
+        assert result is not None
+        assert result.id == "snap001"
+        assert result.record_count == 10
+
+    async def test_returns_none_when_not_found(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None)
+
+        result = await store.get_snapshot("ws1", "missing")
+
+        assert result is None
+
+
+class TestDeleteSnapshot:
+    async def test_returns_true_when_deleted(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None, rowcount=1)
+
+        assert await store.delete_snapshot("ws1", "snap001") is True
+
+    async def test_returns_false_when_not_found(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, None, rowcount=0)
+
+        assert await store.delete_snapshot("ws1", "missing") is False
+
+
+class TestListSnapshots:
+    async def test_returns_snapshots_for_agent(self) -> None:
+        store, engine = _make_store()
+        _conn_with_row(engine, _SNAPSHOT_ROW)
+
+        snapshots = await store.list_snapshots("ws1", "agent1")
+
+        assert len(snapshots) == 1
+        assert snapshots[0].id == "snap001"

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -1,4 +1,4 @@
-"""Tests for MemoryService (WS1 Stage 2)."""
+"""Tests for MemoryService (WS1 — PG + Qdrant + Redis + Neo4j)."""
 
 from __future__ import annotations
 
@@ -11,12 +11,18 @@ from metatron.core.exceptions import MemoryNotFoundError
 from metatron.core.models import MemoryRecord, MemoryScope
 
 
-def _make_service():
+def _make_service(workspace_id: str = "ws1"):
     """Create a MemoryService with mocked dependencies."""
     redis_cache = AsyncMock()
     qdrant_store = AsyncMock()
-    service = MemoryService(redis_cache=redis_cache, qdrant_store=qdrant_store)
-    return service, redis_cache, qdrant_store
+    pg_store = AsyncMock()
+    service = MemoryService(
+        redis_cache=redis_cache,
+        qdrant_store=qdrant_store,
+        pg_store=pg_store,
+        workspace_id=workspace_id,
+    )
+    return service, redis_cache, qdrant_store, pg_store
 
 
 def _sample_record(**overrides) -> MemoryRecord:
@@ -26,6 +32,7 @@ def _sample_record(**overrides) -> MemoryRecord:
         "agent_id": "agent1",
         "scope": MemoryScope.SESSION,
         "session_id": "sess1",
+        "content": "user prefers dark mode",
     }
     defaults.update(overrides)
     return MemoryRecord(**defaults)
@@ -38,7 +45,7 @@ def _sample_record(**overrides) -> MemoryRecord:
 
 class TestCacheSession:
     async def test_writes_to_redis_and_neo4j(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, _ = _make_service()
         record = _sample_record()
         redis_cache.cache.return_value = record
 
@@ -55,7 +62,7 @@ class TestCacheSession:
         mock_graph.assert_called_once_with(record)
 
     async def test_passes_ttl_override(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, _ = _make_service()
         record = _sample_record()
         redis_cache.cache.return_value = record
 
@@ -70,7 +77,7 @@ class TestCacheSession:
         )
 
     async def test_neo4j_failure_does_not_block_cache(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, _ = _make_service()
         record = _sample_record()
         redis_cache.cache.return_value = record
 
@@ -91,7 +98,7 @@ class TestCacheSession:
 
 class TestGetSession:
     async def test_returns_from_redis(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, _ = _make_service()
         expected = _sample_record()
         redis_cache.get.return_value = expected
 
@@ -101,17 +108,29 @@ class TestGetSession:
         redis_cache.get.assert_called_once_with("ws1", "sess1", "mem001")
 
     async def test_returns_none_when_not_cached(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, pg_store = _make_service()
         redis_cache.get.return_value = None
+        pg_store.get.return_value = None
 
         result = await service.get_session("ws1", "sess1", "missing")
 
         assert result is None
 
+    async def test_falls_back_to_pg_on_redis_miss(self) -> None:
+        service, redis_cache, _, pg_store = _make_service()
+        expected = _sample_record()
+        redis_cache.get.return_value = None
+        pg_store.get.return_value = expected
+
+        result = await service.get_session("ws1", "sess1", "mem001")
+
+        assert result is expected
+        pg_store.get.assert_called_once_with("ws1", "mem001")
+
 
 class TestListSession:
     async def test_delegates_to_redis(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, _ = _make_service()
         records = [_sample_record(id="m1"), _sample_record(id="m2")]
         redis_cache.list.return_value = records
 
@@ -123,7 +142,7 @@ class TestListSession:
 
 class TestInvalidateSession:
     async def test_delegates_to_redis(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, _ = _make_service()
         redis_cache.invalidate.return_value = 3
 
         count = await service.invalidate_session("ws1", "sess1")
@@ -134,7 +153,7 @@ class TestInvalidateSession:
 
 class TestExtendSessionTtl:
     async def test_delegates_to_redis(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, _ = _make_service()
         redis_cache.extend_ttl.return_value = True
 
         result = await service.extend_session_ttl("ws1", "sess1", 7200)
@@ -144,25 +163,46 @@ class TestExtendSessionTtl:
 
 
 # ---------------------------------------------------------------------------
-# Persistent memory (Qdrant + Neo4j)
+# Persistent memory (PG + Qdrant + Neo4j)
 # ---------------------------------------------------------------------------
 
 
 class TestSave:
-    async def test_writes_to_qdrant_and_neo4j(self) -> None:
-        service, _, qdrant_store = _make_service()
+    async def test_writes_to_pg_qdrant_neo4j(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
         record = _sample_record(scope=MemoryScope.PER_AGENT)
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
 
         with patch("metatron.agent.memory_service.save_memory_to_graph") as mock_graph:
             result = await service.save("ws1", record)
 
         assert result.id == "mem001"
+        pg_store.save.assert_awaited_once_with(record)
         qdrant_store.upsert.assert_awaited_once_with(record)
         mock_graph.assert_called_once_with(record)
 
-    async def test_neo4j_failure_does_not_block_save(self) -> None:
-        service, _, qdrant_store = _make_service()
+    async def test_pg_is_called_first(self) -> None:
+        """PG write must happen before Qdrant — PG is source of truth."""
+        service, _, qdrant_store, pg_store = _make_service()
         record = _sample_record(scope=MemoryScope.PER_AGENT)
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
+
+        call_order: list[str] = []
+        pg_store.save.side_effect = lambda r: call_order.append("pg") or record
+        qdrant_store.upsert.side_effect = lambda r: call_order.append("qdrant")
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            await service.save("ws1", record)
+
+        assert call_order == ["pg", "qdrant"]
+
+    async def test_neo4j_failure_does_not_block_save(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
+        record = _sample_record(scope=MemoryScope.PER_AGENT)
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
 
         with patch(
             "metatron.agent.memory_service.save_memory_to_graph",
@@ -171,15 +211,179 @@ class TestSave:
             result = await service.save("ws1", record)
 
         assert result.id == "mem001"
+        pg_store.save.assert_awaited_once()
         qdrant_store.upsert.assert_awaited_once()
 
-    async def test_qdrant_failure_propagates(self) -> None:
-        service, _, qdrant_store = _make_service()
+    async def test_pg_failure_propagates(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
         record = _sample_record(scope=MemoryScope.PER_AGENT)
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.side_effect = Exception("pg down")
+
+        with pytest.raises(Exception, match="pg down"):
+            await service.save("ws1", record)
+
+        qdrant_store.upsert.assert_not_awaited()
+
+    async def test_qdrant_failure_propagates(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
+        record = _sample_record(scope=MemoryScope.PER_AGENT)
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
         qdrant_store.upsert.side_effect = Exception("qdrant down")
 
-        with pytest.raises(Exception, match="qdrant down"):
+        with (
+            patch("metatron.agent.memory_service.save_memory_to_graph"),
+            pytest.raises(Exception, match="qdrant down"),
+        ):
             await service.save("ws1", record)
+
+    async def test_sets_content_hash(self) -> None:
+        service, _, _, pg_store = _make_service()
+        record = _sample_record(scope=MemoryScope.PER_AGENT, content="hello")
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            await service.save("ws1", record)
+
+        assert record.content_hash != ""
+
+    async def test_dedup_returns_existing_record(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
+        existing = _sample_record(id="existing001", scope=MemoryScope.PER_AGENT)
+        pg_store.get_by_hash.return_value = existing
+
+        new_record = _sample_record(id="new001", scope=MemoryScope.PER_AGENT)
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            result = await service.save("ws1", new_record)
+
+        assert result.id == "existing001"
+        pg_store.save.assert_not_awaited()
+        qdrant_store.upsert.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    async def test_deletes_from_all_stores(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
+        pg_store.delete.return_value = True
+
+        with patch("metatron.agent.memory_service.delete_memory_node") as mock_graph:
+            mock_graph.return_value = True
+            result = await service.delete("ws1", "mem001")
+
+        assert result is True
+        pg_store.delete.assert_awaited_once_with("ws1", "mem001")
+        qdrant_store.delete.assert_awaited_once_with("mem001")
+
+    async def test_returns_false_when_not_in_pg(self) -> None:
+        service, _, _, pg_store = _make_service()
+        pg_store.delete.return_value = False
+
+        result = await service.delete("ws1", "missing")
+
+        assert result is False
+
+    async def test_qdrant_failure_does_not_block_delete(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
+        pg_store.delete.return_value = True
+        qdrant_store.delete.side_effect = Exception("qdrant down")
+
+        with patch("metatron.agent.memory_service.delete_memory_node"):
+            result = await service.delete("ws1", "mem001")
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Get persistent
+# ---------------------------------------------------------------------------
+
+
+class TestGet:
+    async def test_returns_from_pg(self) -> None:
+        service, _, _, pg_store = _make_service()
+        expected = _sample_record(scope=MemoryScope.PER_AGENT)
+        pg_store.get.return_value = expected
+
+        result = await service.get("ws1", "mem001")
+
+        assert result is expected
+        pg_store.get.assert_awaited_once_with("ws1", "mem001")
+
+    async def test_returns_none_when_not_found(self) -> None:
+        service, _, _, pg_store = _make_service()
+        pg_store.get.return_value = None
+
+        result = await service.get("ws1", "missing")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+class TestListPersistent:
+    async def test_delegates_to_pg(self) -> None:
+        service, _, _, pg_store = _make_service()
+        records = [_sample_record(id="m1"), _sample_record(id="m2")]
+        pg_store.list_records.return_value = records
+
+        result = await service.list_records("ws1", agent_id="agent1")
+
+        assert len(result) == 2
+        pg_store.list_records.assert_awaited_once_with(
+            "ws1", agent_id="agent1", scope=None, limit=100, offset=0
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    async def test_resets_pg_qdrant_neo4j(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
+        pg_store.reset.return_value = (2, ["m1", "m2"])
+
+        with patch("metatron.agent.memory_service.delete_memory_node") as mock_graph:
+            mock_graph.return_value = True
+            count = await service.reset("ws1", agent_id="agent1")
+
+        assert count == 2
+        pg_store.reset.assert_awaited_once_with("ws1", agent_id="agent1", scope=None)
+        assert qdrant_store.delete.await_count == 2
+        qdrant_store.delete.assert_any_await("m1")
+        qdrant_store.delete.assert_any_await("m2")
+
+    async def test_reset_with_scope_only_cleans_derived_stores(self) -> None:
+        """Scope-only reset (agent_id=None) must still clean Qdrant + Neo4j."""
+        service, _, qdrant_store, pg_store = _make_service()
+        pg_store.reset.return_value = (1, ["m1"])
+
+        with patch("metatron.agent.memory_service.delete_memory_node"):
+            count = await service.reset("ws1", scope=MemoryScope.GLOBAL)
+
+        assert count == 1
+        qdrant_store.delete.assert_awaited_once_with("m1")
+
+    async def test_reset_returns_zero_skips_cleanup(self) -> None:
+        service, _, qdrant_store, pg_store = _make_service()
+        pg_store.reset.return_value = (0, [])
+
+        count = await service.reset("ws1", agent_id="agent1")
+
+        assert count == 0
+        qdrant_store.delete.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -189,21 +393,26 @@ class TestSave:
 
 class TestPromote:
     async def test_promotes_session_record(self) -> None:
-        service, redis_cache, qdrant_store = _make_service()
+        service, redis_cache, qdrant_store, pg_store = _make_service()
         record = _sample_record(scope=MemoryScope.SESSION, session_id="sess1")
         redis_cache.get.return_value = record
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
 
         with patch("metatron.agent.memory_service.save_memory_to_graph"):
             result = await service.promote("ws1", "sess1", "mem001")
 
         assert result.scope == MemoryScope.PER_AGENT
+        pg_store.save.assert_awaited_once()
         qdrant_store.upsert.assert_awaited_once()
         redis_cache.delete_record.assert_awaited_once_with("ws1", "sess1", "mem001")
 
     async def test_promote_with_custom_scope(self) -> None:
-        service, redis_cache, _ = _make_service()
+        service, redis_cache, _, pg_store = _make_service()
         record = _sample_record(scope=MemoryScope.SESSION)
         redis_cache.get.return_value = record
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
 
         with patch("metatron.agent.memory_service.save_memory_to_graph"):
             result = await service.promote(
@@ -215,9 +424,24 @@ class TestPromote:
 
         assert result.scope == MemoryScope.GLOBAL
 
-    async def test_promote_raises_when_not_found(self) -> None:
-        service, redis_cache, _ = _make_service()
+    async def test_promote_falls_back_to_pg_on_redis_miss(self) -> None:
+        service, redis_cache, _, pg_store = _make_service()
+        record = _sample_record(scope=MemoryScope.SESSION)
         redis_cache.get.return_value = None
+        pg_store.get.return_value = record
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.return_value = record
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            result = await service.promote("ws1", "sess1", "mem001")
+
+        assert result.scope == MemoryScope.PER_AGENT
+        pg_store.get.assert_awaited_once_with("ws1", "mem001")
+
+    async def test_promote_raises_when_not_found(self) -> None:
+        service, redis_cache, _, pg_store = _make_service()
+        redis_cache.get.return_value = None
+        pg_store.get.return_value = None
 
         with pytest.raises(MemoryNotFoundError):
             await service.promote("ws1", "sess1", "missing")
@@ -232,11 +456,14 @@ class TestServiceSearch:
     async def test_delegates_to_search_service(self) -> None:
         redis_cache = AsyncMock()
         qdrant_store = AsyncMock()
+        pg_store = AsyncMock()
         search = AsyncMock()
         search.hybrid_search.return_value = ["result"]
         service = MemoryService(
             redis_cache=redis_cache,
             qdrant_store=qdrant_store,
+            pg_store=pg_store,
+            workspace_id="ws1",
             search=search,
         )
 
@@ -262,7 +489,71 @@ class TestServiceSearch:
         )
 
     async def test_raises_when_search_not_configured(self) -> None:
-        service, _, _ = _make_service()
+        service, _, _, _ = _make_service()
 
         with pytest.raises(RuntimeError, match="search not configured"):
             await service.search("ws1", "query")
+
+
+# ---------------------------------------------------------------------------
+# Workspace isolation
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceIsolation:
+    async def test_rejects_mismatched_workspace(self) -> None:
+        service, _, _, _ = _make_service(workspace_id="ws1")
+
+        with pytest.raises(ValueError, match="workspace_id mismatch"):
+            await service.save("ws_other", _sample_record(scope=MemoryScope.PER_AGENT))
+
+    async def test_rejects_mismatch_on_get(self) -> None:
+        service, _, _, _ = _make_service(workspace_id="ws1")
+
+        with pytest.raises(ValueError, match="workspace_id mismatch"):
+            await service.get("ws_other", "mem001")
+
+
+# ---------------------------------------------------------------------------
+# Content hash exact-match semantics
+# ---------------------------------------------------------------------------
+
+
+class TestContentHashSemantics:
+    async def test_whitespace_difference_is_not_deduped(self) -> None:
+        """'hello' and 'hello ' must produce different hashes."""
+        service, _, _, pg_store = _make_service()
+        r1 = _sample_record(id="m1", scope=MemoryScope.PER_AGENT, content="hello")
+        r2 = _sample_record(id="m2", scope=MemoryScope.PER_AGENT, content="hello ")
+        pg_store.get_by_hash.return_value = None
+        pg_store.save.side_effect = lambda r: r
+
+        with patch("metatron.agent.memory_service.save_memory_to_graph"):
+            await service.save("ws1", r1)
+            await service.save("ws1", r2)
+
+        assert r1.content_hash != r2.content_hash
+
+
+# ---------------------------------------------------------------------------
+# Promote partial failure
+# ---------------------------------------------------------------------------
+
+
+class TestPromotePartialFailure:
+    async def test_redis_cleaned_on_qdrant_failure_in_dedup_branch(self) -> None:
+        """If Qdrant upsert raises during dedup-promote, Redis record is
+        still cleaned up and the exception propagates."""
+        service, redis_cache, qdrant_store, pg_store = _make_service()
+        record = _sample_record(scope=MemoryScope.SESSION, session_id="sess1")
+        existing = _sample_record(id="existing001", scope=MemoryScope.SESSION)
+        redis_cache.get.return_value = record
+        pg_store.get_by_hash.return_value = existing
+        pg_store.save.return_value = existing
+        qdrant_store.upsert.side_effect = Exception("qdrant down")
+
+        with (
+            patch("metatron.agent.memory_service.save_memory_to_graph"),
+            pytest.raises(Exception, match="qdrant down"),
+        ):
+            await service.promote("ws1", "sess1", "mem001")


### PR DESCRIPTION
…on (WS1 Stage 2-3)

Adds PostgreSQL as the source of truth for agent memory and wires the MemoryService orchestrator across Redis + Qdrant + PG + Neo4j.

- migration 013: memory_records + memory_snapshots tables with ws/agent/ scope/ttl indexes and GIN on tags
- storage/memory_postgres.py: MemoryPostgresStore with CRUD, dedup-by-hash and TTL cleanup; snapshot metadata CRUD
- agent/memory_service.py: compose PG + Qdrant + Redis + Neo4j with content-hash dedup, PG-first writes, best-effort Neo4j writes, Redis→PG session fallback, promote() that upgrades existing record scope on dedup hit, and reset() that enumerates IDs first to keep derived stores consistent across scope-only and agent-only filters
- CLAUDE.md updates in core/, storage/, agent/ reflecting current model shapes, scope values and interface method names