### PR TITLE
docs(MTRNIX-319): CHANGELOG + Agent Registry lifecycle caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 ## [Unreleased]
 
 ### Added
+- chore: Pre-rollout validation gate closed (MTRNIX-319). Eval dataset
+  v1.3 refreshes 11 Confluence doc_label IDs that drifted to new
+  page IDs after a workspace reorg — restored measurable retrieval
+  quality (P@10 0.05 → 0.14, MRR 0.26 → 0.63, NDCG 0.22 → 0.58).
+  New onboarding doc `docs/ROLLOUT_NOTES_2026-04-24.md` for teams
+  picking up the project. Remaining loose ends (eval event-loop flake,
+  temporal-query hygiene, Agent Registry UX, optional OAI smoke)
+  tracked as MTRNIX-323.
+
+### Fixed
+- fix: `MemoryService.resolve_review` is now atomic across its three
+  PG writes (MTRNIX-319, PR #89). Previously each of update_lifecycle /
+  delete_review_entry / save_machine_event ran in its own
+  `engine.begin()` transaction — a failure on the third left the first
+  two committed while the caller received an error. Added
+  `MemoryPostgresStore.begin()` + optional `conn` kwarg on the three
+  store methods; the service now opens one transaction and threads
+  the connection through. Same PR also fixes misleading error
+  bucketing: DB-error exceptions (`DBAPIError`, `OperationalError`,
+  `UntranslatableCharacterError`, etc.) no longer get bucketed as
+  `WORKSPACE_NOT_FOUND` based on the SQL text containing
+  `workspace_id`. 14 new unit tests.
+
+### Added
 - feat: Freshness worker syncs memory Qdrant status payload on every
   lifecycle transition (MTRNIX-322). `MemoryTarget.sync_downstream_stores`
   now writes `{"status": status.value}` onto the per-workspace Qdrant

--- a/src/metatron/agents/.claude/CLAUDE.md
+++ b/src/metatron/agents/.claude/CLAUDE.md
@@ -79,7 +79,10 @@ Aligns with the `memory/` convention:
   own the contract.
 - **Lifecycle is DB-only** — start/stop/pause flip the `status` flag; no
   process control, no scheduler coupling. A separate service will observe
-  status changes and act.
+  status changes and act. `_transition_status` does not validate the
+  source → target edge, so `POST /start` on an archived agent transitions
+  it back to ACTIVE — effectively an un-delete. UX decision pending under
+  MTRNIX-323; callers doing DELETE → retry → /start should be aware.
 - **Versioning on config change only** — lifecycle transitions do NOT bump
   `config_version`. Each version row contains a full snapshot (not a diff)
   so rollback is a simple swap.


### PR DESCRIPTION
Post-merge documentation audit found two stale spots:

## 1. CHANGELOG.md

The in-code fixes from today (PR #89 `resolve_review` atomicity + error classification, PR #91 eval dataset v1.3 refresh + rollout notes) were merged without CHANGELOG entries. Adding them under the existing `[Unreleased]` section:

- **Added**: chore note about MTRNIX-319 validation gate closing, eval dataset refresh, and the new `docs/ROLLOUT_NOTES_2026-04-24.md` onboarding doc
- **Fixed**: `resolve_review` atomicity fix + error-bucketing fix from PR #89

MTRNIX-322 entry from earlier was already present.

## 2. `src/metatron/agents/.claude/CLAUDE.md`

The "Lifecycle is DB-only" bullet said start/stop/pause flip the status flag, but didn't note that `_transition_status` accepts **any** source state — so `POST /start` on an archived agent un-deletes it. MTRNIX-319 §5 testing surfaced this; MTRNIX-323 holds the UX decision. Adding a one-sentence caveat so anyone reading the module docs sees it.

## Test plan

- [x] No code changes — markdown only
- [x] References match reality (MTRNIX-323 exists, PR #89 / #91 merged, ROLLOUT_NOTES file present)