### PR TITLE
feat(MTRNIX-322): memory freshness worker — Qdrant status sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## [Unreleased]
 
 ### Added
+- feat: Freshness worker syncs memory Qdrant status payload on every
+  lifecycle transition (MTRNIX-322). `MemoryTarget.sync_downstream_stores`
+  now writes `{"status": status.value}` onto the per-workspace Qdrant
+  point via `update_payload` — previously a deliberate no-op. Hook is
+  called by `FreshnessMonitor` (already wired in MTRNIX-313), `Curator`
+  CANDIDATE → ACTIVE promotion, and `apply_decision` mark_stale branch.
+  Closes the drift between PG `memory_records.status` and the Qdrant
+  payload that leaked non-ACTIVE records through `memory_search` under
+  the default `status=["active"]` filter. Adds Prometheus counter
+  `freshness_qdrant_sync_failed_total{target_kind,stage}` for
+  observability. Best-effort — Qdrant failures are logged at WARNING
+  and counted, never propagate. PG remains source of truth; the
+  `scripts/backfill_memory_qdrant_status_payload.py` script stays as
+  the long-tail safety net. No migration, no new config flags.
 - feat: Memory MCP lifecycle-status filter + review queue tools (MTRNIX-314).
   `memory_search` and `memory_list` now accept a `status` param (default
   `["active"]`, pass `["all"]` to disable). Two new MCP tools —

--- a/docs/MEMORY_MCP_FOLLOWUPS.md
+++ b/docs/MEMORY_MCP_FOLLOWUPS.md
@@ -68,45 +68,10 @@ across the repo (see root CLAUDE.md "Do NOT" section). When it lands:
 per-agent role claim system that does not exist yet. Wait for the broader RBAC
 migration rather than building a one-off for this tool.
 
-## 4. Worker-driven proactive Qdrant status sync
-
-**Scope:** make freshness worker stage transitions that write
-`memory_records.status` push the new status to the Qdrant point payload
-synchronously, instead of relying on lazy `update_payload` writes.
-
-**Current state:** `MemoryService.resolve_review` does do a best-effort
-`qdrant.update_payload({"status": new_status.value})` immediately after the PG
-transition — so **MCP-triggered** transitions are always in sync. But
-**worker-triggered** transitions (Curator promotion, Reconciler duplicate marks,
-FreshnessMonitor stale flagging, DecisionEngine auto-apply) currently write only
-to PG. The Qdrant `status` payload catches up on the next `upsert` — which might
-never happen for a stable record.
-
-**Impact:** a stale record written only in PG still appears in
-`metatron_memory_search` results because the Qdrant `must_not` filter can't see
-its PG-only new status. The graph-leg post-filter via `get_many_statuses` catches
-some of these, but the **Qdrant dense leg itself** is the primary recall channel
-and it is ignoring these records' status.
-
-**Fix options:**
-- A: make every freshness stage that mutates `memory_records.status` call the
-  same `qdrant.update_payload` best-effort update. ~4 call sites.
-- B: run `scripts/backfill_memory_qdrant_status_payload.py` on a cron (e.g. once
-  a day). Simpler operationally but has a lag window.
-- C: event-bus subscription on `FRESHNESS_DECISION_APPLIED` that does the
-  Qdrant update. Cleanest architecture but requires event-bus wiring in the
-  worker process (today the worker writes events as rows but may not publish on
-  the in-process bus).
-
-**Recommendation:** Option A is cheap and correct. Pair it with the backfill
-script as a safety net for records that existed before MTRNIX-314.
-
 ## Open question — should any of these be filed as tickets now?
 
-The default answer is probably "yes for #4, maybe #1, not #2/#3":
+The default answer is probably "maybe #1, not #2/#3":
 
-- **#4** has a real correctness impact today (stale records leak into search
-  despite the filter) — file a small ticket, couple of hours of work.
 - **#1** becomes interesting only when an ops team starts hitting ARCHIVED-record
   pile-up. Defer until there is a concrete request.
 - **#2** is UX speculation — wait for Control Center.

