### PR TITLE
fix: search-during-sync — client-side RRF, ingest embed throttle

### DIFF
--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -167,6 +167,11 @@ class Settings(BaseSettings):
     # --- Embedding cache ---
     embedding_cache_ttl: int = Field(3600, alias="EMBEDDING_CACHE_TTL")
     embedding_cache_maxsize: int = Field(2048, alias="EMBEDDING_CACHE_MAXSIZE")
+    # Caps concurrent ingest-path Ollama embedding calls so mass document
+    # ingestion does not starve concurrent query embeddings. Query path
+    # (``get_cached_embedding``) is deliberately NOT throttled — searches
+    # always get priority at the Ollama instance.
+    ingest_embed_concurrency: int = Field(2, alias="INGEST_EMBED_CONCURRENCY")
 
     # --- Retrieval tuning ---
     embedding_dim: int = 768

--- a/src/metatron/llm/embeddings.py
+++ b/src/metatron/llm/embeddings.py
@@ -9,6 +9,7 @@ Thread-safe with lock protection on cache reads and writes.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import threading
 import time
@@ -254,6 +255,42 @@ def get_cached_embedding_split(
         left_results = get_cached_embedding_split(left, model, depth + 1)
         right_results = get_cached_embedding_split(right, model, depth + 1)
         return left_results + right_results
+
+
+_ingest_semaphore: asyncio.Semaphore | None = None
+_ingest_semaphore_init_lock = threading.Lock()
+
+
+def _get_ingest_semaphore() -> asyncio.Semaphore:
+    """Return the ingest-embedding throttle, creating it on first use.
+
+    Deferred construction keeps the asyncio.Semaphore out of the import
+    path — useful for test harnesses that build Settings with a custom
+    ``ingest_embed_concurrency`` before the module is first exercised.
+    """
+    global _ingest_semaphore  # noqa: PLW0603
+    if _ingest_semaphore is None:
+        with _ingest_semaphore_init_lock:
+            if _ingest_semaphore is None:
+                _ingest_semaphore = asyncio.Semaphore(_settings.ingest_embed_concurrency)
+    return _ingest_semaphore
+
+
+async def embed_for_ingest(
+    text: str,
+    model: str = "nomic-embed-text:latest",
+) -> list[tuple[str, list[float]]]:
+    """Ingest-side throttled wrapper around ``get_cached_embedding_split``.
+
+    Caps concurrent Ollama ``/api/embeddings`` calls to
+    ``METATRON_INGEST_EMBED_CONCURRENCY`` (default 2) so a mass connector
+    sync does not saturate Ollama and push concurrent query embeddings
+    into timeout territory. Query path uses ``get_cached_embedding``
+    directly (no semaphore) so searches stay ahead of ingest in the queue.
+    """
+    sem = _get_ingest_semaphore()
+    async with sem:
+        return await asyncio.to_thread(get_cached_embedding_split, text, model)
 
 
 def get_embedding_cache_stats() -> dict:

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -34,6 +34,7 @@ from qdrant_client.models import (
 from metatron.core.config import get_settings
 from metatron.ingestion.bm25 import compute_bm25_sparse_vector, compute_query_sparse_vector
 from metatron.llm.embeddings import (  # TODO: async migration
+    embed_for_ingest,
     get_cached_embedding,
     get_cached_embedding_split,
 )
@@ -716,7 +717,7 @@ class AsyncQdrantVectorStore:
         metadata = metadata or {}
         metadata["workspace_id"] = self.workspace_id
 
-        embedding_pairs = await asyncio.to_thread(get_cached_embedding_split, text)
+        embedding_pairs = await embed_for_ingest(text)
 
         title = (metadata or {}).get("title", "")
         points: list[PointStruct] = []
@@ -806,67 +807,51 @@ class AsyncQdrantVectorStore:
         sparse_weight: float = 0.3,
         rrf_k: int | None = None,
     ) -> list[dict]:
-        """Hybrid search via Reciprocal Rank Fusion (RRF).
+        """Hybrid search via client-side Reciprocal Rank Fusion.
 
-        When rrf_k is provided, dense + sparse are queried separately and
-        fused client-side with the given k. When None, Qdrant server-side
-        fusion is used (backward compatible).
+        Dense + sparse legs are queried separately and fused in-process.
+        Server-side ``query_points(prefetch=[...], query=FusionQuery('rrf'))``
+        was removed because qdrant-client 1.16 serialises that payload in a
+        way Qdrant server 1.17 rejects (400: Format error at column ~15000);
+        see 2db89ce for the equivalent fix on ``memory_qdrant``.
+
+        ``rrf_k`` defaults to ``Settings.rrf_k`` (60) when ``None``.
         """
         await self._ensure_collection()
+        if rrf_k is None:
+            rrf_k = get_settings().rrf_k
         dense_query = await asyncio.to_thread(get_cached_embedding, query)
         sparse_indices, sparse_values = await asyncio.to_thread(_compute_query_sparse, query)
         try:
-            if rrf_k is not None:
-                dense_raw = await self.dense_search_raw(
-                    dense_query,
-                    limit=limit * 3,
-                    filter_conditions=filter_conditions,
-                )
-                sparse_raw = await self.sparse_search_raw(
-                    sparse_indices,
-                    sparse_values,
-                    limit=limit * 3,
-                    filter_conditions=filter_conditions,
-                )
-                from metatron.retrieval.hybrid import rrf_fusion
+            dense_raw = await self.dense_search_raw(
+                dense_query,
+                limit=limit * 3,
+                filter_conditions=filter_conditions,
+            )
+            sparse_raw = await self.sparse_search_raw(
+                sparse_indices,
+                sparse_values,
+                limit=limit * 3,
+                filter_conditions=filter_conditions,
+            )
+            from metatron.retrieval.hybrid import rrf_fusion
 
-                fused = rrf_fusion(dense_raw, sparse_raw, k=rrf_k, top_k=limit)
-                if not fused:
-                    return []
-                fused_ids = [doc_id for doc_id, _ in fused]
-                fetched = await self.client.retrieve(
-                    collection_name=self.collection_name,
-                    ids=fused_ids,
-                    with_payload=True,
-                )
-                id_to_point = {str(p.id): p for p in fetched}
-                results_list = []
-                for doc_id, score in fused:
-                    point = id_to_point.get(doc_id)
-                    if point:
-                        results_list.append(self._format_result(point, score))
-                return results_list
-            results = await self.client.query_points(
+            fused = rrf_fusion(dense_raw, sparse_raw, k=rrf_k, top_k=limit)
+            if not fused:
+                return []
+            fused_ids = [doc_id for doc_id, _ in fused]
+            fetched = await self.client.retrieve(
                 collection_name=self.collection_name,
-                prefetch=[
-                    Prefetch(
-                        query=dense_query,
-                        using=DENSE_VECTOR_NAME,
-                        limit=limit * 3,
-                        filter=filter_conditions,
-                    ),
-                    Prefetch(
-                        query=SparseVector(indices=sparse_indices, values=sparse_values),
-                        using=SPARSE_VECTOR_NAME,
-                        limit=limit * 3,
-                        filter=filter_conditions,
-                    ),
-                ],
-                query=FusionQuery(fusion="rrf"),
-                limit=limit,
+                ids=fused_ids,
                 with_payload=True,
             )
-            return [self._format_result(p, p.score) for p in results.points]
+            id_to_point = {str(p.id): p for p in fetched}
+            results_list = []
+            for doc_id, score in fused:
+                point = id_to_point.get(doc_id)
+                if point:
+                    results_list.append(self._format_result(point, score))
+            return results_list
         except Exception as e:
             logger.warning(
                 "qdrant.async.hybrid_search.fallback",

--- a/tests/unit/test_qdrant_async.py
+++ b/tests/unit/test_qdrant_async.py
@@ -74,7 +74,7 @@ class TestEnsureCollection:
 
 
 class TestAddDocument:
-    @patch("metatron.storage.qdrant.get_cached_embedding_split")
+    @patch("metatron.storage.qdrant.embed_for_ingest")
     @patch("metatron.storage.qdrant.compute_bm25_sparse_vector")
     async def test_add_document_calls_upsert(self, mock_bm25, mock_embed):
         mock_embed.return_value = [("chunk text", [0.1] * 768)]
@@ -100,7 +100,7 @@ class TestAddDocument:
 
 
 class TestHybridSearch:
-    @patch("metatron.storage.qdrant.compute_query_sparse_vector")
+    @patch("metatron.storage.qdrant._compute_query_sparse")
     @patch("metatron.storage.qdrant.get_cached_embedding")
     async def test_hybrid_search_returns_results(self, mock_embed, mock_sparse):
         mock_embed.return_value = [0.1] * 768
@@ -109,13 +109,18 @@ class TestHybridSearch:
         store = AsyncQdrantVectorStore(workspace_id="ws1")
         store.client = AsyncMock()
         store._collection_ensured = True
-        store.client.query_points.return_value = SimpleNamespace(points=[_make_point()])
+        # Client-side RRF: two query_points calls (dense + sparse legs) each
+        # return a raw (id, score) point, then retrieve() fetches the payload.
+        raw_point = SimpleNamespace(id="p1", score=0.9)
+        store.client.query_points.return_value = SimpleNamespace(points=[raw_point])
+        store.client.retrieve.return_value = [_make_point()]
 
         results = await store.hybrid_search("test query", limit=5)
 
         assert len(results) == 1
         assert results[0]["data"] == "hello"
-        store.client.query_points.assert_awaited_once()
+        assert store.client.query_points.await_count == 2
+        store.client.retrieve.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three related fixes for the failure mode where `recall_dense_async` silently returned `[]` under concurrent connector sync load.

- `AsyncQdrantVectorStore.hybrid_search` now always fuses dense + sparse client-side via `rrf_fusion`. Removed the server-side `query_points(prefetch=[...], query=FusionQuery("rrf"))` path — qdrant-client 1.16 serialises that payload in a way Qdrant server 1.17 rejects (400: Format error at column ~15000). Same root cause as commit 2db89ce on memory_qdrant; here the sparse leg is preserved instead of dropped. `rrf_k` defaults to `Settings.rrf_k` (60) when not provided.
- New `embed_for_ingest()` in `llm/embeddings.py` caps concurrent ingest-side Ollama `/api/embeddings` calls via `asyncio.Semaphore` sized by `METATRON_INGEST_EMBED_CONCURRENCY` (default 2). Query path (`get_cached_embedding`) stays unthrottled so searches keep priority at the Ollama instance during mass connector syncs.
- `AsyncQdrantVectorStore.add_document` now calls `embed_for_ingest` instead of `asyncio.to_thread(get_cached_embedding_split)`. Sync `QdrantVectorStore` path unchanged.

## Test plan
- [x] `test_add_document_calls_upsert` patches `embed_for_ingest`
- [x] `test_hybrid_search_returns_results` mocks two `query_points` calls plus one `retrieve` under the client-side RRF flow
- [ ] Smoke: run a connector sync and confirm searches continue to return results mid-sync