### PR TITLE
fix(MTRNIX-319): resolve_review atomicity + error classification

### DIFF
--- a/src/metatron/mcp/errors.py
+++ b/src/metatron/mcp/errors.py
@@ -66,6 +66,26 @@ _ERROR_HINTS: dict[ErrorCode, str] = {
     ErrorCode.INVALID_PARAMS: "Review the tool parameters and provide valid values",
 }
 
+# Exception type names (uppercased) that should always be bucketed as
+# INTERNAL_ERROR — not mapped by substring matching against the message.
+# SQL errors routinely contain column names like ``workspace_id`` in the
+# reflected SQL text, which used to trigger a false-positive
+# WORKSPACE_NOT_FOUND. See MTRNIX-319 for the incident.
+_DB_ERROR_TYPE_NAMES: frozenset[str] = frozenset(
+    {
+        "DBAPIERROR",
+        "OPERATIONALERROR",
+        "INTEGRITYERROR",
+        "PROGRAMMINGERROR",
+        "DATAERROR",
+        "INTERNALERROR",
+        "INTERFACEERROR",
+        "UNTRANSLATABLECHARACTERERROR",
+        "NOTSUPPORTEDERROR",
+        "INVALIDREQUESTERROR",
+    }
+)
+
 
 def handle_tool_error(
     tool_name: str,
@@ -85,10 +105,16 @@ def handle_tool_error(
     error_code = ErrorCode.INTERNAL_ERROR
     error_message = str(exception)
 
-    # Map common exceptions to error codes
+    # Map common exceptions to error codes.
     exception_type = type(exception).__name__.upper()
 
-    if "WORKSPACE" in exception_type or "workspace" in error_message.lower():
+    # DB-layer exceptions get mapped to INTERNAL_ERROR regardless of message
+    # contents — the SQL text routinely contains column names like
+    # ``workspace_id`` that would otherwise trigger false positives like
+    # WORKSPACE_NOT_FOUND (see MTRNIX-319 for the incident).
+    if exception_type in _DB_ERROR_TYPE_NAMES:
+        error_code = ErrorCode.INTERNAL_ERROR
+    elif "WORKSPACE" in exception_type:
         error_code = ErrorCode.WORKSPACE_NOT_FOUND
     elif "QDRANT" in exception_type or "qdrant" in error_message.lower():
         error_code = ErrorCode.QDRANT_UNAVAILABLE
@@ -108,6 +134,11 @@ def handle_tool_error(
         error_code = ErrorCode.AUTH_REQUIRED
     elif "429" in error_message or "rate" in error_message.lower():
         error_code = ErrorCode.RATE_LIMITED
+    elif "workspace" in error_message.lower():
+        # Fallback: message-based match, only if no better bucket applied.
+        # DB errors are handled above so column names in SQL text cannot
+        # leak into WORKSPACE_NOT_FOUND here.
+        error_code = ErrorCode.WORKSPACE_NOT_FOUND
 
     # Get hint from mapping or generate default
     hint = _ERROR_HINTS.get(error_code)

--- a/src/metatron/memory/service.py
+++ b/src/metatron/memory/service.py
@@ -528,20 +528,14 @@ class MemoryService:
             msg = f"Unknown action: {action}"
             raise ValueError(msg)
 
-        # 4. Transition. ``superseded_by=None`` means "leave unchanged" per
-        # ``update_lifecycle`` semantics; we only pass it for merge_into.
-        await self._pg.update_lifecycle(
-            workspace_id,
-            entry.target_id,
-            status=new_status,
-            verification_state=verification_state,
-            superseded_by=superseded_by,
-        )
-
-        # 5. Delete the review entry.
-        await self._freshness_store.delete_review_entry(workspace_id, review_id)
-
-        # 6. MachineEvent audit row.
+        # 4-6. Transition + delete review + audit event — atomic in a single
+        # transaction (MTRNIX-319 fix). Previously these ran as three
+        # separate ``engine.begin()`` blocks; a failure on the third could
+        # leave partially-committed state (lifecycle changed, review deleted,
+        # but no audit row), and the caller received a misleading error
+        # while the DB had already moved on. All three stores share the
+        # same AsyncEngine (wired in ``_memory_deps.py``), so a single
+        # transaction can span all of them.
         truncated_notes = (notes or "")[:1024]
         evt = MachineEvent(
             workspace_id=workspace_id,
@@ -559,7 +553,19 @@ class MemoryService:
                 "notes": truncated_notes,
             },
         )
-        saved_evt = await self._freshness_store.save_machine_event(evt)
+        async with self._pg.begin() as conn:
+            # ``superseded_by=None`` means "leave unchanged" per
+            # ``update_lifecycle`` semantics; we only pass it for merge_into.
+            await self._pg.update_lifecycle(
+                workspace_id,
+                entry.target_id,
+                status=new_status,
+                verification_state=verification_state,
+                superseded_by=superseded_by,
+                conn=conn,
+            )
+            await self._freshness_store.delete_review_entry(workspace_id, review_id, conn=conn)
+            saved_evt = await self._freshness_store.save_machine_event(evt, conn=conn)
 
         # 7. Best-effort Qdrant payload sync.
         try:

--- a/src/metatron/storage/freshness_pg.py
+++ b/src/metatron/storage/freshness_pg.py
@@ -26,7 +26,7 @@ from sqlalchemy import text
 from metatron.core.models import MachineEvent, ReviewEntry
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncEngine
+    from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
 logger = structlog.get_logger()
 
@@ -236,17 +236,29 @@ class FreshnessStore:
             count = result.scalar()
         return int(count or 0)
 
-    async def delete_review_entry(self, workspace_id: str, review_id: str) -> bool:
+    async def delete_review_entry(
+        self,
+        workspace_id: str,
+        review_id: str,
+        *,
+        conn: AsyncConnection | None = None,
+    ) -> bool:
         """Delete a review entry by id, scoped to workspace.
 
         Returns ``True`` if a row was deleted, ``False`` if the id was missing
         (or the workspace did not match — cross-tenant deletes are a no-op).
+
+        When ``conn`` is provided, the DELETE runs on the caller-supplied
+        connection — used by ``MemoryService.resolve_review`` to group the
+        update + delete + event-write into one transaction (MTRNIX-319 fix).
         """
-        async with self._engine.begin() as conn:
-            result = await conn.execute(
-                text("DELETE FROM review_entries WHERE id = :id AND workspace_id = :ws"),
-                {"id": review_id, "ws": workspace_id},
-            )
+        sql = text("DELETE FROM review_entries WHERE id = :id AND workspace_id = :ws")
+        params = {"id": review_id, "ws": workspace_id}
+        if conn is not None:
+            result = await conn.execute(sql, params)
+            return bool(result.rowcount and result.rowcount > 0)
+        async with self._engine.begin() as own_conn:
+            result = await own_conn.execute(sql, params)
             return bool(result.rowcount and result.rowcount > 0)
 
     async def find_review_entry(
@@ -307,33 +319,45 @@ class FreshnessStore:
     # MachineEvent
     # ------------------------------------------------------------------
 
-    async def save_machine_event(self, event: MachineEvent) -> MachineEvent:
-        """Append a machine event — retries are safe via PK conflict."""
-        async with self._engine.begin() as conn:
-            await conn.execute(
-                text(
-                    """
-                    INSERT INTO machine_events (
-                        id, workspace_id, event_type, actor, target_kind,
-                        target_id, payload, created_at
-                    ) VALUES (
-                        :id, :workspace_id, :event_type, :actor, :target_kind,
-                        :target_id, CAST(:payload AS jsonb), :created_at
-                    )
-                    ON CONFLICT (id) DO NOTHING
-                    """
-                ),
-                {
-                    "id": event.id,
-                    "workspace_id": event.workspace_id,
-                    "event_type": event.event_type,
-                    "actor": event.actor,
-                    "target_kind": event.target_kind,
-                    "target_id": event.target_id,
-                    "payload": json.dumps(event.payload, default=str),
-                    "created_at": event.created_at,
-                },
+    async def save_machine_event(
+        self,
+        event: MachineEvent,
+        *,
+        conn: AsyncConnection | None = None,
+    ) -> MachineEvent:
+        """Append a machine event — retries are safe via PK conflict.
+
+        When ``conn`` is provided, the INSERT runs on the caller-supplied
+        connection so it can be grouped with other writes in a single
+        transaction (MTRNIX-319 fix).
+        """
+        sql = text(
+            """
+            INSERT INTO machine_events (
+                id, workspace_id, event_type, actor, target_kind,
+                target_id, payload, created_at
+            ) VALUES (
+                :id, :workspace_id, :event_type, :actor, :target_kind,
+                :target_id, CAST(:payload AS jsonb), :created_at
             )
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+        params = {
+            "id": event.id,
+            "workspace_id": event.workspace_id,
+            "event_type": event.event_type,
+            "actor": event.actor,
+            "target_kind": event.target_kind,
+            "target_id": event.target_id,
+            "payload": json.dumps(event.payload, default=str),
+            "created_at": event.created_at,
+        }
+        if conn is not None:
+            await conn.execute(sql, params)
+        else:
+            async with self._engine.begin() as own_conn:
+                await own_conn.execute(sql, params)
         return event
 
     async def list_events_for_target(

--- a/src/metatron/storage/memory_postgres.py
+++ b/src/metatron/storage/memory_postgres.py
@@ -26,7 +26,9 @@ from metatron.core.models import (
 )
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncEngine
+    from contextlib import AbstractAsyncContextManager
+
+    from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
 logger = structlog.get_logger()
 
@@ -145,6 +147,18 @@ class MemoryPostgresStore:
 
     def __init__(self, engine: AsyncEngine) -> None:
         self._engine = engine
+
+    def begin(self) -> AbstractAsyncContextManager[AsyncConnection]:
+        """Open a transactional connection on the underlying engine.
+
+        Thin public wrapper around ``AsyncEngine.begin()``. Lets callers
+        coordinate writes across multiple store methods in a single
+        transaction by passing the yielded connection via the optional
+        ``conn`` kwarg on each method (``update_lifecycle``, etc). Used by
+        ``MemoryService.resolve_review`` to make the update + delete +
+        machine-event-insert triple atomic (MTRNIX-319).
+        """
+        return self._engine.begin()
 
     # ------------------------------------------------------------------
     # Records — CRUD
@@ -392,6 +406,7 @@ class MemoryPostgresStore:
         valid_until: datetime | None = None,
         append_tag: str | None = None,
         append_tags: list[str] | None = None,
+        conn: AsyncConnection | None = None,
     ) -> MemoryRecord | None:
         """Freshness-pipeline partial update for lifecycle columns.
 
@@ -401,6 +416,11 @@ class MemoryPostgresStore:
         variant used by the freshness DecisionEngine to merge N tags in a
         single UPDATE (no N+1); dedup happens in SQL so concurrent writers
         cannot race a read-modify-write.
+
+        When ``conn`` is provided, the UPDATE runs on the caller-supplied
+        connection so multiple writes can be grouped in one transaction
+        (MTRNIX-319 fix). When ``conn`` is None, a self-managed transaction
+        is used — the pre-MTRNIX-319 behaviour.
         """
         set_parts: list[str] = []
         params: dict[str, Any] = {"id": record_id, "ws": workspace_id}
@@ -464,16 +484,19 @@ class MemoryPostgresStore:
         params["updated_at"] = datetime.now(UTC)
         set_clause = ", ".join(set_parts)
 
-        async with self._engine.begin() as conn:
-            result = await conn.execute(
-                text(
-                    f"UPDATE memory_records SET {set_clause} "
-                    f"WHERE id = :id AND workspace_id = :ws "
-                    f"RETURNING {_RECORD_COLUMNS}"
-                ),
-                params,
-            )
+        sql = text(
+            f"UPDATE memory_records SET {set_clause} "
+            f"WHERE id = :id AND workspace_id = :ws "
+            f"RETURNING {_RECORD_COLUMNS}"
+        )
+
+        if conn is not None:
+            result = await conn.execute(sql, params)
             row = result.first()
+        else:
+            async with self._engine.begin() as own_conn:
+                result = await own_conn.execute(sql, params)
+                row = result.first()
 
         if row is None:
             return None

--- a/tests/unit/mcp/test_errors.py
+++ b/tests/unit/mcp/test_errors.py
@@ -1,0 +1,90 @@
+"""Unit tests for ``metatron.mcp.errors.handle_tool_error``.
+
+MTRNIX-319: regression — a PG ``UntranslatableCharacterError`` whose message
+contained the SQL text (with the string ``workspace_id`` in column names)
+was misclassified as ``WORKSPACE_NOT_FOUND``. These tests pin the strict
+exception-type-first mapping that fixes that."""
+
+from __future__ import annotations
+
+import pytest
+
+from metatron.mcp.errors import ErrorCode, handle_tool_error
+
+
+# Class names matter for ``handle_tool_error`` — it keys off ``type(exc).__name__``.
+# These locally-defined classes are named after the real SQLAlchemy / asyncpg
+# types so the mapper buckets them correctly.
+class DBAPIError(Exception):  # noqa: N818 — match SQLAlchemy's real class name
+    """Stand-in for a SQLAlchemy ``DBAPIError`` so the unit test stays
+    dependency-free."""
+
+
+class UntranslatableCharacterError(Exception):  # noqa: N818
+    """Stand-in for the asyncpg-level encoding error."""
+
+
+class WorkspaceNotFoundError(Exception):
+    pass
+
+
+class TestDBErrorMapping:
+    def test_db_error_with_workspace_in_message_is_not_workspace_not_found(self) -> None:
+        # Simulate the MTRNIX-319 incident: SQL INSERT with a Unicode
+        # character landing on a SQL_ASCII-encoded cluster. The error
+        # message contains the SQL text, which in turn contains the column
+        # name ``workspace_id``. Before the fix this was bucketed as
+        # WORKSPACE_NOT_FOUND with a misleading hint.
+        exc = DBAPIError(
+            "unsupported Unicode escape sequence\n"
+            "DETAIL:  Unicode escape value could not be translated to the server's "
+            "encoding SQL_ASCII.\n"
+            "[SQL: INSERT INTO machine_events (id, workspace_id, event_type, ...)]"
+        )
+        err = handle_tool_error("metatron_memory_review_resolve", exc)
+
+        assert err.code == ErrorCode.INTERNAL_ERROR
+        # And specifically NOT the pre-fix false positive.
+        assert err.code != ErrorCode.WORKSPACE_NOT_FOUND
+
+    def test_untranslatable_character_error_maps_to_internal(self) -> None:
+        exc = UntranslatableCharacterError("Unicode escape value could not be translated")
+        err = handle_tool_error("tool_x", exc)
+        assert err.code == ErrorCode.INTERNAL_ERROR
+
+
+class TestWorkspaceErrorMapping:
+    def test_workspace_typed_exception_still_maps_correctly(self) -> None:
+        # A real workspace-typed exception still resolves to WORKSPACE_NOT_FOUND.
+        exc = WorkspaceNotFoundError("Workspace 'abc' not found")
+        err = handle_tool_error("tool_x", exc)
+        assert err.code == ErrorCode.WORKSPACE_NOT_FOUND
+
+    def test_workspace_in_message_on_untyped_error_still_maps(self) -> None:
+        # Plain ``Exception`` whose message mentions workspace — message-based
+        # fallback still applies (for non-DB exceptions).
+        exc = Exception("workspace lookup failed")
+        err = handle_tool_error("tool_x", exc)
+        assert err.code == ErrorCode.WORKSPACE_NOT_FOUND
+
+
+class TestOtherBuckets:
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            ("Qdrant connection refused", ErrorCode.QDRANT_UNAVAILABLE),
+            ("Neo4j session expired", ErrorCode.GRAPH_UNAVAILABLE),
+            ("Invalid cursor provided", ErrorCode.INVALID_CURSOR),
+            ("Document not found", ErrorCode.DOCUMENT_NOT_FOUND),
+            ("validation failed", ErrorCode.INVALID_PARAMS),
+            ("unauthorized access", ErrorCode.AUTH_REQUIRED),
+            ("HTTP 429 rate limited", ErrorCode.RATE_LIMITED),
+        ],
+    )
+    def test_message_based_buckets_still_work(self, message: str, expected: ErrorCode) -> None:
+        err = handle_tool_error("tool_x", Exception(message))
+        assert err.code == expected
+
+    def test_unknown_exception_maps_to_internal(self) -> None:
+        err = handle_tool_error("tool_x", Exception("something weird happened"))
+        assert err.code == ErrorCode.INTERNAL_ERROR

--- a/tests/unit/memory/test_service_review.py
+++ b/tests/unit/memory/test_service_review.py
@@ -66,6 +66,10 @@ def _make_service(
     pg_store: MagicMock | None = None,
 ) -> tuple[MemoryService, dict]:
     pg = pg_store or MagicMock()
+    # MTRNIX-319: resolve_review opens a shared transaction via
+    # ``pg_store.begin()`` and threads the connection through three store
+    # methods. Mock the async context manager so tests can proceed.
+    pg.begin = MagicMock(return_value=_FakeTxn())
     qdrant = MagicMock()
     qdrant.update_payload = AsyncMock()
     redis = MagicMock()
@@ -78,6 +82,21 @@ def _make_service(
         event_bus=event_bus,
     )
     return service, {"pg": pg, "qdrant": qdrant, "redis": redis}
+
+
+class _FakeTxn:
+    """Minimal async context manager standing in for ``AsyncEngine.begin()``.
+
+    Yields a ``MagicMock`` as the connection — the service just threads it
+    through to store methods (also mocked), so the connection does not need
+    real DB behaviour.
+    """
+
+    async def __aenter__(self) -> MagicMock:
+        return MagicMock(name="fake-conn")
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
 
 
 class TestListReviewEntries:
@@ -120,7 +139,7 @@ class TestResolveReviewKeep:
         fs.list_review_entries = AsyncMock(return_value=[_review()])
         fs.delete_review_entry = AsyncMock(return_value=True)
         fs.save_machine_event = AsyncMock(
-            side_effect=lambda evt: MachineEvent(
+            side_effect=lambda evt, **_kw: MachineEvent(
                 id="evt001",
                 workspace_id=evt.workspace_id,
                 event_type=evt.event_type,
@@ -158,7 +177,8 @@ class TestResolveReviewKeep:
         assert kw["verification_state"] == "keep_resolved"
         assert kw.get("superseded_by") is None
 
-        fs.delete_review_entry.assert_awaited_once_with("ws1", "r1")
+        fs.delete_review_entry.assert_awaited_once()
+        assert fs.delete_review_entry.await_args.args == ("ws1", "r1")
         fs.save_machine_event.assert_awaited_once()
         saved_evt = fs.save_machine_event.await_args.args[0]
         assert saved_evt.event_type == "freshness_review_resolved"
@@ -181,7 +201,7 @@ class TestResolveReviewArchive:
         fs = MagicMock()
         fs.list_review_entries = AsyncMock(return_value=[_review()])
         fs.delete_review_entry = AsyncMock(return_value=True)
-        fs.save_machine_event = AsyncMock(side_effect=lambda evt: evt)
+        fs.save_machine_event = AsyncMock(side_effect=lambda evt, **_kw: evt)
         pg = MagicMock()
         pg.get = AsyncMock(return_value=_record())
         pg.update_lifecycle = AsyncMock(return_value=_record(status=LifecycleStatus.ARCHIVED))
@@ -200,7 +220,7 @@ class TestResolveReviewMerge:
         fs = MagicMock()
         fs.list_review_entries = AsyncMock(return_value=[_review()])
         fs.delete_review_entry = AsyncMock(return_value=True)
-        fs.save_machine_event = AsyncMock(side_effect=lambda evt: evt)
+        fs.save_machine_event = AsyncMock(side_effect=lambda evt, **_kw: evt)
         pg = MagicMock()
         # First get: source record. Second get: merge target.
         pg.get = AsyncMock(
@@ -251,7 +271,7 @@ class TestResolveReviewDiscard:
         fs = MagicMock()
         fs.list_review_entries = AsyncMock(return_value=[_review()])
         fs.delete_review_entry = AsyncMock(return_value=True)
-        fs.save_machine_event = AsyncMock(side_effect=lambda evt: evt)
+        fs.save_machine_event = AsyncMock(side_effect=lambda evt, **_kw: evt)
         pg = MagicMock()
         pg.get = AsyncMock(return_value=_record())
         pg.update_lifecycle = AsyncMock(return_value=_record(status=LifecycleStatus.ARCHIVED))
@@ -308,7 +328,7 @@ class TestResolveReviewErrors:
 
         saved_events = []
 
-        def capture(evt: MachineEvent) -> MachineEvent:
+        def capture(evt: MachineEvent, **_kw: object) -> MachineEvent:
             saved_events.append(evt)
             return evt
 
@@ -323,6 +343,74 @@ class TestResolveReviewErrors:
 
         assert saved_events
         assert len(saved_events[0].payload["notes"]) == 1024
+
+
+class TestResolveReviewAtomicity:
+    """MTRNIX-319: resolve_review must group the three PG writes into one
+    transaction via ``pg_store.begin()`` so a failure on save_machine_event
+    does not leave a partially-committed state behind."""
+
+    async def test_all_three_writes_receive_shared_connection(self) -> None:
+        fs = MagicMock()
+        fs.list_review_entries = AsyncMock(return_value=[_review()])
+        fs.delete_review_entry = AsyncMock(return_value=True)
+        fs.save_machine_event = AsyncMock(side_effect=lambda evt, **_kw: evt)
+        pg = MagicMock()
+        pg.get = AsyncMock(return_value=_record())
+        pg.update_lifecycle = AsyncMock(return_value=_record(status=LifecycleStatus.ACTIVE))
+        service, _ = _make_service(freshness_store=fs, pg_store=pg)
+
+        await service.resolve_review("ws1", review_id="r1", action="keep")
+
+        # ``pg.begin()`` entered exactly once (shared transaction).
+        pg.begin.assert_called_once_with()
+
+        # All three store writes received ``conn`` kwarg.
+        assert "conn" in pg.update_lifecycle.await_args.kwargs
+        assert "conn" in fs.delete_review_entry.await_args.kwargs
+        assert "conn" in fs.save_machine_event.await_args.kwargs
+
+        # And it was the SAME connection object across all three.
+        shared_conn = pg.update_lifecycle.await_args.kwargs["conn"]
+        assert fs.delete_review_entry.await_args.kwargs["conn"] is shared_conn
+        assert fs.save_machine_event.await_args.kwargs["conn"] is shared_conn
+
+    async def test_machine_event_failure_aborts_whole_transaction(self) -> None:
+        """When save_machine_event raises, the transaction context manager's
+        ``__aexit__`` receives the exception — real DB would roll back the
+        two earlier writes. Here we only assert the exception propagates
+        unchanged (no swallowing) and no best-effort Qdrant sync happens."""
+
+        class _RollbackTxn:
+            entered = False
+            exited_with_exception = False
+
+            async def __aenter__(self) -> MagicMock:
+                _RollbackTxn.entered = True
+                return MagicMock(name="rollback-conn")
+
+            async def __aexit__(self, exc_type, exc, tb) -> bool:
+                if exc is not None:
+                    _RollbackTxn.exited_with_exception = True
+                return False  # do not suppress
+
+        fs = MagicMock()
+        fs.list_review_entries = AsyncMock(return_value=[_review()])
+        fs.delete_review_entry = AsyncMock(return_value=True)
+        fs.save_machine_event = AsyncMock(side_effect=RuntimeError("db boom"))
+        pg = MagicMock()
+        pg.get = AsyncMock(return_value=_record())
+        pg.update_lifecycle = AsyncMock(return_value=_record(status=LifecycleStatus.ACTIVE))
+        service, deps = _make_service(freshness_store=fs, pg_store=pg)
+        pg.begin = MagicMock(return_value=_RollbackTxn())
+
+        with pytest.raises(RuntimeError, match="db boom"):
+            await service.resolve_review("ws1", review_id="r1", action="keep")
+
+        assert _RollbackTxn.entered
+        assert _RollbackTxn.exited_with_exception
+        # Best-effort Qdrant sync must not run when the transaction fails.
+        deps["qdrant"].update_payload.assert_not_awaited()
 
 
 class TestSearchStatusFilterPlumbing:


### PR DESCRIPTION
## Context

Two bugs surfaced while running §4 (review-queue e2e) from MTRNIX-319. Both live in code shipped by MTRNIX-314.

## Bug #1 — Partial commit in `resolve_review`

`MemoryService.resolve_review` called three store methods sequentially, each opening its own `engine.begin()` transaction:

1. `update_lifecycle` (PG) — changes `memory_records.status`
2. `delete_review_entry` (PG) — drops the queue row
3. `save_machine_event` (PG) — writes the audit row

If the third failed (encountered in testing as a DB-level insert error), the first two had already committed. The caller received an error response, meanwhile the DB had already transitioned the record and deleted the queue row. No rollback, no way for the caller to know the state.

**Fix:** exposed `MemoryPostgresStore.begin()`, added an optional `conn` kwarg on all three store methods (`update_lifecycle`, `delete_review_entry`, `save_machine_event`). `resolve_review` now opens a single transaction via `pg_store.begin()` and threads the connection through — all three commit together or roll back together.

## Bug #2 — Misleading error bucketing

`mcp.errors.handle_tool_error` did substring matching on the exception message *before* exception-type matching. A SQLAlchemy error whose message embedded the SQL text (containing the column name `workspace_id`) was bucketed as `WORKSPACE_NOT_FOUND` with hint "Check that the workspace_id is correct or create a new workspace" — actively misleading to operators.

**Fix:** added `_DB_ERROR_TYPE_NAMES` frozenset. Before any message-based match runs, if `type(exc).__name__.upper()` is in this set, the error buckets to `INTERNAL_ERROR`. Covers `DBAPIError`, `OperationalError`, `IntegrityError`, `UntranslatableCharacterError`, etc. Workspace-typed exceptions still bucket correctly; the message-based fallback is preserved for non-DB exceptions (so plain `Exception("workspace lookup failed")` still maps to `WORKSPACE_NOT_FOUND`).

## Scope

### Changed
- `src/metatron/memory/service.py` — `resolve_review` uses single-transaction context
- `src/metatron/storage/memory_postgres.py` — `begin()` helper + `conn` kwarg on `update_lifecycle`
- `src/metatron/storage/freshness_pg.py` — `conn` kwarg on `delete_review_entry` + `save_machine_event`
- `src/metatron/mcp/errors.py` — `_DB_ERROR_TYPE_NAMES` guard + reordered substring checks

### Tests
- `tests/unit/memory/test_service_review.py` — 2 new tests under `TestResolveReviewAtomicity`:
  - shared connection threading verified across all three writes
  - machine-event failure propagates without triggering best-effort Qdrant sync
- `tests/unit/mcp/test_errors.py` — 12 new tests covering the regression + existing buckets

## Test plan

- [x] `make lint` — clean on touched files (pre-existing E501 / UP042 on unchanged lines)
- [x] `make typecheck` — clean on touched files (one pre-existing mypy error on `errors.py:54` unchanged)
- [x] Unit suite: 192 tests passing across memory/storage/mcp (no regressions)
- [ ] Live verification — reproduce a `save_machine_event` failure path and confirm: (a) error bucketing is now `INTERNAL_ERROR`, (b) `memory_records.status` and `review_entries` are not modified on failure.

## Not fixed here (tracked separately)

- **Admin-only `memory_force_delete` MCP tool** — see `docs/MEMORY_MCP_FOLLOWUPS.md`.