### PR TITLE
fix: connection update 500 + QDRANT_API_KEY support

### DIFF
--- a/migrations/versions/015_connections_updated_at_tz.py
+++ b/migrations/versions/015_connections_updated_at_tz.py
@@ -1,0 +1,44 @@
+"""Align connections.updated_at with created_at/last_synced_at (timestamptz).
+
+The column was originally created in migration 007 as ``TIMESTAMP WITHOUT TIME
+ZONE`` via ``sa.DateTime``.  The runtime code passes ``datetime.now(UTC)`` (tz
+aware), which asyncpg rejects when binding to a naive TIMESTAMP column, so
+``PUT /api/v1/connections/{id}`` crashes with 500.  Converting the column to
+``timestamptz`` matches the sibling timestamp columns and the code's intent.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-04-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "015"
+down_revision: str = "014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "connections",
+        "updated_at",
+        type_=sa.DateTime(timezone=True),
+        existing_type=sa.DateTime(timezone=False),
+        existing_nullable=True,
+        postgresql_using="updated_at AT TIME ZONE 'UTC'",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "connections",
+        "updated_at",
+        type_=sa.DateTime(timezone=False),
+        existing_type=sa.DateTime(timezone=True),
+        existing_nullable=True,
+        postgresql_using="updated_at AT TIME ZONE 'UTC'",
+    )

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     qdrant_host: str = Field("localhost", alias="QDRANT_HOST")
     qdrant_http_port: int = Field(6333, alias="QDRANT_HTTP_PORT")
     qdrant_grpc_port: int = Field(6334, alias="QDRANT_GRPC_PORT")
+    qdrant_api_key: str = Field("", alias="QDRANT_API_KEY")
 
     # --- Neo4j (graph database) ---
     neo4j_host: str = Field(

--- a/src/metatron/storage/cleanup.py
+++ b/src/metatron/storage/cleanup.py
@@ -38,7 +38,12 @@ def _get_qdrant_client() -> QdrantClient:
     from metatron.core.config import Settings
 
     settings = Settings()
-    return QdrantClient(host=settings.qdrant_host, port=settings.qdrant_http_port, timeout=60)
+    return QdrantClient(
+        host=settings.qdrant_host,
+        port=settings.qdrant_http_port,
+        timeout=60,
+        api_key=settings.qdrant_api_key or None,
+    )
 
 
 def list_qdrant_collections() -> list[str]:

--- a/src/metatron/storage/memory_qdrant.py
+++ b/src/metatron/storage/memory_qdrant.py
@@ -67,6 +67,7 @@ class MemoryQdrantStore:
             host=host or settings.qdrant_host,
             port=port or settings.qdrant_http_port,
             timeout=60,
+            api_key=settings.qdrant_api_key or None,
         )
         self._collection_ensured = False
 

--- a/src/metatron/storage/pg_models.py
+++ b/src/metatron/storage/pg_models.py
@@ -149,9 +149,9 @@ class ConnectionRow(Base):  # type: ignore[misc]
     status = Column(String(32), nullable=False, server_default="active")
     enabled = Column(Boolean, server_default="true")
     error_message = Column(Text, nullable=True)
-    last_synced_at = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = Column(DateTime, nullable=True)
+    last_synced_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime(timezone=True), nullable=True)
 
     workspace = relationship("WorkspaceRow", back_populates="connections")
 

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -148,11 +148,15 @@ class QdrantVectorStore:
     # TODO: async migration
 
     def __init__(
-        self, workspace_id: str | None = None, host: str = "localhost", port: int = 6333
+        self,
+        workspace_id: str | None = None,
+        host: str = "localhost",
+        port: int = 6333,
+        api_key: str | None = None,
     ) -> None:
         self.workspace_id = _normalize_workspace_id(workspace_id)
         self.collection_name = get_collection_name(workspace_id)
-        self.client = QdrantClient(host=host, port=port, timeout=60)
+        self.client = QdrantClient(host=host, port=port, timeout=60, api_key=api_key or None)
         self._ensure_collection()
 
     def _ensure_collection(self) -> None:
@@ -625,10 +629,11 @@ class AsyncQdrantVectorStore:
         workspace_id: str | None = None,
         host: str = "localhost",
         port: int = 6333,
+        api_key: str | None = None,
     ) -> None:
         self.workspace_id = _normalize_workspace_id(workspace_id)
         self.collection_name = get_collection_name(workspace_id)
-        self.client = AsyncQdrantClient(host=host, port=port, timeout=60)
+        self.client = AsyncQdrantClient(host=host, port=port, timeout=60, api_key=api_key or None)
         self._collection_ensured = False
 
     async def _ensure_collection(self) -> None:
@@ -1138,19 +1143,20 @@ def get_hybrid_store(
 ) -> QdrantVectorStore:
     """Get or create QdrantVectorStore for a workspace (cached singleton).
 
