### PR TITLE
chore(MTRNIX-319): eval dataset v1.3 refresh + rollout notes

### DIFF
--- a/docs/ROLLOUT_NOTES_2026-04-24.md
+++ b/docs/ROLLOUT_NOTES_2026-04-24.md
@@ -1,0 +1,139 @@
+# Metatron Core — Rollout Notes
+
+**Cut date:** 2026-04-24
+**Baseline commit:** develop @ `65cb4f5` (post-MTRNIX-322)
+**Preceded by:** MTRNIX-319 pre-prod validation gate
+
+This note is for teams picking up Metatron Core for the first time. It covers what ships, what is known-safe, what is known-broken-but-flag-gated, and what to expect operationally.
+
+## What you get
+
+- **MCP server** (`/mcp`, Streamable HTTP) with 14 tools — document RAG + agent memory + review queue. Full reference: `docs/MCP_API.md`, integration guide: `docs/HERMES_INTEGRATION.md`.
+- **OpenAI-compatible endpoint** (`/v1/chat/completions`) — RAG-backed completions for OpenWebUI / LibreChat / any OAI SDK.
+- **REST API** (`/api/v1/*`) — raw CRUD for memory, documents, workspaces, connectors, **agents** (new — MTRNIX-270).
+- **Freshness worker** (opt-in, `python -m metatron.memory.freshness`) — background lifecycle maintenance for agent memory and KB.
+- **Enterprise plugin** (optional) — JWT auth, RBAC, audit log, usage metering. Loaded automatically when the package is present.
+
+## What has been validated
+
+Ran through MTRNIX-319 pre-prod gate:
+
+| Area | Status | Notes |
+|---|---|---|
+| Search quality on live corpus | ✅ Baseline: P@10=0.14, MRR=0.63, NDCG@10=0.58 on refreshed v1.3 eval set | Honest numbers; includes known drift since March |
+| Connector sync with non-ASCII content | ✅ Russian Confluence article synced end-to-end, top-1 score 1.00 on Russian query | Tested on live Confluence during validation |
+| Freshness worker | ✅ Starts clean, idles correctly on empty queue, processes jobs in ~700ms through all 5 stages | Flag-gated via `METATRON_FRESHNESS_ENABLED` |
+| Review-queue e2e via MCP | ✅ Reconciler flags near-duplicates, `memory_review_resolve` is atomic (PR #89) | Unicode `notes` payload round-trips byte-for-byte |
+| Agent Registry CRUD + lifecycle + RBAC | ✅ 13 checks green; see "Quirks" below for UX notes | `/api/v1/agents/*` |
+| Neo4j post-restart | ✅ 2448 nodes / 7827 rels healthy, Russian entities stored natively | Per-workspace scoping works |
+| Status filter on memory search | ✅ Push-down filter works on Qdrant + PG + graph legs | Default `["active"]`; `["all"]` disables |
+| UTF-8 across the stack | ✅ JSONB writes with Russian/em-dash/emoji round-trip cleanly | Metadata migration done locally; docker-compose default already UTF-8 |
+
+## What ships flag-off (safe default)
+
+These features are in the codebase but gated off. Flipping them requires explicit decision and validation.
+
+| Flag | Default | What flipping does | Pre-flip gate |
+|---|---|---|---|
+| `METATRON_FRESHNESS_ENABLED` | `false` | Starts the memory freshness worker | Run worker on staging ≥15 min on empty queue first |
+| `METATRON_FRESHNESS_KB_ENABLED` | `false` | Enables the KB (raw_documents) freshness pipeline | Requires `FRESHNESS_ENABLED=true`. Run `make eval-compare` with/without to gauge drift |
+| `METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED` | `false` | Push-down ARCHIVED/SUPERSEDED filter into document retrieval | Run `make eval-compare`; ±0.5 pp NDCG band |
+| `METATRON_FRESHNESS_WEIGHT` | `0.0` | Adds a freshness signal to the scoring formula | Any value > 0 changes rankings; grid-search weights first |
+| `HYDE_ENABLED` | `false` | HyDE for short/vague queries | Currently regresses eval, off by default |
+| `ADAPTIVE_RRF_ENABLED` | `false` | Adaptive RRF fusion | Currently regresses eval, off by default |
+
+## Known issues & workarounds
+
+### Event loop flake in `scripts/run_eval.py`
+
+Running `make eval-compare` produces 8 `qdrant.async.hybrid_search.fallback` events out of 29 queries — an async client lifecycle bug in the eval script itself (not in the product). Queries degrade to partial recall silently on those 8 items. Tracked in MTRNIX-323 (eval infra cleanup).
+
+**Workaround:** eval numbers are a ±0.02 P@K noise band. Treat metrics as directional.
+
+### Eval dataset v1.3 — temporal queries still pinned
+
+The dataset we shipped today fixes **11 Confluence doc_label IDs** that had moved after a workspace reorg (MTRNIX-319 §5). Remaining caveat: queries like `time-01 "What tickets were created this month?"` or `exec-02 "What tasks are currently in progress?"` still reference specific Jira tickets that were "in progress last sprint" — those tickets transitioned to Done, so these queries will always miss now. Tracked in MTRNIX-323 for refresh.
+
+**Workaround:** focus on the non-temporal categories (doc, rel, mix, ru, typo) for meaningful quality signal.
+
+### Agent Registry soft-delete semantics
+
+`DELETE /api/v1/agents/{id}` is a soft-delete (`status=archived`) — `GET /{id}` after DELETE returns 200 with the archived record (by design — admin visibility). More surprisingly, `POST /{id}/start` on an archived agent **transitions it back to `active`** — effectively an un-delete via lifecycle. Not technically a bug (the spec says lifecycle is a simple status flip), but UX-non-obvious.
+
+**Workaround:** if you want a truly destructive delete, use direct DB access or wait for the explicit `force_delete` API. If you want "undelete", `POST /{id}/start` is the path — document this in your client code.
+
+### Pre-existing code regressions accepted
+
+- Recall channels refactor (~March 31) introduced a documented −6–8% on eval metrics. Accepted trade-off for cleaner architecture; will be revisited once WS1 lands end-to-end.
+- `recall_dense_async` previously returned `[]` silently under heavy concurrent sync load. Fixed in PR #88 (`2026-04-23`), but older snapshots of develop may still show it.
+
+## Operational setup
+
+### Required services
+
+All on default ports unless noted:
+
+- PostgreSQL 16+ (UTF-8 encoding required for JSONB freshness payloads — docker-compose `postgres:16-alpine` defaults to this)
+- Qdrant v1.16+
+- Neo4j CE v5
+- Redis (for session cache + freshness queue)
+- Ollama OR any OpenAI-compatible LLM endpoint
+
+### Auth surface
+
+- **MCP endpoint** (`/mcp`) — single bearer token via `METATRON_MCP_API_KEY`
+- **REST API + OAI-compat** — JWT via `/api/v1/auth/login` (email + password) OR personal API keys `mtk_...`
+- **Enterprise plugin** forces `AUTH_ENABLED=true` when present
+
+### First-run checklist
+
+1. Set `.env` per `docs/GETTING_STARTED.md`
+2. `make docker-up` for PG / Qdrant / Neo4j / Redis
+3. `make migrate` (Alembic auto-runs on app startup too)
+4. `python -m metatron.app` — API + channels (Telegram/Slack/Discord if configured)
+5. Optional, in a separate terminal: `python -m metatron.memory.freshness` — only after setting `METATRON_FRESHNESS_ENABLED=true` in `.env`
+
+### Smoke test recipe
+
+After first run, validate with:
+
+```bash
+# 1. Health
+curl -sS http://localhost:8000/health
+
+# 2. JWT login (enterprise plugin)
+TOKEN=$(curl -sS -X POST http://localhost:8000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"<admin@your.domain>","password":"<pw>"}' | jq -r .token)
+
+# 3. Store a memory
+curl -sS -X POST http://localhost:8000/api/v1/memory/records \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"agent_id":"smoke","content":"test memory","scope":"per_agent"}'
+
+# 4. Search it back
+curl -sS -X POST http://localhost:8000/api/v1/memory/search \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"agent_id":"smoke","query":"test memory"}'
+
+# 5. Create an agent
+curl -sS -X POST http://localhost:8000/api/v1/agents \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"smoke","model":"claude-sonnet-4-5"}'
+```
+
+For MCP validation, use a real MCP client (Claude Desktop / Cursor / Hermes with a working LLM) and call `metatron_search_fast`.
+
+## Roadmap items filed as follow-ups
+
+- **MTRNIX-323** — pre-rollout follow-ups bundle (eval infra flake, dataset refresh, Agent Registry UX decision, optional OAI-compat smoke)
+- **MTRNIX-322** — Memory freshness Qdrant sync (already merged — `2026-04-24`)
+- **MTRNIX-316** — Freshness queue reliability (pre-prod gate for flipping `FRESHNESS_ENABLED=true` in a production environment)
+
+## References
+
+- Architecture — `docs/ARCHITECTURE.md`
+- MCP reference — `docs/MCP_API.md`
+- Hermes integration — `docs/HERMES_INTEGRATION.md`
+- Memory MCP follow-ups — `docs/MEMORY_MCP_FOLLOWUPS.md`
+- Per-module rules — `src/metatron/*/.claude/CLAUDE.md`

--- a/src/metatron/benchmarker/fixtures/search_quality_testset.yaml
+++ b/src/metatron/benchmarker/fixtures/search_quality_testset.yaml
@@ -1,11 +1,11 @@
-version: "1.2"
+version: "1.3"
 description: >
   Search quality evaluation test set for MTRNIX workspace.
   Queries across 12 intent categories with ground-truth doc_labels.
   doc_labels match the doc_label field in Qdrant payloads.
   Categories with expected_doc_labels: [] are negative tests —
   the system should NOT return relevant results for these.
-  Based on real MTRNIX workspace data. Last updated 2026-03-30.
+  Based on real MTRNIX workspace data. Last updated 2026-04-24 (Confluence doc_label IDs refreshed after workspace reorg — MTRNIX-319 §5).
 
 queries:
   # --- Category: execution/status-heavy (Jira primary) ---
@@ -37,23 +37,23 @@ queries:
     text: "What is Metatron?"
     category: "documentation-heavy"
     expected_doc_labels:
-      - "285343747"
-      - "361398273"
-      - "285409288"
+      - "3835512"
+      - "3834245"
+      - "3835541"
     notes: "Should find Metatron overview pages: Unified Knowledge Fabric, PRD v2.0, Enterprise Knowledge Core"
 
   - id: "doc-02"
     text: "What are the coding standards and development rules?"
     category: "documentation-heavy"
     expected_doc_labels:
-      - "266862595"
+      - "3834017"
     notes: "Should find 'Development guide and rules' confluence page"
 
   - id: "doc-03"
     text: "What research has been done on graph databases?"
     category: "documentation-heavy"
     expected_doc_labels:
-      - "314245121"
+      - "3834085"
       - "MTRNIX-69"
     notes: "FalkorDB vs Memgraph evaluation + Ultra-fast Graph DB RnD ticket"
 
@@ -79,7 +79,7 @@ queries:
     text: "What are the FP-Service model testing results?"
     category: "user-file-heavy"
     expected_doc_labels:
-      - "244187137"
+      - "3833925"
     notes: "FP-Service Model Testing Results confluence page"
 
   # --- Category: relationship-heavy (graph primary) ---
@@ -89,7 +89,7 @@ queries:
     expected_doc_labels:
       - "MTRNIX-104"
       - "MTRNIX-154"
-      - "345112578"
+      - "3836625"
     notes: "RBAC ticket + RBAC for uploads ticket + RBAC Implementation Plan"
 
   - id: "rel-02"
@@ -104,7 +104,7 @@ queries:
     text: "How is Metatron used for customer experience intelligence?"
     category: "relationship-heavy"
     expected_doc_labels:
-      - "285376513"
+      - "3835526"
     notes: "Customer Experience Intelligence confluence page"
 
   # --- Category: mixed (balanced) ---
@@ -112,7 +112,7 @@ queries:
     text: "What is the RBAC implementation plan for Metatron?"
     category: "mixed"
     expected_doc_labels:
-      - "345112578"
+      - "3836625"
       - "MTRNIX-104"
     notes: "Confluence plan + Jira implementation ticket"
 
@@ -120,15 +120,15 @@ queries:
     text: "What are the search enhancement improvements?"
     category: "mixed"
     expected_doc_labels:
-      - "341999617"
+      - "3836457"
     notes: "Search enhancement confluence page"
 
   - id: "mix-03"
     text: "How does the cost savings analytics work?"
     category: "mixed"
     expected_doc_labels:
-      - "345669633"
-      - "329351178"
+      - "3834225"
+      - "3836373"
     notes: "Cost Savings Analytics + FinOps Dashboard analytics pages"
 
   - id: "mix-04"
@@ -152,7 +152,7 @@ queries:
     text: "What was the latest update on RBAC?"
     category: "temporal"
     expected_doc_labels:
-      - "345112578"
+      - "3836625"
       - "MTRNIX-104"
       - "MTRNIX-154"
     notes: "Most recent RBAC-related activity — should surface latest docs"
@@ -169,9 +169,9 @@ queries:
     text: "Show me documentation updated in 2026"
     category: "temporal"
     expected_doc_labels:
-      - "345112578"
-      - "345669633"
-      - "341999617"
+      - "3836625"
+      - "3834225"
+      - "3836457"
     notes: "Broad temporal filter — should find recently updated confluence pages"
 
   - id: "time-05"
@@ -188,9 +188,9 @@ queries:
     text: "Что такое Метатрон?"
     category: "russian"
     expected_doc_labels:
-      - "285343747"
-      - "361398273"
-      - "285409288"
+      - "3835512"
+      - "3834245"
+      - "3835541"
     notes: "Russian version of doc-01 — should find Metatron overview pages"
 
   - id: "ru-02"
@@ -206,7 +206,7 @@ queries:
     text: "Расскажи про план внедрения RBAC"
     category: "russian"
     expected_doc_labels:
-      - "345112578"
+      - "3836625"
       - "MTRNIX-104"
     notes: "Russian version of mix-01 — RBAC implementation plan"
 
@@ -223,8 +223,8 @@ queries:
     text: "Как работает аналитика экономии затрат?"
     category: "russian"
     expected_doc_labels:
-      - "345669633"
-      - "329351178"
+      - "3834225"
+      - "3836373"
     notes: "Russian version of mix-03 — cost savings analytics"
 
   # --- Category: typo (misspellings, wrong identifiers) ---
@@ -232,9 +232,9 @@ queries:
     text: "What is Metatorn?"
     category: "typo"
     expected_doc_labels:
-      - "285343747"
-      - "361398273"
-      - "285409288"
+      - "3835512"
+      - "3834245"
+      - "3835541"
     notes: "Misspelling of 'Metatron' — should still find Metatron overview pages"
 
   - id: "typo-02"
@@ -248,7 +248,7 @@ queries:
     text: "What research was done on FalkerDB?"
     category: "typo"
     expected_doc_labels:
-      - "314245121"
+      - "3834085"
       - "MTRNIX-69"
     notes: "Misspelling of FalkorDB — should still find graph DB research"
 
@@ -305,14 +305,14 @@ queries:
     text: "List all confluence pages about RBAC"
     category: "aggregation"
     expected_doc_labels:
-      - "345112578"
+      - "3836625"
     notes: "List/enumeration query — should find RBAC Implementation Plan page"
 
   - id: "agg-03"
     text: "What are all the research topics explored?"
     category: "aggregation"
     expected_doc_labels:
-      - "314245121"
+      - "3834085"
       - "MTRNIX-69"
       - "MTRNIX-35"
       - "MTRNIX-92"


### PR DESCRIPTION
## Summary

Closes the MTRNIX-319 pre-prod validation gate. Two artefacts:

### 1. Eval dataset v1.3 refresh

The Confluence workspace was reorganised at some point between the March 31 eval baseline and today — pages moved from the old ID range (2xx-3xx M) to a new range (3.8 M). 11 doc_label IDs in the test set pointed at pages that no longer exist. Search was finding the right content at the new IDs, but eval scored it as misses.

Mapping (old → new):
- `285343747` → `3835512` (Unified Knowledge Fabric)
- `361398273` → `3834245` (PRD v2.0)
- `285409288` → `3835541` (Enterprise Knowledge Core)
- `266862595` → `3834017` (Development guide)
- `314245121` → `3834085` (FalkorDB vs Memgraph)
- `244187137` → `3833925` (FP-Service Model Testing)
- `285376513` → `3835526` (Customer Experience Intelligence)
- `345112578` → `3836625` (RBAC Implementation Plan)
- `341999617` → `3836457` (Search enhancement)
- `345669633` → `3834225` (Cost Savings Analytics)
- `329351178` → `3836373` (FinOps Dashboard)

28 doc_label references updated. Version bumped 1.2 → 1.3.

### 2. Impact on measured quality

|  | Before (stale IDs) | After (refreshed) |
|---|---|---|
| P@10 | 0.05 | **0.14** (+201%) |
| MRR | 0.26 | **0.63** (+145%) |
| NDCG@10 | 0.22 | **0.58** (+165%) |

44 improvements, 0 regressions — the fix exposes the actual retrieval quality that was hidden by stale ground truth.

### 3. Rollout notes

`docs/ROLLOUT_NOTES_2026-04-24.md` — single-file onboarding doc for a team picking up Metatron Core for the first time:
- What ships (MCP, OAI-compat, REST, freshness worker, enterprise plugin)
- What's been validated through MTRNIX-319 §1–6
- Flag-gated defaults table (freshness flags, HyDE, adaptive RRF)
- Known issues + workarounds (documented honestly, not glossed)
- First-run smoke test recipe
- Links to MTRNIX-316 / 322 / 323 followups

## What's NOT in this PR

Items flagged in the rollout note but tracked separately in MTRNIX-323 (filed today):
1. `Event loop is closed` flake in `scripts/run_eval.py` (8/29 queries degrade silently)
2. Temporal/status queries in the eval set still pinned to March (exec-02, time-01, agg-01…)
3. Agent Registry `DELETE → start` un-delete UX
4. Optional OAI-compat `/v1/chat/completions` smoke

## Test plan

- [x] `make eval-compare` run after refresh — numbers in the table above
- [x] No code changes — yaml + docs only, lint/typecheck unaffected
- [x] MTRNIX-323 filed with full scope and priorities

## References

- MTRNIX-319 — validation gate (to be closed after this PR merges)
- MTRNIX-322 — worker→Qdrant sync (merged `65cb4f5`)
- MTRNIX-323 — pre-rollout follow-ups (new)