### PR TITLE
fix: add retrieval metrics to benchmarker + fix dashboard graph-stats…

### DIFF
--- a/migrations/versions/014_benchmarker_retrieval_metrics.py
+++ b/migrations/versions/014_benchmarker_retrieval_metrics.py
@@ -1,0 +1,38 @@
+"""Add retrieval metrics (ndcg, mrr, precision) to test_runs and test_results.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-04-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "014"
+down_revision: str = "013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # test_runs: avg retrieval metrics
+    op.add_column("test_runs", sa.Column("avg_ndcg_at_10", sa.Float(), nullable=True))
+    op.add_column("test_runs", sa.Column("avg_mrr", sa.Float(), nullable=True))
+    op.add_column("test_runs", sa.Column("avg_precision_at_k", sa.Float(), nullable=True))
+
+    # test_results: per-question retrieval metrics
+    op.add_column("test_results", sa.Column("ndcg_at_10", sa.Float(), nullable=True))
+    op.add_column("test_results", sa.Column("mrr", sa.Float(), nullable=True))
+    op.add_column("test_results", sa.Column("precision_at_k", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("test_results", "precision_at_k")
+    op.drop_column("test_results", "mrr")
+    op.drop_column("test_results", "ndcg_at_10")
+
+    op.drop_column("test_runs", "avg_precision_at_k")
+    op.drop_column("test_runs", "avg_mrr")
+    op.drop_column("test_runs", "avg_ndcg_at_10")

--- a/src/metatron/benchmarker/api/test_runs.py
+++ b/src/metatron/benchmarker/api/test_runs.py
@@ -74,6 +74,9 @@ def save_test_run(request: SaveTestRunRequest) -> dict:
             "context_precision",
             "context_recall",
             "confidence",
+            "ndcg_at_10",
+            "mrr",
+            "precision_at_k",
         ]
         avg_metrics: dict[str, float | None] = {}
         for metric in metric_names:
@@ -108,6 +111,9 @@ def save_test_run(request: SaveTestRunRequest) -> dict:
                 avg_context_precision=avg_metrics["context_precision"],
                 avg_context_recall=avg_metrics["context_recall"],
                 avg_confidence=avg_metrics["confidence"],
+                avg_ndcg_at_10=avg_metrics["ndcg_at_10"],
+                avg_mrr=avg_metrics["mrr"],
+                avg_precision_at_k=avg_metrics["precision_at_k"],
             )
 
             crud.create_test_results(session, run.id, results_dicts)

--- a/src/metatron/benchmarker/api/testing.py
+++ b/src/metatron/benchmarker/api/testing.py
@@ -160,6 +160,9 @@ async def run_tests(request: RunTestsRequest) -> dict:
                         "context_precision": mr.context_precision,
                         "context_recall": mr.context_recall,
                         "confidence": mr.confidence,
+                        "ndcg_at_10": mr.ndcg_at_10,
+                        "mrr": mr.mrr,
+                        "precision_at_k": mr.precision_at_k,
                         "claim_scores": mr.claim_scores,
                         "context": ctx.to_dict(),
                     }
@@ -180,6 +183,9 @@ async def run_tests(request: RunTestsRequest) -> dict:
                 "avg_context_precision": test_run.avg_context_precision,
                 "avg_context_recall": test_run.avg_context_recall,
                 "avg_confidence": test_run.avg_confidence,
+                "avg_ndcg_at_10": test_run.avg_ndcg_at_10,
+                "avg_mrr": test_run.avg_mrr,
+                "avg_precision_at_k": test_run.avg_precision_at_k,
                 "results": [
                     {
                         "id": tr.id,
@@ -191,6 +197,9 @@ async def run_tests(request: RunTestsRequest) -> dict:
                         "context_precision": tr.context_precision,
                         "context_recall": tr.context_recall,
                         "confidence": tr.confidence,
+                        "ndcg_at_10": tr.ndcg_at_10,
+                        "mrr": tr.mrr,
+                        "precision_at_k": tr.precision_at_k,
                         "claim_scores": tr.claim_scores,
                     }
                     for tr in test_result_rows

--- a/src/metatron/benchmarker/db/crud.py
+++ b/src/metatron/benchmarker/db/crud.py
@@ -30,6 +30,9 @@ _METRIC_NAMES = (
     "context_precision",
     "context_recall",
     "confidence",
+    "ndcg_at_10",
+    "mrr",
+    "precision_at_k",
 )
 
 
@@ -365,6 +368,9 @@ def create_test_run(
     avg_context_precision: float | None = None,
     avg_context_recall: float | None = None,
     avg_confidence: float | None = None,
+    avg_ndcg_at_10: float | None = None,
+    avg_mrr: float | None = None,
+    avg_precision_at_k: float | None = None,
 ) -> TestRunRow:
     """Create a new test run with pre-computed average metrics."""
     run = TestRunRow(
@@ -379,6 +385,9 @@ def create_test_run(
         avg_context_precision=avg_context_precision,
         avg_context_recall=avg_context_recall,
         avg_confidence=avg_confidence,
+        avg_ndcg_at_10=avg_ndcg_at_10,
+        avg_mrr=avg_mrr,
+        avg_precision_at_k=avg_precision_at_k,
         created_at=datetime.utcnow(),
     )
     session.add(run)
@@ -474,6 +483,9 @@ def create_test_results(
             context_precision=r.get("context_precision"),
             context_recall=r.get("context_recall"),
             confidence=r.get("confidence"),
+            ndcg_at_10=r.get("ndcg_at_10"),
+            mrr=r.get("mrr"),
+            precision_at_k=r.get("precision_at_k"),
             claim_scores=r.get("claim_scores"),
             context=r.get("context"),
         )

--- a/src/metatron/benchmarker/db/models.py
+++ b/src/metatron/benchmarker/db/models.py
@@ -95,6 +95,9 @@ class TestRunRow(Base):  # type: ignore[misc]
     avg_context_precision = Column(Float, nullable=True)
     avg_context_recall = Column(Float, nullable=True)
     avg_confidence = Column(Float, nullable=True)
+    avg_ndcg_at_10 = Column(Float, nullable=True)
+    avg_mrr = Column(Float, nullable=True)
+    avg_precision_at_k = Column(Float, nullable=True)
 
     benchmark_set = relationship("BenchmarkSetRow", back_populates="test_runs")
     test_results = relationship(
@@ -125,6 +128,9 @@ class TestResultRow(Base):  # type: ignore[misc]
     context_precision = Column(Float, nullable=True)
     context_recall = Column(Float, nullable=True)
     confidence = Column(Float, nullable=True)
+    ndcg_at_10 = Column(Float, nullable=True)
+    mrr = Column(Float, nullable=True)
+    precision_at_k = Column(Float, nullable=True)
     claim_scores = Column(JSON, nullable=True)
     context = Column(JSON, nullable=True)  # white-box data
 

--- a/src/metatron/storage/dashboard_queries.py
+++ b/src/metatron/storage/dashboard_queries.py
@@ -318,13 +318,18 @@ def get_graph_stats_data(workspace_id: str) -> dict:
 
             orphan_result = session.run(
                 "MATCH (n) WHERE n.workspace_id = $ws AND NOT (n)--() "
-                "RETURN n.name AS name, labels(n) AS labels LIMIT 100",
+                "RETURN elementId(n) AS id, n.name AS name,"
+                " labels(n) AS labels LIMIT 100",
                 {"ws": workspace_id},
             )
             orphan_records = list(orphan_result)
             result["orphan_nodes"] = len(orphan_records)
             result["orphan_list"] = [
-                {"name": r["name"], "labels": r["labels"]}
+                {
+                    "id": r["id"],
+                    "label": r["labels"][0] if r["labels"] else "Unknown",
+                    "name": r["name"] or "unnamed",
+                }
                 for r in orphan_records
             ]
 


### PR DESCRIPTION
… orphan query

Benchmarker: runner._compute_avg_metrics() produces avg_ndcg_at_10, avg_mrr, avg_precision_at_k but TestRunRow/create_test_run() did not accept them (TypeError). Added 3 columns to test_runs and test_results, wired through crud, testing.py, test_runs.py. Migration 014.

Dashboard: graph-stats orphan_list Cypher returned "labels" (list) but OrphanNode expected "id" + "label" (str) — fixed query and dict keys.