-    Host/port default to values from Settings (env vars) when not provided.
+    Host/port/api_key default to values from Settings (env vars) when not provided.
     """
     ws = _normalize_workspace_id(workspace_id)
     if ws not in _hybrid_stores:
         with _store_lock:
             if ws not in _hybrid_stores:
-                if host is None or port is None:
-                    from metatron.core.config import get_settings
+                from metatron.core.config import get_settings
 
-                    s = get_settings()
-                    host = host or s.qdrant_host
-                    port = port or s.qdrant_http_port
-                _hybrid_stores[ws] = QdrantVectorStore(workspace_id, host=host, port=port)
+                s = get_settings()
+                host = host or s.qdrant_host
+                port = port or s.qdrant_http_port
+                _hybrid_stores[ws] = QdrantVectorStore(
+                    workspace_id, host=host, port=port, api_key=s.qdrant_api_key
+                )
     return _hybrid_stores[ws]
 
 
@@ -1175,19 +1181,18 @@ async def get_async_hybrid_store(
 ) -> AsyncQdrantVectorStore:
     """Get or create AsyncQdrantVectorStore for a workspace (cached singleton).
 
-    Host/port default to values from Settings (env vars) when not provided.
+    Host/port/api_key default to values from Settings (env vars) when not provided.
     """
     ws = _normalize_workspace_id(workspace_id)
     if ws not in _async_hybrid_stores:
         async with _async_store_lock:
             if ws not in _async_hybrid_stores:
-                if host is None or port is None:
-                    from metatron.core.config import get_settings
+                from metatron.core.config import get_settings
 
-                    s = get_settings()
-                    host = host or s.qdrant_host
-                    port = port or s.qdrant_http_port
+                s = get_settings()
+                host = host or s.qdrant_host
+                port = port or s.qdrant_http_port
                 _async_hybrid_stores[ws] = AsyncQdrantVectorStore(
-                    workspace_id, host=host, port=port
+                    workspace_id, host=host, port=port, api_key=s.qdrant_api_key
                 )
     return _async_hybrid_stores[ws]

--- a/tests/unit/test_connections_update.py
+++ b/tests/unit/test_connections_update.py
@@ -1,0 +1,202 @@
+"""Tests for PUT /api/v1/connections/{id}/ endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from metatron.api.app import create_app
+from metatron.core.config import Settings
+
+_FERNET_KEY = "dGVzdC1mZXJuZXQta2V5LTMyLWJ5dGVzLWxvbmc="  # 32-byte base64
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=True,
+        AUTH_PASSWORD="testpass",
+        METATRON_SECRET_KEY="test-secret",
+        FERNET_KEY=_FERNET_KEY,
+        DEFAULT_WORKSPACE_ID="ws_test",
+    )
+
+
+@pytest.fixture
+def app(settings: Settings):
+    return create_app(settings)
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_token(
+    role: str = "admin",
+    workspace_ids: list[str] | None = None,
+    secret: str = "test-secret",
+) -> str:
+    from metatron.auth.jwt import create_token
+
+    return create_token(
+        user_id="testuser",
+        role=role,
+        workspace_ids=workspace_ids or ["ws_test"],
+        secret_key=secret,
+    )
+
+
+_EXISTING_JIRA = {
+    "id": "conn_001",
+    "workspace_id": "ws_test",
+    "connector_type": "jira",
+    "name": "Jira",
+    "config": {
+        "url": "https://acme.atlassian.net/",
+        "username": "bot@acme.com",
+        "api_token": "***",
+        "project_key": "PROJ",
+    },
+    "status": "active",
+    "enabled": True,
+    "error_message": None,
+    "last_synced_at": None,
+    "created_at": "2026-01-01T00:00:00+00:00",
+    "updated_at": None,
+}
+
+
+def _updated_row(**overrides) -> dict:
+    row = dict(_EXISTING_JIRA)
+    row["updated_at"] = "2026-04-16T12:00:00+00:00"
+    row.update(overrides)
+    return row
+
+
+class TestUpdateConnection:
+    """PUT /api/v1/connections/{id}/."""
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_happy_path_with_masked_secret(self, mock_store, client: TestClient) -> None:
+        """User saves form with api_token still '***' — update must succeed (200)."""
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_JIRA)
+        store.update_connection = AsyncMock(
+            return_value=_updated_row(name="Jira renamed"),
+        )
+
+        token = _make_token(role="admin")
+        body = {
+            "name": "Jira renamed",
+            "config": {
+                "url": "https://acme.atlassian.net/",
+                "username": "bot@acme.com",
+                "api_token": "***",
+                "project_key": "PROJ",
+            },
+        }
+        r = client.put(
+            "/api/v1/connections/conn_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+        assert r.status_code == 200, r.text
+        payload = r.json()
+        assert payload["name"] == "Jira renamed"
+        assert payload["config"]["api_token"] == "***"  # still masked on response
+        assert payload["updated_at"] == "2026-04-16T12:00:00+00:00"
+
+        # Masked secret must be forwarded verbatim — merge_config unmasks it in the store.
+        update_args = store.update_connection.await_args
+        assert update_args is not None
+        forwarded_updates = update_args.args[1]
+        assert forwarded_updates["name"] == "Jira renamed"
+        assert forwarded_updates["config"]["api_token"] == "***"
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_rotates_secret_when_real_value_sent(self, mock_store, client: TestClient) -> None:
+        """Non-masked api_token is passed through to the store as-is."""
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_JIRA)
+        store.update_connection = AsyncMock(return_value=_updated_row())
+
+        token = _make_token(role="admin")
+        body = {
+            "config": {
+                "url": "https://acme.atlassian.net/",
+                "username": "bot@acme.com",
+                "api_token": "fresh-token-xyz",
+                "project_key": "PROJ",
+            },
+        }
+        r = client.put(
+            "/api/v1/connections/conn_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+        assert r.status_code == 200, r.text
+        forwarded = store.update_connection.await_args.args[1]["config"]
+        assert forwarded["api_token"] == "fresh-token-xyz"
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_missing_required_field_returns_422(self, mock_store, client: TestClient) -> None:
+        """Removing a required non-secret field fails validation even if secret is masked."""
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_JIRA)
+        store.update_connection = AsyncMock()
+
+        token = _make_token(role="admin")
+        # Drop required `url` while keeping the secret masked.
+        body = {
+            "config": {
+                "username": "bot@acme.com",
+                "api_token": "***",
+                "project_key": "PROJ",
+            },
+        }
+        r = client.put(
+            "/api/v1/connections/conn_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+        assert r.status_code == 422
+        assert "Jira URL" in r.json()["detail"]
+        store.update_connection.assert_not_called()
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_wrong_workspace_returns_404(self, mock_store, client: TestClient) -> None:
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(
+            return_value={**_EXISTING_JIRA, "workspace_id": "other_ws"},
+        )
+
+        token = _make_token(role="admin")
+        r = client.put(
+            "/api/v1/connections/conn_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "renamed"},
+        )
+
+        assert r.status_code == 404
+
+    @patch("metatron.api.routes.connections._get_store")
+    def test_no_fields_to_update_returns_422(self, mock_store, client: TestClient) -> None:
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_JIRA)
+
+        token = _make_token(role="admin")
+        r = client.put(
+            "/api/v1/connections/conn_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json={},
+        )
+
+        assert r.status_code == 422
+        assert "No fields to update" in r.json()["detail"]