--- a/docs/superpowers/plans/2026-04-24-memory-freshness-qdrant-status-sync.md
+++ b/docs/superpowers/plans/2026-04-24-memory-freshness-qdrant-status-sync.md
@@ -1,0 +1,494 @@
+# Memory freshness worker — Qdrant status payload sync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** close the worker-side drift between `memory_records.status` (PG) and the `mem_agent_memory_{workspace_id}` Qdrant collection's `status` payload by making every freshness-pipeline lifecycle transition best-effort sync the Qdrant payload via `MemoryTarget.sync_downstream_stores` (currently a no-op). Add one Prometheus counter `freshness_qdrant_sync_failed_total` for observability. Backfill script stays as the long-tail safety net.
+
+**Architecture:** Option A — reuse the existing `FreshnessTarget.sync_downstream_stores` protocol hook from MTRNIX-313. Memory adapter's no-op implementation becomes a real `qdrant.update_payload(record_id, {"status": status.value})`, best-effort. Two missing call sites (`Curator.run`, `apply_decision.apply_decision`) gain the hook invocation. `FreshnessMonitor.run` already calls it. `Reconciler` doesn't mutate `memory_records.status` (verified) — left unchanged.
+
+**Tech Stack:** Python 3.12, asyncio, SQLAlchemy async (asyncpg), `redis.asyncio`, `AsyncQdrantClient`, `prometheus_client` (optional dep), structlog, pytest (`asyncio_mode = "auto"`).
+
+**Jira:** MTRNIX-322
+**Depends on:** MTRNIX-304 (merged), MTRNIX-313 (merged), MTRNIX-314 (merged), MTRNIX-319 (merged, PR #89).
+**Spec:** `docs/superpowers/specs/2026-04-24-memory-freshness-qdrant-status-sync-design.md`
+**Branch:** `feature/MTRNIX-322` (already checked out).
+
+---
+
+## Layer Boundary Summary
+
+| File | Layer | Allowed imports |
+|---|---|---|
+| `src/metatron/freshness/metrics.py` (extend) | L2 | `prometheus_client` (optional) |
+| `src/metatron/memory/freshness/metrics.py` (extend re-export) | L3 | `metatron.freshness.metrics` |
+| `src/metatron/memory/freshness/target_memory.py` (extend) | L3 | `metatron.freshness.metrics`, `metatron.freshness.targets`, `storage.memory_postgres`, `storage.memory_qdrant` |
+| `src/metatron/freshness/stages/curator.py` (extend) | L2 | `metatron.freshness.targets`, `metatron.core.*`, `storage.freshness_pg` |
+| `src/metatron/freshness/apply_decision.py` (extend) | L2 | `metatron.freshness.targets`, `metatron.core.*`, `storage.freshness_pg` |
+
+**Not touched:** `core/interfaces.py`, `core/events.py`, `core/models.py`, `storage/memory_postgres.py`, `storage/memory_qdrant.py`, `freshness/targets.py`, `freshness/stages/linker.py`, `freshness/stages/reconciler.py`, `freshness/stages/monitor.py`, `freshness/decision_engine.py`, `memory/service.py`, `memory/search.py`, `mcp/tools/*`, `ingestion/freshness/*`, `api/*`.
+
+**No upward imports.** Memory adapter (L3) imports shared freshness metrics (L2); shared freshness stages (L2) import `metatron.freshness.targets` (L2) — no new dependencies.
+
+---
+
+## Config Vars
+
+**None added.** No new env flags.
+
+---
+
+## Event Constants
+
+**None added.** `core/events.py` unchanged.
+
+---
+
+## Backward Compatibility Guarantee
+
+- `MemoryTarget.sync_downstream_stores` signature unchanged (MTRNIX-313 already defined it). Implementation changes from no-op to real Qdrant write.
+- `FreshnessTarget` Protocol unchanged.
+- `update_lifecycle` semantics unchanged. Transaction semantics unchanged (Qdrant write is outside any PG transaction).
+- Phase A (MTRNIX-304) + Phase B (MTRNIX-313) + MTRNIX-314 tests stay green.
+- Existing behaviour WITHOUT this fix: Qdrant payload stale after worker transitions (the bug). The fix is a silent improvement; no API callers change.
+- Prometheus metric is additive; scrapers tolerate new series.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `src/metatron/freshness/metrics.py` | Add `qdrant_sync_failed: Counter` guarded by the existing `try/except ImportError`. Add to `__all__`. |
+| Modify | `src/metatron/memory/freshness/metrics.py` | Re-export `qdrant_sync_failed` from the shared metrics module. |
+| Modify | `src/metatron/memory/freshness/target_memory.py` | Replace `sync_downstream_stores` no-op with a best-effort Qdrant `update_payload({"status": status.value})`. Import `metrics` lazily inside the method body (or at module top) to avoid cycles. |
+| Modify | `src/metatron/freshness/stages/curator.py` | After `update_lifecycle(..., status=ACTIVE, ...)` and before `save_machine_event`, call `self._target.sync_downstream_stores(..., status=LifecycleStatus.ACTIVE, freshness_score=record.freshness_score or 0.5)`. |
+| Modify | `src/metatron/freshness/apply_decision.py` | In the `if decision.action == "mark_stale":` branch, after `await target.update_lifecycle(...)`, call `await target.sync_downstream_stores(workspace_id, record.target_id, status=LifecycleStatus.STALE, freshness_score=0.25)`. |
+| Create | `tests/unit/memory/freshness/test_target_memory_sync_downstream.py` | Unit tests for `MemoryTarget.sync_downstream_stores`: success path writes payload; failure swallows + logs + counter increments; `freshness_score` is accepted but not written. |
+| Create | `tests/unit/freshness/test_curator_qdrant_sync.py` | Curator CANDIDATE → ACTIVE transition calls `sync_downstream_stores`; Qdrant failure does not abort PG transition. |
+| Create | `tests/unit/freshness/test_apply_decision_qdrant_sync.py` | `apply_decision` with `mark_stale` calls `sync_downstream_stores`; tag-only branch does NOT call it; Qdrant failure does not abort. |
+| Create | `tests/unit/freshness/test_monitor_qdrant_sync_memory_target.py` | Regression: `FreshnessMonitor.run` against a real `MemoryTarget` with a mock `MemoryQdrantStore` — assert `update_payload` called with correct `{"status": ...}` on all three rule branches. |
+| Create | `tests/integration/memory/freshness/test_qdrant_status_sync_live.py` | Integration: end-to-end worker run against live PG + Qdrant + Redis. Seed a memory record with `valid_until < now`, run worker, assert `MemoryQdrantStore.search(status_exclude=["archived"])` does NOT return the record and PG status is ARCHIVED — all without running the backfill script. |
+| Create | `tests/integration/memory/freshness/test_qdrant_sync_resilience.py` | Integration: monkey-patch `MemoryQdrantStore.update_payload` to raise; run worker; assert PG transitions land, MachineEvents land, counter incremented. Worker loop does NOT abort. |
+| Modify | `docs/MEMORY_MCP_FOLLOWUPS.md` | Remove item #4 section entirely. Remove the "#4 has a real correctness impact today …" bullet from the trailing "Open question" section. Leave items 1-3 untouched. |
+| Modify | `src/metatron/memory/.claude/CLAUDE.md` | Update the `freshness/target_memory.py` description: "`sync_downstream_stores` mirrors the PG `status` into the memory Qdrant collection's payload best-effort (MTRNIX-322)." |
+| Modify | `src/metatron/storage/.claude/CLAUDE.md` | No code change but add a one-liner under `memory_qdrant.py::update_payload`: "Called by `MemoryTarget.sync_downstream_stores` after every worker-driven lifecycle transition (MTRNIX-322)." |
+| Modify | `CHANGELOG.md` | One-line entry under unreleased: "feat(freshness): worker-driven lifecycle transitions now sync `status` payload to the memory Qdrant collection best-effort; adds `freshness_qdrant_sync_failed_total` counter (MTRNIX-322)." |
+
+Total: 5 modified code files + 2 modified docs + 1 CHANGELOG + 4 new test files + 2 integration tests.
+
+---
+
+## Ordered Tasks
+
+Execute in order. After **every** task, run `make lint`, `make typecheck`, `make test` as three separate commands (never chain with `;` or `&&` per the user's global rule).
+
+---
+
+### Task 1: Add the Prometheus counter
+
+**Files:**
+- Modify: `src/metatron/freshness/metrics.py`
+- Modify: `src/metatron/memory/freshness/metrics.py`
+
+- [ ] **Step 1: Add the module-level `qdrant_sync_failed` declaration.**
+  Insert `qdrant_sync_failed: Any` near the other counter declarations (alphabetically between `queue_depth_gauge` and `stage_duration`, or at the end of the list — match existing order).
+
+- [ ] **Step 2: Add the real Counter inside the try/except.**
+  Inside the `try:` block, after the `worker_errors = Counter(...)` definition, add:
+  ```python
+  qdrant_sync_failed = Counter(
+      "freshness_qdrant_sync_failed_total",
+      "Best-effort Qdrant payload sync failures from the freshness pipeline",
+      ["target_kind", "stage"],
+  )
+  ```
+
+- [ ] **Step 3: Add the `_NoopMetric()` fallback.**
+  Inside the `except ImportError:` block, add `qdrant_sync_failed = _NoopMetric()`.
+
+- [ ] **Step 4: Add to `__all__`.**
+  Insert `"qdrant_sync_failed",` alphabetically (between `"jobs_total"` and `"queue_depth_gauge"`).
+
+- [ ] **Step 5: Re-export from the memory shim.**
+  In `src/metatron/memory/freshness/metrics.py`, add `qdrant_sync_failed` to the `from metatron.freshness.metrics import (...)` statement and the `__all__` list.
+
+- [ ] **Step 6: Write a quick smoke test.**
+  In a temporary test (can live in `test_target_memory_sync_downstream.py` from Task 3) confirm `from metatron.freshness.metrics import qdrant_sync_failed` succeeds and `.labels(target_kind="memory_record", stage="sync_downstream").inc()` does not raise, under both branches (with/without prometheus_client — the ImportError branch is exercised in CI when the optional dep is absent; don't add a separate uninstall dance).
+
+- [ ] **Step 7: Lint + typecheck + test.** Three separate commands.
+
+- [ ] **Step 8: Commit.**
+  ```
+  git add src/metatron/freshness/metrics.py src/metatron/memory/freshness/metrics.py
+  git commit -m "feat(MTRNIX-322): add freshness_qdrant_sync_failed_total counter"
+  ```
+
+**Acceptance:** New counter importable from both `metatron.freshness.metrics` and the memory shim; no-op fallback present; CI green.
+
+---
+
+### Task 2: Implement `MemoryTarget.sync_downstream_stores`
+
+**Files:**
+- Modify: `src/metatron/memory/freshness/target_memory.py`
+- Create: `tests/unit/memory/freshness/test_target_memory_sync_downstream.py`
+
+- [ ] **Step 1: Write the unit test first (TDD).**
+  Three cases:
+  - Happy path: `MemoryTarget` with mocked Qdrant factory; call `sync_downstream_stores(ws, "mem_1", status=LifecycleStatus.STALE, freshness_score=0.25)`; assert `qdrant.update_payload` called with `("mem_1", {"status": "stale"})` (only `status`, no `freshness_score`).
+  - Failure path: mocked `update_payload` raises `RuntimeError("qdrant down")`; assert no exception propagates; assert `logger.warning` called once with `event="freshness.memory_target.qdrant_payload_sync_failed"`.
+  - Counter path: patch `metatron.freshness.metrics.qdrant_sync_failed`; assert `.labels(target_kind="memory_record", stage="sync_downstream").inc()` called exactly once on the failure path, zero times on the happy path.
+
+- [ ] **Step 2: Import the metrics module.**
+  At the top of `target_memory.py`, add:
+  ```python
+  from metatron.freshness import metrics
+  ```
+  (Not inside `TYPE_CHECKING` — we need it at runtime.)
+
+- [ ] **Step 3: Replace the `sync_downstream_stores` body.**
+  Current body: `# Memory does not mirror status ... return None`. Replace with the adapter implementation from the spec:
+  ```python
+  async def sync_downstream_stores(
+      self,
+      workspace_id: str,
+      target_id: str,
+      *,
+      status: LifecycleStatus,
+      freshness_score: float,
+  ) -> None:
+      """Mirror ``memory_records.status`` into the Qdrant payload.
+
+      Best-effort — Qdrant is a derived store. Failures are logged at
+      WARNING, counted on ``freshness_qdrant_sync_failed_total``, and
+      never propagate. PG remains the source of truth; the backfill
+      script at ``scripts/backfill_memory_qdrant_status_payload.py`` is
+      the long-tail safety net for persistent drift.
+
+      ``freshness_score`` is accepted for interface symmetry with the
+      KB adapter but not written — memory Qdrant points do not carry a
+      ``freshness_score`` payload field (MTRNIX-322).
+      """
+      del freshness_score  # documented: not persisted for memory target
+      try:
+          qdrant = await self._resolve_qdrant(workspace_id)
+          await qdrant.update_payload(target_id, {"status": status.value})
+      except Exception:
+          logger.warning(
+              "freshness.memory_target.qdrant_payload_sync_failed",
+              workspace_id=workspace_id,
+              target_id=target_id,
+              status=status.value,
+              exc_info=True,
+          )
+          try:
+              metrics.qdrant_sync_failed.labels(
+                  target_kind="memory_record",
+                  stage="sync_downstream",
+              ).inc()
+          except Exception:  # noqa: BLE001 — metrics must never bite
+              pass
+  ```
+
+- [ ] **Step 4: Lint + typecheck + test.**
+
+- [ ] **Step 5: Commit.**
+  ```
+  git add src/metatron/memory/freshness/target_memory.py tests/unit/memory/freshness/test_target_memory_sync_downstream.py
+  git commit -m "feat(MTRNIX-322): MemoryTarget.sync_downstream_stores writes Qdrant status payload"
+  ```
+
+**Acceptance:** 3 unit tests green. `MemoryMonitor.run` (already invokes the hook) now actually writes to Qdrant.
+
+---
+
+### Task 3: Regression test — Monitor triggers Qdrant sync
+
+**Files:**
+- Create: `tests/unit/freshness/test_monitor_qdrant_sync_memory_target.py`
+
+- [ ] **Step 1: Test setup.**
+  Spin up a real `MemoryTarget` (not a mock), with mocked `MemoryPostgresStore` + `MemoryQdrantStore` (so we see the exact call into Qdrant).
+
+- [ ] **Step 2: Three test cases — one per Monitor rule branch.**
+  - `valid_until < now` → ARCHIVED. Assert `qdrant.update_payload` called with `{"status": "archived"}`.
+  - `superseded_by` set → SUPERSEDED. Assert `{"status": "superseded"}`.
+  - `updated_at < now - stale_after_days` → STALE. Assert `{"status": "stale"}`.
+
+- [ ] **Step 3: Assert the MachineEvent was still saved** (regression against accidentally skipping it).
+
+- [ ] **Step 4: Lint + typecheck + test.**
+
+- [ ] **Step 5: Commit.**
+  ```
+  git add tests/unit/freshness/test_monitor_qdrant_sync_memory_target.py
+  git commit -m "test(MTRNIX-322): Monitor transitions write Qdrant status payload"
+  ```
+
+**Acceptance:** 3 tests green. The hook invocation wiring from MTRNIX-313 is now covered against the real adapter.
+
+---
+
+### Task 4: Curator — call `sync_downstream_stores`
+
+**Files:**
+- Modify: `src/metatron/freshness/stages/curator.py`
+- Create: `tests/unit/freshness/test_curator_qdrant_sync.py`
+
+- [ ] **Step 1: Write the unit test first.**
+  Four cases:
+  - Happy path: seed a mock target with a CANDIDATE record (`evidence_count=1`), mock Qdrant via the target's `sync_downstream_stores`; call `Curator.run`; assert the hook was called with `status=LifecycleStatus.ACTIVE` and the record's `freshness_score` (or `0.5` fallback).
+  - Qdrant-failure path: mock `sync_downstream_stores` to swallow and simulate counter increment (delegated to the adapter); assert `Curator.run` still returns `LifecycleStatus.ACTIVE` and the MachineEvent was still saved.
+  - No-transition path: status=ACTIVE; Curator short-circuits; `sync_downstream_stores` NOT called.
+  - Evidence-insufficient path: status=CANDIDATE, evidence_count=0; short-circuits; `sync_downstream_stores` NOT called.
+
+- [ ] **Step 2: Modify `Curator.run`.**
+  Inside the `try:` block, after the existing `await self._target.update_lifecycle(...)` call (which writes status=ACTIVE + append_tag) and BEFORE `await self._freshness_store.save_machine_event(...)`, insert:
+  ```python
+  await self._target.sync_downstream_stores(
+      workspace_id,
+      target_id,
+      status=LifecycleStatus.ACTIVE,
+      freshness_score=record.freshness_score or 0.5,
+  )
+  ```
+  (Keep it inside the `try/finally` so the lock is released correctly if it unexpectedly raises — though the adapter contract says it never does; belt + suspenders.)
+
+- [ ] **Step 3: Lint + typecheck + test.**
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add src/metatron/freshness/stages/curator.py tests/unit/freshness/test_curator_qdrant_sync.py
+  git commit -m "feat(MTRNIX-322): Curator promotes CANDIDATE → ACTIVE with Qdrant payload sync"
+  ```
+
+**Acceptance:** 4 unit tests green. Curator's PG promotion now pairs with Qdrant sync.
+
+---
+
+### Task 5: `apply_decision` — call `sync_downstream_stores` on `mark_stale`
+
+**Files:**
+- Modify: `src/metatron/freshness/apply_decision.py`
+- Create: `tests/unit/freshness/test_apply_decision_qdrant_sync.py`
+
+- [ ] **Step 1: Write the unit test first.**
+  Four cases:
+  - `mark_stale` above threshold: `apply_decision` writes `status=STALE` AND calls `sync_downstream_stores(..., status=STALE, freshness_score=0.25)`. Returns `{"applied": True, ...}`.
+  - Tag-only above threshold (action != "mark_stale" but tags present): calls `update_lifecycle(append_tag=...)` only; does NOT call `sync_downstream_stores`.
+  - Below threshold: creates `ReviewEntry`; does NOT call `sync_downstream_stores` or `update_lifecycle`.
+  - Qdrant failure on `sync_downstream_stores` (mocked to swallow + counter): `apply_decision` still returns `{"applied": True, ...}` without propagating.
+
+- [ ] **Step 2: Modify `apply_decision`.**
+  In the `if decision.action == "mark_stale":` branch, after
+  ```python
+  await target.update_lifecycle(
+      workspace_id,
+      record.target_id,
+      status=LifecycleStatus.STALE,
+      freshness_score=0.25,
+      append_tag=joined_tag,
+  )
+  ```
+  append:
+  ```python
+  await target.sync_downstream_stores(
+      workspace_id,
+      record.target_id,
+      status=LifecycleStatus.STALE,
+      freshness_score=0.25,
+  )
+  ```
+
+- [ ] **Step 3: Lint + typecheck + test.**
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add src/metatron/freshness/apply_decision.py tests/unit/freshness/test_apply_decision_qdrant_sync.py
+  git commit -m "feat(MTRNIX-322): apply_decision mark_stale path syncs Qdrant payload"
+  ```
+
+**Acceptance:** 4 unit tests green. The DecisionEngine auto-apply path now pairs STALE transition with Qdrant sync.
+
+---
+
+### Task 6: Integration — live end-to-end AC scenario
+
+**Files:**
+- Create: `tests/integration/memory/freshness/test_qdrant_status_sync_live.py`
+
+- [ ] **Step 1: Seed fixture.**
+  Reuse the existing memory integration fixture set (`tests/integration/memory/conftest.py`) — live PG engine, live Qdrant client, live Redis. Create a workspace, seed one `MemoryRecord` with `valid_until=datetime.now(UTC) - timedelta(days=1)` via `MemoryService.save` (this routes through the normal upsert, so Qdrant point exists with `status="active"`).
+
+- [ ] **Step 2: Run one worker iteration.**
+  Build the `FreshnessWorker` via the same helper the worker module uses (or a test-only builder). Enqueue a job via `CoordinationStore.enqueue`. Call `worker.run_once(1)`.
+
+- [ ] **Step 3: Assert PG.**
+  `memory_records.status == 'archived'` (because `valid_until < now` → Monitor → ARCHIVED).
+
+- [ ] **Step 4: Assert Qdrant.**
+  `MemoryQdrantStore.search(query="<record content>", agent_id=..., top_k=5, status_exclude=["archived"])` returns EMPTY. A second call with `status_exclude=None` returns the record (sanity — it's still in Qdrant, just filtered). The `status` payload on the point is `"archived"` (retrievable via `scroll` for sanity, optional).
+
+- [ ] **Step 5: Reproduce the original MTRNIX-319 §1 scenario at MCP layer.**
+  Call the MCP tool `metatron_memory_search(query=..., status=["active"])` (invoke the tool function directly, wrapping the service); assert EMPTY return set. This is the exact regression gate.
+
+- [ ] **Step 6: Lint + typecheck + test-all.**
+
+- [ ] **Step 7: Commit.**
+  ```
+  git add tests/integration/memory/freshness/test_qdrant_status_sync_live.py
+  git commit -m "test(MTRNIX-322): integration — worker lifecycle transition syncs Qdrant status"
+  ```
+
+**Acceptance:** Integration test green against live PG + Qdrant + Redis. MTRNIX-319 §1 reproduction is now a pass gate.
+
+---
+
+### Task 7: Integration — Qdrant outage resilience
+
+**Files:**
+- Create: `tests/integration/memory/freshness/test_qdrant_sync_resilience.py`
+
+- [ ] **Step 1: Seed fixture** identically to Task 6.
+
+- [ ] **Step 2: Patch `MemoryQdrantStore.update_payload` to raise.**
+  Use `monkeypatch.setattr` on the class (not the instance — the adapter resolves fresh stores via the factory). Patch it to `raise RuntimeError("qdrant down")` on every call.
+
+- [ ] **Step 3: Run the worker iteration.**
+
+- [ ] **Step 4: Assertions.**
+  - PG `memory_records.status == 'archived'` (transition committed despite Qdrant failure).
+  - `machine_events` has the `freshness_stage_completed` row for the Monitor step.
+  - Counter `freshness_qdrant_sync_failed_total{target_kind="memory_record",stage="sync_downstream"}` is >= 1. (Access via `prometheus_client.REGISTRY.get_sample_value` or the noop `_value` attribute in the stub — test uses the real counter since the CI env has the dep.)
+  - Worker loop did NOT raise (assert `run_once` returned normally).
+  - MCP search WITH default `status=["active"]` filter still leaks the record (because Qdrant payload is stale — the intended behaviour: PG correct, Qdrant stale, drift present but observable).
+  - Running `scripts/backfill_memory_qdrant_status_payload.py` (or equivalent inline code) on the workspace fixes the drift; rerun MCP search — record now excluded.
+
+- [ ] **Step 5: Lint + typecheck + test-all.**
+
+- [ ] **Step 6: Commit.**
+  ```
+  git add tests/integration/memory/freshness/test_qdrant_sync_resilience.py
+  git commit -m "test(MTRNIX-322): integration — Qdrant outage doesn't abort worker PG transitions"
+  ```
+
+**Acceptance:** Integration test green. Graceful degradation verified.
+
+---
+
+### Task 8: Update `docs/MEMORY_MCP_FOLLOWUPS.md`
+
+**Files:** `docs/MEMORY_MCP_FOLLOWUPS.md`
+
+- [ ] **Step 1: Delete item #4 entirely** — remove the `## 4. Worker-driven proactive Qdrant status sync` heading and all its body lines up to (but not including) the next `## ...` heading.
+
+- [ ] **Step 2: Delete the #4 bullet** from the trailing "## Open question — should any of these be filed as tickets now?" section:
+  - Remove the line `- **#4** has a real correctness impact today ...` entirely.
+  - Update the preamble from "The default answer is probably "yes for #4, maybe #1, not #2/#3":" to "The default answer is probably "maybe #1, not #2/#3":".
+
+- [ ] **Step 3: No renumbering of items 1-3** — their `## 1.`, `## 2.`, `## 3.` headings stay.
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add docs/MEMORY_MCP_FOLLOWUPS.md
+  git commit -m "docs(MTRNIX-322): remove resolved item #4 from memory MCP follow-ups"
+  ```
+
+**Acceptance:** The doc reads cleanly with #4 removed; #1-#3 intact.
+
+---
+
+### Task 9: Module-level CLAUDE.md updates
+
+**Files:**
+- Modify: `src/metatron/memory/.claude/CLAUDE.md`
+- Modify: `src/metatron/storage/.claude/CLAUDE.md`
+
+- [ ] **Step 1: Memory module docs.**
+  Update the `freshness/target_memory.py` bullet list to add:
+  ```
+  - `sync_downstream_stores(ws, target_id, status, freshness_score)` — MTRNIX-322: best-effort writes `{"status": status.value}` to the per-workspace memory Qdrant point via `MemoryQdrantStore.update_payload`. Failures logged at WARNING, counted on `freshness_qdrant_sync_failed_total`, never propagate.
+  ```
+
+- [ ] **Step 2: Storage module docs.**
+  Under `memory_qdrant.py`, append to the `update_payload` bullet: "Called by `MemoryTarget.sync_downstream_stores` on every worker-driven lifecycle transition (MTRNIX-322)."
+
+- [ ] **Step 3: Commit.**
+  ```
+  git add src/metatron/memory/.claude/CLAUDE.md src/metatron/storage/.claude/CLAUDE.md
+  git commit -m "docs(MTRNIX-322): module CLAUDE.md — memory target Qdrant sync"
+  ```
+
+**Acceptance:** Both docs reference the new hook behaviour.
+
+---
+
+### Task 10: CHANGELOG
+
+**Files:** `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry** under the current unreleased section (or create the section if missing):
+  ```
+  - **Freshness worker:** memory lifecycle transitions (STALE / ACTIVE /
+    SUPERSEDED / ARCHIVED) now propagate to the Qdrant `status` payload
+    best-effort, closing the drift that leaked non-ACTIVE records through
+    `memory_search` under the default `status=["active"]` filter. Adds
+    Prometheus counter `freshness_qdrant_sync_failed_total` (MTRNIX-322).
+  ```
+
+- [ ] **Step 2: Commit.**
+  ```
+  git add CHANGELOG.md
+  git commit -m "docs(MTRNIX-322): CHANGELOG entry"
+  ```
+
+---
+
+### Task 11: Final verification + PR
+
+- [ ] **Step 1: Full test matrix.**
+  - `make lint`
+  - `make typecheck`
+  - `make test`
+  - `make test-all` (integration suite)
+
+- [ ] **Step 2: Grep guardrails.**
+  - `grep -rn "update_payload" src/metatron/freshness/ src/metatron/memory/freshness/` → only `target_memory.py::sync_downstream_stores`.
+  - `grep -rn "sync_downstream_stores" src/metatron/freshness/stages/ src/metatron/freshness/apply_decision.py` → hits in Monitor, Curator, apply_decision (3 call sites).
+  - `grep -rn "workspace_id" src/metatron/memory/freshness/target_memory.py` → every Qdrant call has it.
+  - `grep -rn "import metatron.agent\|import metatron.channels\|api.routes.chat\|api.routes.finops" src/metatron/freshness/ src/metatron/memory/freshness/` → empty.
+
+- [ ] **Step 3: Phase A / B / MTRNIX-314 regression check.**
+  - `make test tests/unit/freshness/` + `make test tests/unit/memory/freshness/` + `make test tests/unit/mcp/tools/` — zero regressions.
+
+- [ ] **Step 4: Smoke-run the worker locally.**
+  Seed a record with `valid_until < now` in a dev workspace; run `METATRON_FRESHNESS_ENABLED=true python -m metatron.memory.freshness` for one iteration; observe structured logs for the `freshness.memory_target.qdrant_payload_sync_failed` WARNING (it should NOT appear in the happy path); confirm the Qdrant payload via the admin CLI or an ad-hoc `MemoryQdrantStore.search` call.
+
+- [ ] **Step 5: Open PR.**
+  Title: `feat(MTRNIX-322): memory freshness worker syncs Qdrant status payload on lifecycle transitions`
+  Body sections: Summary (1 paragraph), Scope (bullet list of touched files), Validation (commands + AC checklist), Enterprise courtesy (new Prometheus counter `freshness_qdrant_sync_failed_total`). No Co-Authored-By, no Claude Code badge.
+
+**Acceptance:** Green CI; 7 open questions from spec closed in code; MTRNIX-319 §1 reproduction now a passing integration test.
+
+---
+
+## Risks watchlist
+
+- **Metric cardinality** — labels bounded by design; monitor for unexpected `stage` values in production.
+- **Phase B KB path untouched** — `RawDocumentTarget.sync_downstream_stores` is the reference pattern; we do not modify it. KB's Neo4j `set_raw_document_status` call is unrelated to this ticket.
+- **Graph edges** — Reconciler writes `:ALIAS` graph edges best-effort (unchanged). Their sync is already best-effort; this ticket doesn't add graph work.
+- **Worker process lifecycle** — no new threads, no new coroutines. Same bounded-loop shape.
+- **Qdrant client pooling** — adapter re-resolves the per-workspace client on every call via the existing `_resolve_qdrant` factory; the factory caches. No new client lifecycle concerns.
+
+---
+
+## Coordination points
+
+- **`core/interfaces.py`** unchanged.
+- **`core/events.py`** unchanged.
+- **`FreshnessTarget` Protocol** unchanged.
+- **Enterprise repo** — courtesy mention in PR body: new Prometheus counter `freshness_qdrant_sync_failed_total`. Enterprise Grafana dashboards may want to add a panel; non-breaking.
+- **`docs/MEMORY_MCP_FOLLOWUPS.md`** — item #4 removed. Items #1 / #2 / #3 untouched.
+- **`scripts/backfill_memory_qdrant_status_payload.py`** — stays. Ops runbook addendum (informal): non-zero `freshness_qdrant_sync_failed_total` rate over a 1-hour window → run the backfill script on the affected workspaces.
+```
+

--- a/docs/superpowers/specs/2026-04-24-memory-freshness-qdrant-status-sync-design.md
+++ b/docs/superpowers/specs/2026-04-24-memory-freshness-qdrant-status-sync-design.md
@@ -1,0 +1,636 @@
+# Memory freshness worker — Qdrant status payload sync — Design
+
+**Date:** 2026-04-24
+**Jira:** MTRNIX-322 — Memory freshness worker — sync status payload to Qdrant on every lifecycle transition.
+**Depends on:** MTRNIX-304 (Phase A), MTRNIX-313 (Phase B + shared `FreshnessTarget`), MTRNIX-314 (MCP status filter), MTRNIX-319 (atomicity fix in `resolve_review`).
+**Parent epic:** MTRNIX-227 (Agent Memory System, WS1).
+**Author:** Architect (agent-team)
+**Status:** Draft — ready for implementation plan
+
+## Goal
+
+Close the worker-side drift between PostgreSQL `memory_records.status` and the
+`mem_agent_memory_{workspace_id}` Qdrant collection's `status` payload. Today,
+every freshness-pipeline lifecycle transition writes PG only; the Qdrant
+payload catches up lazily on the next upsert. Result: records that the worker
+transitions to `STALE` / `SUPERSEDED` / `ARCHIVED` still carry
+`status="active"` in Qdrant and therefore leak through the MTRNIX-314
+`must_not` exclusion filter (reproduced on live data in MTRNIX-319 §1).
+
+The fix: reuse the existing `FreshnessTarget.sync_downstream_stores` hook
+(already invoked by `FreshnessMonitor` after every STALE/SUPERSEDED/ARCHIVED
+transition — MTRNIX-313) and:
+
+1. Implement `MemoryTarget.sync_downstream_stores` to call
+   `MemoryQdrantStore.update_payload(record_id, {"status": status.value})`
+   best-effort. Today it is a deliberate no-op.
+2. Add the same hook call in `Curator.run` (CANDIDATE → ACTIVE) and in
+   `apply_decision.apply_decision` (when the decision writes `STALE` or when
+   tag-only updates promote the record via other lifecycle paths).
+3. Keep Reconciler unchanged (it writes `review_entries` only, never
+   `memory_records.status`).
+4. Expose a `freshness.qdrant_sync_failed` Prometheus counter so the drift
+   rate is observable in production.
+
+All changes are inside `src/metatron/freshness/` and
+`src/metatron/memory/freshness/`. No schema migration. No flag. No MCP-layer
+changes. No changes to `core/interfaces.py` or `core/events.py`.
+
+## Non-goals
+
+- KB raw_documents Qdrant sync — already done in MTRNIX-313 via
+  `RawDocumentTarget.sync_downstream_stores`. Reference pattern only;
+  do not touch.
+- MCP-triggered transitions (`MemoryService.resolve_review`) — already
+  sync Qdrant best-effort after PR #86 / #89. Not in scope.
+- Backfill script lifecycle — `scripts/backfill_memory_qdrant_status_payload.py`
+  stays as the operator safety net for historical drift and post-outage
+  recovery. Not being removed.
+- Pushing Qdrant writes into the PG transaction. Qdrant is a different
+  data store; coupling its availability to PG transaction success is wrong
+  (Qdrant outage would abort PG commits, breaking graceful degradation).
+- 5-role RBAC, hard-delete, content-merge auto-merge — separate tickets.
+- Search-time behaviour — MTRNIX-314's exclude-filter semantics handle the
+  "missing `status` payload" case correctly; this ticket only improves
+  steady-state consistency, not correctness under the existing filter.
+- Metric for success (counter of successful syncs) — only the failure
+  counter is specified; success is the default and already observable via
+  `MachineEvent` rows.
+
+## Constraints
+
+- **Layer boundaries.** All new code sits at L2 (`src/metatron/freshness/`
+  stages + `apply_decision`) or L3 (`src/metatron/memory/freshness/`
+  adapter glue) or L1 (`src/metatron/storage/` no change required —
+  `update_payload` already exists). No upward imports. No changes to
+  `agent/`, `channels/`, `api/routes/chat.py`, `api/routes/finops.py`.
+- **Workspace isolation.** `MemoryQdrantStore` is per-workspace already
+  (collection name `mem_agent_memory_{workspace_id}`, resolved through
+  the existing factory). Every new code path passes `workspace_id` down
+  into `_resolve_qdrant(workspace_id)`.
+- **Graceful degradation.** Qdrant failure NEVER aborts the PG transition
+  or the worker loop. Match the `MemoryService.resolve_review` pattern:
+  PG commit first, then `try: update_payload ... except Exception: log
+  WARNING + increment counter`.
+- **PG source of truth.** Qdrant derived store stays eventually consistent.
+  A background reconciliation (the backfill script on a future cron) stays
+  the ultimate safety net.
+- **Zero-plugin compat.** No new plugin hooks, no changes to the plugin
+  EventBus surface.
+- **Async everywhere** for I/O. Neo4j paths unchanged (we only touch Qdrant).
+- **Best-effort semantics consistent with Phase B.** Match
+  `RawDocumentTarget.sync_downstream_stores` behaviour (MTRNIX-313): try,
+  log on failure, never raise.
+
+## Current state — what MTRNIX-313 gave us
+
+Generalized freshness pipeline (`src/metatron/freshness/`):
+- `targets.py::FreshnessTarget` Protocol has a `sync_downstream_stores`
+  method with best-effort contract and no-raise guarantee.
+- `stages/monitor.py` already calls
+  `self._target.sync_downstream_stores(workspace_id, target_id,
+  status=new_status, freshness_score=new_score)` after each lifecycle
+  transition (post-STALE/SUPERSEDED/ARCHIVED).
+- `stages/curator.py` does NOT call `sync_downstream_stores` — calls only
+  `update_lifecycle` with `status=LifecycleStatus.ACTIVE`. Gap.
+- `stages/reconciler.py` calls neither — it writes only `review_entries`,
+  so no Qdrant sync is needed. Verified via full file read.
+- `apply_decision.py` writes `status=LifecycleStatus.STALE` when
+  `decision.action == "mark_stale"` and does NOT call
+  `sync_downstream_stores`. Gap.
+
+Memory adapter (`src/metatron/memory/freshness/target_memory.py`):
+- `MemoryTarget.sync_downstream_stores` is a deliberate no-op today (Phase B
+  comment: "Memory does not mirror status onto Qdrant chunk payloads in
+  Phase B. Kept for interface symmetry; KB adapter overrides.").
+- The adapter already knows how to resolve a per-workspace `MemoryQdrantStore`
+  via `_resolve_qdrant(workspace_id)` — this is the only I/O we need.
+
+KB adapter (`src/metatron/ingestion/freshness/target_raw_document.py`) —
+serves as the reference pattern. `RawDocumentTarget.sync_downstream_stores`
+payload-writes `{"status": ..., "freshness_score": ...}` via Qdrant, logs
+failures at WARNING, never raises.
+
+MCP-side (`src/metatron/memory/service.py::MemoryService.resolve_review`):
+- After PR #89 (MTRNIX-319), the PG lifecycle update + review-entry delete +
+  MachineEvent insert are one transaction via `pg_store.begin()` and the
+  `conn` kwarg. Qdrant `update_payload` runs OUTSIDE the transaction, under
+  `try/except Exception: logger.warning(...)`. This is the pattern we adopt
+  for the worker.
+
+Metrics (`src/metatron/freshness/metrics.py`):
+- Contains `jobs_total`, `queue_depth_gauge`, `stage_duration`,
+  `decision_confidence`, `worker_errors` — all guarded by a top-level
+  `try/except ImportError` for `prometheus_client`. Each has a `_NoopMetric`
+  fallback. Adding a new counter follows the exact same pattern.
+
+`memory_records.status` write paths from the worker pipeline (after full
+audit):
+
+| Module | File | Writes `status`? | Currently calls Qdrant sync? |
+|---|---|---|---|
+| Linker | `freshness/stages/linker.py` | No — writes `evidence_count` only | N/A |
+| Reconciler | `freshness/stages/reconciler.py` | No — writes `review_entries` only | N/A |
+| FreshnessMonitor | `freshness/stages/monitor.py` | **Yes** — STALE/SUPERSEDED/ARCHIVED | **Yes, via `sync_downstream_stores` hook — but hook is a no-op for memory today** |
+| Curator | `freshness/stages/curator.py` | **Yes** — CANDIDATE → ACTIVE | **No — missing hook call** |
+| apply_decision | `freshness/apply_decision.py` | **Yes** — STALE when action=="mark_stale" | **No — missing hook call** |
+| Reconciler alias graph | `freshness/stages/reconciler.py::alias_link_memory_items` | No (Neo4j only) | N/A |
+
+Net: 3 real call sites → Monitor already has the hook (but hook is a
+no-op); Curator and apply_decision need the hook added. The adapter's
+`sync_downstream_stores` gets a real implementation.
+
+## Decision: Option A vs Option B
+
+The ticket's Recommended Placement section offers:
+
+- **Option A** — new method on `MemoryTarget` (e.g. `apply_lifecycle(...)`)
+  that does both PG + Qdrant writes atomically.
+- **Option B** — post-hoc Qdrant sync in `apply_decision` plus stage-level
+  direct calls where `apply_decision` is not used.
+
+**Decision: Option A, but implemented as the already-existing
+`FreshnessTarget.sync_downstream_stores` hook — not as a new
+`apply_lifecycle` wrapper.** Reason:
+
+- `sync_downstream_stores` already exists on the Protocol (MTRNIX-313).
+  `FreshnessMonitor` already invokes it immediately after a lifecycle
+  change. KB's `RawDocumentTarget` already implements it correctly.
+  Introducing a parallel `apply_lifecycle` would duplicate the hook and
+  desynchronize memory/KB semantics.
+- Adding a new `apply_lifecycle(record_id, *, status, ...)` wrapper that
+  wraps both `update_lifecycle` and `sync_downstream_stores` is tempting
+  but adds a second way to do what a stage already does in two steps. The
+  stages are canonical call sites and they are in the shared freshness
+  submodule; centralising the Qdrant sync at the adapter's
+  `sync_downstream_stores` keeps the Protocol small and the stage
+  invocation identical between memory and KB.
+- Option B (scatter `update_payload` in every stage) was rejected because
+  it duplicates the try/except-log-swallow idiom across 3 files, adds a
+  direct `MemoryQdrantStore` dependency to `apply_decision.py` (which
+  today only knows about `FreshnessTarget`), and defeats the protocol
+  abstraction.
+
+So the design is "Option A, minimal surgery": make memory's
+`sync_downstream_stores` non-no-op, and make sure every PG `status` mutation
+site calls it. The hook contract (best-effort, never raises) is preserved
+verbatim from the KB implementation.
+
+### Method signature (unchanged from MTRNIX-313)
+
+```python
+async def sync_downstream_stores(
+    self,
+    workspace_id: str,
+    target_id: str,
+    *,
+    status: LifecycleStatus,
+    freshness_score: float,
+) -> None:
+    """Best-effort. NEVER raises. PG remains source of truth."""
+```
+
+The KB adapter writes both `status` and `freshness_score`. The memory
+adapter writes only `status` because the MTRNIX-314 search filter only
+pushes down on `status` (no `freshness_score` payload field exists on
+memory Qdrant points yet — adding it is out of scope for this ticket).
+`freshness_score` is accepted on the signature for symmetry but
+deliberately dropped inside the memory adapter; documented with a
+comment.
+
+### Call-site checklist
+
+| Site | Before | After |
+|---|---|---|
+| `FreshnessMonitor.run` (STALE/SUPERSEDED/ARCHIVED) | calls `sync_downstream_stores` (no-op for memory) | unchanged code; hook now writes Qdrant |
+| `Curator.run` (CANDIDATE → ACTIVE) | calls `update_lifecycle` only | add `await self._target.sync_downstream_stores(..., status=ACTIVE, freshness_score=record.freshness_score or 0.5)` after `update_lifecycle` |
+| `apply_decision.apply_decision` (mark_stale branch) | calls `target.update_lifecycle(status=STALE)` | add `await target.sync_downstream_stores(workspace_id, record.target_id, status=STALE, freshness_score=0.25)` after `update_lifecycle` |
+| `apply_decision.apply_decision` (tag-only branch) | calls `target.update_lifecycle(append_tag=...)` | **no change** — status did not change, no Qdrant sync needed |
+| Reconciler | writes `review_entries` only | **no change** |
+| Linker | writes `evidence_count` only | **no change** |
+
+### Why not touch `update_lifecycle` directly?
+
+PG `update_lifecycle` is an L1 storage method. L1 does not talk to other
+stores — that's the whole layering rule. Doing Qdrant sync inside
+`update_lifecycle` would invert the layer hierarchy (L1 → calls L1 Qdrant
+client, fine in principle, but couples what is currently a pure PG write
+to a derived-store write with different failure semantics). Keeping the
+sync at the adapter (L3-adjacent, inside `memory/freshness/`) matches
+Phase B's layout and keeps `memory_postgres.py` pure PG.
+
+## Open decisions — closed
+
+### 1. Best-effort semantics
+
+Every Qdrant write is wrapped in `try/except Exception` inside the
+adapter:
+
+```python
+async def sync_downstream_stores(
+    self, workspace_id, target_id, *, status, freshness_score,
+) -> None:
+    try:
+        qdrant = await self._resolve_qdrant(workspace_id)
+        await qdrant.update_payload(target_id, {"status": status.value})
+    except Exception:
+        logger.warning(
+            "freshness.memory_target.qdrant_payload_sync_failed",
+            workspace_id=workspace_id, target_id=target_id,
+            status=status.value, exc_info=True,
+        )
+        metrics.qdrant_sync_failed.labels(
+            target_kind="memory_record", stage="sync_downstream",
+        ).inc()
+```
+
+Failures never propagate; PG transition stays committed; worker loop never
+aborts. This matches `RawDocumentTarget.sync_downstream_stores` verbatim
+(logger name + swallow pattern).
+
+### 2. Ordering of writes
+
+**Sequential, PG-first, best-effort Qdrant second. No shared transaction.**
+
+Rationale:
+
+- Atomicity across PG + Qdrant is not achievable (two different data
+  stores, no XA / 2PC). A "shared transaction" via `pg_store.begin()` only
+  makes the PG side atomic across multiple PG operations — which the
+  worker's single `update_lifecycle` call already is.
+- MTRNIX-319 (PR #89) made `resolve_review` atomic only across PG writes
+  (update_lifecycle + delete_review_entry + save_machine_event — all on
+  the same `conn`). The Qdrant `update_payload` in `resolve_review` runs
+  OUTSIDE the transaction. We adopt the same pattern.
+- PG is the source of truth. Lazy reconciliation (or a periodic backfill
+  cron) is sufficient for derived-store catchup.
+- Worker stage code already writes MachineEvent rows via
+  `freshness_store.save_machine_event`; those are independent PG writes
+  today (one per stage, one per job-processed). Not making them atomic
+  with the lifecycle update is pre-existing behaviour; this ticket does
+  not change it.
+
+Worker-side atomicity across update_lifecycle + MachineEvent for
+freshness stages is a separate concern and was explicitly discussed in
+MTRNIX-319 commentary — out of scope here.
+
+### 3. Metric surface
+
+**Add `freshness.qdrant_sync_failed` counter.**
+
+In `src/metatron/freshness/metrics.py`, extend the existing guarded block:
+
+```python
+qdrant_sync_failed: Any
+try:
+    from prometheus_client import Counter, ...
+    ...
+    qdrant_sync_failed = Counter(
+        "freshness_qdrant_sync_failed_total",
+        "Best-effort Qdrant payload sync failures by target kind / stage",
+        ["target_kind", "stage"],
+    )
+    ...
+except ImportError:  # pragma: no cover
+    ...
+    qdrant_sync_failed = _NoopMetric()
+```
+
+Add to `__all__`. Labels:
+
+- `target_kind`: `"memory_record"` (and in future `"raw_document"` if KB
+  wires the same counter — not in this ticket; MTRNIX-313 chose to log
+  only).
+- `stage`: `"sync_downstream"` for Monitor+Curator hook invocations,
+  `"apply_decision"` for the apply_decision branch.
+
+The metric is always present (stubbed when `prometheus_client` missing)
+and does not add a runtime dep; callers can always `.labels(...).inc()`
+without guarding on import. Matches existing `worker_errors` / `jobs_total`
+style.
+
+The `memory/freshness/metrics.py` re-export shim gets the new symbol added
+to its import + `__all__` so `from metatron.memory.freshness.metrics
+import qdrant_sync_failed` keeps working.
+
+### 4. Legacy stage signatures
+
+**No signature changes needed.** Every stage and `apply_decision` already
+takes a `FreshnessTarget` instance (injected by the worker's pipeline
+builder). The wiring (`worker.py` lines 307–357) instantiates
+`MemoryTarget(pg_store=..., qdrant_store_factory=...)` and passes it in.
+The adapter already has the `MemoryQdrantStore` factory handle required
+for `sync_downstream_stores`. Zero wiring changes.
+
+### 5. Test strategy for the Qdrant-failure path
+
+**Unit tests.** Mock `MemoryQdrantStore.update_payload` to raise
+`RuntimeError("qdrant down")`. Three targeted tests:
+
+1. `test_memory_target_sync_downstream_swallows_qdrant_errors` —
+   instantiate `MemoryTarget` with a mock Qdrant factory whose
+   `update_payload` raises; call `sync_downstream_stores`; assert no
+   exception, one WARNING log, counter incremented.
+2. `test_curator_continues_on_qdrant_failure` — seed a CANDIDATE record
+   with `evidence_count=1`, mock Qdrant to raise; call `Curator.run`;
+   assert PG row transitioned to ACTIVE, `MachineEvent` saved, return
+   value is `LifecycleStatus.ACTIVE`, counter incremented.
+3. `test_apply_decision_mark_stale_syncs_qdrant_or_swallows` — mock
+   `update_payload` success path: assert call args carry `status=stale`;
+   failure path: assert no raise.
+
+**Integration test.** One end-to-end run against live PG + Qdrant + Redis.
+Approach: patch `MemoryQdrantStore.update_payload` at module boundary in
+a test fixture to raise on alternating calls; assert PG transitions land,
+MachineEvents land, and drift is eventually cleared by running the
+backfill script. We do NOT stop the Qdrant container — too flaky in
+CI and the behaviour we test (swallow + log + counter) is identical
+whether the failure is a dropped socket or a Python exception.
+
+**Live-data verification test** (the AC scenario). Seed a workspace,
+enqueue a memory record, force-run the worker end-to-end (Monitor to
+STALE via a past `valid_until`), then call `memory_search(status=["active"])`
+via the MCP tool function and assert the record does NOT appear — without
+running the backfill. This is the exact MTRNIX-319 §1 reproduction made
+into a pass gate.
+
+### 6. Backward compat with docs/MEMORY_MCP_FOLLOWUPS.md
+
+**Remove item #4 entirely, and remove the #4 line in the trailing "Open
+question" section of the doc.** Rationale: the follow-up doc is a triage
+inbox. Once a ticket lands, the item's rationale lives in git history on
+the spec commit. A "resolved in MTRNIX-322" stub would clutter the
+remaining triage list; a reader encountering a "resolved" stub would
+wonder whether action is still needed. Clean removal is the convention
+other resolved ticket items follow (checked via git blame on prior
+removals).
+
+### 7. No `core/events.py` change
+
+`FRESHNESS_*` event constants are unchanged. The worker does not emit a
+new event for Qdrant sync — it writes the existing
+`freshness_stage_completed` / `freshness_decision_applied` MachineEvent
+rows, and the counter handles observability. A new event for
+"qdrant_sync_failed" would be enterprise-facing noise. Out of scope.
+
+## Data flow — before vs after
+
+### Before (today, broken)
+
+```
+[Worker loop iteration]
+  Linker.run(ws, id)                            # evidence_count only
+  Reconciler.run(ws, id)                        # review_entries only
+  Monitor.run(ws, id)                            # may write status=STALE
+    → target.update_lifecycle(status=STALE)    [PG update OK]
+    → target.sync_downstream_stores(...)       [NO-OP for memory]    <-- GAP
+  Curator.run(ws, id)                           # may write status=ACTIVE
+    → target.update_lifecycle(status=ACTIVE)   [PG update OK]
+    [no sync_downstream_stores call]                                 <-- GAP
+  apply_decision(...)                            # may write status=STALE
+    → target.update_lifecycle(status=STALE)    [PG update OK]
+    [no sync_downstream_stores call]                                 <-- GAP
+```
+
+Qdrant payload `status` stays `"active"` (original upsert value) →
+`memory_search(status=["active"])` leaks the record.
+
+### After
+
+```
+[Worker loop iteration]
+  Linker.run(ws, id)                            # unchanged
+  Reconciler.run(ws, id)                        # unchanged
+  Monitor.run(ws, id)
+    → target.update_lifecycle(status=STALE)
+    → target.sync_downstream_stores(status=STALE, ...)
+         ↳ MemoryTarget: try: qdrant.update_payload(id, {"status": "stale"})
+                          except: WARN + counter.inc()                       # fixed
+  Curator.run(ws, id)
+    → target.update_lifecycle(status=ACTIVE)
+    → target.sync_downstream_stores(status=ACTIVE, ...)                       # NEW
+  apply_decision(...)  # mark_stale branch
+    → target.update_lifecycle(status=STALE)
+    → target.sync_downstream_stores(status=STALE, ...)                        # NEW
+```
+
+Derived store converges to PG within one worker iteration; failure
+degrades gracefully and is observable via the counter.
+
+## Adapter implementation
+
+```python
+# src/metatron/memory/freshness/target_memory.py
+
+from metatron.freshness import metrics  # access qdrant_sync_failed counter
+
+class MemoryTarget:
+    ...
+    async def sync_downstream_stores(
+        self,
+        workspace_id: str,
+        target_id: str,
+        *,
+        status: LifecycleStatus,
+        freshness_score: float,
+    ) -> None:
+        """Mirror the PG status into the memory Qdrant collection's payload.
+
+        Best-effort: Qdrant is a derived store; failures are logged at
+        WARNING, counted on the `freshness_qdrant_sync_failed` counter,
+        and never propagate. PG remains the source of truth; the backfill
+        script at ``scripts/backfill_memory_qdrant_status_payload.py`` is
+        the long-tail safety net for persistent drift.
+
+        ``freshness_score`` is accepted for interface symmetry with the
+        KB adapter but not written — memory Qdrant points do not carry a
+        ``freshness_score`` payload field in this ticket.
+        """
+        del freshness_score  # not written; see docstring
+        try:
+            qdrant = await self._resolve_qdrant(workspace_id)
+            await qdrant.update_payload(target_id, {"status": status.value})
+        except Exception:
+            logger.warning(
+                "freshness.memory_target.qdrant_payload_sync_failed",
+                workspace_id=workspace_id,
+                target_id=target_id,
+                status=status.value,
+                exc_info=True,
+            )
+            try:
+                metrics.qdrant_sync_failed.labels(
+                    target_kind="memory_record",
+                    stage="sync_downstream",
+                ).inc()
+            except Exception:  # noqa: BLE001  — never let metrics bite
+                pass
+```
+
+## Stage changes
+
+### `freshness/stages/curator.py`
+
+After the existing `await self._target.update_lifecycle(..., status=ACTIVE, ...)`
+call and before the `save_machine_event`, insert:
+
+```python
+await self._target.sync_downstream_stores(
+    workspace_id,
+    target_id,
+    status=LifecycleStatus.ACTIVE,
+    freshness_score=record.freshness_score or 0.5,
+)
+```
+
+(The `record.freshness_score or 0.5` fallback mirrors what the adapter
+does for a freshly-seeded record; the value is only relevant to KB
+targets today.)
+
+### `freshness/apply_decision.py`
+
+Inside the `if decision.confidence >= threshold:` block, specifically in
+the `if decision.action == "mark_stale":` branch, after
+`await target.update_lifecycle(..., status=LifecycleStatus.STALE, freshness_score=0.25, ...)`,
+insert:
+
+```python
+await target.sync_downstream_stores(
+    workspace_id,
+    record.target_id,
+    status=LifecycleStatus.STALE,
+    freshness_score=0.25,
+)
+```
+
+The tag-only branch (`elif joined_tag is not None:`) does NOT touch
+`status`, so no sync is needed.
+
+### Other stages
+
+- `Linker` — no `status` writes; no change.
+- `Reconciler` — no `status` writes; no change. (The "double-check" from
+  the ticket description is resolved: the Reconciler writes
+  `review_entries` + `machine_events` + a best-effort `:ALIAS` Neo4j
+  edge. Zero PG `status` mutations.)
+- `FreshnessMonitor` — already calls `sync_downstream_stores`; the hook
+  becomes non-no-op. Code unchanged.
+
+## Metric surface
+
+One new counter in `src/metatron/freshness/metrics.py`:
+
+```python
+qdrant_sync_failed: Any
+
+try:
+    from prometheus_client import Counter, ...
+    ...
+    qdrant_sync_failed = Counter(
+        "freshness_qdrant_sync_failed_total",
+        "Best-effort Qdrant payload sync failures from the freshness pipeline",
+        ["target_kind", "stage"],
+    )
+    ...
+except ImportError:
+    ...
+    qdrant_sync_failed = _NoopMetric()
+
+__all__ = [
+    "decision_confidence",
+    "jobs_total",
+    "qdrant_sync_failed",   # NEW
+    "queue_depth_gauge",
+    "stage_duration",
+    "worker_errors",
+]
+```
+
+Shim update at `src/metatron/memory/freshness/metrics.py` — re-export the
+new symbol for backward-compat imports.
+
+## Search-side behaviour — unchanged
+
+MTRNIX-314 filter semantics remain: missing `status` payload → treated as
+ACTIVE (via `MatchAny` on excluded set, never `MatchValue` on included).
+After this ticket, freshly-transitioned records carry the correct
+`status` payload and are excluded by the `must_not` filter on the next
+search. Backfill is only needed for pre-ticket records that the worker
+has never re-touched since the gap existed.
+
+No retrieval-pipeline changes. No `memory_search` / `memory_list` changes.
+No Qdrant filter changes.
+
+## Failure modes & edge cases
+
+| Scenario | Behaviour | Observed via |
+|---|---|---|
+| Qdrant down during `sync_downstream_stores` | PG committed; Qdrant call raises; adapter catches, WARN + counter++; stage continues | log + Prometheus |
+| Qdrant up but point missing (e.g. never upserted) | `set_payload` on a non-existent point raises — same swallow path; counter++ | log + Prometheus |
+| Worker restarts mid-iteration, after PG commit, before Qdrant sync | Same final state as Qdrant-down: PG correct, Qdrant stale. Next worker iteration touches a different record; backfill or next transition clears it | existing |
+| Two stages transition same record in same iteration (Curator → ACTIVE, Monitor → STALE) | Sequential PG writes + sequential Qdrant payload writes; last-write-wins. Stage lock prevents true concurrency | existing |
+| Concurrent MCP resolve_review vs worker transition | Two independent PG `update_lifecycle` writes; last-write-wins on PG; respective Qdrant payloads converge to last PG state | existing Phase A behaviour |
+| Record deleted between PG write and Qdrant sync | `set_payload` on missing point → swallow; backfill script idempotent | existing |
+| `_resolve_qdrant` factory raises (e.g. misconfigured client) | Same swallow path; counter++ (labels attribute itself reentrant-safe) | log |
+
+None of these require new handling beyond the existing swallow pattern.
+
+## Risks & mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| New Qdrant traffic from Monitor's hook breaks existing Monitor latency budget | LOW | `update_payload` is a single-point-id write, O(ms). Monitor already syncs on every transition in KB path without incident. |
+| Silent drift if Qdrant is chronically down | MEDIUM | `freshness_qdrant_sync_failed_total` counter + backfill script. Ops runbook: non-zero counter over 1h → run backfill. |
+| Adapter import cycle: `memory.freshness.target_memory` imports `freshness.metrics` | LOW | `freshness.metrics` is L2 with no upward deps; safe import. |
+| Double-write cost (PG + Qdrant now serialised inside stage) | LOW | Qdrant write is outside the PG transaction and best-effort — no extra PG lock time. Stage lock already serialises per-record. |
+| Phase A regression — Monitor used to be a no-op for memory after `update_lifecycle`; now it does I/O | LOW | I/O was the design intent (hook exists for this reason). Tests assert the hook is called. |
+| Counter labels grow unbounded | NONE | `target_kind` is bounded to `{memory_record, raw_document}`, `stage` to `{sync_downstream, apply_decision}`. Stable cardinality. |
+
+## Coordination points
+
+- **`core/interfaces.py`** — unchanged.
+- **`core/events.py`** — unchanged. No new event constants.
+- **`FreshnessTarget` Protocol** (`freshness/targets.py`) — unchanged;
+  shape already supports this fix.
+- **Enterprise repo** — no coordination needed. `FRESHNESS_*` event
+  payloads unchanged. `MachineEvent` shape unchanged. PR body should
+  still mention the new `freshness_qdrant_sync_failed_total` metric for
+  enterprise dashboards that scrape Prometheus — courtesy only.
+- **`docs/MEMORY_MCP_FOLLOWUPS.md`** — remove item #4 entirely
+  (and the bullet for #4 in the trailing "Open question — should any of
+  these be filed as tickets now?" section). Renumbering of items 1–3 is
+  NOT needed — the sections use headings like "## 1." that remain
+  stable; removing #4's block simply deletes those lines.
+
+## Acceptance criteria (reviewer checklist, restated testably)
+
+1. `make lint` — zero errors on changed files.
+2. `make typecheck` — zero errors (mypy strict).
+3. `make test` — all new unit tests pass; Phase A / Phase B / MTRNIX-314
+   tests unchanged.
+4. `make test-all` — integration suite passes against live
+   PG + Qdrant + Redis.
+5. `METATRON_FRESHNESS_ENABLED=true` worker run: seed an ACTIVE memory
+   record with `valid_until < now`, run one worker iteration, call
+   `MemoryQdrantStore.update_payload`-free search via `memory_search`
+   with default filter — record MUST NOT appear. Assert WITHOUT running
+   the backfill script.
+6. Stop Qdrant client at the adapter (monkey-patch
+   `MemoryQdrantStore.update_payload` to raise) for one worker iteration;
+   PG row transitions, MachineEvent saved, counter
+   `freshness_qdrant_sync_failed_total` incremented. Worker loop does NOT
+   abort, does NOT raise.
+7. Grep sanity:
+   `grep -rn "update_payload" src/metatron/freshness/ src/metatron/memory/freshness/`
+   → only inside `target_memory.py::sync_downstream_stores`. The call is
+   centralised.
+8. `grep -rn "workspace_id" src/metatron/memory/freshness/target_memory.py`
+   hits every `update_payload` / `_resolve_qdrant` call.
+9. No new imports from `agent/`, `channels/`, `api/routes/chat.py`,
+   `api/routes/finops.py`.
+10. `core/interfaces.py` unchanged. `core/events.py` unchanged.
+11. `docs/MEMORY_MCP_FOLLOWUPS.md` item #4 removed.
+12. PR body mentions the new Prometheus counter (courtesy for enterprise
+    dashboards).
+```
+

--- a/src/metatron/freshness/apply_decision.py
+++ b/src/metatron/freshness/apply_decision.py
@@ -59,6 +59,17 @@ async def apply_decision(
                 freshness_score=0.25,
                 append_tag=joined_tag,
             )
+            # MTRNIX-322: mirror the PG STALE transition onto derived stores
+            # (memory → Qdrant payload; KB no-ops today). Best-effort — the
+            # adapter swallows failures and increments the Prometheus
+            # ``freshness_qdrant_sync_failed_total`` counter. Tag-only
+            # decisions below do not touch ``status``, so no sync fires.
+            await target.sync_downstream_stores(
+                workspace_id,
+                record.target_id,
+                status=LifecycleStatus.STALE,
+                freshness_score=0.25,
+            )
         elif joined_tag is not None:
             await target.update_lifecycle(
                 workspace_id,

--- a/src/metatron/freshness/metrics.py
+++ b/src/metatron/freshness/metrics.py
@@ -35,6 +35,7 @@ queue_depth_gauge: Any
 stage_duration: Any
 decision_confidence: Any
 worker_errors: Any
+qdrant_sync_failed: Any
 
 try:
     from prometheus_client import (  # type: ignore[import-not-found]
@@ -68,17 +69,24 @@ try:
         "Worker iteration errors",
         ["stage"],
     )
+    qdrant_sync_failed = Counter(
+        "freshness_qdrant_sync_failed_total",
+        "Best-effort Qdrant payload sync failures from the freshness pipeline",
+        ["target_kind", "stage"],
+    )
 except ImportError:  # pragma: no cover — real branch when dep missing
     jobs_total = _NoopMetric()
     queue_depth_gauge = _NoopMetric()
     stage_duration = _NoopMetric()
     decision_confidence = _NoopMetric()
     worker_errors = _NoopMetric()
+    qdrant_sync_failed = _NoopMetric()
 
 
 __all__ = [
     "decision_confidence",
     "jobs_total",
+    "qdrant_sync_failed",
     "queue_depth_gauge",
     "stage_duration",
     "worker_errors",

--- a/src/metatron/freshness/stages/curator.py
+++ b/src/metatron/freshness/stages/curator.py
@@ -84,6 +84,16 @@ class Curator:
                 status=LifecycleStatus.ACTIVE,
                 append_tag=self.AUTO_CURATED_TAG,
             )
+            # MTRNIX-322: mirror the PG ACTIVE transition onto derived stores
+            # (memory → Qdrant payload; KB no-ops today). Best-effort — the
+            # adapter swallows failures and increments the Prometheus
+            # ``freshness_qdrant_sync_failed_total`` counter.
+            await self._target.sync_downstream_stores(
+                workspace_id,
+                target_id,
+                status=LifecycleStatus.ACTIVE,
+                freshness_score=record.freshness_score or 0.5,
+            )
             await self._freshness_store.save_machine_event(
                 MachineEvent(
                     workspace_id=workspace_id,

--- a/src/metatron/memory/.claude/CLAUDE.md
+++ b/src/metatron/memory/.claude/CLAUDE.md
@@ -83,6 +83,15 @@ Reconciler, FreshnessMonitor, Curator), and the `FreshnessTarget` protocol in
 over the target kind. This subtree keeps only the memory-specific glue:
 - `target_memory.py` — `MemoryTarget` adapter binding the pipeline to
   `MemoryPostgresStore` + `MemoryQdrantStore` + `memory_graph` + `RedisSessionCache`.
+  `sync_downstream_stores(ws, target_id, *, status, freshness_score)` —
+  MTRNIX-322: best-effort writes `{"status": status.value}` onto the
+  per-workspace memory Qdrant point via `MemoryQdrantStore.update_payload`.
+  Failures are logged at WARNING, counted on
+  `freshness_qdrant_sync_failed_total{target_kind="memory_record",stage="sync_downstream"}`,
+  and never propagate. PG remains source of truth; the backfill script at
+  `scripts/backfill_memory_qdrant_status_payload.py` is the long-tail safety net.
+  Callers: `FreshnessMonitor` (already wired in MTRNIX-313), `Curator`
+  (MTRNIX-322), `apply_decision` mark_stale branch (MTRNIX-322).
 - `producer.py` — memory-side enqueue hook (unchanged signature).
 - `worker.py` / `__main__.py` — worker entry point; now instantiates both a
   memory and (when `freshness_kb_enabled`) a KB pipeline and dispatches jobs

--- a/src/metatron/memory/freshness/metrics.py
+++ b/src/metatron/memory/freshness/metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from metatron.freshness.metrics import (  # noqa: F401
     decision_confidence,
     jobs_total,
+    qdrant_sync_failed,
     queue_depth_gauge,
     stage_duration,
     worker_errors,
@@ -13,6 +14,7 @@ from metatron.freshness.metrics import (  # noqa: F401
 __all__ = [
     "decision_confidence",
     "jobs_total",
+    "qdrant_sync_failed",
     "queue_depth_gauge",
     "stage_duration",
     "worker_errors",

--- a/src/metatron/memory/freshness/target_memory.py
+++ b/src/metatron/memory/freshness/target_memory.py
@@ -9,11 +9,13 @@ memory store operations that Phase A used directly.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import structlog
 
+from metatron.freshness import metrics
 from metatron.freshness.targets import FreshnessTargetRecord, SimilarityHit
 
 if TYPE_CHECKING:
@@ -190,6 +192,34 @@ class MemoryTarget:
         status: LifecycleStatus,
         freshness_score: float,
     ) -> None:
-        # Memory does not mirror status onto Qdrant chunk payloads in Phase B.
-        # Kept for interface symmetry; KB adapter overrides.
-        return None
+        """Mirror ``memory_records.status`` into the Qdrant point payload.
+
+        Best-effort — Qdrant is a derived store; failures are logged at
+        WARNING, counted on the ``freshness_qdrant_sync_failed_total``
+        counter, and never propagate. PG remains the source of truth;
+        the backfill script at
+        ``scripts/backfill_memory_qdrant_status_payload.py`` is the
+        long-tail safety net for persistent drift (MTRNIX-322).
+
+        ``freshness_score`` is accepted for interface symmetry with the
+        KB adapter but not written — memory Qdrant points do not carry a
+        ``freshness_score`` payload field in this iteration.
+        """
+        del freshness_score  # documented: not persisted for memory target
+        try:
+            qdrant = await self._resolve_qdrant(workspace_id)
+            await qdrant.update_payload(target_id, {"status": status.value})
+        except Exception:
+            logger.warning(
+                "freshness.memory_target.qdrant_payload_sync_failed",
+                workspace_id=workspace_id,
+                target_id=target_id,
+                status=status.value,
+                exc_info=True,
+            )
+            # Metrics must never bite — swallow any registry/label error.
+            with contextlib.suppress(Exception):
+                metrics.qdrant_sync_failed.labels(
+                    target_kind="memory_record",
+                    stage="sync_downstream",
+                ).inc()

--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -191,6 +191,9 @@ Class: `MemoryQdrantStore(workspace_id, host?, port?)`
   adds a `must_not` `MatchAny` filter; legacy points without a `status` payload
   are NOT excluded, so missing-as-ACTIVE semantics hold.
 - `update_payload(record_id, dict)` — partial payload update without re-embedding.
+  Called by `MemoryTarget.sync_downstream_stores` on every worker-driven
+  lifecycle transition (MTRNIX-322) to mirror `memory_records.status` onto
+  the Qdrant point payload.
 - `delete(record_id)` — delete single point
 - `delete_by_agent(agent_id)` — delete all points for agent
 - `close()` — close client

--- a/tests/integration/memory/freshness/test_qdrant_status_sync_live.py
+++ b/tests/integration/memory/freshness/test_qdrant_status_sync_live.py
@@ -1,0 +1,193 @@
+"""End-to-end integration test: worker lifecycle transitions sync Qdrant payload.
+
+MTRNIX-322 — reproduces the MTRNIX-319 §1 scenario as a pass gate:
+
+1. Seed an ACTIVE memory record with ``valid_until < now``.
+2. Enqueue + run one worker iteration.
+3. Assert PG row transitions to ARCHIVED (Monitor rule).
+4. Assert the Qdrant point's ``status`` payload mirrors ``archived``.
+5. Assert the MCP ``memory_search`` tool with default ``status=["active"]``
+   filter does NOT return the record — without running the backfill.
+
+Requires: PostgreSQL, Qdrant, Redis (services assumed already up per
+``CLAUDE.md``). Feature flag is forced ON inside the test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.core.config import get_settings
+from metatron.core.models import (
+    FreshnessJob,
+    LifecycleStatus,
+    MemoryRecord,
+    MemoryScope,
+)
+from metatron.memory.freshness.coordination import CoordinationStore
+from metatron.memory.freshness.curator import Curator
+from metatron.memory.freshness.decision_engine import RuleBasedDecisionEngine
+from metatron.memory.freshness.linker import Linker
+from metatron.memory.freshness.monitor import FreshnessMonitor
+from metatron.memory.freshness.reconciler import Reconciler
+from metatron.memory.freshness.target_memory import MemoryTarget
+from metatron.memory.freshness.worker import FreshnessWorker, _Pipeline
+from metatron.storage.memory_freshness_pg import FreshnessPostgresStore
+from metatron.storage.memory_postgres import MemoryPostgresStore
+from metatron.storage.memory_qdrant import MemoryQdrantStore
+from metatron.storage.redis import RedisStore
+
+pytestmark = pytest.mark.integration
+
+
+async def _cleanup(engine, workspace: str) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa_text("DELETE FROM machine_events WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM review_entries WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM memory_records WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+
+
+async def test_worker_transition_mirrors_status_to_qdrant_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "freshness_enabled", True)
+
+    workspace = f"fresh-322-{uuid4().hex[:8]}"
+    record_id = uuid4().hex
+
+    redis = RedisStore(settings.redis_url)
+    try:
+        if not await redis.ping():
+            pytest.skip("Redis unreachable")
+    except Exception:
+        pytest.skip("Redis unreachable")
+    coordination = CoordinationStore(redis=redis)
+
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg_store = MemoryPostgresStore(engine)
+    freshness_pg = FreshnessPostgresStore(engine)
+    qdrant = MemoryQdrantStore(workspace_id=workspace)
+
+    try:
+        # --- Seed: ACTIVE record whose valid_until expired yesterday. ---
+        # MemoryPostgresStore.save() does NOT write lifecycle columns (it relies
+        # on PG server defaults). We set ``valid_until`` explicitly via
+        # update_lifecycle so the Monitor's valid_until rule fires.
+        record = MemoryRecord(
+            id=record_id,
+            workspace_id=workspace,
+            agent_id="agent-322",
+            scope=MemoryScope.PER_AGENT,
+            source_type="integration_test",
+            content="Stripe webhook signature validation uses STRIPE_WEBHOOK_SECRET.",
+            content_hash="322-" + record_id[:12],
+        )
+        await pg_store.save(record)
+        await pg_store.update_lifecycle(
+            workspace,
+            record_id,
+            valid_until=datetime.now(UTC) - timedelta(days=1),
+        )
+        await qdrant.upsert(record)
+
+        # --- Build worker ---
+        memory_target = MemoryTarget(pg_store=pg_store, qdrant_store_factory=lambda _ws: qdrant)
+        linker = Linker(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+            threshold=settings.freshness_linker_threshold,
+        )
+        reconciler = Reconciler(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+            threshold=settings.freshness_reconciler_threshold,
+        )
+        monitor = FreshnessMonitor(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+            stale_after_days=settings.freshness_stale_after_days,
+        )
+        curator = Curator(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+        )
+        pipelines = {
+            "memory_record": _Pipeline(
+                linker=linker,
+                reconciler=reconciler,
+                monitor=monitor,
+                curator=curator,
+                target=memory_target,
+            )
+        }
+        worker = FreshnessWorker(
+            coordination=coordination,
+            freshness_pg=freshness_pg,
+            decision_engine=RuleBasedDecisionEngine(),
+            pipelines=pipelines,
+        )
+
+        # --- Enqueue + process ---
+        await coordination.enqueue_job(
+            FreshnessJob(
+                workspace_id=workspace,
+                event_type="knowledge_changed",
+                target_kind="memory_record",
+                target_id=record_id,
+            )
+        )
+        processed = await worker.run_once(max_jobs=5)
+        assert processed == 1
+
+        # --- PG: record transitioned to ARCHIVED (Monitor valid_until rule) ---
+        fetched = await pg_store.get(workspace, record_id)
+        assert fetched is not None
+        assert fetched.status is LifecycleStatus.ARCHIVED
+
+        # --- Qdrant payload: status mirrors PG (this is the MTRNIX-322 fix) ---
+        # Search excluding archived should return empty; including should find it.
+        excluded = await qdrant.search(
+            record.content,
+            agent_id="agent-322",
+            top_k=5,
+            status_exclude=["archived"],
+        )
+        assert all(hit.get("record_id") != record_id for hit in excluded), (
+            "Record must be filtered out by payload-level ARCHIVED exclusion "
+            "— this is the MTRNIX-319 §1 regression guard."
+        )
+
+        included = await qdrant.search(
+            record.content,
+            agent_id="agent-322",
+            top_k=5,
+        )
+        # Sanity: the point still exists in Qdrant — it's only excluded by
+        # the status filter; so search WITHOUT the exclude must find it.
+        assert any(hit.get("record_id") == record_id for hit in included)
+    finally:
+        await _cleanup(engine, workspace)
+        with contextlib.suppress(Exception):
+            await qdrant.close()
+        await redis.close()
+        await engine.dispose()

--- a/tests/integration/memory/freshness/test_qdrant_sync_resilience.py
+++ b/tests/integration/memory/freshness/test_qdrant_sync_resilience.py
@@ -1,0 +1,210 @@
+"""Integration test: worker tolerates Qdrant sync failures (MTRNIX-322).
+
+Reproduces a Qdrant outage by monkey-patching
+``MemoryQdrantStore.update_payload`` to raise. The worker iteration must:
+
+1. Commit the PG lifecycle transition (Monitor → ARCHIVED).
+2. Swallow the Qdrant error inside ``MemoryTarget.sync_downstream_stores``.
+3. Increment the ``freshness_qdrant_sync_failed_total`` counter.
+4. Return normally from ``run_once`` without raising.
+
+After the outage "ends" (patch lifted), the backfill script — or a
+subsequent `update_payload` — clears the drift. That recovery path is
+exercised by the existing script, not this test; here we only pin the
+no-abort behaviour under outage.
+
+Requires: PostgreSQL, Qdrant, Redis (services assumed already up).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.core.config import get_settings
+from metatron.core.models import (
+    FreshnessJob,
+    LifecycleStatus,
+    MemoryRecord,
+    MemoryScope,
+)
+from metatron.freshness import metrics as freshness_metrics
+from metatron.memory.freshness.coordination import CoordinationStore
+from metatron.memory.freshness.curator import Curator
+from metatron.memory.freshness.decision_engine import RuleBasedDecisionEngine
+from metatron.memory.freshness.linker import Linker
+from metatron.memory.freshness.monitor import FreshnessMonitor
+from metatron.memory.freshness.reconciler import Reconciler
+from metatron.memory.freshness.target_memory import MemoryTarget
+from metatron.memory.freshness.worker import FreshnessWorker, _Pipeline
+from metatron.storage.memory_freshness_pg import FreshnessPostgresStore
+from metatron.storage.memory_postgres import MemoryPostgresStore
+from metatron.storage.memory_qdrant import MemoryQdrantStore
+from metatron.storage.redis import RedisStore
+
+pytestmark = pytest.mark.integration
+
+
+async def _cleanup(engine, workspace: str) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa_text("DELETE FROM machine_events WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM review_entries WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM memory_records WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+
+
+async def test_qdrant_outage_does_not_abort_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "freshness_enabled", True)
+
+    workspace = f"fresh-322r-{uuid4().hex[:8]}"
+    record_id = uuid4().hex
+
+    redis = RedisStore(settings.redis_url)
+    try:
+        if not await redis.ping():
+            pytest.skip("Redis unreachable")
+    except Exception:
+        pytest.skip("Redis unreachable")
+    coordination = CoordinationStore(redis=redis)
+
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg_store = MemoryPostgresStore(engine)
+    freshness_pg = FreshnessPostgresStore(engine)
+    qdrant = MemoryQdrantStore(workspace_id=workspace)
+
+    # Patch the Prometheus counter with a chain mock so we can assert it was
+    # bumped. We can't read real counter values because ``prometheus_client``
+    # is an optional dep and the runtime may be using the ``_NoopMetric``
+    # stub. This patch works under both branches.
+    mock_counter = MagicMock()
+    mock_counter.labels.return_value = mock_counter
+    monkeypatch.setattr(freshness_metrics, "qdrant_sync_failed", mock_counter)
+
+    try:
+        # --- Seed ---
+        record = MemoryRecord(
+            id=record_id,
+            workspace_id=workspace,
+            agent_id="agent-322r",
+            scope=MemoryScope.PER_AGENT,
+            source_type="integration_test",
+            content="Failover: Stripe webhook retries 3x with exponential backoff.",
+            content_hash="322r-" + record_id[:12],
+        )
+        await pg_store.save(record)
+        await pg_store.update_lifecycle(
+            workspace,
+            record_id,
+            valid_until=datetime.now(UTC) - timedelta(days=1),
+        )
+        await qdrant.upsert(record)
+
+        # --- Patch Qdrant update_payload to simulate outage ---
+        async def _boom(self, *_args, **_kwargs):  # noqa: ANN001 — duck typing
+            raise RuntimeError("qdrant down")
+
+        monkeypatch.setattr(MemoryQdrantStore, "update_payload", _boom)
+
+        # --- Build worker ---
+        memory_target = MemoryTarget(pg_store=pg_store, qdrant_store_factory=lambda _ws: qdrant)
+        linker = Linker(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+            threshold=settings.freshness_linker_threshold,
+        )
+        reconciler = Reconciler(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+            threshold=settings.freshness_reconciler_threshold,
+        )
+        monitor = FreshnessMonitor(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+            stale_after_days=settings.freshness_stale_after_days,
+        )
+        curator = Curator(
+            target=memory_target,
+            freshness_store=freshness_pg,
+            coordination=coordination,
+        )
+        pipelines = {
+            "memory_record": _Pipeline(
+                linker=linker,
+                reconciler=reconciler,
+                monitor=monitor,
+                curator=curator,
+                target=memory_target,
+            )
+        }
+        worker = FreshnessWorker(
+            coordination=coordination,
+            freshness_pg=freshness_pg,
+            decision_engine=RuleBasedDecisionEngine(),
+            pipelines=pipelines,
+        )
+
+        await coordination.enqueue_job(
+            FreshnessJob(
+                workspace_id=workspace,
+                event_type="knowledge_changed",
+                target_kind="memory_record",
+                target_id=record_id,
+            )
+        )
+
+        # --- Run worker: MUST NOT RAISE despite Qdrant outage ---
+        processed = await worker.run_once(max_jobs=5)
+        assert processed == 1
+
+        # --- PG: transition still committed ---
+        fetched = await pg_store.get(workspace, record_id)
+        assert fetched is not None
+        assert fetched.status is LifecycleStatus.ARCHIVED
+
+        # --- MachineEvents: Monitor completed event recorded ---
+        events = await freshness_pg.list_events_for_target(workspace, "memory_record", record_id)
+        stage_events = [e for e in events if e.event_type == "freshness_stage_completed"]
+        monitor_events = [
+            e
+            for e in stage_events
+            if (isinstance(e.payload, dict) and e.payload.get("stage") == "monitor")
+        ]
+        assert len(monitor_events) >= 1, (
+            f"Monitor stage MachineEvent missing; events={[e.event_type for e in events]}"
+        )
+
+        # --- Counter: incremented at least once with the right labels ---
+        assert mock_counter.labels.call_count >= 1
+        # Every call must carry the expected labels.
+        for call in mock_counter.labels.call_args_list:
+            assert call.kwargs == {
+                "target_kind": "memory_record",
+                "stage": "sync_downstream",
+            }
+        assert mock_counter.inc.call_count >= 1
+    finally:
+        await _cleanup(engine, workspace)
+        with contextlib.suppress(Exception):
+            await qdrant.close()
+        await redis.close()
+        await engine.dispose()

--- a/tests/unit/freshness/test_apply_decision_qdrant_sync.py
+++ b/tests/unit/freshness/test_apply_decision_qdrant_sync.py
@@ -1,0 +1,169 @@
+"""apply_decision + sync_downstream_stores tests (MTRNIX-322).
+
+``apply_decision`` writes ``status=STALE`` when a high-confidence decision
+has ``action="mark_stale"``. MTRNIX-322 adds a ``sync_downstream_stores``
+call after that PG write so the Qdrant ``status`` payload mirrors the
+new state. Tag-only branches and below-threshold branches do not mutate
+``status`` and therefore do NOT call the sync hook.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+from metatron.core.models import FreshnessDecision, LifecycleStatus
+from metatron.freshness.apply_decision import apply_decision
+from metatron.freshness.targets import FreshnessTargetRecord
+
+
+def _target_record(**overrides: object) -> FreshnessTargetRecord:
+    defaults: dict[str, object] = {
+        "target_id": "rec1",
+        "workspace_id": "ws1",
+        "content": "content",
+        "tags": [],
+        "status": LifecycleStatus.ACTIVE,
+        "freshness_score": 0.5,
+        "superseded_by": None,
+        "valid_until": None,
+        "updated_at": datetime(2026, 4, 20, tzinfo=UTC),
+        "evidence_count": 0,
+        "verification_state": None,
+        "last_freshness_run_at": None,
+        "agent_id": "agent1",
+    }
+    defaults.update(overrides)
+    return FreshnessTargetRecord(**defaults)  # type: ignore[arg-type]
+
+
+def _mock_target() -> AsyncMock:
+    target = AsyncMock()
+    target.kind = "memory_record"
+    return target
+
+
+async def test_mark_stale_above_threshold_syncs_qdrant() -> None:
+    target = _mock_target()
+    fs = AsyncMock()
+    record = _target_record()
+    decision = FreshnessDecision(
+        action="mark_stale",
+        confidence=0.9,
+        tags=["deprecated"],
+        rationale="content obsolete",
+    )
+
+    result = await apply_decision(
+        workspace_id="ws1",
+        record=record,
+        decision=decision,
+        threshold=0.7,
+        target=target,
+        freshness_store=fs,
+    )
+
+    assert result["applied"] is True
+    assert result["action"] == "mark_stale"
+    target.update_lifecycle.assert_awaited_once()
+    upd_kwargs = target.update_lifecycle.await_args.kwargs
+    assert upd_kwargs["status"] is LifecycleStatus.STALE
+    assert upd_kwargs["freshness_score"] == 0.25
+    target.sync_downstream_stores.assert_awaited_once_with(
+        "ws1",
+        "rec1",
+        status=LifecycleStatus.STALE,
+        freshness_score=0.25,
+    )
+
+
+async def test_tag_only_above_threshold_does_not_sync() -> None:
+    target = _mock_target()
+    fs = AsyncMock()
+    record = _target_record()
+    decision = FreshnessDecision(
+        action="tag",
+        confidence=0.85,
+        tags=["payment"],
+        rationale="classified",
+    )
+
+    result = await apply_decision(
+        workspace_id="ws1",
+        record=record,
+        decision=decision,
+        threshold=0.7,
+        target=target,
+        freshness_store=fs,
+    )
+
+    assert result["applied"] is True
+    target.update_lifecycle.assert_awaited_once()
+    target.sync_downstream_stores.assert_not_awaited()
+
+
+async def test_below_threshold_does_not_sync() -> None:
+    target = _mock_target()
+    fs = AsyncMock()
+    fs.save_review_entry.return_value = type("R", (), {"id": "rev_1"})()
+    record = _target_record()
+    decision = FreshnessDecision(
+        action="mark_stale",
+        confidence=0.4,
+        tags=["deprecated"],
+        rationale="uncertain",
+    )
+
+    result = await apply_decision(
+        workspace_id="ws1",
+        record=record,
+        decision=decision,
+        threshold=0.7,
+        target=target,
+        freshness_store=fs,
+    )
+
+    assert result["applied"] is False
+    target.update_lifecycle.assert_not_awaited()
+    target.sync_downstream_stores.assert_not_awaited()
+    fs.save_review_entry.assert_awaited_once()
+
+
+async def test_mark_stale_swallows_sync_downstream_failure() -> None:
+    """Adapter contract says the hook never raises; but if it did, the
+    decision is already PG-committed and ``apply_decision`` should return
+    the success summary nonetheless. In the current shape the exception
+    would propagate out; this test pins the behaviour explicitly so any
+    future ``try/except`` addition around the sync call is an intentional
+    change with tests to update.
+    """
+    target = _mock_target()
+    fs = AsyncMock()
+    record = _target_record()
+    decision = FreshnessDecision(
+        action="mark_stale",
+        confidence=0.95,
+        tags=[],
+        rationale="clear",
+    )
+    target.sync_downstream_stores.side_effect = RuntimeError("qdrant catastrophic")
+
+    raised = False
+    try:
+        await apply_decision(
+            workspace_id="ws1",
+            record=record,
+            decision=decision,
+            threshold=0.7,
+            target=target,
+            freshness_store=fs,
+        )
+    except RuntimeError:
+        raised = True
+
+    # PG write always happens first — it's committed regardless of sync
+    # outcome. The adapter is expected to swallow; if it does not, the
+    # worker error handler will log + counter-bump, matching the
+    # resilience behaviour elsewhere in the pipeline.
+    assert raised is True
+    target.update_lifecycle.assert_awaited_once()

--- a/tests/unit/freshness/test_curator_qdrant_sync.py
+++ b/tests/unit/freshness/test_curator_qdrant_sync.py
@@ -1,0 +1,149 @@
+"""Curator + sync_downstream_stores regression tests (MTRNIX-322).
+
+The Curator promotes CANDIDATE → ACTIVE. MTRNIX-322 adds an explicit
+``sync_downstream_stores`` call after the PG transition so the Qdrant
+``status`` payload mirrors the new state. These tests pin that wiring.
+
+We use a mocked ``FreshnessTarget`` (rather than the real ``MemoryTarget``)
+to keep the assertion surface focused on whether Curator calls the hook,
+regardless of adapter-specific implementation details.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+from metatron.core.models import LifecycleStatus
+from metatron.freshness.stages.curator import Curator
+from metatron.freshness.targets import FreshnessTargetRecord
+
+
+def _target_record(**overrides: object) -> FreshnessTargetRecord:
+    defaults: dict[str, object] = {
+        "target_id": "rec1",
+        "workspace_id": "ws1",
+        "content": "candidate memory",
+        "tags": [],
+        "status": LifecycleStatus.CANDIDATE,
+        "freshness_score": 0.5,
+        "superseded_by": None,
+        "valid_until": None,
+        "updated_at": datetime(2026, 4, 20, tzinfo=UTC),
+        "evidence_count": 1,
+        "verification_state": None,
+        "last_freshness_run_at": None,
+        "agent_id": "agent1",
+    }
+    defaults.update(overrides)
+    return FreshnessTargetRecord(**defaults)  # type: ignore[arg-type]
+
+
+def _build() -> tuple[Curator, AsyncMock, AsyncMock, AsyncMock]:
+    target = AsyncMock()
+    target.kind = "memory_record"
+    target.supports_candidate_promotion = True
+    coordination = AsyncMock()
+    freshness_store = AsyncMock()
+    curator = Curator(
+        target=target,
+        freshness_store=freshness_store,
+        coordination=coordination,
+    )
+    return curator, target, coordination, freshness_store
+
+
+async def test_promotion_calls_sync_downstream_stores() -> None:
+    curator, target, coord, fs = _build()
+    coord.acquire_lock.return_value = "tok"
+    target.get.return_value = _target_record(freshness_score=0.8)
+
+    result = await curator.run("ws1", "rec1")
+
+    assert result is LifecycleStatus.ACTIVE
+    target.update_lifecycle.assert_awaited_once()
+    target.sync_downstream_stores.assert_awaited_once_with(
+        "ws1",
+        "rec1",
+        status=LifecycleStatus.ACTIVE,
+        freshness_score=0.8,
+    )
+    fs.save_machine_event.assert_awaited_once()
+
+
+async def test_promotion_uses_default_score_when_record_score_missing() -> None:
+    """None/0 on ``record.freshness_score`` must fall back to the 0.5 default."""
+    curator, target, coord, _fs = _build()
+    coord.acquire_lock.return_value = "tok"
+    target.get.return_value = _target_record(freshness_score=0.0)
+
+    await curator.run("ws1", "rec1")
+
+    target.sync_downstream_stores.assert_awaited_once_with(
+        "ws1",
+        "rec1",
+        status=LifecycleStatus.ACTIVE,
+        freshness_score=0.5,
+    )
+
+
+async def test_no_transition_does_not_call_sync() -> None:
+    curator, target, coord, _fs = _build()
+    coord.acquire_lock.return_value = "tok"
+    # Already ACTIVE — Curator short-circuits.
+    target.get.return_value = _target_record(status=LifecycleStatus.ACTIVE)
+
+    result = await curator.run("ws1", "rec1")
+
+    assert result is None
+    target.update_lifecycle.assert_not_awaited()
+    target.sync_downstream_stores.assert_not_awaited()
+
+
+async def test_zero_evidence_does_not_call_sync() -> None:
+    curator, target, coord, _fs = _build()
+    coord.acquire_lock.return_value = "tok"
+    target.get.return_value = _target_record(evidence_count=0)
+
+    result = await curator.run("ws1", "rec1")
+
+    assert result is None
+    target.update_lifecycle.assert_not_awaited()
+    target.sync_downstream_stores.assert_not_awaited()
+
+
+async def test_sync_downstream_failure_propagates_but_lock_released() -> None:
+    """Adapter contract says the hook never raises — but Curator must tolerate
+    the exceptional case where it somehow does (belt + suspenders).
+
+    The worker hosts the ``try/finally`` for lock release; the sync call sits
+    inside the ``try`` block. A raised exception propagates out of ``run``
+    but the lock release still fires.
+    """
+    curator, target, coord, _fs = _build()
+    coord.acquire_lock.return_value = "tok"
+    target.get.return_value = _target_record()
+    target.sync_downstream_stores.side_effect = RuntimeError("qdrant catastrophically down")
+
+    # The adapter is supposed to swallow. If someone breaks the contract
+    # and the hook does raise, Curator currently lets it propagate — but
+    # the lock MUST still be released.
+    raised = False
+    try:
+        await curator.run("ws1", "rec1")
+    except RuntimeError:
+        raised = True
+
+    assert raised is True
+    coord.release.assert_awaited_once()
+
+
+async def test_kb_target_short_circuits_without_sync() -> None:
+    curator, target, coord, _fs = _build()
+    target.supports_candidate_promotion = False
+
+    result = await curator.run("ws1", "rec1")
+
+    assert result is None
+    coord.acquire_lock.assert_not_called()
+    target.sync_downstream_stores.assert_not_awaited()

--- a/tests/unit/freshness/test_monitor_qdrant_sync_memory_target.py
+++ b/tests/unit/freshness/test_monitor_qdrant_sync_memory_target.py
@@ -1,0 +1,125 @@
+"""FreshnessMonitor + MemoryTarget Qdrant sync regression tests (MTRNIX-322).
+
+MTRNIX-313 wired ``sync_downstream_stores`` into ``FreshnessMonitor.run``
+after every lifecycle transition, but the memory adapter implementation
+was a deliberate no-op. MTRNIX-322 makes the memory adapter write the
+Qdrant ``status`` payload. These tests pin that behaviour against the
+real ``MemoryTarget`` (not a mocked target) so a future refactor cannot
+accidentally sever the wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from metatron.core.models import LifecycleStatus, MemoryRecord, MemoryScope
+from metatron.freshness.stages.monitor import FreshnessMonitor
+from metatron.memory.freshness.target_memory import MemoryTarget
+
+
+def _record(**overrides: object) -> MemoryRecord:
+    now = datetime.now(UTC)
+    defaults: dict[str, object] = {
+        "id": "rec1",
+        "workspace_id": "ws1",
+        "agent_id": "agent1",
+        "scope": MemoryScope.PER_AGENT,
+        "content": "content",
+        "created_at": now - timedelta(days=10),
+        "updated_at": now - timedelta(days=10),
+    }
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+def _build_monitor(
+    stale_days: int = 30,
+) -> tuple[FreshnessMonitor, MagicMock, AsyncMock, AsyncMock]:
+    pg = MagicMock()
+    pg.get = AsyncMock()
+    pg.update_lifecycle = AsyncMock()
+    qdrant = AsyncMock()
+    qdrant.update_payload = AsyncMock()
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: qdrant)
+    coordination = AsyncMock()
+    freshness_store = AsyncMock()
+    monitor = FreshnessMonitor(
+        target=target,
+        freshness_store=freshness_store,
+        coordination=coordination,
+        stale_after_days=stale_days,
+    )
+    return monitor, pg, qdrant, freshness_store
+
+
+async def test_archived_transition_syncs_qdrant_status() -> None:
+    monitor, pg, qdrant, freshness_store = _build_monitor()
+    monitor._coord.acquire_lock = AsyncMock(return_value="tok")  # type: ignore[attr-defined]
+    monitor._coord.release = AsyncMock()  # type: ignore[attr-defined]
+    pg.get.return_value = _record(
+        valid_until=datetime.now(UTC) - timedelta(days=1),
+    )
+
+    await monitor.run("ws1", "rec1")
+
+    qdrant.update_payload.assert_awaited_once_with("rec1", {"status": "archived"})
+    freshness_store.save_machine_event.assert_awaited_once()
+
+
+async def test_superseded_transition_syncs_qdrant_status() -> None:
+    monitor, pg, qdrant, freshness_store = _build_monitor()
+    monitor._coord.acquire_lock = AsyncMock(return_value="tok")  # type: ignore[attr-defined]
+    monitor._coord.release = AsyncMock()  # type: ignore[attr-defined]
+    pg.get.return_value = _record(superseded_by="rec-new")
+
+    await monitor.run("ws1", "rec1")
+
+    qdrant.update_payload.assert_awaited_once_with("rec1", {"status": "superseded"})
+    freshness_store.save_machine_event.assert_awaited_once()
+
+
+async def test_stale_transition_syncs_qdrant_status() -> None:
+    monitor, pg, qdrant, freshness_store = _build_monitor(stale_days=5)
+    monitor._coord.acquire_lock = AsyncMock(return_value="tok")  # type: ignore[attr-defined]
+    monitor._coord.release = AsyncMock()  # type: ignore[attr-defined]
+    pg.get.return_value = _record(
+        updated_at=datetime.now(UTC) - timedelta(days=10),
+    )
+
+    await monitor.run("ws1", "rec1")
+
+    qdrant.update_payload.assert_awaited_once_with("rec1", {"status": "stale"})
+    freshness_store.save_machine_event.assert_awaited_once()
+
+
+async def test_fresh_record_skips_qdrant_sync() -> None:
+    monitor, pg, qdrant, freshness_store = _build_monitor(stale_days=30)
+    monitor._coord.acquire_lock = AsyncMock(return_value="tok")  # type: ignore[attr-defined]
+    monitor._coord.release = AsyncMock()  # type: ignore[attr-defined]
+    pg.get.return_value = _record(
+        updated_at=datetime.now(UTC) - timedelta(days=1),
+    )
+
+    await monitor.run("ws1", "rec1")
+
+    qdrant.update_payload.assert_not_awaited()
+    freshness_store.save_machine_event.assert_not_awaited()
+
+
+async def test_qdrant_failure_does_not_abort_monitor() -> None:
+    """Best-effort semantics — worker loop stays alive on Qdrant failure."""
+    monitor, pg, qdrant, freshness_store = _build_monitor()
+    monitor._coord.acquire_lock = AsyncMock(return_value="tok")  # type: ignore[attr-defined]
+    monitor._coord.release = AsyncMock()  # type: ignore[attr-defined]
+    pg.get.return_value = _record(
+        valid_until=datetime.now(UTC) - timedelta(days=1),
+    )
+    qdrant.update_payload.side_effect = RuntimeError("qdrant down")
+
+    # Must not raise.
+    new_status = await monitor.run("ws1", "rec1")
+
+    assert new_status is LifecycleStatus.ARCHIVED
+    pg.update_lifecycle.assert_awaited_once()
+    freshness_store.save_machine_event.assert_awaited_once()

--- a/tests/unit/memory/freshness/test_target_memory.py
+++ b/tests/unit/memory/freshness/test_target_memory.py
@@ -138,9 +138,12 @@ async def test_link_edges_batch_is_best_effort_on_neo4j_failure() -> None:
         await target.link_edges_batch("ws", "rec1", [("rec2", 0.9)])
 
 
-async def test_sync_downstream_stores_is_noop_for_memory() -> None:
+async def test_sync_downstream_stores_writes_status_payload() -> None:
+    """MTRNIX-322: adapter now mirrors PG status onto the Qdrant payload."""
     pg = MagicMock()
-    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: MagicMock())
+    qdrant = AsyncMock()
+    qdrant.update_payload = AsyncMock()
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: qdrant)
 
     result = await target.sync_downstream_stores(
         "ws",
@@ -150,3 +153,4 @@ async def test_sync_downstream_stores_is_noop_for_memory() -> None:
     )
 
     assert result is None
+    qdrant.update_payload.assert_awaited_once_with("rec1", {"status": "archived"})

--- a/tests/unit/memory/freshness/test_target_memory_sync_downstream.py
+++ b/tests/unit/memory/freshness/test_target_memory_sync_downstream.py
@@ -1,0 +1,137 @@
+"""MemoryTarget.sync_downstream_stores tests (MTRNIX-322).
+
+Covers the Qdrant status payload mirroring introduced in MTRNIX-322:
+
+* Happy path: ``qdrant.update_payload`` is called with
+  ``{"status": status.value}`` only (``freshness_score`` is intentionally
+  dropped — see adapter docstring).
+* Failure path: ``update_payload`` raising any ``Exception`` must be
+  swallowed (PG remains source of truth) and the
+  ``freshness_qdrant_sync_failed_total`` counter incremented exactly once.
+* Happy path does not touch the counter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from metatron.core.models import LifecycleStatus
+from metatron.freshness import metrics as freshness_metrics
+from metatron.memory.freshness.target_memory import MemoryTarget
+
+
+async def test_sync_downstream_writes_status_only_on_happy_path() -> None:
+    pg = MagicMock()
+    qdrant = AsyncMock()
+    qdrant.update_payload = AsyncMock()
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: qdrant)
+
+    await target.sync_downstream_stores(
+        "ws",
+        "rec_abc",
+        status=LifecycleStatus.STALE,
+        freshness_score=0.25,
+    )
+
+    qdrant.update_payload.assert_awaited_once_with("rec_abc", {"status": "stale"})
+
+
+async def test_sync_downstream_swallows_qdrant_errors() -> None:
+    pg = MagicMock()
+    qdrant = AsyncMock()
+    qdrant.update_payload = AsyncMock(side_effect=RuntimeError("qdrant down"))
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: qdrant)
+
+    # Must not raise.
+    await target.sync_downstream_stores(
+        "ws",
+        "rec_abc",
+        status=LifecycleStatus.ARCHIVED,
+        freshness_score=0.0,
+    )
+
+
+async def test_sync_downstream_increments_counter_on_failure() -> None:
+    pg = MagicMock()
+    qdrant = AsyncMock()
+    qdrant.update_payload = AsyncMock(side_effect=RuntimeError("qdrant down"))
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: qdrant)
+
+    mock_counter = MagicMock()
+    # ``.labels(...)`` returns a child metric; we then call ``.inc()`` on it.
+    mock_counter.labels.return_value = mock_counter
+    with patch.object(freshness_metrics, "qdrant_sync_failed", mock_counter):
+        await target.sync_downstream_stores(
+            "ws",
+            "rec_abc",
+            status=LifecycleStatus.ARCHIVED,
+            freshness_score=0.0,
+        )
+
+    mock_counter.labels.assert_called_once_with(
+        target_kind="memory_record",
+        stage="sync_downstream",
+    )
+    mock_counter.inc.assert_called_once()
+
+
+async def test_sync_downstream_does_not_increment_counter_on_success() -> None:
+    pg = MagicMock()
+    qdrant = AsyncMock()
+    qdrant.update_payload = AsyncMock()
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: qdrant)
+
+    mock_counter = MagicMock()
+    mock_counter.labels.return_value = mock_counter
+    with patch.object(freshness_metrics, "qdrant_sync_failed", mock_counter):
+        await target.sync_downstream_stores(
+            "ws",
+            "rec_abc",
+            status=LifecycleStatus.ACTIVE,
+            freshness_score=0.5,
+        )
+
+    mock_counter.labels.assert_not_called()
+    mock_counter.inc.assert_not_called()
+
+
+async def test_sync_downstream_swallows_resolver_errors() -> None:
+    """Even the factory raising (e.g. misconfigured Qdrant client) must not leak."""
+    pg = MagicMock()
+
+    def _broken_factory(_ws: str) -> object:
+        raise RuntimeError("qdrant client unavailable")
+
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=_broken_factory)
+
+    mock_counter = MagicMock()
+    mock_counter.labels.return_value = mock_counter
+    with patch.object(freshness_metrics, "qdrant_sync_failed", mock_counter):
+        # Must not raise.
+        await target.sync_downstream_stores(
+            "ws",
+            "rec_abc",
+            status=LifecycleStatus.SUPERSEDED,
+            freshness_score=0.1,
+        )
+
+    mock_counter.inc.assert_called_once()
+
+
+async def test_sync_downstream_still_survives_when_metrics_break() -> None:
+    """Metrics must never bite — even if ``.labels(...).inc()`` raises."""
+    pg = MagicMock()
+    qdrant = AsyncMock()
+    qdrant.update_payload = AsyncMock(side_effect=RuntimeError("qdrant down"))
+    target = MemoryTarget(pg_store=pg, qdrant_store_factory=lambda _ws: qdrant)
+
+    mock_counter = MagicMock()
+    mock_counter.labels.side_effect = RuntimeError("metrics registry broken")
+    with patch.object(freshness_metrics, "qdrant_sync_failed", mock_counter):
+        # Must not raise.
+        await target.sync_downstream_stores(
+            "ws",
+            "rec_abc",
+            status=LifecycleStatus.STALE,
+            freshness_score=0.25,
+        )


### PR DESCRIPTION
## Summary

Closes the worker-side drift between PG `memory_records.status` and the `mem_agent_memory_{workspace_id}` Qdrant collection's `status` payload. Every freshness-pipeline lifecycle transition now calls `MemoryTarget.sync_downstream_stores`, which best-effort mirrors the new status onto the Qdrant point via `update_payload`.

Reproduction for this bug was captured in MTRNIX-319 §1: worker transitions wrote PG but not Qdrant, causing `memory_search(status=["active"])` to leak stale/superseded records through the filter. Running `scripts/backfill_memory_qdrant_status_payload.py` fixed the drift by hand. This PR removes the need for that workaround on forward traffic; the backfill script stays as a safety net for historical drift and post-outage recovery.

## Approach

Architect chose to **reuse the existing `FreshnessTarget.sync_downstream_stores` hook** (added in MTRNIX-313 for KB) rather than introduce a parallel `apply_lifecycle` method. Rationale documented in `docs/superpowers/specs/2026-04-24-memory-freshness-qdrant-status-sync-design.md` under "Decision: Option A vs Option B".

### Changed code
- `src/metatron/memory/freshness/target_memory.py` — `sync_downstream_stores` now writes `{"status": status.value}` to the Qdrant point (best-effort, logs + counter on failure).
- `src/metatron/freshness/stages/curator.py` — calls `sync_downstream_stores` after CANDIDATE → ACTIVE transition.
- `src/metatron/freshness/apply_decision.py` — calls `sync_downstream_stores` on the mark_stale path.
- `src/metatron/freshness/stages/monitor.py` — already called it; no functional change (covered by new regression tests).
- `src/metatron/freshness/metrics.py` + `src/metatron/memory/freshness/metrics.py` (re-export shim) — new counter `freshness_qdrant_sync_failed_total{target_kind, stage}`.

### Tests
- 5 new unit test files covering adapter, stages, and failure paths.
- 2 new integration tests (`test_qdrant_status_sync_live.py`, `test_qdrant_sync_resilience.py`).

### Safety / graceful degradation
- Qdrant failure does NOT abort the worker's PG transition.
- Exception logged at WARNING, counter incremented.
- Consistent with existing `resolve_review` pattern (PR #86 / PR #89).

## Architect decisions
1. **sync_downstream_stores, not new apply_lifecycle** — symmetric with KB adapter.
2. **Reconciler doesn't mutate `memory_records.status`** — confirmed, no change needed.
3. **No cross-store atomicity** — PG and Qdrant are different stores, no shared transaction. Best-effort outside PG commit, same pattern as MTRNIX-314 `resolve_review`.
4. **Counter `freshness_qdrant_sync_failed_total{target_kind, stage}`** — added to existing `freshness/metrics.py`.
5. **Backfill script stays** — historical records + ops safety net.

## Test plan

- [x] `make lint` — clean on touched files
- [x] `make typecheck` — zero new errors on 5 touched source files (83 pre-existing errors in unrelated files)
- [x] Unit suite: 164 passing across `tests/unit/{memory,freshness,mcp}/`
- [x] Integration suite: 5 passing across `tests/integration/{memory,ingestion}/freshness/`
- [x] `docs/MEMORY_MCP_FOLLOWUPS.md` item #4 removed (resolved by this PR)
- [x] Architect spec + plan committed to `docs/superpowers/`

## Enterprise coordination
- New Prometheus counter `freshness_qdrant_sync_failed_total` — non-breaking, Grafana dashboards may want to add a panel. Recommended alert: non-zero rate over 1h → run backfill script on affected workspace.