### PR DESCRIPTION
## Summary
- **fix: PUT /connections returns 500** — `connections.updated_at` was `TIMESTAMP WITHOUT TIME ZONE` (migration 007), but code writes `datetime.now(UTC)` (tz-aware). asyncpg rejects the binding. Migration 015 alters the column to `timestamptz`, aligning with `created_at`/`last_synced_at`.
- **feat: QDRANT_API_KEY** — new env var propagated to all QdrantClient/AsyncQdrantClient constructors (qdrant.py, memory_qdrant.py, cleanup.py). Empty = no auth (backward compatible).

## Changes
| File | Change |
|------|--------|
| `migrations/versions/015_connections_updated_at_tz.py` | ALTER `updated_at` → `timestamptz` |
| `src/metatron/storage/pg_models.py` | ConnectionRow timestamps → `DateTime(timezone=True)` |
| `src/metatron/core/config.py` | Add `qdrant_api_key` field |
| `src/metatron/storage/qdrant.py` | Pass `api_key` to both sync/async constructors + factories |
| `src/metatron/storage/memory_qdrant.py` | Pass `api_key` to AsyncQdrantClient |
| `src/metatron/storage/cleanup.py` | Pass `api_key` to QdrantClient |
| `tests/unit/test_connections_update.py` | 5 tests: masked secret, rotation, validation, workspace, empty |

## Test plan
- [x] Direct `store.update_connection()` with tz-aware datetime succeeds after migration
- [x] PUT route: masked `***` secret → 200 (unit test)
- [x] PUT route: real token rotation → 200 (unit test)
- [x] PUT route: missing required field → 422 (unit test)
- [x] No new regressions in `make test`
- [ ] Verify QDRANT_API_KEY on authenticated Qdrant instance
- [ ] Restart API after deploy (asyncpg pool caches old column type)