### PR TITLE
feat(MTRNIX-316): freshness queue reliability — reclaim + scheduled scan + env prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 ## [Unreleased]
 
 ### Added
+- feat: Freshness queue reliability — processing-list reclaim + scheduled-scan
+  safety net + env-prefixed Redis keys close the Phase A pre-prod gaps
+  (MTRNIX-316). **Requires Redis >= 6.2 for `LMOVE`.** The worker no longer
+  loses jobs on a SIGKILL mid-batch: each worker claims a unique
+  `worker_id = {hostname}:{pid}:{short-uuid}` at bootstrap and moves
+  dequeued jobs into its own `freshness:{env}:processing:{worker_id}` list
+  via `LMOVE`. A heartbeat key (`freshness:{env}:heartbeat:{worker_id}`,
+  TTL 20s) plus a per-workspace reclaim pass (every
+  `METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS`, default 30 iterations)
+  drains any dead peer's processing list back to the main queue. A
+  scheduled-scan safety net (memory only in this ticket; KB deferred)
+  periodically enqueues freshness jobs for records that never received
+  a write-triggered event. Every freshness Redis key is now namespaced
+  by `METATRON_ENV` so dev rigs sharing a Redis instance can't collide;
+  legacy unprefixed keys are opportunistically drained at startup when
+  `METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP=true`. Six new settings:
+  `METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS` (20),
+  `METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS` (30),
+  `METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED` (True),
+  `METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS` (3600),
+  `METATRON_FRESHNESS_SCAN_BATCH_LIMIT` (500),
+  `METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP` (False). Five new
+  Prometheus counters: `freshness_orphans_reclaimed_total`,
+  `freshness_reclaim_errors_total`,
+  `freshness_scheduled_scan_jobs_enqueued_total`,
+  `freshness_scheduled_scan_errors_total`,
+  `freshness_legacy_keys_drained_total`. Backwards-compatible when
+  `METATRON_ENV` is unset — the key shape is byte-identical to Phase A.
 - chore: Pre-rollout validation gate closed (MTRNIX-319). Eval dataset
   v1.3 refreshes 11 Confluence doc_label IDs that drifted to new
   page IDs after a workspace reorg — restored measurable retrieval

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,13 @@ Graph extraction is decoupled from sync (process_all_unsynced_graphs, graph-proc
 - METATRON_FRESHNESS_BACKOFF_BASE_SECONDS (2.0) — exponential backoff base when worker errors repeat
 - METATRON_FRESHNESS_BACKOFF_MAX_SECONDS (60.0) — exponential backoff cap
 - METATRON_FRESHNESS_MAX_CONSECUTIVE_ERRORS (10) — consecutive-error count after which worker aborts
+- METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS (20) — worker heartbeat key TTL; reclaim pass treats missing heartbeat as dead worker (MTRNIX-316)
+- METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS (30) — cadence of the orphan-reclaim pass inside the worker loop (MTRNIX-316)
+- METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED (true) — master flag for the safety-net scheduled scan that re-enqueues memory records missing a recent freshness event (MTRNIX-316)
+- METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS (3600) — scheduled-scan cadence (MTRNIX-316)
+- METATRON_FRESHNESS_SCAN_BATCH_LIMIT (500) — per-workspace cap on stale candidates the scan enqueues per pass (MTRNIX-316)
+- METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP (false) — one-shot drain of legacy unprefixed Redis keys into env-prefixed keys at worker startup; flip on once per deployment during the env-prefix rollout (MTRNIX-316)
+- METATRON_ENV (unset) — deployment environment tag; when set, freshness Redis keys become `freshness:{env}:queue:...` etc. Empty/unset preserves the Phase A unprefixed shape for backward compat (MTRNIX-316)
 - METATRON_FRESHNESS_KB_ENABLED (false) — KB-side freshness producer flag (MTRNIX-313 Phase B); requires `METATRON_FRESHNESS_ENABLED=true`. When off, the KB producer hook in connector sync is a no-op and the worker's KB pipeline is never invoked
 - METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED (false) — retrieval-side ARCHIVED/SUPERSEDED filter pushdown; when on, recall channels combine the filter with `access_filter` via `_combine_filters`
 - METATRON_FRESHNESS_WEIGHT (0.0) — scoring weight for the `freshness` signal in `compute_signal_score`; default 0.0 keeps the formula numerically identical to Phase A

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,7 @@ services:
     restart: unless-stopped
 
   redis:
+    # Redis >= 6.2 required for LMOVE (MTRNIX-316).
     image: redis:7-alpine
     container_name: metatron-redis
     ports:

--- a/docs/MEMORY_MCP_FOLLOWUPS.md
+++ b/docs/MEMORY_MCP_FOLLOWUPS.md
@@ -68,6 +68,33 @@ across the repo (see root CLAUDE.md "Do NOT" section). When it lands:
 per-agent role claim system that does not exist yet. Wait for the broader RBAC
 migration rather than building a one-off for this tool.
 
+## 4. KB scheduled scan (MTRNIX-316 follow-up)
+
+MTRNIX-316 added a scheduled-scan safety net to the freshness worker — a
+periodic pass that enqueues stale records the write-triggered producer
+missed. Scope was explicitly limited to the memory target. The KB target's
+`RawDocumentTarget.list_stale_candidates` returns an empty list today, so
+the shared `ScheduledScan` orchestrator is a no-op for `raw_document`.
+
+**Follow-up sketch:**
+
+- Extend `RawDocumentTarget.list_stale_candidates` to SELECT from
+  `raw_documents` where `status NOT IN ('archived', 'superseded')` AND
+  `(last_freshness_run_at IS NULL OR last_freshness_run_at < :older_than)`.
+  The column already exists (migration 018) so no new schema needed.
+- Wire a second `ScheduledScan` instance in
+  `metatron.memory.freshness.worker._build_worker` alongside the memory
+  one, using `settings.freshness_kb_stale_after_days` (already 90 by
+  default).
+- Gate behind `METATRON_FRESHNESS_KB_ENABLED` so the KB side stays opt-in.
+- Integration test analogous to
+  `tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py`
+  against the KB path.
+
+**Priority:** low. KB ingest already produces write-triggered jobs when
+connectors sync, so the hot path is covered. The scan is a rescue for
+records that never sync — valuable long-term but not a pre-prod gate.
+
 ## Open question — should any of these be filed as tickets now?
 
 The default answer is probably "maybe #1, not #2/#3":

--- a/docs/superpowers/plans/2026-04-24-freshness-queue-reliability.md
+++ b/docs/superpowers/plans/2026-04-24-freshness-queue-reliability.md
@@ -1,0 +1,744 @@
+# Freshness queue reliability — processing-list reclaim + scheduled scan — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** replace the lossy atomic-batch LPOP in `CoordinationStore.dequeue_batch` with a `LMOVE`-into-per-worker processing list, add a periodic reclaim pass that rescues orphaned processing lists from dead workers, add a scheduled-scan safety-net task inside the worker loop, and namespace every freshness Redis key with the existing `METATRON_ENV` value. Five new Prometheus counters for observability. No PG schema change. No `core/interfaces.py` / `core/events.py` change. Backwards-compatible when `METATRON_ENV` is unset (empty prefix → Phase A key shape).
+
+**Architecture:**
+- Redis primitives — add `lmove_rightleft`, `peek_tail`, `lrem` to `RedisStore` (L1).
+- Coordination — new methods on `CoordinationStore` for heartbeat, processing-list dequeue/complete, orphan reclaim, legacy drain (L2).
+- Target — optional `FreshnessTarget.list_stale_candidates` with default `return []`; memory adapter overrides it via a new `MemoryPostgresStore.list_stale_candidates` (L3).
+- Scheduled scan — new `scheduled_scan.py` module; worker wires one instance per target kind (L2).
+- Worker — build `worker_id` at boot, heartbeat each iteration, reclaim on startup + every N iterations, run scheduled scan on a timer.
+- Env prefix — `METATRON_ENV` drives `freshness:{env}:*` key shape; empty env keeps Phase A shape.
+
+**Tech Stack:** Python 3.12, asyncio, `redis.asyncio` (Redis >= 6.2 required for `LMOVE`), SQLAlchemy async (asyncpg), `prometheus_client` (optional dep), structlog, pytest (`asyncio_mode = "auto"`), subprocess + `os.kill` for the SIGKILL integration test.
+
+**Jira:** MTRNIX-316
+**Depends on:** MTRNIX-304 (merged), MTRNIX-313 (merged), MTRNIX-322 (merged).
+**Spec:** `docs/superpowers/specs/2026-04-24-freshness-queue-reliability-design.md`
+**Branch:** `feature/MTRNIX-316` (already checked out).
+
+---
+
+## Layer Boundary Summary
+
+| File | Layer | Allowed imports |
+|---|---|---|
+| `src/metatron/storage/redis.py` (extend) | L1 | `redis.asyncio` only |
+| `src/metatron/freshness/coordination.py` (extend) | L2 | `core.config`, `core.models`, `storage.redis`, `freshness.metrics` |
+| `src/metatron/freshness/metrics.py` (extend) | L2 | `prometheus_client` (optional) |
+| `src/metatron/freshness/worker_id.py` (new) | L2 | stdlib only (`os`, `socket`, `uuid`) |
+| `src/metatron/freshness/scheduled_scan.py` (new) | L2 | `core.config`, `core.models`, `freshness.coordination`, `freshness.metrics`, `freshness.targets` |
+| `src/metatron/freshness/targets.py` (extend) | L2 | no new imports |
+| `src/metatron/memory/freshness/target_memory.py` (extend) | L3 | `storage.memory_postgres`, existing |
+| `src/metatron/memory/freshness/worker.py` (extend) | L3 | same as today + `freshness.worker_id`, `freshness.scheduled_scan` |
+| `src/metatron/storage/memory_postgres.py` (extend) | L1 | existing |
+| `src/metatron/core/config.py` (extend) | L0 | existing |
+
+**Not touched:** `core/interfaces.py`, `core/events.py`, `core/models.py`, `storage/postgres.py` (apart from if `list_workspaces` needs a thin confirmation), `storage/memory_qdrant.py`, `memory/service.py`, `memory/search.py`, `mcp/tools/*`, `ingestion/freshness/*`, `api/*`.
+
+**No upward imports.** Memory worker (L3) depends on shared freshness (L2); shared freshness depends on storage (L1) and core (L0). No reverse edges introduced.
+
+---
+
+## Config Vars (new, all `METATRON_` prefixed)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS` | `20` | Heartbeat key TTL. Reclaim considers a worker dead when the key is missing. |
+| `METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS` | `30` | Reclaim pass cadence inside the worker loop. |
+| `METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED` | `True` | Master flag for the safety-net scan. |
+| `METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS` | `3600` | Scan cadence. |
+| `METATRON_FRESHNESS_SCAN_BATCH_LIMIT` | `500` | Cap per-workspace stale candidates enqueued per scan. |
+| `METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP` | `False` | One-time flag for the env-prefix rollout (legacy unprefixed → prefixed drain). |
+
+Reuses existing `METATRON_ENV` for the key prefix (no new var for that).
+
+---
+
+## Event Constants
+
+**None added.** `core/events.py` unchanged. `FreshnessJob.event_type="scheduled_scan"` is already a valid free-form value (Phase A producer reserves it — see `memory/freshness/producer.py` docstring).
+
+---
+
+## Backward Compatibility Guarantee
+
+- `CoordinationStore.enqueue_job` signature unchanged; wire format of serialised jobs unchanged (producer call sites untouched).
+- `CoordinationStore.dequeue_batch` signature changes to require `worker_id` (kwarg-only); a thin compatibility shim accepts calls without `worker_id` for Phase A unit tests (emits DeprecationWarning; synthesises a test worker id).
+- Producer path unchanged — `enqueue_if_enabled` still calls `coordination.enqueue_job`. The key shape inside `queue_key_for` now consults `settings.env`. When `METATRON_ENV` is unset or empty, the key shape is byte-identical to Phase A.
+- `FreshnessTarget` Protocol gains one method with a default body (`return []`). KB adapter (`RawDocumentTarget`) keeps default behaviour — MTRNIX-313 tests stay green.
+- Phase A (MTRNIX-304) + Phase B (MTRNIX-313) + MTRNIX-314 + MTRNIX-322 tests stay green.
+- Worker started without `METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED` set inherits the default `True` — safety net is on by default. To preserve legacy dev-rig behaviour exactly, ops may set it to `False`; in a greenfield deploy leaving it on adds only one background DB query per hour.
+- Prometheus counters are additive; scrapers tolerate new series.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `src/metatron/storage/redis.py` | Add async wrappers: `lmove_rightleft`, `peek_tail`, `lrem`. |
+| Modify | `src/metatron/core/config.py` | Add six new `freshness_*` settings (heartbeat, reclaim cadence, scheduled scan, batch limit, drain flag). |
+| Modify | `src/metatron/freshness/metrics.py` | Add five new counters (+ noop fallbacks + `__all__` entries). |
+| Create | `src/metatron/freshness/worker_id.py` | `build_worker_id() -> str` helper. Composes `{hostname}:{pid}:{short-uuid}`. Supports `METATRON_FRESHNESS_TEST_WORKER_ID` env override for integration tests. |
+| Modify | `src/metatron/freshness/coordination.py` | Prefix queue/processing/heartbeat/lock keys with `settings.env`; add methods: `tick_heartbeat`, `is_worker_alive`, `release_worker`, `complete_job`, `list_processing_workers`, `reclaim_worker_orphans`, `drain_legacy_unprefixed`. Rework `dequeue_batch` to take `worker_id` kwarg and use `LMOVE`. Keep the old signature as a deprecation-warn shim for unit tests. |
+| Modify | `src/metatron/freshness/targets.py` | Add `list_stale_candidates` to the Protocol with a default `return []` body. |
+| Create | `src/metatron/freshness/scheduled_scan.py` | `ScheduledScan` dataclass + `run()` method. |
+| Modify | `src/metatron/memory/freshness/target_memory.py` | Override `list_stale_candidates` → delegates to `MemoryPostgresStore.list_stale_candidates`. |
+| Modify | `src/metatron/storage/memory_postgres.py` | Add `list_stale_candidates(workspace_id, older_than, limit) -> list[str]` — SELECT id WHERE workspace_id, status NOT IN ('stale','superseded','archived'), updated_at < :older_than ORDER BY updated_at ASC LIMIT :limit. |
+| Modify | `src/metatron/memory/freshness/worker.py` | Build `worker_id` at bootstrap; call `tick_heartbeat` + `reclaim_orphans` + `drain_legacy_unprefixed` at startup; tick heartbeat per iteration; reclaim every N iterations; run scheduled scans on a timer; pass `worker_id` to `dequeue_batch`; call `complete_job` in the job `finally`. Release worker on graceful shutdown. |
+| Create | `tests/unit/storage/test_redis_lmove.py` | Unit tests: `lmove_rightleft` returns moved value, None on empty; `peek_tail`; `lrem`. Uses `fakeredis.aioredis` if available, otherwise `pytest.importorskip`. |
+| Create | `tests/unit/freshness/test_coordination_heartbeat.py` | Unit tests: tick + exists/missing; release; prefix when env set vs empty. |
+| Create | `tests/unit/freshness/test_coordination_processing_list.py` | Unit tests: `dequeue_batch(worker_id=...)` moves jobs to processing list; `complete_job` LREMs; orphan detection via `list_processing_workers`; `reclaim_worker_orphans` drains dead worker back to source workspace queue; race — simulate concurrent reclaim on same worker (second call acquires lock fails, returns 0). |
+| Create | `tests/unit/freshness/test_coordination_env_prefix.py` | Unit tests: `METATRON_ENV="development"` → prefixed keys; unset → unprefixed; `drain_legacy_unprefixed` moves old→new. |
+| Create | `tests/unit/freshness/test_worker_id.py` | Unit tests: uniqueness across calls; shape; env override for tests. |
+| Create | `tests/unit/freshness/test_scheduled_scan.py` | Unit tests: calls `target.list_stale_candidates` per workspace; enqueues `scheduled_scan` jobs with correct payload; counter increments; empty-workspaces path; per-workspace error swallow. |
+| Create | `tests/unit/memory/freshness/test_memory_target_stale_candidates.py` | Unit tests: `MemoryTarget.list_stale_candidates` delegates; `MemoryPostgresStore.list_stale_candidates` filters + orders + limits. |
+| Create | `tests/unit/memory/freshness/test_worker_reclaim_loop.py` | Unit tests: `_run_loop` calls reclaim once at startup; subsequent reclaim every N iterations; heartbeat ticked; scheduled scan timer fires on time. |
+| Create | `tests/integration/memory/freshness/test_reclaim_sigkill.py` | Integration: subprocess worker + SIGKILL + second worker reclaims. Live PG + Qdrant + Redis. |
+| Create | `tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py` | Integration: seed stale records; run one `ScheduledScan.run()`; assert jobs enqueued. |
+| Create | `tests/integration/memory/freshness/test_env_prefix_isolation.py` | Integration: worker A (env=staging) + worker B (env=development) — enqueue under A's key; B never sees it. |
+| Modify | `docs/MEMORY_MCP_FOLLOWUPS.md` | Add short entry: "KB scheduled scan is deferred — implement `RawDocumentTarget.list_stale_candidates` and wire a second `ScheduledScan` in `_build_worker`. Follow-up to MTRNIX-316." |
+| Modify | `src/metatron/memory/.claude/CLAUDE.md` | Add bullet to `freshness/worker.py`: "worker_id-based processing list reclaim + scheduled scan (MTRNIX-316)." Update `freshness/target_memory.py` bullet: "`list_stale_candidates` delegates to `MemoryPostgresStore.list_stale_candidates` for the scheduled-scan safety net (MTRNIX-316)." |
+| Modify | `src/metatron/storage/.claude/claude.md` | Under `redis.py`, add bullet: "`lmove_rightleft`, `peek_tail`, `lrem` — primitives for the freshness processing-list reclaim pattern (MTRNIX-316)." Under `memory_postgres.py`, add bullet: "`list_stale_candidates(workspace_id, older_than, limit)` — scheduled-scan rescue path (MTRNIX-316)." |
+| Modify | `CHANGELOG.md` | Entry: "feat(freshness): processing-list reclaim + scheduled-scan safety net + env-prefixed Redis keys (MTRNIX-316). Requires Redis >= 6.2 for `LMOVE`. Adds five Prometheus counters: `freshness_orphans_reclaimed_total`, `freshness_reclaim_errors_total`, `freshness_scheduled_scan_jobs_enqueued_total`, `freshness_scheduled_scan_errors_total`, `freshness_legacy_keys_drained_total`." |
+| Modify | `docker-compose.yml` | Add comment near the redis service: `# Redis >= 6.2 required for LMOVE (MTRNIX-316)`. Confirm the pinned image (`redis:7-alpine`) already satisfies this. |
+
+Total: **10 modified code files + 3 modified docs + 1 CHANGELOG + 1 compose comment + 2 new source files + 8 new test files (6 unit, 3 integration — wait: 6 unit files below, 3 integration). Correction: 7 unit + 3 integration = 10 new test files.**
+
+---
+
+## Ordered Tasks
+
+Execute in order. After **every** task, run `make lint`, `make typecheck`, `make test` as three separate commands (never chain with `;` or `&&`, per the user's global rule).
+
+---
+
+### Task 1: Redis primitives — `lmove_rightleft`, `peek_tail`, `lrem`
+
+**Files:**
+- Modify: `src/metatron/storage/redis.py`
+- Create: `tests/unit/storage/test_redis_lmove.py`
+
+- [ ] **Step 1: Write unit tests first (TDD).**
+  Cases:
+  - `lmove_rightleft`: src has `["a","b","c"]` (LPUSH order → `c,b,a` in Redis); call → moves tail `a` to dst head; assert returned value equals `"a"`; assert src now `["c","b"]`, dst `["a"]`.
+  - `lmove_rightleft` on empty src: returns `None`; src/dst unchanged.
+  - `peek_tail` on list of 3: returns tail value without mutating.
+  - `peek_tail` on missing key: returns `None`.
+  - `lrem` with matching value and `count=1`: removes one; returns 1.
+  - `lrem` with non-matching value: returns 0.
+
+- [ ] **Step 2: Add the three methods to `RedisStore`.**
+  Follow the existing pattern — `cast("Awaitable[...]", self._client.<cmd>(...))` for typing hygiene. Use `redis-py`'s `lmove`, `lindex`, `lrem` directly.
+
+- [ ] **Step 3: Lint + typecheck + test.** Three separate commands.
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add src/metatron/storage/redis.py tests/unit/storage/test_redis_lmove.py
+  git commit -m "feat(MTRNIX-316): RedisStore primitives — lmove_rightleft, peek_tail, lrem"
+  ```
+
+**Acceptance:** Six unit tests green.
+
+---
+
+### Task 2: Settings — six new `freshness_*` knobs
+
+**Files:**
+- Modify: `src/metatron/core/config.py`
+- Create: `tests/unit/core/test_config_freshness_reliability.py`
+
+- [ ] **Step 1: Write unit tests first.**
+  - Defaults: `heartbeat_ttl_seconds=20`, `reclaim_interval_iterations=30`, `scheduled_scan_enabled=True`, `scheduled_scan_interval_seconds=3600`, `scan_batch_limit=500`, `drain_legacy_at_startup=False`.
+  - Env override: set each var; assert parsed value.
+  - Boolean parsing: `"false"` / `"FALSE"` / `"0"` → False.
+
+- [ ] **Step 2: Add six `Field(...)` entries** in the Freshness pipeline section (right after `freshness_max_consecutive_errors`). Use the exact alias names from the Config Vars table above.
+
+- [ ] **Step 3: Lint + typecheck + test.**
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add src/metatron/core/config.py tests/unit/core/test_config_freshness_reliability.py
+  git commit -m "feat(MTRNIX-316): six new METATRON_FRESHNESS_* reliability settings"
+  ```
+
+---
+
+### Task 3: Prometheus counters
+
+**Files:**
+- Modify: `src/metatron/freshness/metrics.py`
+- Modify: `src/metatron/memory/freshness/metrics.py` (re-export shim)
+
+- [ ] **Step 1: Add five new `Any` declarations** alongside `qdrant_sync_failed`:
+  `orphans_reclaimed`, `reclaim_errors`, `scheduled_scan_jobs_enqueued`, `scheduled_scan_errors`, `legacy_keys_drained`.
+
+- [ ] **Step 2: Inside the `try: from prometheus_client import ...` block,** define the five real `Counter(...)` instances using the metric names and labels from the spec § 12.
+
+- [ ] **Step 3: Inside the `except ImportError:` block,** assign each to `_NoopMetric()`.
+
+- [ ] **Step 4: Add all five to `__all__`** alphabetically.
+
+- [ ] **Step 5: Re-export from the memory shim** (`src/metatron/memory/freshness/metrics.py`): extend the `from metatron.freshness.metrics import ...` tuple and the shim's `__all__`.
+
+- [ ] **Step 6: Lint + typecheck + test.**
+
+- [ ] **Step 7: Commit.**
+  ```
+  git add src/metatron/freshness/metrics.py src/metatron/memory/freshness/metrics.py
+  git commit -m "feat(MTRNIX-316): five new Prometheus counters for reclaim + scheduled scan"
+  ```
+
+**Acceptance:** `from metatron.freshness.metrics import orphans_reclaimed` (and the other four) succeeds; `.labels(...).inc()` is a no-op-safe call.
+
+---
+
+### Task 4: `build_worker_id` helper
+
+**Files:**
+- Create: `src/metatron/freshness/worker_id.py`
+- Create: `tests/unit/freshness/test_worker_id.py`
+
+- [ ] **Step 1: Write unit tests first.**
+  - `build_worker_id()` returns a string matching `^[^:]+:\d+:[0-9a-f]{8}$`.
+  - Two calls return different values (uuid suffix differs).
+  - With `METATRON_FRESHNESS_TEST_WORKER_ID=my-fixed-id` env var set, the function returns `"my-fixed-id"` verbatim.
+
+- [ ] **Step 2: Implement `build_worker_id`.**
+  ```python
+  import os, socket, uuid
+  def build_worker_id() -> str:
+      override = os.environ.get("METATRON_FRESHNESS_TEST_WORKER_ID")
+      if override:
+          return override
+      return f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+  ```
+
+- [ ] **Step 3: Lint + typecheck + test.**
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add src/metatron/freshness/worker_id.py tests/unit/freshness/test_worker_id.py
+  git commit -m "feat(MTRNIX-316): build_worker_id() helper with test-env override"
+  ```
+
+---
+
+### Task 5: `CoordinationStore` — env prefix + heartbeat + processing-list dequeue
+
+**Files:**
+- Modify: `src/metatron/freshness/coordination.py`
+- Create: `tests/unit/freshness/test_coordination_env_prefix.py`
+- Create: `tests/unit/freshness/test_coordination_heartbeat.py`
+- Create: `tests/unit/freshness/test_coordination_processing_list.py`
+
+- [ ] **Step 1: Write `test_coordination_env_prefix.py` first (TDD).**
+  - With `monkeypatch.setattr(settings, "env", "development")`: `queue_key_for("ws-1")` returns `"freshness:development:queue:ws-1"`.
+  - With `settings.env = ""`: returns `"freshness:queue:ws-1"` (legacy).
+  - Stage-lock key pattern prefixed the same way.
+  - `list_active_workspaces` matches only the current env prefix (seed keys under two envs, assert only one env's keys are returned).
+
+- [ ] **Step 2: Refactor key helpers.**
+  Replace the module-level constants `_QUEUE_PREFIX`, `_LOCK_PREFIX` with a single `_key_prefix() -> str` helper that reads `settings.env`. All key builders (`queue_key_for`, `_lock_key`, plus new ones below) go through `_key_prefix()`.
+
+- [ ] **Step 3: Write `test_coordination_heartbeat.py`.**
+  - `tick_heartbeat(worker_id, ttl=5)` sets a key with TTL; `is_worker_alive(worker_id)` → True; `await asyncio.sleep(6)` on fakeredis → False.
+  - `release_worker(worker_id)` deletes the key; `is_worker_alive` → False immediately.
+
+- [ ] **Step 4: Implement `tick_heartbeat`, `is_worker_alive`, `release_worker`.**
+  Heartbeat key shape: `freshness:{env}:heartbeat:{worker_id}`. Use plain `SET key worker_id EX ttl` (not NX) — idempotent upsert. `is_worker_alive` uses `EXISTS` and returns False on any Redis exception (fail-closed).
+
+- [ ] **Step 5: Write `test_coordination_processing_list.py`.**
+  - Enqueue N jobs on workspace `ws-A`; `dequeue_batch(ws-A, 5, worker_id="w1")` returns 5 jobs AND leaves them on processing list `freshness:{env}:processing:w1`.
+  - After `complete_job("w1", job)`, processing list shrinks by 1.
+  - `list_processing_workers` returns `["w1"]`.
+  - Deprecation shim: `dequeue_batch(ws, 5)` (no `worker_id`) issues a `DeprecationWarning`, uses a synthetic worker id.
+
+- [ ] **Step 6: Rework `dequeue_batch` + add `complete_job`.**
+  - Signature: `dequeue_batch(workspace_id, max_items, *, worker_id)`.
+  - Body: loop up to `max_items` times, `raw = await self._redis.lmove_rightleft(queue_key_for(ws), processing_key_for(worker_id))`; break on None; try-parse; skip poison (same log line as today). Return the collected `FreshnessJob` list. Poison items stay on the processing list — they get cleaned up by later `lrem`; defer to the existing poison-handling docstring in `_deserialize_job`.
+  - Compat shim: define the old signature as `def dequeue_batch(self, workspace_id, max_items)` via `*args` inspection; emit `warnings.warn("…", DeprecationWarning, stacklevel=2)`; call the new method with `worker_id=_compat_worker_id()`.
+  - `complete_job(worker_id, job)`: `await self._redis.lrem(processing_key_for(worker_id), _serialize_job(job), count=1)`.
+  - New helper `processing_key_for(worker_id) -> str` mirrors `queue_key_for`.
+
+- [ ] **Step 7: Add `list_processing_workers`.**
+  `SCAN freshness:{env}:processing:*` via existing `scan_keys` helper. Strip prefix; return worker ids (sorted). Swallow exceptions → return `[]` (reclaim pass degrades gracefully).
+
+- [ ] **Step 8: Lint + typecheck + test.**
+
+- [ ] **Step 9: Commit.**
+  ```
+  git add src/metatron/freshness/coordination.py tests/unit/freshness/test_coordination_env_prefix.py tests/unit/freshness/test_coordination_heartbeat.py tests/unit/freshness/test_coordination_processing_list.py
+  git commit -m "feat(MTRNIX-316): env-prefixed Redis keys + heartbeat + processing-list dequeue"
+  ```
+
+**Acceptance:** All unit tests green. `grep -rn "freshness:queue:" src/` → only inside `queue_key_for` and its call-through.
+
+---
+
+### Task 6: `CoordinationStore` — reclaim + legacy drain
+
+**Files:**
+- Modify: `src/metatron/freshness/coordination.py`
+- Extend: `tests/unit/freshness/test_coordination_processing_list.py`
+
+- [ ] **Step 1: Extend the test file with reclaim + drain cases.**
+  - Reclaim happy path: worker `w1` popped 3 jobs to its processing list; `release_worker("w1")` (simulate death); from worker `w2` call `reclaim_worker_orphans("w1")` — returns 3; `queue_key_for(ws)` now has the 3 jobs back; `processing:w1` is empty.
+  - Reclaim skips live worker: w1 is alive (heartbeat); reclaim returns 0.
+  - Reclaim concurrency: simulate two calls to `reclaim_worker_orphans("w1")` racing — first acquires lock, second gets the lock-busy branch and returns 0.
+  - Reclaim race on LREM: pre-LMOVE, remove the tail manually (simulates a late live-worker LREM); `LMOVE` returns None on next iteration; loop exits; returned count is correct.
+  - `drain_legacy_unprefixed`: seed unprefixed `freshness:queue:ws-x` with 2 jobs; with `settings.env="development"`, call the drain; assert prefixed `freshness:development:queue:ws-x` has 2 jobs and unprefixed is empty; counter incremented by 2.
+
+- [ ] **Step 2: Implement `reclaim_worker_orphans`.**
+  Follows the spec § 5 algorithm:
+  ```python
+  async def reclaim_worker_orphans(self, worker_id: str) -> int:
+      if await self.is_worker_alive(worker_id):
+          return 0
+      lock_key = f"{_key_prefix()}reclaim_lock:{worker_id}"
+      token = uuid4().hex
+      if not await self._redis.acquire_lock(lock_key, 30, token):
+          return 0
+      recovered = 0
+      processing_key = processing_key_for(worker_id)
+      try:
+          while True:
+              raw = await self._redis.peek_tail(processing_key)
+              if raw is None:
+                  break
+              job = _deserialize_job(raw)
+              if job is None:
+                  # poison — drop from processing list to avoid infinite loop
+                  await self._redis.lrem(processing_key, raw, count=1)
+                  continue
+              dst = queue_key_for(job.workspace_id)
+              moved = await self._redis.lmove_rightleft(processing_key, dst)
+              if moved is None:
+                  break  # race: list emptied under us
+              recovered += 1
+              settings = get_settings()
+              wid_hash = hashlib.sha1(worker_id.encode()).hexdigest()[:4]
+              metrics.orphans_reclaimed.labels(env=settings.env, worker_id_hash=wid_hash).inc()
+      finally:
+          await self._redis.release_lock(lock_key, token)
+      return recovered
+  ```
+
+- [ ] **Step 3: Implement `drain_legacy_unprefixed`.**
+  Only meaningful when `_key_prefix() != "freshness:"` (i.e. env is set):
+  ```python
+  async def drain_legacy_unprefixed(self) -> int:
+      settings = get_settings()
+      if not settings.env:
+          return 0
+      legacy_keys = await self._redis.scan_keys("freshness:queue:*")
+      # Filter out prefixed keys accidentally matching (e.g. env "queue")
+      # by excluding anything with more than one ":" between "freshness:" and the remainder.
+      legacy_keys = [k for k in legacy_keys if k.count(":") == 2 and not k.startswith(f"freshness:{settings.env}:")]
+      moved = 0
+      for k in legacy_keys:
+          ws = k.split(":", 2)[2]
+          new_key = queue_key_for(ws)  # prefixed
+          while True:
+              v = await self._redis.lmove_rightleft(k, new_key)
+              if v is None:
+                  break
+              moved += 1
+      if moved:
+          metrics.legacy_keys_drained.labels(env=settings.env).inc(moved)
+      return moved
+  ```
+  Swallow exceptions at the outer caller (the worker) — not inside this method; we want tests to be able to assert on raises from a truly-broken Redis.
+
+- [ ] **Step 4: Lint + typecheck + test.**
+
+- [ ] **Step 5: Commit.**
+  ```
+  git add src/metatron/freshness/coordination.py tests/unit/freshness/test_coordination_processing_list.py
+  git commit -m "feat(MTRNIX-316): orphan reclaim + legacy key drain"
+  ```
+
+---
+
+### Task 7: `FreshnessTarget` protocol + memory adapter override
+
+**Files:**
+- Modify: `src/metatron/freshness/targets.py`
+- Modify: `src/metatron/memory/freshness/target_memory.py`
+- Modify: `src/metatron/storage/memory_postgres.py`
+- Create: `tests/unit/memory/freshness/test_memory_target_stale_candidates.py`
+
+- [ ] **Step 1: Write unit tests first.**
+  - `MemoryPostgresStore.list_stale_candidates(ws, older_than, limit=10)` — seed rows with `updated_at` both before and after the threshold, different statuses (`ACTIVE`, `STALE`, `ARCHIVED`). Assert only non-terminal-status rows older than `older_than` are returned, ordered ASC by `updated_at`, up to `limit`.
+  - `MemoryTarget.list_stale_candidates` — mock `MemoryPostgresStore`; assert it forwards args 1:1.
+  - Default `FreshnessTarget.list_stale_candidates` via a minimal mock class that does not override — returns `[]`.
+
+- [ ] **Step 2: Extend the Protocol.**
+  In `targets.py`, add the method with a default body:
+  ```python
+  async def list_stale_candidates(
+      self,
+      workspace_id: str,
+      *,
+      older_than: datetime,
+      limit: int,
+  ) -> list[str]:
+      return []
+  ```
+  Note: Python Protocols can provide default method bodies only if they inherit from `Protocol` with no methods in `__init_subclass__` gymnastics — if mypy complains, make it a regular ABC-style base class OR add the method as a required Protocol member and implement the default in a mixin. Simpler path: add the method to the Protocol as required (no default) and add implementations in BOTH concrete classes (`RawDocumentTarget` → `return []`, `MemoryTarget` → delegate). Pick whichever passes mypy strict — see `freshness/targets.py` current shape; if other methods already have bodies (ABC style), follow suit. If strict Protocol, define in both.
+
+- [ ] **Step 3: Implement `MemoryPostgresStore.list_stale_candidates`.**
+  ```python
+  async def list_stale_candidates(
+      self,
+      workspace_id: str,
+      *,
+      older_than: datetime,
+      limit: int = 500,
+  ) -> list[str]:
+      async with self._engine.begin() as conn:
+          result = await conn.execute(
+              text("""
+                  SELECT id
+                  FROM memory_records
+                  WHERE workspace_id = :ws
+                    AND status NOT IN ('stale', 'superseded', 'archived')
+                    AND updated_at < :older_than
+                  ORDER BY updated_at ASC
+                  LIMIT :limit
+              """),
+              {"ws": workspace_id, "older_than": older_than, "limit": limit},
+          )
+          return [row[0] for row in result.fetchall()]
+  ```
+
+- [ ] **Step 4: Implement `MemoryTarget.list_stale_candidates`.**
+  Thin delegate to `self._pg_store.list_stale_candidates(...)`.
+
+- [ ] **Step 5: If KB uses a non-default Protocol (see Step 2 note), add the `return []` to `RawDocumentTarget` explicitly.**
+
+- [ ] **Step 6: Lint + typecheck + test.**
+
+- [ ] **Step 7: Commit.**
+  ```
+  git add src/metatron/freshness/targets.py src/metatron/memory/freshness/target_memory.py src/metatron/storage/memory_postgres.py tests/unit/memory/freshness/test_memory_target_stale_candidates.py
+  git commit -m "feat(MTRNIX-316): FreshnessTarget.list_stale_candidates + memory implementation"
+  ```
+
+---
+
+### Task 8: `ScheduledScan` module
+
+**Files:**
+- Create: `src/metatron/freshness/scheduled_scan.py`
+- Create: `tests/unit/freshness/test_scheduled_scan.py`
+
+- [ ] **Step 1: Write unit tests first.**
+  Cases:
+  - Happy path: two workspaces, stub `workspace_lister` returns both; target returns 3 ids for ws1 and 0 for ws2; 3 `enqueue_job` calls with correct `event_type="scheduled_scan"`, `target_kind`, `target_id`, `payload["older_than_iso"]`; `scheduled_scan_jobs_enqueued` counter += 3.
+  - `workspace_lister` raises: return 0; `scheduled_scan_errors` counter += 1.
+  - Per-workspace target raise: error swallowed; other workspaces still processed; counter += 1.
+  - Empty workspaces: returns 0; no counter changes.
+
+- [ ] **Step 2: Implement `ScheduledScan`** per the spec § "Scheduled-scan module".
+
+- [ ] **Step 3: Lint + typecheck + test.**
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add src/metatron/freshness/scheduled_scan.py tests/unit/freshness/test_scheduled_scan.py
+  git commit -m "feat(MTRNIX-316): ScheduledScan module — safety-net enqueue for stale records"
+  ```
+
+---
+
+### Task 9: Worker wiring — heartbeat + reclaim + scheduled scan
+
+**Files:**
+- Modify: `src/metatron/memory/freshness/worker.py`
+- Create: `tests/unit/memory/freshness/test_worker_reclaim_loop.py`
+
+- [ ] **Step 1: Write unit tests first.**
+  Mock `CoordinationStore` at the call-boundary; assert:
+  - Startup path: `tick_heartbeat`, `reclaim_worker_orphans` for every worker in `list_processing_workers`, optional `drain_legacy_unprefixed` (when flag true).
+  - Per-iteration: `tick_heartbeat` called; `list_processing_workers + reclaim_worker_orphans` called only every N iterations (N=3 in test).
+  - Scheduled scan: `ScheduledScan.run` called on timer boundary (fake `time.monotonic`).
+  - `complete_job` called in `_process_job` finally, both on success and on exception.
+  - Graceful shutdown (CancelledError bubbled up to `main`): `release_worker` called.
+
+- [ ] **Step 2: Modify `FreshnessWorker.__init__`.**
+  Add kwargs: `worker_id`, `scheduled_scanners`, `heartbeat_ttl`, `reclaim_interval_iterations`, `scheduled_scan_interval_seconds`. Store on `self`. Initialise `self._iteration_count = 0` and `self._last_scan_monotonic = 0.0`.
+
+- [ ] **Step 3: Modify `run_once`.**
+  - At entry: `self._iteration_count += 1`; `await self._coord.tick_heartbeat(self._worker_id, self._heartbeat_ttl)` (swallow on exception, bump `reclaim_errors{stage="heartbeat"}`).
+  - Every `self._reclaim_interval_iterations` iterations: `await self._reclaim_all_orphans()`.
+  - If scheduled scans due: `await self._run_scheduled_scans()`.
+  - Dequeue call: pass `worker_id=self._worker_id`.
+  - In `_process_job` `finally`: after `save_machine_event(freshness_job_processed)`, `await self._coord.complete_job(self._worker_id, job)` (swallow on exception; log WARNING).
+
+- [ ] **Step 4: Implement `_reclaim_all_orphans`.**
+  Swallows all errors:
+  ```python
+  async def _reclaim_all_orphans(self) -> None:
+      try:
+          worker_ids = await self._coord.list_processing_workers()
+      except Exception:
+          metrics.reclaim_errors.labels(env=get_settings().env, stage="discover").inc()
+          logger.warning("freshness.reclaim.discover_failed", exc_info=True)
+          return
+      logger.info("freshness.reclaim.discovered", worker_count=len(worker_ids))
+      for wid in worker_ids:
+          if wid == self._worker_id:
+              continue  # never reclaim ourselves
+          try:
+              n = await self._coord.reclaim_worker_orphans(wid)
+              if n:
+                  logger.info("freshness.reclaim.jobs_recovered", dead_worker_id=wid, count=n)
+          except Exception:
+              metrics.reclaim_errors.labels(env=get_settings().env, stage="drain").inc()
+              logger.warning("freshness.reclaim.drain_failed", dead_worker_id=wid, exc_info=True)
+  ```
+
+- [ ] **Step 5: Implement `_run_scheduled_scans`.**
+  - Check `self._scheduled_scanners` list; for each, call `.run()` (method swallows its own errors); set `self._last_scan_monotonic = time.monotonic()`.
+
+- [ ] **Step 6: Modify `_build_worker` + `main`.**
+  - Build `worker_id = build_worker_id()`.
+  - Wire one `ScheduledScan` for memory (pass `MemoryTarget` + coordination + a workspace-lister lambda that calls `PostgresStore.list_workspaces` + the memory settings for `stale_after_days` and `scan_batch_limit`).
+  - Pass `worker_id` + `scheduled_scanners=[...]` + the four timing knobs from settings into the `FreshnessWorker` ctor.
+  - In `main`, before entering `_run_loop`: `await coord.tick_heartbeat(worker_id, ...)`; `await worker._reclaim_all_orphans()`; if `settings.freshness_drain_legacy_at_startup`: `await coord.drain_legacy_unprefixed()`.
+  - Register a signal-agnostic graceful-shutdown path: wrap `_run_loop` in a try / `asyncio.CancelledError` handler; `await coord.release_worker(worker_id)` in `finally`.
+
+- [ ] **Step 7: Lint + typecheck + test.**
+
+- [ ] **Step 8: Commit.**
+  ```
+  git add src/metatron/memory/freshness/worker.py tests/unit/memory/freshness/test_worker_reclaim_loop.py
+  git commit -m "feat(MTRNIX-316): worker — heartbeat + reclaim pass + scheduled scan wiring"
+  ```
+
+**Acceptance:** Unit tests green. Manual smoke run: `METATRON_FRESHNESS_ENABLED=true python -m metatron.memory.freshness` — log output shows `worker_id_assigned`, `heartbeat_tick`, `reclaim.start`, `scheduled_scan.start`.
+
+---
+
+### Task 10: Integration — SIGKILL mid-batch reclaim
+
+**Files:**
+- Create: `tests/integration/memory/freshness/test_reclaim_sigkill.py`
+
+- [ ] **Step 1: Test scaffolding.**
+  - Reuse conftest fixtures for PG/Redis/Qdrant connections.
+  - Helper `_spawn_worker(worker_id: str, env_overrides: dict[str, str]) -> subprocess.Popen`:
+    spawns `[sys.executable, "-m", "metatron.memory.freshness"]` with `METATRON_FRESHNESS_TEST_WORKER_ID=<id>` + `METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS=<ms>` in env.
+
+- [ ] **Step 2: Add a test-only knob to the worker.**
+  Inside `_process_job`, if `METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS` is set, `await asyncio.sleep(int(...) / 1000)` BEFORE the pipeline calls. This widens the window between LMOVE and LREM deterministically. Guard with `if os.environ.get(...)`.
+
+- [ ] **Step 3: Write the test.**
+  ```python
+  @pytest.mark.integration
+  async def test_reclaim_after_sigkill_recovers_all_jobs(...):
+      workspace = f"fresh-it-{uuid4().hex[:8]}"
+      # Seed N=5 memory records + enqueue jobs
+      # ...
+      worker_a = _spawn_worker("worker-a", env={"METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS": "3000"})
+      # Poll processing-list LLEN until it shows >=1 item (or 5s timeout)
+      await _wait_for_processing_list("worker-a", min_items=1, timeout_s=5)
+      # Kill
+      os.kill(worker_a.pid, signal.SIGKILL)
+      worker_a.wait(timeout=5)
+      # Count total jobs still alive (queue + processing)
+      total = await coord.queue_depth(workspace) + await _llen_processing("worker-a")
+      assert total == 5
+      # Spawn worker B (no sleep)
+      worker_b = _spawn_worker("worker-b", env={})
+      try:
+          # Wait for PG to show all 5 records processed
+          await _wait_for_events(workspace, event_type="freshness_job_processed",
+                                  expected_count=5, timeout_s=30)
+          # Processing list for dead worker should be empty now
+          assert await _llen_processing("worker-a") == 0
+      finally:
+          worker_b.send_signal(signal.SIGTERM)
+          worker_b.wait(timeout=5)
+  ```
+
+- [ ] **Step 4: Cleanup path (both on success and failure).**
+  DELETE memory_records / review_entries / machine_events for workspace; DEL all `freshness:*` keys under the current env; dispose engine + redis + qdrant clients.
+
+- [ ] **Step 5: Lint + typecheck + test-all.**
+
+- [ ] **Step 6: Commit.**
+  ```
+  git add tests/integration/memory/freshness/test_reclaim_sigkill.py src/metatron/memory/freshness/worker.py
+  git commit -m "test(MTRNIX-316): integration — SIGKILL mid-batch + second worker reclaims"
+  ```
+
+**Acceptance:** Test passes under `make test-all`. The AC gate for the ticket.
+
+---
+
+### Task 11: Integration — scheduled scan enqueues stale
+
+**Files:**
+- Create: `tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py`
+
+- [ ] **Step 1: Seed three memory records** with `updated_at = now - (stale_after_days + 5) days`, ACTIVE status; one control record with `updated_at = now`; all under a single workspace.
+
+- [ ] **Step 2: Instantiate a `ScheduledScan`** with a stubbed `workspace_lister` that returns just this workspace, `stale_after_days=1` (to be strictly older than the seeded date — adjust accordingly).
+
+- [ ] **Step 3: Call `scan.run()`; assert 3 jobs enqueued** (the three stale ones); control record NOT enqueued.
+
+- [ ] **Step 4: Spawn a worker (same pattern as Task 10)**; wait for PG to show the 3 records transitioned to `STALE` by the Monitor stage.
+
+- [ ] **Step 5: Cleanup + commit.**
+  ```
+  git commit -m "test(MTRNIX-316): integration — scheduled scan rescues stale records without write event"
+  ```
+
+---
+
+### Task 12: Integration — env-prefix isolation
+
+**Files:**
+- Create: `tests/integration/memory/freshness/test_env_prefix_isolation.py`
+
+- [ ] **Step 1: Enqueue one job** using a `CoordinationStore` wired to `METATRON_ENV=staging`.
+- [ ] **Step 2: Spawn a worker** with `METATRON_ENV=development`; `METATRON_FRESHNESS_TEST_WORKER_ID=w-dev`.
+- [ ] **Step 3: Wait 5s**, then assert:
+  - No `freshness_job_received` MachineEvent for the seeded workspace.
+  - The staging queue still holds the job (unprocessed).
+- [ ] **Step 4: Spawn a second worker** with `METATRON_ENV=staging`; assert the job gets processed.
+- [ ] **Step 5: Cleanup + commit.**
+  ```
+  git commit -m "test(MTRNIX-316): integration — env-prefixed keys isolate environments"
+  ```
+
+---
+
+### Task 13: Docs — CLAUDE.md updates
+
+**Files:**
+- Modify: `src/metatron/memory/.claude/CLAUDE.md`
+- Modify: `src/metatron/storage/.claude/claude.md`
+- Modify: `docs/MEMORY_MCP_FOLLOWUPS.md`
+
+- [ ] **Step 1: Memory module.**
+  Add a bullet under `freshness/worker.py`:
+  "Processing-list reclaim + periodic safety-net scheduled scan (MTRNIX-316). Each worker maintains `freshness:{env}:processing:{worker_id}` and `freshness:{env}:heartbeat:{worker_id}`. Orphaned processing lists (expired heartbeat) are drained back to the main queue by any live worker on startup + every `METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS` iterations."
+  Add a bullet under `freshness/target_memory.py`:
+  "`list_stale_candidates(ws, older_than, limit)` — MTRNIX-316: delegates to `MemoryPostgresStore.list_stale_candidates` for the scheduled-scan rescue path."
+
+- [ ] **Step 2: Storage module.**
+  Under `redis.py`:
+  "`lmove_rightleft(src, dst)`, `peek_tail(key)`, `lrem(key, value, count)` — primitives for the freshness processing-list reclaim pattern (MTRNIX-316). Requires Redis >= 6.2."
+  Under `memory_postgres.py`:
+  "`list_stale_candidates(workspace_id, older_than, limit)` — returns ids of non-terminal-status records with `updated_at < older_than`, used by the scheduled-scan safety net (MTRNIX-316)."
+
+- [ ] **Step 3: Follow-ups doc.**
+  Add a new section:
+  "## KB scheduled scan (MTRNIX-316 follow-up). `RawDocumentTarget.list_stale_candidates` defaults to empty. Implement via `raw_documents` with `last_freshness_run_at IS NULL OR < :older_than` and wire a second `ScheduledScan` instance in `_build_worker`. Low priority — producer-triggered scans already cover the KB hot path."
+
+- [ ] **Step 4: Commit.**
+  ```
+  git add src/metatron/memory/.claude/CLAUDE.md src/metatron/storage/.claude/claude.md docs/MEMORY_MCP_FOLLOWUPS.md
+  git commit -m "docs(MTRNIX-316): CLAUDE.md + follow-ups — reclaim + scheduled scan"
+  ```
+
+---
+
+### Task 14: CHANGELOG + docker-compose note
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docker-compose.yml` (one comment line)
+
+- [ ] **Step 1: CHANGELOG entry.**
+  ```
+  - **Freshness worker:** processing-list reclaim + scheduled-scan safety net +
+    env-prefixed Redis keys close the Phase A pre-prod gaps (MTRNIX-316).
+    Requires Redis >= 6.2 for `LMOVE`. Dequeue no longer loses jobs on worker
+    SIGKILL mid-batch; a live worker drains any orphaned processing list on
+    startup + every ~60s. A periodic scan rescues memory records that never
+    received a write-triggered freshness event. Every freshness Redis key is
+    now namespaced by `METATRON_ENV`. Five new Prometheus counters:
+    `freshness_orphans_reclaimed_total`, `freshness_reclaim_errors_total`,
+    `freshness_scheduled_scan_jobs_enqueued_total`,
+    `freshness_scheduled_scan_errors_total`, `freshness_legacy_keys_drained_total`.
+  ```
+
+- [ ] **Step 2: docker-compose.yml.**
+  Add a comment next to the redis service: `# Redis >= 6.2 required for LMOVE (MTRNIX-316)`. Confirm pinned image `redis:7-alpine` satisfies this; no version bump needed.
+
+- [ ] **Step 3: Commit.**
+  ```
+  git add CHANGELOG.md docker-compose.yml
+  git commit -m "docs(MTRNIX-316): CHANGELOG + docker-compose Redis version note"
+  ```
+
+---
+
+### Task 15: Final verification + PR
+
+- [ ] **Step 1: Full test matrix.**
+  - `make lint`
+  - `make typecheck`
+  - `make test`
+  - `make test-all` (integration suite)
+
+- [ ] **Step 2: Grep guardrails.**
+  - `grep -rn "rpop_batch" src/metatron/` → no active prod call-site in freshness/.
+  - `grep -rn "freshness:queue:" src/` → only inside `queue_key_for` (the one key helper).
+  - `grep -rn "worker_id" src/metatron/freshness/ src/metatron/memory/freshness/` → present in coordination + worker.
+  - `grep -rn "import metatron.agent\|import metatron.channels\|api.routes.chat\|api.routes.finops" src/metatron/freshness/ src/metatron/memory/freshness/` → empty.
+  - `grep -rn "METATRON_FRESHNESS_ENV" src/` → empty (we do NOT invent a new var).
+
+- [ ] **Step 3: Regression matrix.**
+  - `make test tests/unit/freshness/`
+  - `make test tests/unit/memory/freshness/`
+  - `make test tests/unit/storage/`
+  - `make test tests/unit/core/`
+  - `make test tests/integration/memory/freshness/`
+
+- [ ] **Step 4: Manual smoke.**
+  - `METATRON_FRESHNESS_ENABLED=true python -m metatron.memory.freshness` for 60s against a dev Redis + PG: expect log lines for `worker_id_assigned`, `heartbeat_tick` every 2s, `reclaim.start` once at boot, scheduled-scan timer logged as pending until it fires.
+
+- [ ] **Step 5: Open PR.**
+  Title: `feat(MTRNIX-316): freshness queue reliability — processing-list reclaim + scheduled scan`
+  Body: Summary (1 paragraph), Scope (bullet list of touched files — files in File Map above), Validation (commands + AC checklist — all 12 spec items), Enterprise courtesy (five new Prometheus counters), Redis version requirement note. No Co-Authored-By, no Claude Code badge.
+
+**Acceptance:** CI green; AC items 1-12 from the spec checklist all verifiable in code.
+
+---
+
+## Risks watchlist
+
+- **Protocol default body portability.** Python's `typing.Protocol` does not always accept method bodies under mypy strict; fallback is to add implementations on both concrete classes (`MemoryTarget`, `RawDocumentTarget`) explicitly. Keep the default empty `return []` on `RawDocumentTarget` if Protocol-default doesn't work. Settled in Task 7 Step 2.
+- **Test-only env-knob leaking into production.** `METATRON_FRESHNESS_TEST_WORKER_ID` and `METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS` are honoured unconditionally. Document them in the module docstring + CLAUDE.md as "integration-test hooks; do not set in production deployments".
+- **Deprecation shim for `dequeue_batch` without `worker_id`.** Keep the shim narrow: just tests. Add a TODO to remove in a follow-up PR once all tests migrate. Do NOT delete in this ticket (breaks Phase A unit tests).
+- **Integration test flakiness.** Poll loops with explicit timeouts (not `time.sleep`). If CI is slow, bump the default poll budget via `METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS=5000` in the test harness.
+- **Docker-compose Redis version drift.** The pinned image is `redis:7-alpine`. If a future change downgrades below 6.2 somebody loses `LMOVE` at runtime. Spec + CHANGELOG + compose comment + release notes all call it out. Consider adding an integration-smoke that asserts `await redis._client.info("server")["redis_version"] >= "6.2"` (deferred to follow-up; low priority).
+- **Worker hostname collision in k8s.** k8s assigns pod-stable hostnames; collision after restart is rare and mitigated by uuid suffix. No action.
+- **Reclaim lock TTL.** 30s is plenty for draining a typical processing list (≤20 items × 2ms RTT). If stuck, TTL expires → next iteration retries. Logged at WARNING via the outer swallow.
+
+---
+
+## Coordination points
+
+- **`core/interfaces.py`** unchanged.
+- **`core/events.py`** unchanged.
+- **`core/models.py`** unchanged. `FreshnessJob.event_type="scheduled_scan"` is already reserved.
+- **`FreshnessTarget` Protocol** — one new method, backwards-compatible default. KB adapter (`RawDocumentTarget`) gets the default `return []` (explicitly or via Protocol default) — KB tests unchanged.
+- **Enterprise repo** — no coordination required for functionality. Courtesy in the PR body: five new Prometheus counters for enterprise Grafana dashboards. `MachineEvent` shape unchanged.
+- **Ops runbook** — add notes (informal, in the PR body):
+  - `freshness_orphans_reclaimed_total > 0` is informational during worker restarts; not a page.
+  - `freshness_reclaim_errors_total` rate > 0 for 10 min → check Redis health.
+  - `freshness_scheduled_scan_errors_total` rate > 0 → check PG.
+  - During env-prefix rollout: set `METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP=true` for ONE deploy, then unset.
+- **Deployment** — Redis >= 6.2 is a hard requirement; current pinned image (`redis:7-alpine`) is fine. Document in PR body.
+- **`docs/MEMORY_MCP_FOLLOWUPS.md`** — gains one "KB scheduled scan" entry.

--- a/docs/superpowers/specs/2026-04-24-freshness-queue-reliability-design.md
+++ b/docs/superpowers/specs/2026-04-24-freshness-queue-reliability-design.md
@@ -1,0 +1,1050 @@
+# Freshness queue reliability — processing-list reclaim + scheduled scan — Design
+
+**Date:** 2026-04-24
+**Jira:** MTRNIX-316 — Freshness queue reliability — processing-list reclaim + scheduled scan (pre-prod gate).
+**Depends on:** MTRNIX-304 (Phase A — merged), MTRNIX-313 (Phase B shared pipeline + `FreshnessTarget` protocol — merged), MTRNIX-322 (Qdrant status sync — merged).
+**Parent ticket / context:** MTRNIX-304 spec, `docs/superpowers/specs/2026-04-20-freshness-worker-agent-memory-design.md` §"Known limitations — pre-prod hardening".
+**Epic:** MTRNIX-227 (Agent Memory System, WS1).
+**Author:** Architect (agent-team)
+**Status:** Draft — ready for implementation plan
+
+## Goal
+
+Close the two pre-prod gaps that block flipping `METATRON_FRESHNESS_ENABLED=true`
+in a production environment:
+
+1. **Lossy dequeue on crash.** Today `CoordinationStore.dequeue_batch()` pops
+   up to `max_items` jobs from `freshness:queue:{workspace_id}` via an atomic
+   Lua `RPOP`×N. If the worker is SIGKILLed (OOM, container eviction, etc.)
+   after popping N but before processing them, those jobs are lost. This
+   makes Phase A under-process on transient failures — acceptable while
+   the flag is off, not acceptable in production.
+2. **Dev-rig key collisions.** `list_active_workspaces()` does
+   `SCAN freshness:queue:*` with no environment tag. When multiple dev
+   environments share a single Redis instance, a worker surfaces workspace
+   ids from the wrong rig. Prod is unaffected (per-env Redis), but the hole
+   is in the key schema, and fixing it before prod means fewer ops surprises.
+
+Also deliver a scheduled-scan safety net so records that never receive a
+write-triggered job (low-traffic workspaces, producer bugs, forgotten
+imports) still get demoted to `STALE` eventually.
+
+The fix is infra-only: Redis key layout, new per-worker Redis list, new
+coordination methods, one new worker background task, one new producer-side
+scan task. No PG schema change. No `core/interfaces.py` change. No
+`core/events.py` change. No retrieval/MCP/API change. Worker started without
+an env prefix still works (backwards-compatible default).
+
+## Non-goals
+
+- **KB scheduled scan.** `raw_documents.last_freshness_run_at` exists
+  (migration 018) and the same scan shape would apply, but the memory side
+  has no `last_freshness_run_at` column and the producer surface differs.
+  This ticket scopes scheduled scan to memory only; KB scheduled scan is a
+  follow-up for MTRNIX-313 owners (note in `docs/MEMORY_MCP_FOLLOWUPS.md`).
+- **Cross-worker job stealing / work-stealing queue.** A worker never takes
+  jobs from another live worker's processing list — only from lists whose
+  owner has stopped heartbeating. Work-stealing is out of scope.
+- **Global Redis lock on reclaim.** Reclaim uses atomic `LMOVE` per item;
+  no outer lock is taken. Two workers trying to reclaim the same orphan
+  simultaneously is resolved by `LMOVE`'s atomicity (only one wins per item).
+- **Exactly-once delivery.** PG status updates remain idempotent (MTRNIX-304
+  design invariant). Reclaim may cause a job to be processed twice; the
+  pipeline's existing idempotency carries the load. We document the
+  at-least-once delivery guarantee, we do not add dedup on record-id.
+- **Key migration tooling.** When env-prefixed keys land, the old
+  unprefixed keys (if any) are drained opportunistically at worker startup.
+  No separate migration script. Rationale: the new worker is the only
+  consumer; old unprefixed queues empty in one poll cycle. See §
+  "Key migration" below.
+- **Worker-process supervisor / autorestart.** Deployment concern. Docker /
+  k8s restarts the worker; we only guarantee the queue survives that event.
+- **New Prometheus label dimensions for per-workspace reclaim rate.**
+  Reclaim is an infra rescue event — one counter with `worker_id` label is
+  sufficient. Per-workspace drill-down comes from log search, not metrics
+  (cardinality cost).
+
+## Constraints
+
+- **Layer boundaries.** All new code sits at L1 (`storage/redis.py` —
+  two new primitives), L2 (`freshness/coordination.py`,
+  `freshness/scheduled_scan.py`, `freshness/worker.py`), or L3
+  (`memory/freshness/target_memory.py` — scheduled-scan provider glue).
+  No upward imports. No changes to `core/interfaces.py`, `core/events.py`,
+  `core/models.py`. `FreshnessTarget` Protocol gains one optional method
+  (with a default `None` return) — backwards-compatible.
+- **Workspace isolation.** Processing lists are per-worker (global key
+  shape `freshness:{env}:processing:{worker_id}`), but every serialised job
+  inside still carries its `workspace_id`. Scheduled scan enumerates
+  workspaces via the existing `postgres.list_workspaces` helper (already
+  used by other background jobs) — never scans across tenants by Redis key
+  alone.
+- **Graceful degradation.** Reclaim and scheduled-scan failures log WARNING
+  + increment a counter, never abort the worker loop. Matches the
+  MTRNIX-322 swallow-pattern.
+- **Backwards compatibility.** `METATRON_ENV` is already validated to
+  `{development, staging, production}`. When the setting is unset in
+  legacy local-dev rigs, the env prefix defaults to `""` and the key shape
+  stays byte-identical to Phase A (`freshness:queue:{workspace_id}`).
+- **Best-effort semantics.** Reclaim loss (Redis down during `LMOVE`, worker
+  crash during reclaim) reduces to the existing PG-source-of-truth + scan
+  safety net. We tolerate it.
+- **At-least-once delivery.** A reclaimed job may run twice. Pipeline
+  stages are idempotent by design (MTRNIX-304 invariant); the DecisionEngine
+  rule-based engine is stable for the same content; `apply_decision` is
+  idempotent on status/tag writes; MachineEvent rows are append-only (two
+  `freshness_job_processed` rows for a reclaimed job is acceptable and
+  discoverable via the audit log).
+- **No new pg indexes.** Scheduled scan reads `memory_records` ordered by
+  `updated_at` with a bounded limit. The existing
+  `idx_memory_records_workspace` + `updated_at` sort is sufficient for the
+  scan's workspace-scoped window (bounded by
+  `METATRON_FRESHNESS_SCAN_BATCH_LIMIT`, default 500).
+
+## Current state — what needs changing
+
+Current `CoordinationStore` (`src/metatron/freshness/coordination.py`):
+
+- Queue key:        `freshness:queue:{workspace_id}` (unprefixed)
+- Lock key:         `freshness:{stage}:{target_id}` (unprefixed)
+- `dequeue_batch` → single atomic `rpop_batch` (Lua). Lossy on crash.
+- `list_active_workspaces` → `SCAN freshness:queue:*` (unprefixed, collides
+  across dev rigs).
+- No processing list. No `worker_id`. No heartbeat key. No reclaim method.
+- No scheduled-scan module.
+
+Current `RedisStore` (`src/metatron/storage/redis.py`):
+
+- Exposes: `lpush`, `rpop_batch`, `llen`, `scan_keys`, `acquire_lock`,
+  `heartbeat_lock`, `release_lock`, `get/set/delete/exists/expire`.
+- **Does NOT expose `LMOVE`, `BRPOPLPUSH`, `LREM`, or blocking-pop
+  primitives.** This ticket adds the minimum needed (`lmove` + `lrem`).
+
+Current `FreshnessWorker` (`src/metatron/memory/freshness/worker.py`):
+
+- `run_once` iterates workspaces → `dequeue_batch` → process. No
+  worker-id concept. No heartbeat tick. No reclaim pass. No scheduled-scan
+  hook.
+- `main()` wraps `_run_loop` with exponential backoff. Hard-exits after N
+  consecutive errors.
+
+Current `FreshnessTarget` Protocol (`src/metatron/freshness/targets.py`):
+
+- Has `get`, `update_lifecycle`, `similarity_search`, `link_edges_batch`,
+  `alias_edge`, `sync_downstream_stores`. No scan / enumerate method. We
+  add one optional method (`list_stale_candidates`) with a default
+  `return []` so KB's `RawDocumentTarget` keeps working untouched.
+
+Current `Settings` (`src/metatron/core/config.py`):
+
+- `env: str = Field("development", alias="METATRON_ENV")`, validated to
+  `{development, staging, production}`. **This is the env-prefix source.**
+  We do NOT add a new `METATRON_FRESHNESS_ENV` — reuse the canonical one.
+- `freshness_*` flags: `freshness_enabled`, `freshness_poll_seconds`,
+  `freshness_lock_ttl_seconds`, `freshness_stale_after_days`,
+  `freshness_max_consecutive_errors`, etc. We add five new flags for the
+  reliability features (§ "Config" below).
+
+## Architecture
+
+### 12 open questions — all closed
+
+#### 1. `BRPOPLPUSH` vs `LMOVE`
+
+**Decision: `LMOVE`.** Redis 6.2 (Feb 2021) made `BRPOPLPUSH` deprecated
+and introduced `LMOVE` as the canonical primitive. Metatron's docker-compose
+stack pins Redis to `redis:7-alpine` (verified in `docker-compose.yml`) and
+the production image target is Redis 7.x, well above 6.2. The `LMOVE`
+signature is:
+
+```
+LMOVE source destination (LEFT|RIGHT) (LEFT|RIGHT)
+```
+
+We use `LMOVE queue processing RIGHT LEFT` — take the oldest queued job
+(RIGHT, FIFO) and push it to the head of the per-worker processing list
+(LEFT). Non-blocking (we poll); when the queue is empty, `LMOVE` returns
+nil and `dequeue_batch` just stops early.
+
+The Lua `RPOP×N` atomic-batch primitive is abandoned. `dequeue_batch`
+becomes a loop of up to N `LMOVE` calls. See § 6 for the perf trade-off.
+
+Redis version requirement: **>= 6.2.0**. Documented in
+`CHANGELOG.md` and `docker-compose.yml` comment.
+
+#### 2. Worker identity
+
+**Decision: composite `{hostname}:{pid}:{short-uuid}`, ephemeral
+(not persisted to disk).**
+
+Rationale:
+
+- `hostname` is stable per container / pod / dev rig. Operators reading
+  logs can eyeball "which machine".
+- `pid` disambiguates multiple workers on the same host (dev rigs running
+  two workers for smoke tests).
+- `short-uuid` (first 8 hex of `uuid4().hex`) disambiguates restart after
+  a crash so the *new* worker's processing list is empty and orphans from
+  the old pid are discoverable by TTL-expired heartbeat (§ 3).
+
+We deliberately do NOT persist `worker_id` to disk:
+
+- Disk persistence complicates docker/k8s (volumes, paths, permissions).
+- Goal is "orphan reclaim after crash," not "same worker picks up its own
+  half-done batch." On crash, we want the orphan list to be visible to
+  the reclaim pass under a dead worker's name.
+- Persistence would also require a worker-side "resume my processing list"
+  code path on startup — more surface area, same end result.
+
+Helper: `src/metatron/freshness/worker_id.py` exposes
+`build_worker_id() -> str`. Called once at worker bootstrap. The worker
+stores it on `self._worker_id` and passes it through to every
+coordination call.
+
+`list_active_workspaces` today SCANs for `freshness:queue:*`. The reclaim
+pass needs the analogous SCAN for `freshness:{env}:processing:*`. New
+coordination method:
+`list_processing_workers() -> list[str]` — strips prefix, returns worker
+ids. See § 5.
+
+#### 3. Heartbeat mechanism
+
+**Decision: per-worker heartbeat key
+`freshness:{env}:heartbeat:{worker_id}` with TTL = `2 × heartbeat_ttl`
+(default `heartbeat_ttl = 10s`, so key TTL = 20s). Worker refreshes the
+key at the start of every `run_once` iteration and after every job's
+`_process_job` return.**
+
+Rationale:
+
+- TTL key semantics give O(1) "is this worker alive?" check:
+  `EXISTS freshness:{env}:heartbeat:{worker_id}` → dead if missing.
+- Two-iteration expiry tolerates a slow poll cycle without false-declaring
+  a live worker dead. Default poll is 2s + up to 20 jobs processing; the
+  20s budget is comfortable.
+- No separate "heartbeat thread / coroutine" — refreshing on iteration
+  boundaries is enough and avoids concurrency bugs. (Long-running single
+  stages already have their own per-lock heartbeat via
+  `CoordinationStore.heartbeat` — this is an orthogonal concern at the
+  worker level.)
+- Token-guarded `SET NX EX` lock primitives are not needed here — the
+  heartbeat key is unique per worker and nobody else writes it; a plain
+  `SET key worker_id EX ttl` (upsert, no NX) is correct.
+
+New `CoordinationStore` methods:
+
+- `async def tick_heartbeat(worker_id: str, ttl: int) -> None`
+  — upsert-set the heartbeat key with TTL.
+- `async def is_worker_alive(worker_id: str) -> bool`
+  — `EXISTS` check; false on Redis failure (fail-closed; reclaim will
+  retry next iteration).
+- `async def release_worker(worker_id: str) -> None`
+  — delete the heartbeat key on graceful shutdown (best-effort, doesn't
+  matter if missed — TTL cleans up).
+
+#### 4. Where reclaim runs
+
+**Decision: inside the worker loop, every N iterations, gated by
+`freshness_reclaim_interval_iterations` (default 30).**
+
+Rationale:
+
+- **Reject (a) startup-only.** A worker that never restarts (healthy
+  prod) never reclaims. Orphans from a sibling crash stay orphaned
+  indefinitely.
+- **Reject (c) separate cron / new process.** Adds deployment complexity
+  (separate container, separate env injection). The worker already runs
+  an async loop; adding a periodic pass costs nothing.
+- **Accept (b) worker-loop periodic.** Simple, guaranteed-running, ops-free.
+  Every ~60s (default poll 2s × 30 iterations) each live worker scans for
+  dead-worker processing lists and reclaims them. Two workers reclaiming
+  the same orphan are safe — `LMOVE` on an empty list is a no-op.
+
+Additional trigger: **worker startup also runs one reclaim pass
+immediately** (before entering `_run_loop`). Rationale: in a single-worker
+deployment, a restart after SIGKILL is the canonical recovery path; we
+want the orphaned processing list drained immediately, not after the 30th
+iteration.
+
+Implementation: new coroutine `FreshnessWorker._reclaim_orphans()` called
+from:
+
+1. `_build_worker` (once, at startup, before `_run_loop`).
+2. `run_once` (every `freshness_reclaim_interval_iterations` iterations —
+   counter lives on `self`).
+
+All reclaim work wrapped in `try/except Exception` — logged, counter
+bumped, never raises.
+
+#### 5. Atomic reclaim
+
+**Decision: per-item `LMOVE source=processing dest=queue RIGHT LEFT`.**
+
+Sequence, per dead worker:
+
+1. Discover: `list_processing_workers` returns all `{worker_id}` with a
+   non-empty processing list for the current env.
+2. For each one: check `is_worker_alive(worker_id)`. If alive → skip.
+3. Drain: repeat `LMOVE processing:{worker_id} queue:{workspace_id}
+   RIGHT LEFT`. But the processing list holds serialised jobs for mixed
+   workspaces — the destination queue depends on the job payload.
+
+**Refinement.** The processing list holds `_serialize_job(job)` strings
+(the exact same bytes the main queue holds). The LIFO-vs-FIFO direction
+doesn't matter for correctness — all that matters is that each moved
+item lands on the right workspace queue.
+
+The naive per-item recipe:
+
+```
+raw = LRANGE processing:{worker_id} -1 -1    -- tail (oldest first in)
+if raw is nil: done
+job = deserialize(raw)
+LMOVE processing:{worker_id} queue:{job.workspace_id} RIGHT LEFT
+```
+
+But `LMOVE` moves by position, not value. Between `LRANGE` and `LMOVE`
+another reclaimer could remove that tail. So we use the standard
+`RPOPLPUSH`-equivalent idiom **with poison recovery**: the job's
+`workspace_id` is extracted on inspection; if `LMOVE` lands on the wrong
+queue, we simply don't — we use the **value-aware** primitive pair:
+
+```
+raw = LINDEX processing:{worker_id} -1
+if raw is nil: done
+dst = queue_key_for(parse(raw).workspace_id)
+moved = LMOVE processing:{worker_id} dst RIGHT LEFT
+  -- moves current tail; if another reclaimer was faster, moves a different
+  -- item to the wrong queue
+```
+
+The race between `LINDEX` + `LMOVE` on the same processing list is the
+classic "concurrent reclaimers on same orphan" problem. We resolve it by
+**serialising reclaim per worker_id with a short-TTL lock key**:
+
+```
+lock_key = freshness:{env}:reclaim_lock:{worker_id}
+if not SET lock_key self NX EX 30: skip   -- another reclaimer has it
+...drain...
+DEL lock_key
+```
+
+Live workers reclaiming their own orphans is physically impossible (they
+wouldn't be orphans). The lock just prevents two live workers from
+stepping on each other while draining a dead peer. The lock's TTL (30s)
+is a safety net — if the reclaimer itself crashes mid-drain, the next
+iteration picks up where it left off.
+
+**Dead-worker heartbeat race.** A "dead" worker might actually be a live
+worker whose heartbeat key expired due to Redis latency. On reclaim we
+`LMOVE` their processing-list tail back into the main queue. The live
+worker then finishes processing and does `LREM processing ... value` —
+the value no longer exists on the processing list, so `LREM` is a no-op.
+The worker then `tick_heartbeat`s and is live again. Worst case: one job
+ran twice. Covered by at-least-once delivery + idempotent stages. Logged
+at INFO (`freshness.reclaim.race`) for observability; does not count as
+an error.
+
+New `CoordinationStore` methods:
+
+- `async def list_processing_workers() -> list[str]` — SCAN
+  `freshness:{env}:processing:*` and strip prefix.
+- `async def processing_list_has_items(worker_id: str) -> bool` — `LLEN > 0`.
+- `async def reclaim_worker_orphans(worker_id: str) -> int` — full drain
+  flow above; returns count moved.
+
+Lua glue for the per-item value-aware drain step sits in `RedisStore`
+(L1) so coordination (L2) stays declarative:
+
+- `async def lmove_rightleft(src: str, dst: str) -> str | None` — thin
+  `LMOVE src dst RIGHT LEFT` wrapper; returns the moved value or None
+  when the source was empty.
+- `async def peek_tail(key: str) -> str | None` — `LINDEX key -1`.
+- `async def lrem(key: str, value: str, count: int = 1) -> int` —
+  `LREM key count value` (LREM wrapper; count=1 matches first from head).
+- Keep existing `acquire_lock` / `release_lock` for the per-worker
+  reclaim lock; the lock_key is a regular Redis key, no Lua changes.
+
+#### 6. `dequeue_batch` no longer atomic — performance hit
+
+**Accepted. Documented.** Today: 1 Lua round-trip pops up to 20 jobs.
+After: 1..N `LMOVE` round-trips pop 1..N jobs.
+
+Quantified:
+
+- Default `freshness_max_jobs_per_iteration = 20` (Phase A).
+- Redis round-trip on localhost: ~0.2-0.5ms. On docker-compose with a
+  shared host: ~0.5-1.0ms. In prod (kube, separate pod): 1-2ms.
+- 20 `LMOVE`s × 2ms = 40ms added latency per iteration.
+- Iteration work dominates: Linker+Reconciler+Monitor+Curator +
+  DecisionEngine + apply_decision runs hundreds of ms per job.
+- Net impact: ~1% iteration overhead. Acceptable.
+
+Alternative rejected: a Lua "atomic multi-LMOVE into processing list"
+script. Lua gets us atomicity for free, but the values on the processing
+list are heterogeneous workspace-id-wise — Lua cannot return "N values +
+their target queue keys" cleanly, and partial-failure recovery adds
+complexity equivalent to just doing N round-trips. The N-round-trip
+version is also trivial to reason about; perf is in the noise.
+
+Optional: when `freshness_max_jobs_per_iteration` is much higher (for
+stress tests), pipelining the N `LMOVE`s via `redis.asyncio.Pipeline`
+cuts RTT by ~30-40%. We add pipelining only if benchmarks show we need
+it (not in scope for MTRNIX-316; `# TODO(perf)` comment).
+
+#### 7. Scheduled-scan placement
+
+**Decision: inside the worker loop (option a), gated by
+`freshness_scheduled_scan_interval_seconds` (default 3600 — hourly).**
+
+Rationale:
+
+- **Reject (b) separate cron/process.** Deployment surface doubles
+  (container, env config, secrets) for a task that runs once an hour for
+  a few seconds. Not worth it.
+- **Accept (a) in-loop.** Worker already runs continuously. Scan is
+  bounded by `freshness_scan_batch_limit` (default 500 records per
+  workspace per scan) — stable cost. Runs every ~1h, taking maybe 1-10s.
+- Triggered by a simple monotonic timer on `self`: if `time.monotonic() -
+  self._last_scan_monotonic > interval`, run scan. Early iterations skip
+  cleanly.
+
+Module layout:
+
+- New: `src/metatron/freshness/scheduled_scan.py` — target-agnostic scan
+  orchestrator. Takes a `FreshnessTarget`, a `CoordinationStore`, the
+  `stale_after_days` config, and the `batch_limit`. Enumerates workspaces
+  via injected `workspace_lister` callable (delegates to
+  `PostgresStore.list_workspaces` — the existing helper already used by
+  the sync-logs background task). For each workspace, asks the target
+  for the stale-candidate IDs and enqueues `scheduled_scan` freshness
+  jobs idempotently.
+- Worker wiring: `FreshnessWorker` gains an optional
+  `scheduled_scanners: list[ScheduledScan]` ctor kwarg (one per target
+  kind). When `scheduled_scan_interval_seconds == 0` or the flag
+  `freshness_scheduled_scan_enabled=False`, skip. Default
+  `freshness_scheduled_scan_enabled=True` (safety net is on by default;
+  it's a pure rescue path).
+
+#### 8. Scheduled-scan scope
+
+**Decision: memory only for this ticket. KB deferred.**
+
+Rationale:
+
+- The memory path has a clean enumeration: `MemoryPostgresStore.list_records`
+  with `updated_at < now - stale_after_days` filter fits natively. Add a
+  thin wrapper: `list_stale_candidates(workspace_id, older_than, limit)`
+  → list of record_ids, ordered by `updated_at ASC`.
+- The KB path already has `raw_documents.last_freshness_run_at` (migration
+  018) — a different and richer signal. The "no `machine_events.
+  freshness_job_processed` in the stale window" predicate from the ticket
+  description is equivalent to `last_freshness_run_at IS NULL OR <
+  now - window`. KB's scan predicate is therefore subtly different, and
+  so is the idempotence protocol (producer enqueues with a dedup key
+  based on `last_freshness_run_at` vs. memory's own per-record tracking).
+- Shipping both in one ticket doubles the surface area and couples the
+  rollout. Memory is the MTRNIX-316 AC gate; KB scheduled scan becomes
+  MTRNIX-316-follow in `docs/MEMORY_MCP_FOLLOWUPS.md`. The shared
+  `ScheduledScan` orchestrator designed here accepts any
+  `FreshnessTarget` with `list_stale_candidates` → trivial extension
+  when KB wants it.
+
+`FreshnessTarget` Protocol — one new optional method with a default:
+
+```python
+async def list_stale_candidates(
+    self,
+    workspace_id: str,
+    *,
+    older_than: datetime,
+    limit: int,
+) -> list[str]:
+    """Return up to ``limit`` target_ids older than ``older_than``.
+
+    Default implementation returns an empty list. Targets opt in by
+    overriding. Used by the scheduled-scan rescue path to enqueue jobs
+    for records that never received a write-triggered freshness event.
+    """
+    return []
+```
+
+Memory adapter (`MemoryTarget`) overrides this method to delegate to
+`MemoryPostgresStore.list_stale_candidates(workspace_id, older_than,
+limit)` — a new method that adds a single parametrised SELECT. KB target
+keeps the default (empty) implementation for now; the KB implementation
+is a trivial follow-up.
+
+#### 9. Env prefix source
+
+**Decision: reuse `settings.env` (`METATRON_ENV`), no new variable.**
+
+- The value is already validated to `{development, staging, production}`
+  (see `Settings.validate_env`).
+- Fallback for edge cases (unset / empty): treat as `""` and emit the
+  Phase A unprefixed key shape — byte-identical to pre-MTRNIX-316
+  behaviour. Rationale: legacy local-dev setups that source a minimal
+  `.env` without `METATRON_ENV` keep working without a code change.
+- Defining a new `METATRON_FRESHNESS_ENV` is explicitly rejected — see
+  ticket guidance. One knob per concern.
+
+Key shape helper:
+
+```python
+def _key_prefix() -> str:
+    env = get_settings().env
+    return f"freshness:{env}:" if env else "freshness:"
+```
+
+Applied consistently to queue, processing, heartbeat, and reclaim-lock
+keys. Lock keys (`freshness:{stage}:{target_id}`) ALSO prefix the env in
+the same way, for symmetry and to prevent dev-rig lock collisions.
+
+#### 10. Key migration
+
+**Decision: opportunistic drain at worker startup. No separate tool.**
+
+When the new code ships:
+
+- If `METATRON_ENV` was set to (say) `development` from day one, the
+  unprefixed keys have never existed — nothing to migrate.
+- If the env was unset before (local dev), the old unprefixed keys stay
+  valid (env defaults to `""` → no prefix) and the worker consumes them
+  normally.
+- If the env gets flipped from unset to a value (dev rig adds `METATRON_
+  ENV=development`), the unprefixed keys become stale. The worker's
+  startup hook checks for both prefixed and unprefixed active workspace
+  queues, drains any unprefixed work into the prefixed equivalents one
+  time, and thereafter only reads prefixed keys.
+
+Implementation: new startup helper
+`CoordinationStore.drain_legacy_unprefixed() -> int`. Runs once in
+`_build_worker` after the first reclaim pass. Best-effort — logs, counter
+bump, never raises. Disabled by default when the env prefix is empty
+(nothing to do). Safe to run repeatedly (idempotent — on the second run
+the legacy keys are empty).
+
+One log line per draining workspace; aggregate counter
+`freshness_legacy_keys_drained_total{env}`. Off by default via gate
+`freshness_drain_legacy_at_startup` — when ops opts-in during the
+env-prefix rollout, flip the flag to true for one deploy cycle, then
+remove from the env. Avoids an unexpected background SCAN on dev rigs
+that pre-date the flag.
+
+#### 11. Integration test
+
+**Decision: subprocess-spawned worker + `os.kill(worker.pid,
+signal.SIGKILL)` mid-batch. No asyncio cancellation.**
+
+Rationale:
+
+- `asyncio.Task.cancel()` injects `CancelledError` which the worker's
+  try/finally catches cleanly — this is NOT what we're testing. We're
+  testing SIGKILL semantics: process dies mid-batch with no chance to
+  release locks, drain processing lists, or close connections.
+- `subprocess.Popen([sys.executable, "-m",
+  "metatron.memory.freshness"])` with the test `METATRON_*` env passed
+  through gives a real process. Integration test orchestrates:
+
+```
+1. Seed workspace + N memory records + enqueue N jobs.
+2. Spawn worker subprocess; wait for processing list to have >= M items
+   (poll `LLEN freshness:{env}:processing:{worker_id}`).
+3. os.kill(proc.pid, signal.SIGKILL); proc.wait(timeout=5).
+4. Assert: queue + processing list combined still contains N jobs (none
+   lost).
+5. Start a second worker subprocess (different worker_id).
+6. Wait for its reclaim pass; assert dead worker's processing list is
+   drained and total N jobs end up processed.
+7. Clean up both processes + PG state + Redis keys.
+```
+
+- Worker spawn is parameterised via a test helper
+  `_spawn_worker(workspace_id, worker_id_override)`. `worker_id_override`
+  is a test-only env var consumed by `build_worker_id` — lets the test
+  pin the id so the reclaim assertion is deterministic.
+- Kill point is chosen via a custom env-injected delay: worker picks up
+  one job, sleeps (mocked via `METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS`)
+  so the test has a deterministic window between "batch popped" and
+  "batch processed" to fire SIGKILL.
+
+Location:
+`tests/integration/memory/freshness/test_reclaim_sigkill.py`.
+`pytest.mark.integration`. Uses live PG + Redis + Qdrant (existing
+integration fixture conventions).
+
+Two additional integration tests:
+
+- `test_scheduled_scan_enqueues_stale.py` — seed 3 records with
+  `updated_at` past the threshold, run the scan once, assert jobs
+  enqueued and processed.
+- `test_env_prefix_isolation.py` — enqueue jobs under
+  `METATRON_ENV=staging` key shape; start a worker with `development`;
+  assert the worker ignores the staging queue entirely.
+
+#### 12. Observability
+
+**Decision: five new counters.** All follow the MTRNIX-322 pattern
+(Prometheus guarded by `try/except ImportError`, noop stubs otherwise),
+added to `src/metatron/freshness/metrics.py`.
+
+| Counter | Labels | Meaning |
+|---|---|---|
+| `freshness_orphans_reclaimed_total` | `env`, `worker_id_hash` | Jobs moved from dead-worker processing list back to queue. `worker_id_hash` = first 4 hex of SHA1(worker_id) — bounded cardinality. |
+| `freshness_reclaim_errors_total` | `env`, `stage` (`discover`, `drain`, `release`) | Reclaim pass failures. |
+| `freshness_scheduled_scan_jobs_enqueued_total` | `env`, `target_kind` | Records enqueued by the scheduled-scan safety net. |
+| `freshness_scheduled_scan_errors_total` | `env`, `target_kind` | Scan failures (PG or Redis). |
+| `freshness_legacy_keys_drained_total` | `env` | Migration counter. |
+
+Cardinality audit:
+
+- `env` bounded to `{"", "development", "staging", "production"}` = 4.
+- `worker_id_hash` bounded to 65536 (4 hex). In practice dev has ~1-2
+  workers; prod has ~1-4. Fine.
+- `target_kind` bounded to `{memory_record, raw_document}` = 2.
+- `stage` bounded to 3.
+
+Gauge (optional, nice-to-have):
+`freshness_processing_list_depth{worker_id_hash, env}` — updated on the
+reclaim pass. **Deferred.** Not in AC; a follow-up once reclaim rates
+are observed.
+
+Structured log events (structlog):
+
+- `freshness.worker.worker_id_assigned` — once at boot (INFO).
+- `freshness.worker.heartbeat_tick` — DEBUG (per iteration).
+- `freshness.reclaim.start` — INFO (per reclaim pass).
+- `freshness.reclaim.discovered` — INFO (workers found).
+- `freshness.reclaim.dead_worker_detected` — WARNING (orphan found).
+- `freshness.reclaim.jobs_recovered` — INFO (per dead worker, count).
+- `freshness.reclaim.race` — INFO (unexpected `LREM` miss).
+- `freshness.reclaim.failed` — WARNING (single-iteration failure).
+- `freshness.scheduled_scan.start` — INFO.
+- `freshness.scheduled_scan.enqueued` — INFO (per workspace, count).
+- `freshness.scheduled_scan.failed` — WARNING.
+- `freshness.legacy.drain.start` — INFO (once).
+- `freshness.legacy.drain.done` — INFO (once, with count).
+
+## Data flow — before vs after
+
+### Dequeue path — before (today, lossy)
+
+```
+run_once:
+  for ws in list_active_workspaces():
+    jobs = dequeue_batch(ws, N)    # atomic RPOP x N
+    for job in jobs:
+      process(job)                  # if worker dies here → jobs gone
+```
+
+### Dequeue path — after
+
+```
+bootstrap:
+  worker_id = build_worker_id()
+  tick_heartbeat(worker_id)
+  reclaim_orphans()                 # immediate one-shot
+
+run_once (every iteration):
+  tick_heartbeat(worker_id)
+  if iteration % reclaim_interval == 0:
+      reclaim_orphans()             # periodic
+  if time_since_last_scan > scan_interval:
+      scheduled_scan_run()          # safety net
+
+  for ws in list_active_workspaces():
+    jobs = dequeue_batch(ws, N, worker_id=worker_id)
+      # under the hood: N loops of
+      #   lmove_rightleft(queue, processing)
+      # parse, collect, return
+    for job in jobs:
+      try:
+        process(job)
+      finally:
+        lrem(processing, _serialize_job(job), count=1)
+        # → job is removed from processing list whether we succeeded,
+        #   failed, or raised. On raise, existing error path still bumps
+        #   worker_errors counter and re-enqueues via retry logic (Phase A
+        #   already has none beyond crash re-enqueue from reclaim — we do
+        #   not add retry; stage-internal errors log + move on).
+```
+
+### Reclaim pass
+
+```
+reclaim_orphans:
+  for worker_id in list_processing_workers():
+    if is_worker_alive(worker_id):
+      continue
+    if not acquire_lock(reclaim_lock:{worker_id}, ttl=30):
+      continue   # another reclaimer has it
+    try:
+      while True:
+        raw = peek_tail(processing:{worker_id})
+        if raw is None: break
+        job = deserialize(raw)
+        dst = queue_key_for(job.workspace_id)
+        moved = lmove_rightleft(processing:{worker_id}, dst)
+        if moved is None: break   # race, loop exits cleanly
+        counter.inc(labels={"env": env, "worker_id_hash": hash(worker_id)})
+    finally:
+      release(reclaim_lock:{worker_id})
+```
+
+### Scheduled scan
+
+```
+scheduled_scan_run:
+  for target_kind, scanner in self._scheduled_scanners.items():
+    try:
+      workspaces = await workspace_lister()   # PG helper
+      older_than = now() - timedelta(days=stale_after_days)
+      for ws in workspaces:
+        ids = await scanner.target.list_stale_candidates(
+            ws, older_than=older_than, limit=scan_batch_limit
+        )
+        for rid in ids:
+          await coordination.enqueue_job(FreshnessJob(
+              workspace_id=ws,
+              event_type="scheduled_scan",
+              target_kind=target_kind,
+              target_id=rid,
+              payload={"older_than_iso": older_than.isoformat()},
+          ))
+        if ids:
+            metrics.scheduled_scan_jobs_enqueued.labels(
+                env=env, target_kind=target_kind,
+            ).inc(len(ids))
+    except Exception:
+      metrics.scheduled_scan_errors.labels(...).inc()
+      logger.warning("freshness.scheduled_scan.failed", ...)
+```
+
+Scan idempotence: the pipeline already dedups by `freshness_job_received`
+MachineEvent — re-enqueuing a record that's recently been processed just
+produces another log row. In Phase B language this is "at-least-once
+delivery, idempotent consumer."
+
+## Config (new env vars, `METATRON_` prefix)
+
+All default values chosen so that enabling env-prefix / scheduled-scan
+is a no-op for pre-MTRNIX-316 dev rigs:
+
+| Env var | Default | Type | Notes |
+|---|---|---|---|
+| `METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS` | `20` | int | 2× iteration poll budget. |
+| `METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS` | `30` | int | Reclaim pass every ~60s (at default `poll_seconds=2`). |
+| `METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED` | `True` | bool | Master flag for the safety-net scan. |
+| `METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS` | `3600` | int | Scan every hour. |
+| `METATRON_FRESHNESS_SCAN_BATCH_LIMIT` | `500` | int | Cap per workspace per scan. |
+| `METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP` | `False` | bool | One-time flag for env-prefix rollout. |
+
+No new config is read by the producer — the producer already uses
+`freshness_enabled` and will continue to enqueue under the new prefixed
+key shape automatically because `queue_key_for` centralises the shape.
+
+## FreshnessTarget Protocol delta
+
+```python
+# src/metatron/freshness/targets.py
+
+class FreshnessTarget(Protocol):
+    ...existing methods...
+
+    async def list_stale_candidates(
+        self,
+        workspace_id: str,
+        *,
+        older_than: datetime,
+        limit: int,
+    ) -> list[str]:
+        """Scheduled-scan rescue path. Default = empty. Memory overrides."""
+        return []
+```
+
+- Default body `return []` means KB's `RawDocumentTarget` is uncharged
+  for this ticket (MTRNIX-316 is memory-only per § 8).
+- Memory's `MemoryTarget.list_stale_candidates` delegates to a new
+  `MemoryPostgresStore.list_stale_candidates(workspace_id, older_than,
+  limit)` method.
+
+## CoordinationStore API delta
+
+New methods on `src/metatron/freshness/coordination.py`:
+
+```python
+# --- worker identity / heartbeat ---
+async def tick_heartbeat(self, worker_id: str, ttl: int) -> None: ...
+async def is_worker_alive(self, worker_id: str) -> bool: ...
+async def release_worker(self, worker_id: str) -> None: ...
+
+# --- processing-list dequeue ---
+async def dequeue_batch(
+    self,
+    workspace_id: str,
+    max_items: int,
+    *,
+    worker_id: str,
+) -> list[FreshnessJob]:
+    """LMOVE up to N from the queue to the per-worker processing list.
+
+    The Phase A call-site (`worker.run_once`) passes `worker_id=self._worker_id`.
+    Unit tests still pass `worker_id="test-worker"`. Signature is
+    kwarg-only so no positional callers break.
+    """
+
+async def complete_job(self, worker_id: str, job: FreshnessJob) -> None:
+    """LREM the job from the processing list on successful processing."""
+
+# --- reclaim ---
+async def list_processing_workers(self) -> list[str]: ...
+async def reclaim_worker_orphans(self, worker_id: str) -> int: ...
+
+# --- migration ---
+async def drain_legacy_unprefixed(self) -> int: ...
+```
+
+Old signature `dequeue_batch(workspace_id, max_items)` → SHIM: emits a
+deprecation warning in dev, routes to the new signature with a
+test-only `worker_id="compat-noworker"`. This keeps Phase A unit tests
+green while coders migrate them in a follow-up PR (NOT in scope for
+MTRNIX-316 — we keep backwards compat during the feature merge).
+Production call-site (`worker.py`) is migrated in this ticket; the shim
+exists only for tests.
+
+## RedisStore API delta
+
+New primitives on `src/metatron/storage/redis.py`:
+
+```python
+async def lmove_rightleft(self, src: str, dst: str) -> str | None:
+    """LMOVE src dst RIGHT LEFT. Returns the moved value or None."""
+    awaitable = cast("Awaitable[str | None]", self._client.lmove(src, dst, "RIGHT", "LEFT"))
+    return await awaitable
+
+async def peek_tail(self, key: str) -> str | None:
+    """LINDEX key -1."""
+    awaitable = cast("Awaitable[str | None]", self._client.lindex(key, -1))
+    return await awaitable
+
+async def lrem(self, key: str, value: str, count: int = 1) -> int:
+    awaitable = cast("Awaitable[int]", self._client.lrem(key, count, value))
+    return int(await awaitable)
+```
+
+`redis-py` already supports all three natively; we just wrap them for
+type hygiene. `rpop_batch` + `_RPOP_BATCH_LUA` remain in the file for
+now (no callers after this ticket, but removal is a cleanup follow-up).
+
+## Key schema — before vs after
+
+| Role | Before (Phase A) | After (MTRNIX-316) |
+|---|---|---|
+| Queue | `freshness:queue:{ws}` | `freshness:{env}:queue:{ws}` (prefix empty when env unset) |
+| Processing | — | `freshness:{env}:processing:{worker_id}` |
+| Heartbeat | — | `freshness:{env}:heartbeat:{worker_id}` |
+| Reclaim lock | — | `freshness:{env}:reclaim_lock:{worker_id}` |
+| Stage lock (memory) | `freshness:{stage}:{target_id}` | `freshness:{env}:{stage}:{target_id}` |
+| Stage lock (KB) | `freshness:{stage}:raw_document:{target_id}` | `freshness:{env}:{stage}:raw_document:{target_id}` |
+
+Compatibility note: changing stage-lock key shape means a worker running
+mid-upgrade could race with a Phase A worker on the same target. Since
+Phase A worker does NOT set the prefix but the new worker DOES, locks
+don't interfere — the two shapes are disjoint. Ops impact: during the
+rollout window, a pre-MTRNIX-316 worker and a post-MTRNIX-316 worker
+could both grab "a" lock on the same record; we accept this as a minor
+rollout blip (same trade-off the queue prefix makes, and worker rollout
+in staging/prod is single-replica).
+
+## Scheduled-scan module
+
+`src/metatron/freshness/scheduled_scan.py` (new file, L2):
+
+```python
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import structlog
+
+from metatron.core.config import get_settings
+from metatron.core.models import FreshnessJob
+from metatron.freshness import metrics
+from metatron.freshness.coordination import CoordinationStore
+from metatron.freshness.targets import FreshnessTarget
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class ScheduledScan:
+    target_kind: str
+    target: FreshnessTarget
+    coordination: CoordinationStore
+    workspace_lister: Callable[[], Awaitable[list[str]]]
+    stale_after_days: int
+    batch_limit: int
+
+    async def run(self) -> int:
+        """Enqueue stale candidates for all workspaces. Returns total enqueued."""
+        settings = get_settings()
+        older_than = datetime.now(UTC) - timedelta(days=self.stale_after_days)
+        total = 0
+        try:
+            workspaces = await self.workspace_lister()
+        except Exception:
+            logger.warning("freshness.scheduled_scan.list_workspaces_failed", exc_info=True)
+            metrics.scheduled_scan_errors.labels(env=settings.env, target_kind=self.target_kind).inc()
+            return 0
+        for ws in workspaces:
+            try:
+                ids = await self.target.list_stale_candidates(
+                    ws, older_than=older_than, limit=self.batch_limit
+                )
+                for rid in ids:
+                    await self.coordination.enqueue_job(
+                        FreshnessJob(
+                            workspace_id=ws,
+                            event_type="scheduled_scan",
+                            target_kind=self.target_kind,
+                            target_id=rid,
+                            payload={"older_than_iso": older_than.isoformat()},
+                        )
+                    )
+                if ids:
+                    metrics.scheduled_scan_jobs_enqueued.labels(
+                        env=settings.env, target_kind=self.target_kind,
+                    ).inc(len(ids))
+                    total += len(ids)
+                    logger.info(
+                        "freshness.scheduled_scan.enqueued",
+                        workspace_id=ws,
+                        target_kind=self.target_kind,
+                        count=len(ids),
+                    )
+            except Exception:
+                logger.warning(
+                    "freshness.scheduled_scan.failed",
+                    workspace_id=ws,
+                    target_kind=self.target_kind,
+                    exc_info=True,
+                )
+                metrics.scheduled_scan_errors.labels(
+                    env=settings.env, target_kind=self.target_kind,
+                ).inc()
+        return total
+```
+
+Workspace lister: `PostgresStore.list_workspaces()` already exists and
+is used by sync-logs recovery (MTRNIX-309). Injected as a callable so
+the scan module stays storage-agnostic and testable.
+
+## Worker changes
+
+`src/metatron/memory/freshness/worker.py` changes, summarised:
+
+1. `_build_worker` populates a `worker_id`, wires `ScheduledScan`
+   instances (one per target_kind — only memory in this ticket), and
+   returns a `FreshnessWorker` with the new kwargs.
+2. `FreshnessWorker.__init__` accepts:
+   - `worker_id: str`
+   - `scheduled_scanners: list[ScheduledScan] | None = None`
+   - `heartbeat_ttl: int | None = None`
+   - `reclaim_interval_iterations: int | None = None`
+   - `scheduled_scan_interval_seconds: int | None = None`
+3. `_run_loop`:
+   - At entry: `await coord.tick_heartbeat(...)`, then
+     `await worker._reclaim_orphans()`, then
+     `await coord.drain_legacy_unprefixed()` iff flag set.
+   - Inside loop: at the top of each iteration,
+     `await coord.tick_heartbeat(...)`; every `reclaim_interval`
+     iterations, `_reclaim_orphans()`; check the scan timer and call
+     each scanner's `.run()` if due.
+   - On `CancelledError` / hard exit: `await coord.release_worker(worker_id)`
+     best-effort so a clean shutdown empties the heartbeat key proactively.
+4. `run_once`:
+   - Passes `worker_id=self._worker_id` to `dequeue_batch`.
+   - In the job processing `finally` block, calls
+     `coord.complete_job(worker_id, job)` after the existing
+     `save_machine_event(freshness_job_processed)`.
+
+`_process_job` is otherwise unchanged — LREM happens in the outer
+`run_once` finally.
+
+## Failure modes
+
+| Scenario | Behaviour | Observed via |
+|---|---|---|
+| SIGKILL mid-batch | Jobs sit on processing list; next live worker (or self on restart) reclaims via `LMOVE` back to queue; eventually processed twice if the original worker had already committed PG for one; idempotent stages handle it | `freshness_orphans_reclaimed_total` + `freshness.reclaim.*` logs |
+| Redis down during reclaim | `LMOVE` raises; swallowed; `freshness_reclaim_errors_total` bumps; next iteration tries again | counter + WARNING log |
+| Redis down during `tick_heartbeat` | `SET` raises; swallowed; heartbeat key stays expired; external reclaimer eventually spots us as dead; we get reclaimed (false positive). Next tick succeeds; we log `freshness.reclaim.race` when we LREM nothing. | counter + INFO log |
+| Worker-id collision (two workers pick the same id) | UUID suffix makes this practically impossible (1 in 4 billion per restart); if it happened, they'd share a processing list and LREM would still work (one owns each entry by value match). Documented; not defended | — |
+| Scheduled scan while PG down | `list_workspaces` raises; swallowed; error counter ticks; next cycle retries | counter + WARNING |
+| Scheduled scan enqueues duplicate of a recently-processed record | `freshness_job_received` MachineEvent tracks idempotency; stage locks prevent double-run | existing behaviour |
+| Env prefix flip (dev rig adds `METATRON_ENV=development`) | Legacy drain at startup moves any unprefixed queue jobs into the prefixed equivalent | `freshness_legacy_keys_drained_total` |
+| Worker processes everything but Redis goes down before `LREM` | Next reclaim pass moves the "orphan" back, pipeline re-processes idempotently | counter + log |
+| A worker never restarts; a peer crashed | The live worker runs reclaim every ~60s and picks up the peer's orphans | counter + log |
+| Two live workers see the same dead worker | Both try to acquire `reclaim_lock:{worker_id}` via SET NX EX; only one wins; the other skips. When winner releases, the other may run the next iteration if orphans are left (normally they're not) | existing behaviour |
+| Scheduled scan finds a target whose `list_stale_candidates` is the default (empty) | Zero jobs enqueued, scan completes cleanly — KB exactly | silent |
+
+## Risks & mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `LMOVE` loop adds Redis RTT overhead | LOW | Quantified in § 6 (~1% iteration overhead). Pipelining as a future optimisation. |
+| Protocol method default-body change leaks into KB | LOW | Default returns `[]`. KB scheduled scan is a separate ticket. Unit test asserts KB target's default behaviour. |
+| Env prefix rollout breaks existing dev rigs | LOW | Empty-env fallback preserves Phase A key shape byte-identically. Legacy drain is flag-gated. |
+| Integration test SIGKILL flaky in CI | MEDIUM | Use an explicit processing-list `LLEN` poll (not `time.sleep`) to confirm batch was popped before killing. Test harness timeout 30s. |
+| False-positive "dead worker" during GC pause | LOW | Heartbeat TTL = 20s = 10× typical worker poll. Python GC pauses are sub-second. |
+| Reclaim counter cardinality explodes with worker churn | LOW | Label is `worker_id_hash` (4 hex = 65k ceiling), not raw id. |
+| `list_workspaces` scan cost grows linearly with tenant count | LOW | Already used by sync-logs recovery at the same cadence. No regression. |
+| Backwards-compat shim for old `dequeue_batch(ws, N)` signature introduces divergent behaviour | LOW | Shim is test-only; prod wiring passes `worker_id`. Deprecation warning flags call sites for follow-up. |
+
+## Coordination points
+
+- **`core/interfaces.py`** — unchanged.
+- **`core/events.py`** — unchanged. No new event constants (scheduled-scan
+  enqueue uses existing `event_type="scheduled_scan"` on `FreshnessJob`,
+  already reserved in the Phase A producer).
+- **`core/models.py`** — unchanged. `FreshnessJob.event_type` is a
+  free-form string; new values don't require schema changes.
+- **`FreshnessTarget` Protocol** — one new optional method with a default
+  body. KB adapter (RawDocumentTarget) unchanged (uses the default).
+- **Enterprise repo** — no coordination needed. New Prometheus counters
+  (`freshness_orphans_reclaimed_total`, `freshness_reclaim_errors_total`,
+  `freshness_scheduled_scan_jobs_enqueued_total`,
+  `freshness_scheduled_scan_errors_total`,
+  `freshness_legacy_keys_drained_total`) — PR body courtesy mention for
+  enterprise Grafana dashboards.
+- **`docs/MEMORY_MCP_FOLLOWUPS.md`** — add a note: "KB scheduled scan is
+  deferred — implement `RawDocumentTarget.list_stale_candidates` and wire
+  a second `ScheduledScan` instance in `_build_worker`." Small follow-up.
+- **Ops runbook** — when `freshness_reclaim_errors_total` rate > 0 for
+  10 minutes: check Redis health; when
+  `freshness_scheduled_scan_errors_total` rate > 0: check PG.
+  `freshness_orphans_reclaimed_total > 0` is informational (expected
+  during worker restarts), not a page.
+
+## Acceptance criteria (reviewer checklist, restated testably)
+
+1. `make lint` — zero errors on changed files.
+2. `make typecheck` — zero errors (mypy strict).
+3. `make test` — Phase A/B/C unit tests unchanged; new unit tests green.
+4. `make test-all` — integration suite green against live PG + Qdrant + Redis.
+5. **SIGKILL integration test** passes: subprocess worker → seed + enqueue
+   N jobs → kill mid-batch → second worker reclaims → all N jobs
+   eventually reach `freshness_job_processed` MachineEvent. No job lost.
+6. **Env-prefix integration test** passes: worker A with env=staging and
+   worker B with env=development each see only their own queue.
+7. **Scheduled-scan integration test** passes: seeded stale records get
+   enqueued and transitioned to `STALE`/`ARCHIVED` without a write event.
+8. Grep sanity:
+   - `grep -rn "rpop_batch" src/metatron/freshness/` → only in comments
+     / deprecation notes (prod call-site is `lmove_rightleft`).
+   - `grep -rn "freshness:queue:" src/` → only in `coordination.py` as a
+     key-shape constant.
+9. `METATRON_FRESHNESS_ENABLED=false` — worker exits immediately; no new
+   Redis keys touched.
+10. `core/interfaces.py` unchanged. `core/events.py` unchanged.
+11. PR body mentions the 5 new Prometheus counters.
+12. Redis version requirement note in `CHANGELOG.md` (>= 6.2.0).

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -242,6 +242,37 @@ class Settings(BaseSettings):
     freshness_max_consecutive_errors: int = Field(
         default=10, alias="METATRON_FRESHNESS_MAX_CONSECUTIVE_ERRORS"
     )
+    # --- Freshness queue reliability (MTRNIX-316) ---
+    freshness_heartbeat_ttl_seconds: int = Field(
+        default=20,
+        alias="METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS",
+        description="Worker heartbeat key TTL. Reclaim considers a worker dead when missing.",
+    )
+    freshness_reclaim_interval_iterations: int = Field(
+        default=30,
+        alias="METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS",
+        description="Reclaim pass cadence inside the worker loop (iterations).",
+    )
+    freshness_scheduled_scan_enabled: bool = Field(
+        default=True,
+        alias="METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED",
+        description="Master flag for the safety-net scheduled scan.",
+    )
+    freshness_scheduled_scan_interval_seconds: int = Field(
+        default=3600,
+        alias="METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS",
+        description="Scheduled-scan cadence (seconds).",
+    )
+    freshness_scan_batch_limit: int = Field(
+        default=500,
+        alias="METATRON_FRESHNESS_SCAN_BATCH_LIMIT",
+        description="Cap per-workspace stale candidates enqueued per scan.",
+    )
+    freshness_drain_legacy_at_startup: bool = Field(
+        default=False,
+        alias="METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP",
+        description="One-time flag for env-prefix rollout (legacy unprefixed → prefixed drain).",
+    )
     # --- KB-freshness (Phase B, MTRNIX-313) ---
     freshness_kb_enabled: bool = Field(
         default=False,

--- a/src/metatron/freshness/coordination.py
+++ b/src/metatron/freshness/coordination.py
@@ -1,23 +1,40 @@
 """Redis coordination primitives for the freshness pipeline.
 
 Moved from ``metatron.memory.freshness.coordination`` in Phase B (MTRNIX-313)
-since the queue and locks serve both memory and KB pipelines.
+since the queue and locks serve both memory and KB pipelines. Reworked in
+MTRNIX-316 to add:
 
-Key conventions (kept in this module so producers and workers cannot
-disagree on the schema):
+* Env-prefixed keys (``freshness:{env}:...``) so dev rigs sharing a Redis
+  instance do not collide. When ``settings.env`` is empty the unprefixed
+  Phase A shape is preserved byte-for-byte.
+* Per-worker processing list — ``dequeue_batch`` now ``LMOVE``s items into
+  ``freshness:{env}:processing:{worker_id}``. Workers SIGKILLed mid-batch
+  leave their processing list intact; a periodic reclaim pass (driven by
+  ``FreshnessWorker._reclaim_all_orphans``) moves the items back to the
+  workspace queue.
+* Worker heartbeat — each iteration ``tick_heartbeat`` upserts
+  ``freshness:{env}:heartbeat:{worker_id}`` with TTL so the reclaim pass
+  can tell live workers from crashed ones.
+* ``drain_legacy_unprefixed`` — one-shot migration helper that moves any
+  pre-MTRNIX-316 ``freshness:queue:*`` lists into their env-prefixed
+  equivalents. Flag-gated in the worker via ``freshness_drain_legacy_at_startup``.
 
-* Queue key        — ``freshness:queue:{workspace_id}``
-  (one queue per workspace; jobs of both target kinds share it and the
-  worker discriminates on ``job.target_kind``)
-* Lock key (memory) — ``freshness:{stage}:{target_id}``
-  (Phase A key shape, preserved for byte-identical behaviour when memory
-  callers omit ``target_kind``)
-* Lock key (KB)    — ``freshness:{stage}:{target_kind}:{target_id}``
-  (prefixed so memory and KB locks do not collide on a coincidental id)
+Key shape summary (``{env}`` is empty when ``METATRON_ENV`` is unset):
+
+================  =================================================
+Queue             ``freshness:{env}:queue:{workspace_id}``
+Processing list   ``freshness:{env}:processing:{worker_id}``
+Heartbeat         ``freshness:{env}:heartbeat:{worker_id}``
+Reclaim lock      ``freshness:{env}:reclaim_lock:{worker_id}``
+Stage lock (mem)  ``freshness:{env}:{stage}:{target_id}``
+Stage lock (KB)   ``freshness:{env}:{stage}:{target_kind}:{target_id}``
+================  =================================================
 
 Workspace isolation: enqueue/dequeue always take ``workspace_id``; the
 worker enumerates queues via ``list_active_workspaces`` and never falls
-back to a shared queue.
+back to a shared queue. Processing lists are per-worker but each
+serialised job still carries its own ``workspace_id`` — reclaim uses that
+to route the item back to the correct workspace queue.
 
 Locks use token-guarded Lua scripts via ``RedisStore`` so a worker cannot
 release or refresh a lock held by another worker.
@@ -25,14 +42,18 @@ release or refresh a lock held by another worker.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import warnings
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import structlog
 
+from metatron.core.config import get_settings
 from metatron.core.models import FreshnessJob
+from metatron.freshness import metrics
 
 if TYPE_CHECKING:
     from metatron.storage.redis import RedisStore
@@ -40,27 +61,53 @@ if TYPE_CHECKING:
 logger = structlog.get_logger()
 
 
-_QUEUE_PREFIX = "freshness:queue:"
-_LOCK_PREFIX = "freshness:"
 _MEMORY_TARGET_KIND = "memory_record"
+_LEGACY_QUEUE_PREFIX = "freshness:queue:"
+
+
+def _key_prefix() -> str:
+    """Return the env-namespaced key prefix.
+
+    When ``settings.env`` is unset or empty, returns ``"freshness:"`` — the
+    Phase A shape. Otherwise ``"freshness:{env}:"`` so multiple dev rigs
+    sharing a single Redis instance stay isolated.
+    """
+    env = getattr(get_settings(), "env", "") or ""
+    if env:
+        return f"freshness:{env}:"
+    return "freshness:"
 
 
 def queue_key_for(workspace_id: str) -> str:
     """Return the Redis list key holding pending jobs for a workspace."""
-    return f"{_QUEUE_PREFIX}{workspace_id}"
+    return f"{_key_prefix()}queue:{workspace_id}"
+
+
+def processing_key_for(worker_id: str) -> str:
+    """Return the per-worker processing list key (MTRNIX-316)."""
+    return f"{_key_prefix()}processing:{worker_id}"
+
+
+def _heartbeat_key(worker_id: str) -> str:
+    return f"{_key_prefix()}heartbeat:{worker_id}"
+
+
+def _reclaim_lock_key(worker_id: str) -> str:
+    return f"{_key_prefix()}reclaim_lock:{worker_id}"
 
 
 def _lock_key(stage: str, target_id: str, target_kind: str = "") -> str:
     """Build the per-stage/per-target lock key.
 
     Backward-compat shape: when ``target_kind`` is empty or
-    ``"memory_record"`` the key matches Phase A exactly so memory callers
-    (which pass only ``stage`` and ``target_id``) keep the same wire format.
-    KB callers must pass ``target_kind="raw_document"`` to get a prefixed key.
+    ``"memory_record"`` the suffix matches Phase A (no target_kind token)
+    so memory callers keep the same wire format. KB callers must pass
+    ``target_kind="raw_document"`` to get a target-discriminated key.
     """
+    prefix = _key_prefix()
     if not target_kind or target_kind == _MEMORY_TARGET_KIND:
-        return f"{_LOCK_PREFIX}{stage}:{target_id}"
-    return f"{_LOCK_PREFIX}{stage}:{target_kind}:{target_id}"
+        return f"{prefix}{stage}:{target_id}"
+    return f"{prefix}{stage}:{target_kind}:{target_id}"
 
 
 def _serialize_job(job: FreshnessJob) -> str:
@@ -86,6 +133,16 @@ def _deserialize_job(raw: str) -> FreshnessJob | None:
         return None
 
 
+def _compat_worker_id() -> str:
+    """Synthetic worker id used by the Phase A deprecation shim."""
+    return f"compat-noworker:{uuid4().hex[:8]}"
+
+
+def _worker_id_hash(worker_id: str) -> str:
+    """4-hex digest of ``worker_id`` — bounded label cardinality."""
+    return hashlib.sha1(worker_id.encode("utf-8"), usedforsecurity=False).hexdigest()[:4]
+
+
 class CoordinationStore:
     """Thin per-pipeline API over ``RedisStore`` primitives."""
 
@@ -100,23 +157,260 @@ class CoordinationStore:
         """LPUSH a job onto its workspace queue."""
         await self._redis.lpush(queue_key_for(job.workspace_id), _serialize_job(job))
 
-    async def dequeue_batch(self, workspace_id: str, max_items: int) -> list[FreshnessJob]:
-        """Atomic multi-pop from the workspace queue. Skips poison messages."""
-        raw_items = await self._redis.rpop_batch(queue_key_for(workspace_id), max_items)
+    async def dequeue_batch(
+        self,
+        workspace_id: str,
+        max_items: int,
+        *,
+        worker_id: str | None = None,
+    ) -> list[FreshnessJob]:
+        """LMOVE up to ``max_items`` jobs into a per-worker processing list.
+
+        Each call loops up to ``max_items`` times, atomically ``LMOVE``-ing
+        one job from the workspace queue (tail) into the per-worker
+        processing list (head). Break as soon as the queue is drained.
+        Items stay on the processing list until either ``complete_job``
+        LREMs them (successful processing) or the reclaim pass LMOVEs them
+        back to the queue (worker crash).
+
+        ``worker_id`` is required for production callers. Phase A unit
+        tests that still call ``dequeue_batch(ws, N)`` without the kwarg
+        hit a deprecation-warn shim that synthesises a worker id.
+        """
+        if worker_id is None:
+            warnings.warn(
+                "dequeue_batch without worker_id is deprecated — pass "
+                "worker_id=<build_worker_id()> (MTRNIX-316).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            worker_id = _compat_worker_id()
+
+        if max_items <= 0:
+            return []
+
+        q_key = queue_key_for(workspace_id)
+        p_key = processing_key_for(worker_id)
         jobs: list[FreshnessJob] = []
-        for raw in raw_items:
+        for _ in range(max_items):
+            raw = await self._redis.lmove_rightleft(q_key, p_key)
+            if raw is None:
+                break
             parsed = _deserialize_job(raw)
             if parsed is not None:
                 jobs.append(parsed)
+            # Poison items (parsed is None) are already on the processing
+            # list; the reclaim pass's poison branch drops them via LREM.
         return jobs
+
+    async def complete_job(self, worker_id: str, job: FreshnessJob) -> None:
+        """Remove a successfully-processed job from the worker's processing list.
+
+        Called from the worker's ``finally`` so the LREM runs even on
+        pipeline errors. Best-effort — Redis failures are logged and
+        swallowed (the reclaim pass picks up orphans).
+        """
+        try:
+            await self._redis.lrem(
+                processing_key_for(worker_id), _serialize_job(job), count=1
+            )
+        except Exception:
+            logger.warning(
+                "freshness.coordination.complete_job_failed",
+                worker_id=worker_id,
+                workspace_id=job.workspace_id,
+                target_id=job.target_id,
+                exc_info=True,
+            )
 
     async def queue_depth(self, workspace_id: str) -> int:
         return await self._redis.llen(queue_key_for(workspace_id))
 
     async def list_active_workspaces(self) -> list[str]:
         """Return the set of workspace_ids that currently have jobs queued."""
-        keys = await self._redis.scan_keys(f"{_QUEUE_PREFIX}*")
-        return [k[len(_QUEUE_PREFIX) :] for k in keys]
+        prefix = f"{_key_prefix()}queue:"
+        keys = await self._redis.scan_keys(f"{prefix}*")
+        return [k[len(prefix) :] for k in keys]
+
+    async def list_processing_workers(self) -> list[str]:
+        """Return worker ids that currently own a processing list (MTRNIX-316).
+
+        Graceful degradation: on any Redis failure return ``[]`` so the
+        reclaim pass degrades to a no-op for this iteration and retries
+        later.
+        """
+        prefix = f"{_key_prefix()}processing:"
+        try:
+            keys = await self._redis.scan_keys(f"{prefix}*")
+        except Exception:
+            logger.warning("freshness.coordination.list_workers_failed", exc_info=True)
+            return []
+        return [k[len(prefix) :] for k in keys]
+
+    # ------------------------------------------------------------------
+    # Worker heartbeat (MTRNIX-316)
+    # ------------------------------------------------------------------
+
+    async def tick_heartbeat(self, worker_id: str, ttl: int) -> None:
+        """Upsert the per-worker heartbeat key with TTL (best-effort)."""
+        try:
+            await self._redis.set(_heartbeat_key(worker_id), worker_id, ttl=ttl)
+        except Exception:
+            logger.warning(
+                "freshness.coordination.heartbeat_failed",
+                worker_id=worker_id,
+                exc_info=True,
+            )
+
+    async def is_worker_alive(self, worker_id: str) -> bool:
+        """Return True iff the worker's heartbeat key exists (fail-closed)."""
+        try:
+            return bool(await self._redis.exists(_heartbeat_key(worker_id)))
+        except Exception:
+            logger.warning(
+                "freshness.coordination.is_alive_failed",
+                worker_id=worker_id,
+                exc_info=True,
+            )
+            return False
+
+    async def release_worker(self, worker_id: str) -> None:
+        """Delete the worker's heartbeat key on graceful shutdown (best-effort)."""
+        try:
+            await self._redis.delete(_heartbeat_key(worker_id))
+        except Exception:
+            logger.warning(
+                "freshness.coordination.release_worker_failed",
+                worker_id=worker_id,
+                exc_info=True,
+            )
+
+    # ------------------------------------------------------------------
+    # Orphan reclaim (MTRNIX-316)
+    # ------------------------------------------------------------------
+
+    async def reclaim_worker_orphans(self, worker_id: str) -> int:
+        """Drain a dead worker's processing list back to its workspace queues.
+
+        Workflow:
+
+        1. Skip if the worker is still alive (heartbeat key present).
+        2. Acquire a short-TTL reclaim lock on the worker so two live
+           reclaimers do not step on each other.
+        3. Peek the tail, parse the workspace_id, then ``LMOVE`` the tail
+           back onto that workspace's queue. Repeat until empty.
+
+        Returns the count of jobs recovered. Poison entries (undeserialisable)
+        are dropped via LREM so they cannot loop forever.
+        """
+        if await self.is_worker_alive(worker_id):
+            return 0
+
+        lock_key = _reclaim_lock_key(worker_id)
+        token = uuid4().hex
+        if not await self._redis.acquire_lock(lock_key, 30, token):
+            return 0
+
+        recovered = 0
+        p_key = processing_key_for(worker_id)
+        settings = get_settings()
+        env_label = settings.env or ""
+        wid_hash = _worker_id_hash(worker_id)
+        try:
+            while True:
+                raw = await self._redis.peek_tail(p_key)
+                if raw is None:
+                    break
+                job = _deserialize_job(raw)
+                if job is None:
+                    # Poison — drop from processing list to avoid infinite loop.
+                    try:
+                        await self._redis.lrem(p_key, raw, count=1)
+                    except Exception:
+                        logger.warning(
+                            "freshness.reclaim.poison_lrem_failed",
+                            worker_id=worker_id,
+                            exc_info=True,
+                        )
+                        break
+                    continue
+                dst = queue_key_for(job.workspace_id)
+                moved = await self._redis.lmove_rightleft(p_key, dst)
+                if moved is None:
+                    # Race: the tail moved between peek and LMOVE. Exit
+                    # cleanly — the next iteration of the reclaim pass
+                    # will revisit if there's still work.
+                    break
+                recovered += 1
+                try:
+                    metrics.orphans_reclaimed.labels(
+                        env=env_label, worker_id_hash=wid_hash
+                    ).inc()
+                except Exception:
+                    pass
+        finally:
+            await self._redis.release_lock(lock_key, token)
+
+        return recovered
+
+    # ------------------------------------------------------------------
+    # Legacy key drain (MTRNIX-316)
+    # ------------------------------------------------------------------
+
+    async def drain_legacy_unprefixed(self) -> int:
+        """One-shot migration: move unprefixed ``freshness:queue:*`` into env keys.
+
+        No-op when ``settings.env`` is empty (the unprefixed shape IS the
+        current shape). Called at worker startup when
+        ``freshness_drain_legacy_at_startup=True``. Safe to call repeatedly
+        — the second call finds empty legacy lists.
+        """
+        settings = get_settings()
+        env = settings.env or ""
+        if not env:
+            return 0
+        # Scan only the unprefixed shape. Filter out any keys that happen
+        # to start with an env-prefixed pattern (paranoia — a key like
+        # ``freshness:queue:ws-development:queue:foo`` would not match, but
+        # we still defend against exotic workspace ids).
+        try:
+            all_keys = await self._redis.scan_keys(f"{_LEGACY_QUEUE_PREFIX}*")
+        except Exception:
+            logger.warning("freshness.legacy.drain.scan_failed", exc_info=True)
+            return 0
+        legacy_keys = [
+            k
+            for k in all_keys
+            if k.count(":") == 2 and not k.startswith(f"freshness:{env}:")
+        ]
+        moved = 0
+        for k in legacy_keys:
+            ws = k.split(":", 2)[2]
+            new_key = queue_key_for(ws)
+            # Drain src → dst. LMOVE RIGHT → LEFT means we take the
+            # oldest item and push it to the head of the new queue, so
+            # worker FIFO order is preserved (next RIGHT pop from the new
+            # queue picks up the oldest).
+            while True:
+                try:
+                    v = await self._redis.lmove_rightleft(k, new_key)
+                except Exception:
+                    logger.warning(
+                        "freshness.legacy.drain.lmove_failed",
+                        legacy_key=k,
+                        exc_info=True,
+                    )
+                    break
+                if v is None:
+                    break
+                moved += 1
+        if moved:
+            try:
+                metrics.legacy_keys_drained.labels(env=env).inc(moved)
+            except Exception:
+                pass
+            logger.info("freshness.legacy.drain.done", moved=moved, env=env)
+        return moved
 
     # ------------------------------------------------------------------
     # Locks

--- a/src/metatron/freshness/coordination.py
+++ b/src/metatron/freshness/coordination.py
@@ -42,6 +42,7 @@ release or refresh a lock held by another worker.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import warnings
@@ -211,9 +212,7 @@ class CoordinationStore:
         swallowed (the reclaim pass picks up orphans).
         """
         try:
-            await self._redis.lrem(
-                processing_key_for(worker_id), _serialize_job(job), count=1
-            )
+            await self._redis.lrem(processing_key_for(worker_id), _serialize_job(job), count=1)
         except Exception:
             logger.warning(
                 "freshness.coordination.complete_job_failed",
@@ -342,12 +341,8 @@ class CoordinationStore:
                     # will revisit if there's still work.
                     break
                 recovered += 1
-                try:
-                    metrics.orphans_reclaimed.labels(
-                        env=env_label, worker_id_hash=wid_hash
-                    ).inc()
-                except Exception:
-                    pass
+                with contextlib.suppress(Exception):
+                    metrics.orphans_reclaimed.labels(env=env_label, worker_id_hash=wid_hash).inc()
         finally:
             await self._redis.release_lock(lock_key, token)
 
@@ -379,9 +374,7 @@ class CoordinationStore:
             logger.warning("freshness.legacy.drain.scan_failed", exc_info=True)
             return 0
         legacy_keys = [
-            k
-            for k in all_keys
-            if k.count(":") == 2 and not k.startswith(f"freshness:{env}:")
+            k for k in all_keys if k.count(":") == 2 and not k.startswith(f"freshness:{env}:")
         ]
         moved = 0
         for k in legacy_keys:
@@ -405,10 +398,8 @@ class CoordinationStore:
                     break
                 moved += 1
         if moved:
-            try:
+            with contextlib.suppress(Exception):
                 metrics.legacy_keys_drained.labels(env=env).inc(moved)
-            except Exception:
-                pass
             logger.info("freshness.legacy.drain.done", moved=moved, env=env)
         return moved
 

--- a/src/metatron/freshness/metrics.py
+++ b/src/metatron/freshness/metrics.py
@@ -36,6 +36,11 @@ stage_duration: Any
 decision_confidence: Any
 worker_errors: Any
 qdrant_sync_failed: Any
+orphans_reclaimed: Any
+reclaim_errors: Any
+scheduled_scan_jobs_enqueued: Any
+scheduled_scan_errors: Any
+legacy_keys_drained: Any
 
 try:
     from prometheus_client import (  # type: ignore[import-not-found]
@@ -74,6 +79,31 @@ try:
         "Best-effort Qdrant payload sync failures from the freshness pipeline",
         ["target_kind", "stage"],
     )
+    orphans_reclaimed = Counter(
+        "freshness_orphans_reclaimed_total",
+        "Jobs moved from a dead-worker processing list back to the queue (MTRNIX-316)",
+        ["env", "worker_id_hash"],
+    )
+    reclaim_errors = Counter(
+        "freshness_reclaim_errors_total",
+        "Reclaim pass failures (MTRNIX-316)",
+        ["env", "stage"],
+    )
+    scheduled_scan_jobs_enqueued = Counter(
+        "freshness_scheduled_scan_jobs_enqueued_total",
+        "Records enqueued by the scheduled-scan safety net (MTRNIX-316)",
+        ["env", "target_kind"],
+    )
+    scheduled_scan_errors = Counter(
+        "freshness_scheduled_scan_errors_total",
+        "Scheduled-scan failures (MTRNIX-316)",
+        ["env", "target_kind"],
+    )
+    legacy_keys_drained = Counter(
+        "freshness_legacy_keys_drained_total",
+        "Legacy unprefixed queue entries drained into env-prefixed keys (MTRNIX-316)",
+        ["env"],
+    )
 except ImportError:  # pragma: no cover — real branch when dep missing
     jobs_total = _NoopMetric()
     queue_depth_gauge = _NoopMetric()
@@ -81,13 +111,23 @@ except ImportError:  # pragma: no cover — real branch when dep missing
     decision_confidence = _NoopMetric()
     worker_errors = _NoopMetric()
     qdrant_sync_failed = _NoopMetric()
+    orphans_reclaimed = _NoopMetric()
+    reclaim_errors = _NoopMetric()
+    scheduled_scan_jobs_enqueued = _NoopMetric()
+    scheduled_scan_errors = _NoopMetric()
+    legacy_keys_drained = _NoopMetric()
 
 
 __all__ = [
     "decision_confidence",
     "jobs_total",
+    "legacy_keys_drained",
+    "orphans_reclaimed",
     "qdrant_sync_failed",
     "queue_depth_gauge",
+    "reclaim_errors",
+    "scheduled_scan_errors",
+    "scheduled_scan_jobs_enqueued",
     "stage_duration",
     "worker_errors",
 ]

--- a/src/metatron/freshness/scheduled_scan.py
+++ b/src/metatron/freshness/scheduled_scan.py
@@ -22,7 +22,7 @@ recently-scanned record.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+import contextlib
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -34,6 +34,8 @@ from metatron.core.models import FreshnessJob
 from metatron.freshness import metrics
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from metatron.freshness.coordination import CoordinationStore
     from metatron.freshness.targets import FreshnessTarget
 
@@ -141,10 +143,8 @@ def _inc_labeled(metric: object, *, env: str, target_kind: str, amount: int = 1)
     Mirrors the MTRNIX-322 swallow pattern — a broken Prometheus registry
     must not disable the scheduled scan.
     """
-    try:
+    with contextlib.suppress(Exception):
         metric.labels(env=env, target_kind=target_kind).inc(amount)  # type: ignore[attr-defined]
-    except Exception:
-        pass
 
 
 __all__ = ["ScheduledScan"]

--- a/src/metatron/freshness/scheduled_scan.py
+++ b/src/metatron/freshness/scheduled_scan.py
@@ -1,0 +1,150 @@
+"""Scheduled-scan safety net for the freshness pipeline (MTRNIX-316).
+
+The primary freshness path is *write-triggered*: memory saves / KB syncs
+call a producer that enqueues a ``FreshnessJob`` on the workspace queue.
+Records that never receive a write (low-traffic workspaces, producer bugs,
+forgotten imports) would otherwise age out of the freshness window and
+never get demoted to ``STALE``. The scheduled-scan module closes that gap
+by periodically asking each ``FreshnessTarget`` for its stale candidates
+and enqueueing synthetic ``scheduled_scan`` jobs for them.
+
+Scope in MTRNIX-316: memory only. KB target's ``list_stale_candidates``
+returns an empty list by default (defer to MTRNIX-316 follow-up). The
+orchestrator is target-agnostic so the KB opt-in is a one-line change in
+the worker wiring.
+
+Pipeline idempotence: enqueuing a record that was recently processed is
+safe — the pipeline's ``freshness_job_received`` MachineEvent dedup-trail
+catches the duplicate and the stage locks prevent concurrent work. At
+worst the scan adds one extra ``freshness_job_processed`` row per
+recently-scanned record.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import structlog
+
+from metatron.core.config import get_settings
+from metatron.core.models import FreshnessJob
+from metatron.freshness import metrics
+
+if TYPE_CHECKING:
+    from metatron.freshness.coordination import CoordinationStore
+    from metatron.freshness.targets import FreshnessTarget
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class ScheduledScan:
+    """One scheduled-scan orchestrator per target kind.
+
+    The worker owns zero-or-more ``ScheduledScan`` instances (typically
+    one for memory, one for KB). Each iteration of the worker's scan
+    timer calls ``run()`` on every instance — failure in one target does
+    not block the others because ``run()`` swallows its own errors.
+    """
+
+    target_kind: str
+    target: FreshnessTarget
+    coordination: CoordinationStore
+    workspace_lister: Callable[[], Awaitable[list[str]]]
+    stale_after_days: int
+    batch_limit: int
+
+    async def run(self) -> int:
+        """Enqueue stale candidates for every workspace. Returns total enqueued.
+
+        All failures are swallowed so a misbehaving workspace cannot take
+        down the whole scan pass. Per-workspace errors bump the
+        ``freshness_scheduled_scan_errors_total`` counter; the overall
+        ``list_workspaces`` failure does the same. PG remains the source
+        of truth; the next scan cycle will retry.
+        """
+        settings = get_settings()
+        env_label = settings.env or ""
+        older_than = datetime.now(UTC) - timedelta(days=self.stale_after_days)
+        total = 0
+        logger.info(
+            "freshness.scheduled_scan.start",
+            target_kind=self.target_kind,
+            stale_after_days=self.stale_after_days,
+            batch_limit=self.batch_limit,
+        )
+        try:
+            workspaces = await self.workspace_lister()
+        except Exception:
+            logger.warning(
+                "freshness.scheduled_scan.list_workspaces_failed",
+                target_kind=self.target_kind,
+                exc_info=True,
+            )
+            _inc_labeled(
+                metrics.scheduled_scan_errors,
+                env=env_label,
+                target_kind=self.target_kind,
+            )
+            return 0
+
+        for ws in workspaces:
+            try:
+                ids = await self.target.list_stale_candidates(
+                    ws, older_than=older_than, limit=self.batch_limit
+                )
+                for rid in ids:
+                    await self.coordination.enqueue_job(
+                        FreshnessJob(
+                            workspace_id=ws,
+                            event_type="scheduled_scan",
+                            target_kind=self.target_kind,
+                            target_id=rid,
+                            payload={"older_than_iso": older_than.isoformat()},
+                        )
+                    )
+                if ids:
+                    _inc_labeled(
+                        metrics.scheduled_scan_jobs_enqueued,
+                        env=env_label,
+                        target_kind=self.target_kind,
+                        amount=len(ids),
+                    )
+                    total += len(ids)
+                    logger.info(
+                        "freshness.scheduled_scan.enqueued",
+                        workspace_id=ws,
+                        target_kind=self.target_kind,
+                        count=len(ids),
+                    )
+            except Exception:
+                logger.warning(
+                    "freshness.scheduled_scan.failed",
+                    workspace_id=ws,
+                    target_kind=self.target_kind,
+                    exc_info=True,
+                )
+                _inc_labeled(
+                    metrics.scheduled_scan_errors,
+                    env=env_label,
+                    target_kind=self.target_kind,
+                )
+        return total
+
+
+def _inc_labeled(metric: object, *, env: str, target_kind: str, amount: int = 1) -> None:
+    """Best-effort ``labels(...).inc(...)`` so a metrics failure cannot bite.
+
+    Mirrors the MTRNIX-322 swallow pattern — a broken Prometheus registry
+    must not disable the scheduled scan.
+    """
+    try:
+        metric.labels(env=env, target_kind=target_kind).inc(amount)  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+
+__all__ = ["ScheduledScan"]

--- a/src/metatron/freshness/targets.py
+++ b/src/metatron/freshness/targets.py
@@ -135,6 +135,24 @@ class FreshnessTarget(Protocol):
         NEVER raises.
         """
 
+    async def list_stale_candidates(
+        self,
+        workspace_id: str,
+        *,
+        older_than: datetime,
+        limit: int,
+    ) -> list[str]:
+        """Return up to ``limit`` target_ids whose freshness clock expired.
+
+        Used by the scheduled-scan safety net (MTRNIX-316) to enqueue
+        records that never received a write-triggered freshness event.
+        Concrete adapters override this; KB's default (see
+        :class:`RawDocumentTarget`) returns an empty list so KB-side
+        scheduled scan stays opt-in for a future ticket. Memory's
+        implementation delegates to ``MemoryPostgresStore.list_stale_candidates``.
+        """
+        return []
+
 
 __all__ = [
     "FreshnessTarget",

--- a/src/metatron/freshness/worker_id.py
+++ b/src/metatron/freshness/worker_id.py
@@ -1,0 +1,39 @@
+"""Worker-id builder for the freshness processing-list reclaim pattern.
+
+MTRNIX-316: every ``FreshnessWorker`` instance claims an ephemeral
+``worker_id = {hostname}:{pid}:{short-uuid}`` at startup. The id keys the
+per-worker processing list (``freshness:{env}:processing:{worker_id}``),
+the heartbeat key (``freshness:{env}:heartbeat:{worker_id}``), and the
+reclaim lock (``freshness:{env}:reclaim_lock:{worker_id}``).
+
+The id is not persisted to disk — on crash + restart the new worker gets
+a fresh id, and the old processing list is discovered + drained by the
+reclaim pass.
+
+Test-only hook: ``METATRON_FRESHNESS_TEST_WORKER_ID`` pins the id so
+the SIGKILL integration test can assert on a deterministic key.
+Setting this variable in production is safe but unnecessary — the default
+composition already gives uniqueness per restart.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+
+
+def build_worker_id() -> str:
+    """Return a fresh worker id.
+
+    Respects the ``METATRON_FRESHNESS_TEST_WORKER_ID`` env override when
+    set to a non-empty value; otherwise composes
+    ``{hostname}:{pid}:{uuid4_prefix}``.
+    """
+    override = os.environ.get("METATRON_FRESHNESS_TEST_WORKER_ID")
+    if override:
+        return override
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+
+
+__all__ = ["build_worker_id"]

--- a/src/metatron/ingestion/freshness/target_raw_document.py
+++ b/src/metatron/ingestion/freshness/target_raw_document.py
@@ -199,6 +199,26 @@ class RawDocumentTarget:
                 exc_info=True,
             )
 
+    async def list_stale_candidates(
+        self,
+        workspace_id: str,
+        *,
+        older_than: datetime,
+        limit: int,
+    ) -> list[str]:
+        """KB scheduled scan is deferred (MTRNIX-316 follow-up).
+
+        Returns an empty list so the shared ``ScheduledScan`` orchestrator
+        is a no-op for the KB target kind. Follow-up ticket:
+        implement via ``raw_documents.last_freshness_run_at IS NULL OR <
+        :older_than`` and wire a second ``ScheduledScan`` in
+        ``_build_worker``.
+        """
+        _ = workspace_id
+        _ = older_than
+        _ = limit
+        return []
+
     async def sync_downstream_stores(
         self,
         workspace_id: str,

--- a/src/metatron/memory/.claude/CLAUDE.md
+++ b/src/metatron/memory/.claude/CLAUDE.md
@@ -92,10 +92,27 @@ over the target kind. This subtree keeps only the memory-specific glue:
   `scripts/backfill_memory_qdrant_status_payload.py` is the long-tail safety net.
   Callers: `FreshnessMonitor` (already wired in MTRNIX-313), `Curator`
   (MTRNIX-322), `apply_decision` mark_stale branch (MTRNIX-322).
+  `list_stale_candidates(ws, *, older_than, limit)` — MTRNIX-316:
+  delegates to `MemoryPostgresStore.list_stale_candidates` for the
+  scheduled-scan safety net. Returns non-terminal rows older than
+  `older_than`, ordered ASC by `updated_at`.
 - `producer.py` — memory-side enqueue hook (unchanged signature).
-- `worker.py` / `__main__.py` — worker entry point; now instantiates both a
-  memory and (when `freshness_kb_enabled`) a KB pipeline and dispatches jobs
-  by `target_kind`.
+- `worker.py` / `__main__.py` — worker entry point. Instantiates both a
+  memory and (when `freshness_kb_enabled`) a KB pipeline and dispatches
+  jobs by `target_kind`. **MTRNIX-316** adds per-worker processing-list
+  reclaim + periodic scheduled scan: each worker claims a
+  `worker_id = {hostname}:{pid}:{short-uuid}` at bootstrap, maintains
+  `freshness:{env}:processing:{worker_id}` and `freshness:{env}:heartbeat:{worker_id}`,
+  and every `METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS` iterations
+  drains any orphaned peer's processing list back to the main queue via
+  `reclaim_worker_orphans`. SIGKILL mid-batch no longer loses jobs.
+  Scheduled scan (memory only in MTRNIX-316; KB deferred) enqueues
+  synthetic `scheduled_scan` jobs for records that never received a
+  write-triggered freshness event. Test-only env vars for the SIGKILL
+  integration harness: `METATRON_FRESHNESS_TEST_WORKER_ID` (pins the
+  worker id so key assertions are deterministic),
+  `METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS` (widens the LMOVE → LREM
+  window so the kill lands mid-batch). Do not set these in production.
 
 The module's sibling files (`linker.py`, `reconciler.py`, `monitor.py`,
 `curator.py`, `coordination.py`, `decision_engine.py`, `metrics.py`) are now

--- a/src/metatron/memory/freshness/metrics.py
+++ b/src/metatron/memory/freshness/metrics.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from metatron.freshness.metrics import (  # noqa: F401
     decision_confidence,
     jobs_total,
+    legacy_keys_drained,
+    orphans_reclaimed,
     qdrant_sync_failed,
     queue_depth_gauge,
+    reclaim_errors,
+    scheduled_scan_errors,
+    scheduled_scan_jobs_enqueued,
     stage_duration,
     worker_errors,
 )
@@ -14,8 +19,13 @@ from metatron.freshness.metrics import (  # noqa: F401
 __all__ = [
     "decision_confidence",
     "jobs_total",
+    "legacy_keys_drained",
+    "orphans_reclaimed",
     "qdrant_sync_failed",
     "queue_depth_gauge",
+    "reclaim_errors",
+    "scheduled_scan_errors",
+    "scheduled_scan_jobs_enqueued",
     "stage_duration",
     "worker_errors",
 ]

--- a/src/metatron/memory/freshness/target_memory.py
+++ b/src/metatron/memory/freshness/target_memory.py
@@ -184,6 +184,24 @@ class MemoryTarget:
                 exc_info=True,
             )
 
+    async def list_stale_candidates(
+        self,
+        workspace_id: str,
+        *,
+        older_than: datetime,
+        limit: int,
+    ) -> list[str]:
+        """Delegate to :class:`MemoryPostgresStore.list_stale_candidates` (MTRNIX-316).
+
+        Returns ids of ``memory_records`` rows in non-terminal status whose
+        ``updated_at`` is older than ``older_than``. Ordered ascending so
+        the oldest candidates are enqueued first. Used by the scheduled-scan
+        rescue path.
+        """
+        return await self._pg.list_stale_candidates(
+            workspace_id, older_than=older_than, limit=limit
+        )
+
     async def sync_downstream_stores(
         self,
         workspace_id: str,

--- a/src/metatron/memory/freshness/worker.py
+++ b/src/metatron/memory/freshness/worker.py
@@ -2,23 +2,35 @@
 
 One ``run_once`` iteration:
 
-1. Enumerate active workspaces.
-2. ``dequeue_batch`` per workspace.
-3. For each job:
+1. Tick the heartbeat key (MTRNIX-316) so live reclaimers know we're alive.
+2. Every ``freshness_reclaim_interval_iterations`` iterations, run the
+   reclaim pass over any dead peer's processing list.
+3. If the scheduled-scan timer is due, kick off a safety-net scan per
+   registered ``ScheduledScan`` instance.
+4. Enumerate active workspaces.
+5. ``dequeue_batch`` per workspace — items are LMOVE'd onto the per-worker
+   processing list (``freshness:{env}:processing:{worker_id}``).
+6. For each job:
    * Log ``freshness_job_received`` MachineEvent (with ``target_kind``).
    * Dispatch to the pipeline matching ``job.target_kind``.
    * Linker → Reconciler → Monitor → Curator.
    * If the record still exists and is eligible, call ``DecisionEngine``
      + ``apply_decision`` through the target adapter.
    * Log ``freshness_job_processed`` MachineEvent.
+   * In the outer ``finally`` — call ``complete_job`` so the job is LREM'd
+     from the processing list whether we succeeded or raised.
 
-``main()`` wraps ``run_once`` in a bounded error-backoff loop and exits
-immediately when ``freshness_enabled=False``.
+``main()`` builds the worker, runs a one-shot reclaim + optional legacy
+drain, then enters the bounded error-backoff loop. On graceful shutdown
+(asyncio.CancelledError) ``release_worker`` deletes the heartbeat key so
+peers don't waste effort trying to reclaim a shutting-down worker.
 
 Workspace isolation: every stage call receives ``job.workspace_id``
-directly; the worker never assumes a default.
+directly; the worker never assumes a default. Processing lists are
+per-worker but each serialised job carries its own ``workspace_id`` —
+reclaim routes items back to the correct queue.
 
-Phase B (MTRNIX-313): the worker hosts *two* pipeline stacks (memory + KB)
+Phase B (MTRNIX-313): the worker hosts two pipeline stacks (memory + KB)
 and routes jobs on ``target_kind``. When the KB flag is off and no KB jobs
 are ever enqueued, the memory path is byte-identical to Phase A.
 """
@@ -27,6 +39,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -36,10 +49,12 @@ import structlog
 from metatron.core.config import get_settings
 from metatron.core.models import FreshnessJob, LifecycleStatus, MachineEvent
 from metatron.freshness import metrics
+from metatron.freshness.worker_id import build_worker_id
 
 if TYPE_CHECKING:
     from metatron.freshness.coordination import CoordinationStore
     from metatron.freshness.decision_engine import DecisionEngine
+    from metatron.freshness.scheduled_scan import ScheduledScan
     from metatron.freshness.stages.curator import Curator
     from metatron.freshness.stages.linker import Linker
     from metatron.freshness.stages.monitor import FreshnessMonitor
@@ -64,6 +79,14 @@ class _Pipeline:
 class FreshnessWorker:
     """Drives the pipeline one iteration at a time.
 
+    MTRNIX-316 adds:
+
+    * ``worker_id`` — composed via :func:`build_worker_id` at bootstrap.
+    * ``scheduled_scanners`` — zero-or-more :class:`ScheduledScan` instances.
+    * Timing knobs: ``heartbeat_ttl``, ``reclaim_interval_iterations``,
+      ``scheduled_scan_interval_seconds``. All default to the ``Settings``
+      values when not supplied.
+
     Phase A constructor kwargs (``linker=``, ``reconciler=``, ...) are still
     accepted for backward compatibility with Phase A test fixtures; when
     supplied they are treated as an implicit ``memory_record`` pipeline.
@@ -78,6 +101,12 @@ class FreshnessWorker:
         freshness_pg: FreshnessStore,
         decision_engine: DecisionEngine,
         pipelines: dict[str, _Pipeline] | None = None,
+        # MTRNIX-316 reliability kwargs.
+        worker_id: str | None = None,
+        scheduled_scanners: list[ScheduledScan] | None = None,
+        heartbeat_ttl: int | None = None,
+        reclaim_interval_iterations: int | None = None,
+        scheduled_scan_interval_seconds: int | None = None,
         # Phase A compat kwargs (deprecated, prefer ``pipelines``).
         linker: Linker | None = None,
         reconciler: Reconciler | None = None,
@@ -110,8 +139,60 @@ class FreshnessWorker:
             )
         self._pipelines = pipelines
 
+        settings = get_settings()
+        self._worker_id = worker_id or build_worker_id()
+        self._heartbeat_ttl = (
+            heartbeat_ttl
+            if heartbeat_ttl is not None
+            else settings.freshness_heartbeat_ttl_seconds
+        )
+        self._reclaim_interval_iterations = (
+            reclaim_interval_iterations
+            if reclaim_interval_iterations is not None
+            else settings.freshness_reclaim_interval_iterations
+        )
+        self._scheduled_scan_interval_seconds = (
+            scheduled_scan_interval_seconds
+            if scheduled_scan_interval_seconds is not None
+            else settings.freshness_scheduled_scan_interval_seconds
+        )
+        self._scheduled_scanners: list[ScheduledScan] = list(scheduled_scanners or [])
+
+        self._iteration_count = 0
+        # Start at 0.0 so the first tick fires immediately (the scan is
+        # cheap — one PG enumerate + a bounded per-workspace SELECT — and
+        # operators appreciate the "scan happened on startup" signal).
+        self._last_scan_monotonic = 0.0
+
+        logger.info(
+            "freshness.worker.worker_id_assigned",
+            worker_id=self._worker_id,
+            heartbeat_ttl=self._heartbeat_ttl,
+            reclaim_interval=self._reclaim_interval_iterations,
+            scheduled_scan_interval=self._scheduled_scan_interval_seconds,
+            scheduled_scanners=len(self._scheduled_scanners),
+        )
+
+    @property
+    def worker_id(self) -> str:
+        return self._worker_id
+
     async def run_once(self, max_jobs: int) -> int:
         """Dequeue + process up to ``max_jobs`` per workspace."""
+        self._iteration_count += 1
+
+        # 1. Heartbeat tick so peers know we're alive.
+        await self._coord.tick_heartbeat(self._worker_id, self._heartbeat_ttl)
+
+        # 2. Periodic reclaim pass.
+        if self._iteration_count % max(self._reclaim_interval_iterations, 1) == 0:
+            await self._reclaim_all_orphans()
+
+        # 3. Scheduled scan (time-based).
+        if self._scheduled_scanners and self._is_scan_due():
+            await self._run_scheduled_scans()
+
+        # 4. Regular dequeue + process loop.
         workspaces = await self._coord.list_active_workspaces()
         processed = 0
         for ws in workspaces:
@@ -121,17 +202,84 @@ class FreshnessWorker:
             except Exception:
                 logger.debug("freshness.worker.gauge_failed", exc_info=True)
 
-            jobs = await self._coord.dequeue_batch(ws, max_items=max_jobs)
+            jobs = await self._coord.dequeue_batch(
+                ws, max_items=max_jobs, worker_id=self._worker_id
+            )
             for job in jobs:
                 await self._process_job(job)
                 processed += 1
         return processed
+
+    async def _reclaim_all_orphans(self) -> None:
+        """Scan for dead-worker processing lists and drain each.
+
+        All failures are swallowed so a flaky Redis cannot take down the
+        main loop. Per-stage errors bump
+        ``freshness_reclaim_errors_total``.
+        """
+        settings = get_settings()
+        env_label = settings.env or ""
+        try:
+            worker_ids = await self._coord.list_processing_workers()
+        except Exception:
+            _inc_reclaim_error(env_label, "discover")
+            logger.warning("freshness.reclaim.discover_failed", exc_info=True)
+            return
+        logger.info(
+            "freshness.reclaim.start",
+            worker_id=self._worker_id,
+            worker_count=len(worker_ids),
+        )
+        for wid in worker_ids:
+            if wid == self._worker_id:
+                continue  # never reclaim self
+            try:
+                n = await self._coord.reclaim_worker_orphans(wid)
+                if n:
+                    logger.info(
+                        "freshness.reclaim.jobs_recovered",
+                        dead_worker_id=wid,
+                        count=n,
+                    )
+            except Exception:
+                _inc_reclaim_error(env_label, "drain")
+                logger.warning(
+                    "freshness.reclaim.drain_failed",
+                    dead_worker_id=wid,
+                    exc_info=True,
+                )
+
+    async def _run_scheduled_scans(self) -> None:
+        """Run each registered ``ScheduledScan.run()``; update the timer.
+
+        ``ScheduledScan.run`` swallows its own errors; we do not need an
+        extra try/except here.
+        """
+        for scanner in self._scheduled_scanners:
+            await scanner.run()
+        self._last_scan_monotonic = time.monotonic()
+
+    def _is_scan_due(self) -> bool:
+        """Return True when the scheduled-scan timer has elapsed."""
+        now = time.monotonic()
+        elapsed = now - self._last_scan_monotonic
+        return elapsed >= self._scheduled_scan_interval_seconds
 
     async def _process_job(self, job: FreshnessJob) -> None:
         ws = job.workspace_id
         target_id = job.target_id
         target_kind = job.target_kind or "memory_record"
         started = time.monotonic()
+
+        # Integration-test knob (MTRNIX-316): widen the window between LMOVE
+        # and LREM so the SIGKILL test can fire mid-batch deterministically.
+        # No-op in production when the env var is unset.
+        test_sleep_ms = os.environ.get("METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS")
+        if test_sleep_ms:
+            try:
+                await asyncio.sleep(int(test_sleep_ms) / 1000)
+            except ValueError:
+                pass
 
         pipeline = self._pipelines.get(target_kind)
         if pipeline is None:
@@ -141,7 +289,6 @@ class FreshnessWorker:
                 target_kind=target_kind,
                 target_id=target_id,
             )
-            # Still audit the skip so operators see the poison job in the log.
             await self._freshness_pg.save_machine_event(
                 MachineEvent(
                     workspace_id=ws,
@@ -155,6 +302,8 @@ class FreshnessWorker:
                     },
                 )
             )
+            # Still LREM the job from the processing list (outer finally).
+            await self._coord.complete_job(self._worker_id, job)
             return
 
         await self._freshness_pg.save_machine_event(
@@ -168,8 +317,6 @@ class FreshnessWorker:
         )
 
         if job.event_type == "knowledge_deleted":
-            # We only log the receipt; lifecycle work for deleted records
-            # is out of scope.
             metrics.jobs_total.labels(status="deleted", workspace_id=ws).inc()
             duration_ms = int((time.monotonic() - started) * 1000)
             await self._freshness_pg.save_machine_event(
@@ -185,6 +332,7 @@ class FreshnessWorker:
                     },
                 )
             )
+            await self._coord.complete_job(self._worker_id, job)
             return
 
         decision_action = "skipped_missing"
@@ -248,6 +396,17 @@ class FreshnessWorker:
                     },
                 )
             )
+            # LREM the job from the processing list (MTRNIX-316). Must
+            # happen whether we succeeded or raised so the orphan-reclaim
+            # pass does not re-process a job we already completed.
+            await self._coord.complete_job(self._worker_id, job)
+
+
+def _inc_reclaim_error(env_label: str, stage: str) -> None:
+    try:
+        metrics.reclaim_errors.labels(env=env_label, stage=stage).inc()
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -256,36 +415,50 @@ class FreshnessWorker:
 
 
 async def _run_loop(worker: FreshnessWorker) -> None:
-    """Shared loop body. Exposed for tests so they can mock ``run_once``."""
+    """Shared loop body. Exposed for tests so they can mock ``run_once``.
+
+    MTRNIX-316: always calls ``release_worker`` on exit so a graceful
+    shutdown proactively drops the heartbeat key (peers don't waste
+    effort reclaiming a worker that's already gone).
+    """
     settings = get_settings()
     consecutive_errors = 0
-    while True:
-        try:
-            processed = await worker.run_once(settings.freshness_max_jobs_per_iteration)
-            consecutive_errors = 0
-            if processed == 0:
-                await asyncio.sleep(settings.freshness_poll_seconds)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            consecutive_errors += 1
-            backoff = min(
-                settings.freshness_backoff_base_seconds * (2 ** (consecutive_errors - 1)),
-                settings.freshness_backoff_max_seconds,
-            )
-            logger.error(
-                "freshness.worker.iteration_failed",
-                attempt=consecutive_errors,
-                backoff=backoff,
-                exc_info=True,
-            )
-            if consecutive_errors >= settings.freshness_max_consecutive_errors:
-                logger.critical(
-                    "freshness.worker.hard_exit",
-                    errors=consecutive_errors,
-                )
+    try:
+        while True:
+            try:
+                processed = await worker.run_once(settings.freshness_max_jobs_per_iteration)
+                consecutive_errors = 0
+                if processed == 0:
+                    await asyncio.sleep(settings.freshness_poll_seconds)
+            except asyncio.CancelledError:
                 raise
-            await asyncio.sleep(backoff)
+            except Exception:
+                consecutive_errors += 1
+                backoff = min(
+                    settings.freshness_backoff_base_seconds * (2 ** (consecutive_errors - 1)),
+                    settings.freshness_backoff_max_seconds,
+                )
+                logger.error(
+                    "freshness.worker.iteration_failed",
+                    attempt=consecutive_errors,
+                    backoff=backoff,
+                    exc_info=True,
+                )
+                if consecutive_errors >= settings.freshness_max_consecutive_errors:
+                    logger.critical(
+                        "freshness.worker.hard_exit",
+                        errors=consecutive_errors,
+                    )
+                    raise
+                await asyncio.sleep(backoff)
+    finally:
+        # Best-effort heartbeat cleanup. Do NOT await inside the
+        # CancelledError-caught branch — we want the finally to run even
+        # under cancellation.
+        try:
+            await worker._coord.release_worker(worker.worker_id)
+        except Exception:
+            pass
 
 
 async def _build_worker() -> FreshnessWorker:
@@ -293,12 +466,14 @@ async def _build_worker() -> FreshnessWorker:
 
     Builds both memory and KB pipelines. When ``freshness_kb_enabled=False``
     the KB pipeline is still constructed but never receives jobs (the KB
-    producer short-circuits before enqueue).
+    producer short-circuits before enqueue). Also wires a memory
+    :class:`ScheduledScan` for the MTRNIX-316 safety-net scan.
     """
     from sqlalchemy.ext.asyncio import create_async_engine
 
     from metatron.freshness.coordination import CoordinationStore
     from metatron.freshness.decision_engine import build_default_decision_engine
+    from metatron.freshness.scheduled_scan import ScheduledScan
     from metatron.freshness.stages.curator import Curator
     from metatron.freshness.stages.linker import Linker
     from metatron.freshness.stages.monitor import FreshnessMonitor
@@ -365,9 +540,6 @@ async def _build_worker() -> FreshnessWorker:
     _kb_qdrant_cache: dict[str, AsyncQdrantVectorStore] = {}
 
     def kb_qdrant_factory(ws: str) -> AsyncQdrantVectorStore:
-        # AsyncQdrantVectorStore is async under the hood (collection
-        # ensured on first call) but the constructor is sync. Cache one
-        # instance per workspace so repeated similarity searches reuse it.
         if ws not in _kb_qdrant_cache:
             _kb_qdrant_cache[ws] = AsyncQdrantVectorStore(
                 workspace_id=ws,
@@ -428,17 +600,41 @@ async def _build_worker() -> FreshnessWorker:
         ),
     }
 
+    # --- Scheduled scan (memory only in MTRNIX-316; KB deferred) ---
+    scheduled_scanners: list[ScheduledScan] = []
+    if settings.freshness_scheduled_scan_enabled:
+        async def memory_workspace_lister() -> list[str]:
+            # Enumerate workspaces via the memory PG store — SELECT DISTINCT
+            # workspace_id FROM memory_records. Scoped by engine; never
+            # leaks across tenants.
+            return await memory_pg_store.list_workspaces()
+
+        scheduled_scanners.append(
+            ScheduledScan(
+                target_kind="memory_record",
+                target=memory_target,
+                coordination=coordination,
+                workspace_lister=memory_workspace_lister,
+                stale_after_days=settings.freshness_stale_after_days,
+                batch_limit=settings.freshness_scan_batch_limit,
+            )
+        )
+
     return FreshnessWorker(
         coordination=coordination,
         freshness_pg=freshness_store,
         decision_engine=build_default_decision_engine(),
         pipelines=pipelines,
+        worker_id=build_worker_id(),
+        scheduled_scanners=scheduled_scanners,
+        heartbeat_ttl=settings.freshness_heartbeat_ttl_seconds,
+        reclaim_interval_iterations=settings.freshness_reclaim_interval_iterations,
+        scheduled_scan_interval_seconds=settings.freshness_scheduled_scan_interval_seconds,
     )
 
 
 async def main() -> None:
     """Entry point for ``python -m metatron.memory.freshness``."""
-    # Core/logging.py configure_logging does structlog; we just tune stdlib.
     logging.getLogger().setLevel(logging.INFO)
     settings = get_settings()
     if not settings.freshness_enabled:
@@ -451,4 +647,25 @@ async def main() -> None:
         kb_enabled=settings.freshness_kb_enabled,
     )
     worker = await _build_worker()
+
+    # Startup: tick heartbeat once so the processing-list lookup doesn't
+    # discover us as dead, then one-shot reclaim of any orphaned peers,
+    # then optional legacy-unprefixed drain when the operator explicitly
+    # opts-in via METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP=true.
+    try:
+        await worker._coord.tick_heartbeat(worker.worker_id, worker._heartbeat_ttl)
+        await worker._reclaim_all_orphans()
+        if settings.freshness_drain_legacy_at_startup:
+            try:
+                moved = await worker._coord.drain_legacy_unprefixed()
+                logger.info(
+                    "freshness.legacy.drain.startup_done",
+                    moved=moved,
+                )
+            except Exception:
+                logger.warning("freshness.legacy.drain.startup_failed", exc_info=True)
+    except Exception:
+        # Startup hooks are best-effort; never block the main loop.
+        logger.warning("freshness.worker.startup_hooks_failed", exc_info=True)
+
     await _run_loop(worker)

--- a/src/metatron/memory/freshness/worker.py
+++ b/src/metatron/memory/freshness/worker.py
@@ -38,6 +38,7 @@ are ever enqueued, the memory path is byte-identical to Phase A.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import time
@@ -276,10 +277,8 @@ class FreshnessWorker:
         # No-op in production when the env var is unset.
         test_sleep_ms = os.environ.get("METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS")
         if test_sleep_ms:
-            try:
+            with contextlib.suppress(ValueError):
                 await asyncio.sleep(int(test_sleep_ms) / 1000)
-            except ValueError:
-                pass
 
         pipeline = self._pipelines.get(target_kind)
         if pipeline is None:
@@ -403,10 +402,8 @@ class FreshnessWorker:
 
 
 def _inc_reclaim_error(env_label: str, stage: str) -> None:
-    try:
+    with contextlib.suppress(Exception):
         metrics.reclaim_errors.labels(env=env_label, stage=stage).inc()
-    except Exception:
-        pass
 
 
 # ---------------------------------------------------------------------------
@@ -455,10 +452,8 @@ async def _run_loop(worker: FreshnessWorker) -> None:
         # Best-effort heartbeat cleanup. Do NOT await inside the
         # CancelledError-caught branch — we want the finally to run even
         # under cancellation.
-        try:
+        with contextlib.suppress(Exception):
             await worker._coord.release_worker(worker.worker_id)
-        except Exception:
-            pass
 
 
 async def _build_worker() -> FreshnessWorker:
@@ -603,6 +598,7 @@ async def _build_worker() -> FreshnessWorker:
     # --- Scheduled scan (memory only in MTRNIX-316; KB deferred) ---
     scheduled_scanners: list[ScheduledScan] = []
     if settings.freshness_scheduled_scan_enabled:
+
         async def memory_workspace_lister() -> list[str]:
             # Enumerate workspaces via the memory PG store — SELECT DISTINCT
             # workspace_id FROM memory_records. Scoped by engine; never

--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -165,6 +165,31 @@ adapter swallows failures since the graph is a derived store.
 - `set_raw_document_status(workspace_id, doc_label, status)` — set
   `d.status` property on `:Document` for graph-side observability (no index).
 
+### `redis.py`
+Thin async wrapper over `redis.asyncio.Redis`. Exposes cache ops, queue
+primitives, and token-guarded locks for the freshness pipeline.
+
+Cache ops: `get`, `set`, `delete`, `exists`, `expire`, `get_json`, `set_json`.
+
+Queue primitives (MTRNIX-304 + MTRNIX-316):
+- `lpush(key, value) -> int` — push to head of list.
+- `rpop_batch(key, max_items) -> list[str]` — atomic Lua multi-pop
+  (legacy Phase A path; production callers use `lmove_rightleft` now).
+- `llen(key) -> int`.
+- `scan_keys(pattern) -> list[str]` — SCAN with bounded pattern.
+- `lmove_rightleft(src, dst) -> str | None` — MTRNIX-316: atomic
+  `LMOVE src dst RIGHT LEFT`, the RPOPLPUSH-style primitive used by the
+  freshness processing-list reclaim pattern. Requires Redis >= 6.2.
+- `peek_tail(key) -> str | None` — MTRNIX-316: `LINDEX key -1`, used by
+  reclaim to inspect the next orphaned job before routing it.
+- `lrem(key, value, count=1) -> int` — MTRNIX-316: remove occurrences of
+  `value` from a list (count=1 by default). Used to drop a serialised
+  job from the per-worker processing list on successful completion.
+
+Lock primitives: token-guarded Lua scripts (`acquire_lock`,
+`heartbeat_lock`, `release_lock`) so a worker cannot release a lock held
+by another worker.
+
 ### `memory_redis.py`
 Redis session cache for Agent Memory (WS1). Wraps existing `RedisStore`.
 
@@ -210,6 +235,8 @@ Class: `MemoryPostgresStore(engine: AsyncEngine)`
 - `list_records(workspace_id, agent_id?, scope?, status?, limit?, offset?) -> list[MemoryRecord]` — filtered list. `status` (MTRNIX-314) adds a `status = ANY(:status_list)` WHERE clause when provided.
 - `count_records(workspace_id, agent_id?, scope?, status?) -> int` — same filter surface so pagination `total` matches `list_records`.
 - `get_many_statuses(workspace_id, record_ids) -> dict[str, LifecycleStatus]` (MTRNIX-314) — batched status lookup used by the hybrid-search graph-leg post-filter.
+- `list_workspaces() -> list[str]` (MTRNIX-316) — `SELECT DISTINCT workspace_id FROM memory_records`. Used by the scheduled-scan safety net to enumerate workspaces without depending on a higher-level manager.
+- `list_stale_candidates(workspace_id, *, older_than, limit) -> list[str]` (MTRNIX-316) — returns ids of non-terminal records older than `older_than`, ordered ASC by `updated_at`. Used by `MemoryTarget.list_stale_candidates` for the scheduled-scan rescue path.
 - `reset(workspace_id, agent_id?, scope?) -> tuple[int, list[str]]` — DELETE RETURNING id, returns (count, deleted_ids)
 - `get_by_hash(workspace_id, agent_id, content_hash) -> MemoryRecord | None` — dedup lookup (ORDER BY created_at DESC)
 - `delete_expired(workspace_id) -> int` — TTL cleanup (not yet wired to a periodic trigger)

--- a/src/metatron/storage/memory_postgres.py
+++ b/src/metatron/storage/memory_postgres.py
@@ -313,6 +313,39 @@ class MemoryPostgresStore:
             )
             return result.scalar() or 0
 
+    async def list_stale_candidates(
+        self,
+        workspace_id: str,
+        *,
+        older_than: datetime,
+        limit: int = 500,
+    ) -> list[str]:
+        """Return ids of non-terminal records older than ``older_than`` (MTRNIX-316).
+
+        Used by the scheduled-scan safety net to enqueue freshness jobs for
+        memory records that never received a write-triggered event. Skips
+        terminal statuses (``stale``, ``superseded``, ``archived``) so the
+        pipeline does not re-process lifecycle-closed rows. Ordered ASC so
+        the oldest rows run first.
+        """
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    """
+                    SELECT id
+                    FROM memory_records
+                    WHERE workspace_id = :ws
+                      AND status NOT IN ('stale', 'superseded', 'archived')
+                      AND updated_at < :older_than
+                    ORDER BY updated_at ASC
+                    LIMIT :limit
+                    """
+                ),
+                {"ws": workspace_id, "older_than": older_than, "limit": limit},
+            )
+            rows = result.fetchall()
+        return [str(row[0]) for row in rows]
+
     async def get_many_statuses(
         self, workspace_id: str, record_ids: list[str]
     ) -> dict[str, LifecycleStatus]:

--- a/src/metatron/storage/memory_postgres.py
+++ b/src/metatron/storage/memory_postgres.py
@@ -313,6 +313,22 @@ class MemoryPostgresStore:
             )
             return result.scalar() or 0
 
+    async def list_workspaces(self) -> list[str]:
+        """Return distinct ``workspace_id`` values present in ``memory_records``.
+
+        Used by the scheduled-scan safety net to enumerate workspaces
+        without having to depend on a higher-level ``WorkspacesManager``
+        (MTRNIX-316). Returns an empty list on PG failure? No — let the
+        exception propagate so the caller can swallow+bump the scan-error
+        counter (``ScheduledScan.run`` already does).
+        """
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT DISTINCT workspace_id FROM memory_records")
+            )
+            rows = result.fetchall()
+        return [str(row[0]) for row in rows]
+
     async def list_stale_candidates(
         self,
         workspace_id: str,

--- a/src/metatron/storage/memory_postgres.py
+++ b/src/metatron/storage/memory_postgres.py
@@ -323,9 +323,7 @@ class MemoryPostgresStore:
         counter (``ScheduledScan.run`` already does).
         """
         async with self._engine.begin() as conn:
-            result = await conn.execute(
-                text("SELECT DISTINCT workspace_id FROM memory_records")
-            )
+            result = await conn.execute(text("SELECT DISTINCT workspace_id FROM memory_records"))
             rows = result.fetchall()
         return [str(row[0]) for row in rows]
 

--- a/src/metatron/storage/redis.py
+++ b/src/metatron/storage/redis.py
@@ -140,6 +140,40 @@ class RedisStore:
         awaitable = cast("Awaitable[int]", self._client.llen(key))
         return int(await awaitable)
 
+    async def lmove_rightleft(self, src: str, dst: str) -> str | None:
+        """Atomically ``LMOVE src dst RIGHT LEFT`` (MTRNIX-316).
+
+        Takes the tail (oldest) item of ``src`` and pushes it to the head
+        of ``dst``. Returns the moved value, or ``None`` when ``src`` is
+        empty. Requires Redis >= 6.2.
+        """
+        awaitable = cast(
+            "Awaitable[str | None]",
+            self._client.lmove(src, dst, "RIGHT", "LEFT"),
+        )
+        return await awaitable
+
+    async def peek_tail(self, key: str) -> str | None:
+        """Return the tail value of ``key`` without mutating — ``LINDEX key -1``.
+
+        Used by the freshness reclaim pass to inspect the next job on a
+        dead worker's processing list before moving it back to its
+        workspace queue (MTRNIX-316).
+        """
+        awaitable = cast("Awaitable[str | None]", self._client.lindex(key, -1))
+        return await awaitable
+
+    async def lrem(self, key: str, value: str, count: int = 1) -> int:
+        """Remove up to ``count`` occurrences of ``value`` from ``key``.
+
+        ``count = 1`` removes the first matching element from head.
+        Returns the number of elements actually removed (0 when nothing
+        matched). Used by the freshness worker to drop a job from its
+        processing list after successful processing (MTRNIX-316).
+        """
+        awaitable = cast("Awaitable[int]", self._client.lrem(key, count, value))
+        return int(await awaitable)
+
     async def scan_keys(self, match: str, count: int = 100) -> list[str]:
         """Non-blocking SCAN over keys matching a pattern.
 

--- a/tests/integration/memory/freshness/test_env_prefix_isolation.py
+++ b/tests/integration/memory/freshness/test_env_prefix_isolation.py
@@ -81,9 +81,7 @@ async def _wait_for_event(
 ) -> bool:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
-        events = await freshness_pg.list_events_for_target(
-            workspace, "memory_record", target_id
-        )
+        events = await freshness_pg.list_events_for_target(workspace, "memory_record", target_id)
         if any(e.event_type == event_type for e in events):
             return True
         await asyncio.sleep(0.5)
@@ -191,9 +189,7 @@ async def test_env_prefixed_keys_isolate_environments(
         await _cleanup_pg(engine, workspace)
         # Wipe any residual freshness keys under both env prefixes.
         for env_name in ("staging", "development"):
-            for suffix_fn in (
-                lambda ws: f"freshness:{env_name}:queue:{ws}",
-            ):
+            for suffix_fn in (lambda ws: f"freshness:{env_name}:queue:{ws}",):
                 try:
                     await redis.delete(suffix_fn(workspace))
                 except Exception:

--- a/tests/integration/memory/freshness/test_env_prefix_isolation.py
+++ b/tests/integration/memory/freshness/test_env_prefix_isolation.py
@@ -11,6 +11,7 @@ Requires PostgreSQL (migration 016 applied), Qdrant, Redis live.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import signal
 import subprocess
@@ -182,18 +183,14 @@ async def test_env_prefixed_keys_isolate_environments(
                     p.send_signal(signal.SIGTERM)
                     p.wait(timeout=5)
                 except Exception:
-                    try:
+                    with contextlib.suppress(Exception):
                         p.kill()
-                    except Exception:
-                        pass
         await _cleanup_pg(engine, workspace)
         # Wipe any residual freshness keys under both env prefixes.
         for env_name in ("staging", "development"):
-            for suffix_fn in (lambda ws: f"freshness:{env_name}:queue:{ws}",):
-                try:
-                    await redis.delete(suffix_fn(workspace))
-                except Exception:
-                    pass
+            key = f"freshness:{env_name}:queue:{workspace}"
+            with contextlib.suppress(Exception):
+                await redis.delete(key)
         # Cleanup per-worker processing lists + heartbeats.
         from metatron.freshness.coordination import (
             _heartbeat_key,
@@ -203,14 +200,10 @@ async def test_env_prefixed_keys_isolate_environments(
 
         for wid in (worker_dev, worker_staging):
             for key_fn in (processing_key_for, _heartbeat_key, _reclaim_lock_key):
-                try:
+                with contextlib.suppress(Exception):
                     await redis.delete(key_fn(wid))
-                except Exception:
-                    pass
         if hasattr(qdrant, "close"):
-            try:
+            with contextlib.suppress(Exception):
                 await qdrant.close()
-            except Exception:
-                pass
         await redis.close()
         await engine.dispose()

--- a/tests/integration/memory/freshness/test_env_prefix_isolation.py
+++ b/tests/integration/memory/freshness/test_env_prefix_isolation.py
@@ -1,0 +1,220 @@
+"""Integration test — env-prefixed keys isolate dev rigs (MTRNIX-316).
+
+Enqueue a freshness job while ``METATRON_ENV=staging`` is in effect. Spawn a
+worker under ``METATRON_ENV=development`` and prove it never touches the
+staging key. Then spawn a second worker under ``METATRON_ENV=staging`` and
+assert the job gets processed.
+
+Requires PostgreSQL (migration 016 applied), Qdrant, Redis live.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+import time
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.core import config as config_mod
+from metatron.core.config import get_settings
+from metatron.core.models import FreshnessJob, MemoryRecord, MemoryScope
+from metatron.freshness.coordination import CoordinationStore
+from metatron.storage.freshness_pg import FreshnessStore
+from metatron.storage.memory_postgres import MemoryPostgresStore
+from metatron.storage.memory_qdrant import MemoryQdrantStore
+from metatron.storage.redis import RedisStore
+
+pytestmark = pytest.mark.integration
+
+
+_WORKSPACE_PREFIX = "fresh-it-env-"
+
+
+def _spawn_worker(env_override: str, worker_id: str) -> subprocess.Popen[bytes]:
+    env = os.environ.copy()
+    env["METATRON_ENV"] = env_override
+    env["METATRON_FRESHNESS_ENABLED"] = "true"
+    env["METATRON_FRESHNESS_TEST_WORKER_ID"] = worker_id
+    env["METATRON_FRESHNESS_POLL_SECONDS"] = "0.5"
+    env["METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS"] = "3"
+    env["METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS"] = "3"
+    env["METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED"] = "false"
+    env["METATRON_FRESHNESS_MAX_JOBS_PER_ITERATION"] = "5"
+    return subprocess.Popen(
+        [sys.executable, "-m", "metatron.memory.freshness"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+async def _cleanup_pg(engine, workspace: str) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa_text("DELETE FROM machine_events WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM review_entries WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM memory_records WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+
+
+async def _wait_for_event(
+    freshness_pg: FreshnessStore,
+    workspace: str,
+    target_id: str,
+    *,
+    event_type: str,
+    timeout_s: float,
+) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        events = await freshness_pg.list_events_for_target(
+            workspace, "memory_record", target_id
+        )
+        if any(e.event_type == event_type for e in events):
+            return True
+        await asyncio.sleep(0.5)
+    return False
+
+
+async def test_env_prefixed_keys_isolate_environments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = get_settings()
+
+    workspace = f"{_WORKSPACE_PREFIX}{uuid4().hex[:8]}"
+    record_id = uuid4().hex
+
+    redis = RedisStore(settings.redis_url)
+    try:
+        if not await redis.ping():
+            pytest.skip("Redis unreachable")
+    except Exception:
+        pytest.skip("Redis unreachable")
+
+    # Force ENV=staging in this process so enqueue uses staging-prefixed key.
+    monkeypatch.setenv("METATRON_ENV", "staging")
+    config_mod._settings = None  # invalidate cached Settings
+    settings_staging = get_settings()
+    assert settings_staging.env == "staging"
+
+    coordination = CoordinationStore(redis=redis)
+    engine = create_async_engine(settings_staging.postgres_dsn, pool_pre_ping=True)
+    pg_store = MemoryPostgresStore(engine)
+    freshness_pg = FreshnessStore(engine)
+    qdrant = MemoryQdrantStore(workspace_id=workspace)
+
+    proc_dev: subprocess.Popen[bytes] | None = None
+    proc_staging: subprocess.Popen[bytes] | None = None
+    worker_dev = "envtest-worker-dev"
+    worker_staging = "envtest-worker-staging"
+
+    try:
+        # Seed record.
+        rec = MemoryRecord(
+            id=record_id,
+            workspace_id=workspace,
+            agent_id="agent-env",
+            scope=MemoryScope.PER_AGENT,
+            source_type="env_prefix_test",
+            content="Env prefix isolation record",
+            content_hash=f"env-{record_id}",
+        )
+        await pg_store.save(rec)
+        await qdrant.upsert(rec)
+
+        # Enqueue under env=staging — the job lands on
+        # freshness:staging:queue:{workspace}.
+        await coordination.enqueue_job(
+            FreshnessJob(
+                workspace_id=workspace,
+                event_type="knowledge_changed",
+                target_kind="memory_record",
+                target_id=record_id,
+            )
+        )
+        staging_depth = await coordination.queue_depth(workspace)
+        assert staging_depth == 1
+
+        # Spawn a development worker — must NOT see the staging job.
+        proc_dev = _spawn_worker("development", worker_dev)
+
+        # Wait 8 seconds; assert no ``freshness_job_received`` event yet.
+        saw_event = await _wait_for_event(
+            freshness_pg,
+            workspace,
+            record_id,
+            event_type="freshness_job_received",
+            timeout_s=8.0,
+        )
+        assert saw_event is False, "development worker processed a staging job"
+
+        # Staging queue still holds it.
+        staging_depth_after_dev = await coordination.queue_depth(workspace)
+        assert staging_depth_after_dev == 1
+
+        # Now spawn a staging worker — it processes the job.
+        proc_staging = _spawn_worker("staging", worker_staging)
+
+        processed = await _wait_for_event(
+            freshness_pg,
+            workspace,
+            record_id,
+            event_type="freshness_job_processed",
+            timeout_s=30.0,
+        )
+        assert processed is True, "staging worker did not process the seeded job"
+    finally:
+        for p in (proc_dev, proc_staging):
+            if p is not None:
+                try:
+                    p.send_signal(signal.SIGTERM)
+                    p.wait(timeout=5)
+                except Exception:
+                    try:
+                        p.kill()
+                    except Exception:
+                        pass
+        await _cleanup_pg(engine, workspace)
+        # Wipe any residual freshness keys under both env prefixes.
+        for env_name in ("staging", "development"):
+            for suffix_fn in (
+                lambda ws: f"freshness:{env_name}:queue:{ws}",
+            ):
+                try:
+                    await redis.delete(suffix_fn(workspace))
+                except Exception:
+                    pass
+        # Cleanup per-worker processing lists + heartbeats.
+        from metatron.freshness.coordination import (
+            _heartbeat_key,
+            _reclaim_lock_key,
+            processing_key_for,
+        )
+
+        for wid in (worker_dev, worker_staging):
+            for key_fn in (processing_key_for, _heartbeat_key, _reclaim_lock_key):
+                try:
+                    await redis.delete(key_fn(wid))
+                except Exception:
+                    pass
+        if hasattr(qdrant, "close"):
+            try:
+                await qdrant.close()
+            except Exception:
+                pass
+        await redis.close()
+        await engine.dispose()

--- a/tests/integration/memory/freshness/test_reclaim_sigkill.py
+++ b/tests/integration/memory/freshness/test_reclaim_sigkill.py
@@ -22,12 +22,12 @@ are assumed running per CLAUDE.md.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import signal
 import subprocess
 import sys
 import time
-from collections.abc import Iterator
 from uuid import uuid4
 
 import pytest
@@ -103,29 +103,21 @@ async def _cleanup_pg(engine, workspace: str) -> None:
 
 async def _cleanup_redis(redis: RedisStore, workspace: str, worker_ids: list[str]) -> None:
     # Wipe any freshness:* keys for the test workspace + workers.
+    from metatron.freshness.coordination import (
+        _heartbeat_key,
+        _reclaim_lock_key,
+        queue_key_for,
+    )
+
     for wid in worker_ids:
-        try:
+        with contextlib.suppress(Exception):
             await redis.delete(processing_key_for(wid))
-        except Exception:
-            pass
-        # Heartbeat + reclaim lock keys use the same env prefix.
-        from metatron.freshness.coordination import _heartbeat_key, _reclaim_lock_key
-
-        try:
+        with contextlib.suppress(Exception):
             await redis.delete(_heartbeat_key(wid))
-        except Exception:
-            pass
-        try:
+        with contextlib.suppress(Exception):
             await redis.delete(_reclaim_lock_key(wid))
-        except Exception:
-            pass
-    # And the workspace queue.
-    from metatron.freshness.coordination import queue_key_for
-
-    try:
+    with contextlib.suppress(Exception):
         await redis.delete(queue_key_for(workspace))
-    except Exception:
-        pass
 
 
 async def _wait_for_processing_items(
@@ -272,7 +264,10 @@ async def test_reclaim_after_sigkill_recovers_all_jobs(
             record_ids,
             event_type="freshness_job_processed",
             expected_count=n_jobs,
-            timeout_s=60.0,
+            # Generous timeout — the pipeline hits Ollama for embeddings
+            # (Linker + Reconciler) and each call can take ~1s under load.
+            # 120s covers slow-CI scenarios with 5 records × 2 stages.
+            timeout_s=120.0,
         )
         assert count == n_jobs, (
             f"only {count}/{n_jobs} records produced freshness_job_processed events"
@@ -287,16 +282,12 @@ async def test_reclaim_after_sigkill_recovers_all_jobs(
                     p.send_signal(signal.SIGTERM)
                     p.wait(timeout=5)
                 except Exception:
-                    try:
+                    with contextlib.suppress(Exception):
                         p.kill()
-                    except Exception:
-                        pass
         await _cleanup_pg(engine, workspace)
         await _cleanup_redis(redis, workspace, [worker_a, worker_b])
         if hasattr(qdrant, "close"):
-            try:
+            with contextlib.suppress(Exception):
                 await qdrant.close()
-            except Exception:
-                pass
         await redis.close()
         await engine.dispose()

--- a/tests/integration/memory/freshness/test_reclaim_sigkill.py
+++ b/tests/integration/memory/freshness/test_reclaim_sigkill.py
@@ -1,0 +1,304 @@
+"""Integration test — SIGKILL mid-batch + second worker reclaims (MTRNIX-316).
+
+This is the MTRNIX-316 AC gate. Exercise:
+
+1. Seed N=5 memory records + enqueue 5 freshness jobs on workspace X.
+2. Spawn worker A as a subprocess with ``METATRON_FRESHNESS_TEST_WORKER_ID``
+   and ``METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS`` set — the latter widens
+   the window between LMOVE (into processing list) and LREM (on complete)
+   so the kill lands mid-batch deterministically.
+3. Poll ``LLEN processing:worker-a`` until >= 1 item is visible — that
+   proves at least one LMOVE completed.
+4. ``os.kill(pid, SIGKILL)`` + ``proc.wait``.
+5. Assert: queue + processing_list_a combined still hold N jobs — no loss.
+6. Spawn worker B (no sleep, different worker id).
+7. Wait for all 5 ``freshness_job_processed`` MachineEvents to be written.
+8. Assert worker A's processing list is empty.
+
+Requires PostgreSQL (migration 016 applied), Qdrant, Redis. All services
+are assumed running per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.core.config import get_settings
+from metatron.core.models import (
+    FreshnessJob,
+    MemoryRecord,
+    MemoryScope,
+)
+from metatron.freshness.coordination import (
+    CoordinationStore,
+    processing_key_for,
+)
+from metatron.storage.freshness_pg import FreshnessStore
+from metatron.storage.memory_postgres import MemoryPostgresStore
+from metatron.storage.memory_qdrant import MemoryQdrantStore
+from metatron.storage.redis import RedisStore
+
+pytestmark = pytest.mark.integration
+
+
+_WORKSPACE_PREFIX = "fresh-it-reclaim-"
+
+
+def _spawn_worker(
+    worker_id: str,
+    *,
+    sleep_ms: int = 0,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.Popen[bytes]:
+    """Spawn ``python -m metatron.memory.freshness`` as a subprocess."""
+    env = os.environ.copy()
+    env["METATRON_FRESHNESS_ENABLED"] = "true"
+    env["METATRON_FRESHNESS_TEST_WORKER_ID"] = worker_id
+    if sleep_ms:
+        env["METATRON_FRESHNESS_TEST_PROCESS_SLEEP_MS"] = str(sleep_ms)
+    # Tight poll so reclaim fires quickly after kill.
+    env["METATRON_FRESHNESS_POLL_SECONDS"] = "0.5"
+    # Short heartbeat so the reclaim pass considers worker A dead fast.
+    env["METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS"] = "3"
+    env["METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS"] = "2"
+    env["METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED"] = "false"
+    env["METATRON_FRESHNESS_MAX_JOBS_PER_ITERATION"] = "5"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.Popen(
+        [sys.executable, "-m", "metatron.memory.freshness"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+async def _cleanup_pg(engine, workspace: str) -> None:
+    from sqlalchemy import text as sa_text
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa_text("DELETE FROM machine_events WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM review_entries WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM memory_records WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+
+
+async def _cleanup_redis(redis: RedisStore, workspace: str, worker_ids: list[str]) -> None:
+    # Wipe any freshness:* keys for the test workspace + workers.
+    for wid in worker_ids:
+        try:
+            await redis.delete(processing_key_for(wid))
+        except Exception:
+            pass
+        # Heartbeat + reclaim lock keys use the same env prefix.
+        from metatron.freshness.coordination import _heartbeat_key, _reclaim_lock_key
+
+        try:
+            await redis.delete(_heartbeat_key(wid))
+        except Exception:
+            pass
+        try:
+            await redis.delete(_reclaim_lock_key(wid))
+        except Exception:
+            pass
+    # And the workspace queue.
+    from metatron.freshness.coordination import queue_key_for
+
+    try:
+        await redis.delete(queue_key_for(workspace))
+    except Exception:
+        pass
+
+
+async def _wait_for_processing_items(
+    redis: RedisStore,
+    worker_id: str,
+    *,
+    min_items: int,
+    timeout_s: float,
+) -> int:
+    """Poll LLEN until >= min_items or timeout. Returns final count."""
+    deadline = time.monotonic() + timeout_s
+    p_key = processing_key_for(worker_id)
+    last = 0
+    while time.monotonic() < deadline:
+        last = await redis.llen(p_key)
+        if last >= min_items:
+            return last
+        await asyncio.sleep(0.1)
+    return last
+
+
+async def _wait_for_events(
+    freshness_pg: FreshnessStore,
+    workspace: str,
+    target_ids: list[str],
+    *,
+    event_type: str,
+    expected_count: int,
+    timeout_s: float,
+) -> int:
+    """Poll until at least ``expected_count`` matching events appear."""
+    deadline = time.monotonic() + timeout_s
+    count = 0
+    while time.monotonic() < deadline:
+        count = 0
+        for tid in target_ids:
+            events = await freshness_pg.list_events_for_target(
+                workspace, "memory_record", tid
+            )
+            if any(e.event_type == event_type for e in events):
+                count += 1
+        if count >= expected_count:
+            return count
+        await asyncio.sleep(0.5)
+    return count
+
+
+async def test_reclaim_after_sigkill_recovers_all_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MTRNIX-316 acceptance gate."""
+    settings = get_settings()
+    monkeypatch.setattr(settings, "freshness_enabled", True)
+
+    workspace = f"{_WORKSPACE_PREFIX}{uuid4().hex[:8]}"
+    n_jobs = 5
+    record_ids = [uuid4().hex for _ in range(n_jobs)]
+
+    # --- Bootstrap clients ---
+    redis = RedisStore(settings.redis_url)
+    try:
+        if not await redis.ping():
+            pytest.skip("Redis unreachable")
+    except Exception:
+        pytest.skip("Redis unreachable")
+
+    coordination = CoordinationStore(redis=redis)
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg_store = MemoryPostgresStore(engine)
+    freshness_pg = FreshnessStore(engine)
+    qdrant = MemoryQdrantStore(workspace_id=workspace)
+
+    worker_a = "mtrnix316-worker-a"
+    worker_b = "mtrnix316-worker-b"
+
+    proc_a: subprocess.Popen[bytes] | None = None
+    proc_b: subprocess.Popen[bytes] | None = None
+    try:
+        # Seed records + enqueue jobs.
+        for rid in record_ids:
+            rec = MemoryRecord(
+                id=rid,
+                workspace_id=workspace,
+                agent_id="agent-kill",
+                scope=MemoryScope.PER_AGENT,
+                source_type="reclaim_test",
+                content=f"Reclaim test record {rid}",
+                content_hash=f"rt-{rid}",
+            )
+            await pg_store.save(rec)
+            await qdrant.upsert(rec)
+            await coordination.enqueue_job(
+                FreshnessJob(
+                    workspace_id=workspace,
+                    event_type="knowledge_changed",
+                    target_kind="memory_record",
+                    target_id=rid,
+                )
+            )
+
+        initial_depth = await coordination.queue_depth(workspace)
+        assert initial_depth == n_jobs
+
+        # Spawn worker A with test sleep so the kill lands mid-batch.
+        # With sleep_ms=5000, the first LMOVE happens, then pipeline sleeps,
+        # giving us a large window to SIGKILL.
+        proc_a = _spawn_worker(worker_a, sleep_ms=5000)
+
+        # Wait until worker A has popped at least one job into its
+        # processing list. Timeout 15s — CI can be slow.
+        final_items = await _wait_for_processing_items(
+            redis, worker_a, min_items=1, timeout_s=15.0
+        )
+        assert final_items >= 1, (
+            f"worker A never populated its processing list (saw {final_items})"
+        )
+
+        # SIGKILL mid-batch.
+        os.kill(proc_a.pid, signal.SIGKILL)
+        try:
+            proc_a.wait(timeout=5)
+        finally:
+            proc_a = None
+
+        # The combined queue + worker-A processing list must still hold
+        # all N jobs (minus any fully processed; the 5s sleep makes full
+        # processing impossible before the first kill).
+        remaining_queue = await coordination.queue_depth(workspace)
+        remaining_processing = await redis.llen(processing_key_for(worker_a))
+        assert remaining_queue + remaining_processing >= 1, (
+            "expected at least one job stranded somewhere after SIGKILL"
+        )
+
+        # Now spawn worker B (no sleep). It should:
+        #   1. detect worker A's processing list via list_processing_workers
+        #   2. detect worker A as dead (heartbeat expired)
+        #   3. LMOVE items back to the workspace queue
+        #   4. dequeue + process them
+        proc_b = _spawn_worker(worker_b, sleep_ms=0)
+
+        # Poll for all N records to hit the ``freshness_job_processed`` event.
+        # Allow generous timeout — reclaim interval + poll + pipeline time.
+        count = await _wait_for_events(
+            freshness_pg,
+            workspace,
+            record_ids,
+            event_type="freshness_job_processed",
+            expected_count=n_jobs,
+            timeout_s=60.0,
+        )
+        assert count == n_jobs, (
+            f"only {count}/{n_jobs} records produced freshness_job_processed events"
+        )
+
+        # Worker A's processing list must now be empty.
+        assert await redis.llen(processing_key_for(worker_a)) == 0
+    finally:
+        for p in (proc_a, proc_b):
+            if p is not None:
+                try:
+                    p.send_signal(signal.SIGTERM)
+                    p.wait(timeout=5)
+                except Exception:
+                    try:
+                        p.kill()
+                    except Exception:
+                        pass
+        await _cleanup_pg(engine, workspace)
+        await _cleanup_redis(redis, workspace, [worker_a, worker_b])
+        if hasattr(qdrant, "close"):
+            try:
+                await qdrant.close()
+            except Exception:
+                pass
+        await redis.close()
+        await engine.dispose()

--- a/tests/integration/memory/freshness/test_reclaim_sigkill.py
+++ b/tests/integration/memory/freshness/test_reclaim_sigkill.py
@@ -162,9 +162,7 @@ async def _wait_for_events(
     while time.monotonic() < deadline:
         count = 0
         for tid in target_ids:
-            events = await freshness_pg.list_events_for_target(
-                workspace, "memory_record", tid
-            )
+            events = await freshness_pg.list_events_for_target(workspace, "memory_record", tid)
             if any(e.event_type == event_type for e in events):
                 count += 1
         if count >= expected_count:

--- a/tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py
+++ b/tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py
@@ -1,0 +1,172 @@
+"""Integration test — scheduled scan rescues stale records (MTRNIX-316).
+
+Seeds memory records with ``updated_at`` past the stale threshold + one
+control record inside the window. Calls ``ScheduledScan.run()`` once and
+asserts only the stale records get enqueued.
+
+Requires PostgreSQL (migration 016 applied), Qdrant, Redis live.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.core.config import get_settings
+from metatron.core.models import MemoryRecord, MemoryScope
+from metatron.freshness.coordination import (
+    CoordinationStore,
+    queue_key_for,
+)
+from metatron.freshness.scheduled_scan import ScheduledScan
+from metatron.memory.freshness.target_memory import MemoryTarget
+from metatron.storage.memory_postgres import MemoryPostgresStore
+from metatron.storage.redis import RedisStore
+
+pytestmark = pytest.mark.integration
+
+
+_WORKSPACE_PREFIX = "fresh-it-scan-"
+
+
+async def _cleanup_pg(engine, workspace: str) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa_text("DELETE FROM machine_events WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM review_entries WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+        await conn.execute(
+            sa_text("DELETE FROM memory_records WHERE workspace_id = :ws"),
+            {"ws": workspace},
+        )
+
+
+async def _force_updated_at(engine, record_id: str, updated_at: datetime) -> None:
+    """Override ``updated_at`` — bypasses the ``save()`` path's default-now behaviour."""
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa_text("UPDATE memory_records SET updated_at = :updated WHERE id = :id"),
+            {"updated": updated_at, "id": record_id},
+        )
+
+
+async def test_scheduled_scan_enqueues_only_stale_records() -> None:
+    settings = get_settings()
+    workspace = f"{_WORKSPACE_PREFIX}{uuid4().hex[:8]}"
+
+    redis = RedisStore(settings.redis_url)
+    try:
+        if not await redis.ping():
+            pytest.skip("Redis unreachable")
+    except Exception:
+        pytest.skip("Redis unreachable")
+
+    coordination = CoordinationStore(redis=redis)
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg_store = MemoryPostgresStore(engine)
+
+    # Seed 3 stale records + 1 control.
+    stale_ids = [uuid4().hex for _ in range(3)]
+    control_id = uuid4().hex
+    stale_updated_at = datetime.now(UTC) - timedelta(days=40)
+
+    try:
+        # Clear out any residual keys.
+        await redis.delete(queue_key_for(workspace))
+
+        # Fake qdrant factory — scheduled-scan path does not embed/upsert.
+        class _FakeQdrant:
+            async def search(self, *_args: object, **_kwargs: object) -> list[object]:
+                return []
+
+            async def update_payload(
+                self, *_args: object, **_kwargs: object
+            ) -> None:
+                return None
+
+        memory_target = MemoryTarget(
+            pg_store=pg_store,
+            qdrant_store_factory=lambda _ws: _FakeQdrant(),  # type: ignore[arg-type, return-value]
+        )
+
+        for rid in stale_ids:
+            rec = MemoryRecord(
+                id=rid,
+                workspace_id=workspace,
+                agent_id="agent-scan",
+                scope=MemoryScope.PER_AGENT,
+                source_type="scan_test",
+                content=f"Stale record {rid}",
+                content_hash=f"scan-{rid}",
+            )
+            await pg_store.save(rec)
+            await _force_updated_at(engine, rid, stale_updated_at)
+
+        rec_control = MemoryRecord(
+            id=control_id,
+            workspace_id=workspace,
+            agent_id="agent-scan",
+            scope=MemoryScope.PER_AGENT,
+            source_type="scan_test",
+            content="Fresh control record",
+            content_hash=f"scan-{control_id}",
+        )
+        await pg_store.save(rec_control)
+
+        async def lister() -> list[str]:
+            return [workspace]
+
+        scan = ScheduledScan(
+            target_kind="memory_record",
+            target=memory_target,
+            coordination=coordination,
+            workspace_lister=lister,
+            stale_after_days=30,  # stale_updated_at is 40 days old → 3 candidates
+            batch_limit=100,
+        )
+
+        enqueued = await scan.run()
+
+        # Exactly 3 stale records enqueued, control untouched.
+        assert enqueued == 3
+        depth = await coordination.queue_depth(workspace)
+        assert depth == 3
+
+        # Drain the queue and verify each payload references a stale id
+        # (worker_id is a kwarg; the scheduled_scan integration does not
+        # need the LMOVE into a processing list — we just inspect payloads
+        # via a direct redis call).
+        jobs = await coordination.dequeue_batch(
+            workspace, max_items=10, worker_id="test-scan-w"
+        )
+        assert len(jobs) == 3
+        seen_ids = {j.target_id for j in jobs}
+        assert seen_ids == set(stale_ids)
+        assert control_id not in seen_ids
+        for job in jobs:
+            assert job.event_type == "scheduled_scan"
+            assert job.target_kind == "memory_record"
+            assert "older_than_iso" in job.payload
+    finally:
+        await _cleanup_pg(engine, workspace)
+        try:
+            await redis.delete(queue_key_for(workspace))
+        except Exception:
+            pass
+        # Also drop any residual processing list for the test worker id.
+        from metatron.freshness.coordination import processing_key_for
+
+        try:
+            await redis.delete(processing_key_for("test-scan-w"))
+        except Exception:
+            pass
+        await redis.close()
+        await engine.dispose()

--- a/tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py
+++ b/tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py
@@ -87,9 +87,7 @@ async def test_scheduled_scan_enqueues_only_stale_records() -> None:
             async def search(self, *_args: object, **_kwargs: object) -> list[object]:
                 return []
 
-            async def update_payload(
-                self, *_args: object, **_kwargs: object
-            ) -> None:
+            async def update_payload(self, *_args: object, **_kwargs: object) -> None:
                 return None
 
         memory_target = MemoryTarget(
@@ -144,9 +142,7 @@ async def test_scheduled_scan_enqueues_only_stale_records() -> None:
         # (worker_id is a kwarg; the scheduled_scan integration does not
         # need the LMOVE into a processing list — we just inspect payloads
         # via a direct redis call).
-        jobs = await coordination.dequeue_batch(
-            workspace, max_items=10, worker_id="test-scan-w"
-        )
+        jobs = await coordination.dequeue_batch(workspace, max_items=10, worker_id="test-scan-w")
         assert len(jobs) == 3
         seen_ids = {j.target_id for j in jobs}
         assert seen_ids == set(stale_ids)

--- a/tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py
+++ b/tests/integration/memory/freshness/test_scheduled_scan_enqueues_stale.py
@@ -9,6 +9,7 @@ Requires PostgreSQL (migration 016 applied), Qdrant, Redis live.
 
 from __future__ import annotations
 
+import contextlib
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
@@ -153,16 +154,11 @@ async def test_scheduled_scan_enqueues_only_stale_records() -> None:
             assert "older_than_iso" in job.payload
     finally:
         await _cleanup_pg(engine, workspace)
-        try:
-            await redis.delete(queue_key_for(workspace))
-        except Exception:
-            pass
-        # Also drop any residual processing list for the test worker id.
         from metatron.freshness.coordination import processing_key_for
 
-        try:
+        with contextlib.suppress(Exception):
+            await redis.delete(queue_key_for(workspace))
+        with contextlib.suppress(Exception):
             await redis.delete(processing_key_for("test-scan-w"))
-        except Exception:
-            pass
         await redis.close()
         await engine.dispose()

--- a/tests/unit/core/test_config_freshness_reliability.py
+++ b/tests/unit/core/test_config_freshness_reliability.py
@@ -90,9 +90,7 @@ class TestBoolParsing:
         assert s.freshness_scheduled_scan_enabled is False
 
     @pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
-    def test_drain_legacy_true_variants(
-        self, monkeypatch: pytest.MonkeyPatch, value: str
-    ) -> None:
+    def test_drain_legacy_true_variants(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
         monkeypatch.setenv("METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP", value)
         s = Settings()
         assert s.freshness_drain_legacy_at_startup is True

--- a/tests/unit/core/test_config_freshness_reliability.py
+++ b/tests/unit/core/test_config_freshness_reliability.py
@@ -1,0 +1,98 @@
+"""Unit tests for freshness-reliability settings (MTRNIX-316).
+
+Covers the six new knobs added in Task 2:
+
+* ``METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS``
+* ``METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS``
+* ``METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED``
+* ``METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS``
+* ``METATRON_FRESHNESS_SCAN_BATCH_LIMIT``
+* ``METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP``
+
+Defaults are chosen so enabling the flag-gated features is a no-op for
+pre-MTRNIX-316 dev rigs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from metatron.core.config import Settings
+
+
+class TestDefaults:
+    def test_heartbeat_ttl_default(self) -> None:
+        s = Settings()
+        assert s.freshness_heartbeat_ttl_seconds == 20
+
+    def test_reclaim_interval_iterations_default(self) -> None:
+        s = Settings()
+        assert s.freshness_reclaim_interval_iterations == 30
+
+    def test_scheduled_scan_enabled_default(self) -> None:
+        s = Settings()
+        assert s.freshness_scheduled_scan_enabled is True
+
+    def test_scheduled_scan_interval_seconds_default(self) -> None:
+        s = Settings()
+        assert s.freshness_scheduled_scan_interval_seconds == 3600
+
+    def test_scan_batch_limit_default(self) -> None:
+        s = Settings()
+        assert s.freshness_scan_batch_limit == 500
+
+    def test_drain_legacy_default(self) -> None:
+        s = Settings()
+        assert s.freshness_drain_legacy_at_startup is False
+
+
+class TestEnvOverrides:
+    def test_heartbeat_ttl_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS", "45")
+        s = Settings()
+        assert s.freshness_heartbeat_ttl_seconds == 45
+
+    def test_reclaim_interval_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS", "5")
+        s = Settings()
+        assert s.freshness_reclaim_interval_iterations == 5
+
+    def test_scheduled_scan_enabled_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED", "false")
+        s = Settings()
+        assert s.freshness_scheduled_scan_enabled is False
+
+    def test_scheduled_scan_interval_seconds_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS", "60")
+        s = Settings()
+        assert s.freshness_scheduled_scan_interval_seconds == 60
+
+    def test_scan_batch_limit_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_SCAN_BATCH_LIMIT", "100")
+        s = Settings()
+        assert s.freshness_scan_batch_limit == 100
+
+    def test_drain_legacy_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP", "true")
+        s = Settings()
+        assert s.freshness_drain_legacy_at_startup is True
+
+
+class TestBoolParsing:
+    @pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off"])
+    def test_scheduled_scan_enabled_false_variants(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED", value)
+        s = Settings()
+        assert s.freshness_scheduled_scan_enabled is False
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+    def test_drain_legacy_true_variants(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP", value)
+        s = Settings()
+        assert s.freshness_drain_legacy_at_startup is True

--- a/tests/unit/freshness/test_coordination_env_prefix.py
+++ b/tests/unit/freshness/test_coordination_env_prefix.py
@@ -55,9 +55,7 @@ class TestProcessingKey:
 
 
 class TestStageLockKey:
-    async def test_stage_lock_prefixed_when_env_set(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_stage_lock_prefixed_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("METATRON_ENV", "development")
         store, redis = _make()
         redis.acquire_lock.return_value = True

--- a/tests/unit/freshness/test_coordination_env_prefix.py
+++ b/tests/unit/freshness/test_coordination_env_prefix.py
@@ -1,0 +1,127 @@
+"""Unit tests for env-prefixed freshness keys (MTRNIX-316).
+
+Ensures ``_key_prefix()`` honours ``settings.env`` and that every freshness
+key (queue, processing, heartbeat, stage lock, reclaim lock) routes through
+it. Backwards-compatible when env is empty.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from metatron.core import config as config_mod
+from metatron.freshness import coordination as coord_mod
+from metatron.freshness.coordination import (
+    CoordinationStore,
+    processing_key_for,
+    queue_key_for,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings() -> None:
+    """Force a fresh ``Settings`` each test so env monkeypatching takes effect."""
+    config_mod._settings = None
+    yield
+    config_mod._settings = None
+
+
+def _make() -> tuple[CoordinationStore, AsyncMock]:
+    redis = AsyncMock()
+    return CoordinationStore(redis=redis), redis
+
+
+class TestQueueKey:
+    def test_prefixed_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        assert queue_key_for("ws-1") == "freshness:development:queue:ws-1"
+
+    def test_legacy_shape_when_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Bypass Settings pydantic validator by patching get_settings directly.
+        monkeypatch.setattr(coord_mod, "get_settings", lambda: _FakeSettings(env=""))
+        assert queue_key_for("ws-1") == "freshness:queue:ws-1"
+
+
+class TestProcessingKey:
+    def test_prefixed_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "staging")
+        assert processing_key_for("worker-a") == "freshness:staging:processing:worker-a"
+
+    def test_unprefixed_when_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(coord_mod, "get_settings", lambda: _FakeSettings(env=""))
+        assert processing_key_for("worker-a") == "freshness:processing:worker-a"
+
+
+class TestStageLockKey:
+    async def test_stage_lock_prefixed_when_env_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.acquire_lock.return_value = True
+
+        token = await store.acquire_lock("linker", "rec1", ttl=30)
+
+        assert token is not None
+        key = redis.acquire_lock.await_args.args[0]
+        assert key == "freshness:development:linker:rec1"
+
+    async def test_stage_lock_kb_target_kind_prefixed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.acquire_lock.return_value = True
+
+        await store.acquire_lock("linker", "doc1", ttl=30, target_kind="raw_document")
+
+        key = redis.acquire_lock.await_args.args[0]
+        assert key == "freshness:development:linker:raw_document:doc1"
+
+    async def test_stage_lock_legacy_shape_when_env_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(coord_mod, "get_settings", lambda: _FakeSettings(env=""))
+        store, redis = _make()
+        redis.acquire_lock.return_value = True
+
+        await store.acquire_lock("linker", "rec1", ttl=30)
+
+        key = redis.acquire_lock.await_args.args[0]
+        assert key == "freshness:linker:rec1"
+
+
+class TestListActiveWorkspaces:
+    async def test_scans_with_env_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.scan_keys.return_value = [
+            "freshness:development:queue:ws-1",
+            "freshness:development:queue:ws-2",
+        ]
+
+        ws = await store.list_active_workspaces()
+
+        assert sorted(ws) == ["ws-1", "ws-2"]
+        redis.scan_keys.assert_awaited_once_with("freshness:development:queue:*")
+
+    async def test_scans_legacy_shape_when_env_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(coord_mod, "get_settings", lambda: _FakeSettings(env=""))
+        store, redis = _make()
+        redis.scan_keys.return_value = ["freshness:queue:ws-1"]
+
+        ws = await store.list_active_workspaces()
+
+        assert ws == ["ws-1"]
+        redis.scan_keys.assert_awaited_once_with("freshness:queue:*")
+
+
+class _FakeSettings:
+    """Minimal Settings duck-type for tests that need env=''."""
+
+    def __init__(self, env: str) -> None:
+        self.env = env

--- a/tests/unit/freshness/test_coordination_heartbeat.py
+++ b/tests/unit/freshness/test_coordination_heartbeat.py
@@ -1,0 +1,90 @@
+"""Unit tests for worker heartbeat helpers on ``CoordinationStore`` (MTRNIX-316)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from metatron.core import config as config_mod
+from metatron.freshness.coordination import CoordinationStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings() -> None:
+    config_mod._settings = None
+    yield
+    config_mod._settings = None
+
+
+def _make() -> tuple[CoordinationStore, AsyncMock]:
+    redis = AsyncMock()
+    return CoordinationStore(redis=redis), redis
+
+
+class TestTickHeartbeat:
+    async def test_sets_key_with_ttl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+
+        await store.tick_heartbeat("worker-a", ttl=20)
+
+        # Plain SET with TTL (no NX): upsert-set.
+        redis.set.assert_awaited_once_with(
+            "freshness:development:heartbeat:worker-a",
+            "worker-a",
+            ttl=20,
+        )
+
+    async def test_swallows_redis_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.set.side_effect = RuntimeError("redis down")
+
+        # Must not raise — best-effort.
+        await store.tick_heartbeat("worker-a", ttl=20)
+
+
+class TestIsWorkerAlive:
+    async def test_returns_true_when_key_exists(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.return_value = True
+
+        assert await store.is_worker_alive("worker-a") is True
+        redis.exists.assert_awaited_once_with("freshness:development:heartbeat:worker-a")
+
+    async def test_returns_false_when_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.return_value = False
+
+        assert await store.is_worker_alive("worker-a") is False
+
+    async def test_fails_closed_on_redis_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.side_effect = RuntimeError("redis down")
+
+        # Fail-closed: treat as dead so reclaim pass retries next iteration.
+        assert await store.is_worker_alive("worker-a") is False
+
+
+class TestReleaseWorker:
+    async def test_deletes_heartbeat_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+
+        await store.release_worker("worker-a")
+
+        redis.delete.assert_awaited_once_with("freshness:development:heartbeat:worker-a")
+
+    async def test_swallows_redis_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.delete.side_effect = RuntimeError("redis down")
+
+        # Best-effort — TTL would expire the key anyway.
+        await store.release_worker("worker-a")

--- a/tests/unit/freshness/test_coordination_heartbeat.py
+++ b/tests/unit/freshness/test_coordination_heartbeat.py
@@ -61,9 +61,7 @@ class TestIsWorkerAlive:
 
         assert await store.is_worker_alive("worker-a") is False
 
-    async def test_fails_closed_on_redis_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_fails_closed_on_redis_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("METATRON_ENV", "development")
         store, redis = _make()
         redis.exists.side_effect = RuntimeError("redis down")

--- a/tests/unit/freshness/test_coordination_processing_list.py
+++ b/tests/unit/freshness/test_coordination_processing_list.py
@@ -1,0 +1,184 @@
+"""Unit tests for processing-list dequeue + complete (MTRNIX-316).
+
+Exercises the ``dequeue_batch`` rework (LMOVE per item into the per-worker
+processing list), ``complete_job`` (LREM on success), and
+``list_processing_workers`` (SCAN over ``freshness:{env}:processing:*``).
+
+Reclaim + legacy-drain tests are added in Task 6.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from unittest.mock import AsyncMock
+
+import pytest
+
+from metatron.core import config as config_mod
+from metatron.core.models import FreshnessJob
+from metatron.freshness.coordination import CoordinationStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings() -> None:
+    config_mod._settings = None
+    yield
+    config_mod._settings = None
+
+
+def _make() -> tuple[CoordinationStore, AsyncMock]:
+    redis = AsyncMock()
+    return CoordinationStore(redis=redis), redis
+
+
+def _serialise(ws: str, tid: str) -> str:
+    return json.dumps(
+        {
+            "workspace_id": ws,
+            "event_type": "knowledge_changed",
+            "target_kind": "memory_record",
+            "target_id": tid,
+            "payload": {},
+        },
+        sort_keys=True,
+    )
+
+
+class TestDequeueBatch:
+    async def test_dequeues_via_lmove_into_processing_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.lmove_rightleft.side_effect = [
+            _serialise("ws-A", "rec-1"),
+            _serialise("ws-A", "rec-2"),
+            None,  # queue drained
+        ]
+
+        jobs = await store.dequeue_batch("ws-A", 5, worker_id="w1")
+
+        assert len(jobs) == 2
+        assert [j.target_id for j in jobs] == ["rec-1", "rec-2"]
+        # Three LMOVE calls (2 successful + 1 terminating None).
+        assert redis.lmove_rightleft.await_count == 3
+        # Each call moves from the workspace queue into the per-worker list.
+        args_list = [c.args for c in redis.lmove_rightleft.await_args_list]
+        assert all(
+            a == ("freshness:development:queue:ws-A", "freshness:development:processing:w1")
+            for a in args_list
+        )
+
+    async def test_stops_early_when_queue_drained(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.lmove_rightleft.side_effect = [None]
+
+        jobs = await store.dequeue_batch("ws-A", 20, worker_id="w1")
+
+        assert jobs == []
+        # Should stop after first None, not try all 20.
+        assert redis.lmove_rightleft.await_count == 1
+
+    async def test_skips_poison_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.lmove_rightleft.side_effect = [
+            "not-json",
+            _serialise("ws-A", "rec-2"),
+            None,
+        ]
+
+        jobs = await store.dequeue_batch("ws-A", 5, worker_id="w1")
+
+        # Poison entries are dropped (not raised); LMOVE already committed them
+        # to the processing list. A later ``complete_job`` is not called for
+        # them — they are cleaned up by the reclaim pass's poison branch.
+        assert len(jobs) == 1
+        assert jobs[0].target_id == "rec-2"
+
+    async def test_deprecation_shim_without_worker_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Phase A tests still pass ``dequeue_batch(ws, N)``. Shim keeps them green.
+
+        Emits a DeprecationWarning and synthesises an internal worker id.
+        """
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.lmove_rightleft.side_effect = [None]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            jobs = await store.dequeue_batch("ws-A", 5)  # type: ignore[call-arg]
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+        assert jobs == []
+
+
+class TestCompleteJob:
+    async def test_lrem_removes_job_from_processing_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.lrem.return_value = 1
+
+        job = FreshnessJob(
+            workspace_id="ws-A",
+            event_type="knowledge_changed",
+            target_kind="memory_record",
+            target_id="rec-1",
+            payload={},
+        )
+        await store.complete_job("w1", job)
+
+        redis.lrem.assert_awaited_once()
+        key, serialised = redis.lrem.await_args.args[:2]
+        assert key == "freshness:development:processing:w1"
+        # serialised shape includes all expected fields
+        assert '"target_id": "rec-1"' in serialised
+        assert redis.lrem.await_args.kwargs.get("count", 1) == 1
+
+    async def test_swallows_redis_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.lrem.side_effect = RuntimeError("redis down")
+
+        job = FreshnessJob(
+            workspace_id="ws-A",
+            event_type="knowledge_changed",
+            target_kind="memory_record",
+            target_id="rec-1",
+            payload={},
+        )
+        # Worker's finally block relies on complete_job not raising.
+        await store.complete_job("w1", job)
+
+
+class TestListProcessingWorkers:
+    async def test_scans_and_strips_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.scan_keys.return_value = [
+            "freshness:development:processing:worker-a",
+            "freshness:development:processing:worker-b",
+        ]
+
+        out = await store.list_processing_workers()
+
+        assert sorted(out) == ["worker-a", "worker-b"]
+        redis.scan_keys.assert_awaited_once_with("freshness:development:processing:*")
+
+    async def test_returns_empty_on_redis_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.scan_keys.side_effect = RuntimeError("redis down")
+
+        # Graceful degradation: reclaim pass sees no workers and retries later.
+        assert await store.list_processing_workers() == []

--- a/tests/unit/freshness/test_coordination_processing_list.py
+++ b/tests/unit/freshness/test_coordination_processing_list.py
@@ -182,3 +182,161 @@ class TestListProcessingWorkers:
 
         # Graceful degradation: reclaim pass sees no workers and retries later.
         assert await store.list_processing_workers() == []
+
+
+class TestReclaimWorkerOrphans:
+    async def test_happy_path_drains_processing_list_into_queue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.return_value = False  # worker dead
+        redis.acquire_lock.return_value = True
+        payloads = [
+            _serialise("ws-A", "rec-1"),
+            _serialise("ws-A", "rec-2"),
+            _serialise("ws-B", "rec-3"),
+        ]
+        # peek_tail returns the next item to move; LMOVE moves and returns it.
+        # After 3 successful moves, peek_tail returns None.
+        redis.peek_tail.side_effect = [*payloads, None]
+        redis.lmove_rightleft.side_effect = payloads
+
+        n = await store.reclaim_worker_orphans("dead-worker")
+
+        assert n == 3
+        # Verify the jobs were routed to correct workspace queues.
+        lmove_args = [c.args for c in redis.lmove_rightleft.await_args_list]
+        assert lmove_args[0] == (
+            "freshness:development:processing:dead-worker",
+            "freshness:development:queue:ws-A",
+        )
+        assert lmove_args[1] == (
+            "freshness:development:processing:dead-worker",
+            "freshness:development:queue:ws-A",
+        )
+        assert lmove_args[2] == (
+            "freshness:development:processing:dead-worker",
+            "freshness:development:queue:ws-B",
+        )
+        redis.release_lock.assert_awaited_once()
+
+    async def test_skips_live_worker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.return_value = True  # worker alive
+
+        n = await store.reclaim_worker_orphans("live-worker")
+
+        assert n == 0
+        redis.acquire_lock.assert_not_called()
+        redis.lmove_rightleft.assert_not_called()
+
+    async def test_lock_busy_returns_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.return_value = False
+        redis.acquire_lock.return_value = False  # someone else holds the lock
+
+        n = await store.reclaim_worker_orphans("dead-worker")
+
+        assert n == 0
+        redis.peek_tail.assert_not_called()
+        redis.lmove_rightleft.assert_not_called()
+
+    async def test_race_lmove_returns_none_exits_cleanly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.return_value = False
+        redis.acquire_lock.return_value = True
+        # peek_tail sees a job, but LMOVE races and returns None (someone
+        # else removed the tail). Loop exits cleanly.
+        redis.peek_tail.return_value = _serialise("ws-A", "rec-1")
+        redis.lmove_rightleft.return_value = None
+
+        n = await store.reclaim_worker_orphans("dead-worker")
+
+        assert n == 0
+        redis.release_lock.assert_awaited_once()
+
+    async def test_poison_entry_is_lrem_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.exists.return_value = False
+        redis.acquire_lock.return_value = True
+        redis.peek_tail.side_effect = ["not-json", _serialise("ws-A", "rec-1"), None]
+        redis.lmove_rightleft.side_effect = [_serialise("ws-A", "rec-1")]
+
+        n = await store.reclaim_worker_orphans("dead-worker")
+
+        # Poison entry doesn't count as recovered, but next iteration moves
+        # the valid one.
+        assert n == 1
+        # LREM called on the poison entry.
+        redis.lrem.assert_awaited_once()
+        assert redis.lrem.await_args.args[1] == "not-json"
+
+
+class TestDrainLegacyUnprefixed:
+    async def test_drains_legacy_into_prefixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        redis.scan_keys.return_value = ["freshness:queue:ws-A", "freshness:queue:ws-B"]
+        # Each legacy key has 2 items; LMOVE returns them in order then None.
+        redis.lmove_rightleft.side_effect = [
+            "job1", "job2", None,  # ws-A drained
+            "job3", "job4", None,  # ws-B drained
+        ]
+
+        moved = await store.drain_legacy_unprefixed()
+
+        assert moved == 4
+        redis.scan_keys.assert_awaited_once_with("freshness:queue:*")
+        # Verify LMOVE from legacy → prefixed keys.
+        lmove_args = [c.args for c in redis.lmove_rightleft.await_args_list]
+        assert lmove_args[0] == (
+            "freshness:queue:ws-A",
+            "freshness:development:queue:ws-A",
+        )
+        assert lmove_args[3] == (
+            "freshness:queue:ws-B",
+            "freshness:development:queue:ws-B",
+        )
+
+    async def test_noop_when_env_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from metatron.freshness import coordination as coord_mod
+
+        monkeypatch.setattr(coord_mod, "get_settings", lambda: _FakeSettings(env=""))
+        store, redis = _make()
+
+        moved = await store.drain_legacy_unprefixed()
+
+        assert moved == 0
+        redis.scan_keys.assert_not_called()
+
+    async def test_filters_env_prefixed_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A key like ``freshness:development:queue:ws-A`` is NOT legacy
+        and must not be re-drained into itself."""
+        monkeypatch.setenv("METATRON_ENV", "development")
+        store, redis = _make()
+        # Only the "freshness:queue:ws-A" (count=2 colons) is legacy; the
+        # prefixed one has count=4 and is filtered out.
+        redis.scan_keys.return_value = [
+            "freshness:queue:ws-A",
+            "freshness:development:queue:ws-B",
+        ]
+        redis.lmove_rightleft.side_effect = ["job1", None]
+
+        moved = await store.drain_legacy_unprefixed()
+
+        assert moved == 1
+        # Only one source key processed.
+        lmove_args = [c.args for c in redis.lmove_rightleft.await_args_list]
+        assert all(src == "freshness:queue:ws-A" for src, _dst in lmove_args)
+
+
+class _FakeSettings:
+    def __init__(self, env: str) -> None:
+        self.env = env

--- a/tests/unit/freshness/test_coordination_processing_list.py
+++ b/tests/unit/freshness/test_coordination_processing_list.py
@@ -70,9 +70,7 @@ class TestDequeueBatch:
             for a in args_list
         )
 
-    async def test_stops_early_when_queue_drained(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_stops_early_when_queue_drained(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("METATRON_ENV", "development")
         store, redis = _make()
         redis.lmove_rightleft.side_effect = [None]
@@ -173,9 +171,7 @@ class TestListProcessingWorkers:
         assert sorted(out) == ["worker-a", "worker-b"]
         redis.scan_keys.assert_awaited_once_with("freshness:development:processing:*")
 
-    async def test_returns_empty_on_redis_failure(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_returns_empty_on_redis_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("METATRON_ENV", "development")
         store, redis = _make()
         redis.scan_keys.side_effect = RuntimeError("redis down")
@@ -286,8 +282,12 @@ class TestDrainLegacyUnprefixed:
         redis.scan_keys.return_value = ["freshness:queue:ws-A", "freshness:queue:ws-B"]
         # Each legacy key has 2 items; LMOVE returns them in order then None.
         redis.lmove_rightleft.side_effect = [
-            "job1", "job2", None,  # ws-A drained
-            "job3", "job4", None,  # ws-B drained
+            "job1",
+            "job2",
+            None,  # ws-A drained
+            "job3",
+            "job4",
+            None,  # ws-B drained
         ]
 
         moved = await store.drain_legacy_unprefixed()

--- a/tests/unit/freshness/test_scheduled_scan.py
+++ b/tests/unit/freshness/test_scheduled_scan.py
@@ -191,6 +191,4 @@ class TestScheduledScanMetrics:
         metrics.scheduled_scan_jobs_enqueued.labels(
             env="development", target_kind="memory_record"
         ).inc(3)
-        metrics.scheduled_scan_errors.labels(
-            env="development", target_kind="memory_record"
-        ).inc()
+        metrics.scheduled_scan_errors.labels(env="development", target_kind="memory_record").inc()

--- a/tests/unit/freshness/test_scheduled_scan.py
+++ b/tests/unit/freshness/test_scheduled_scan.py
@@ -1,0 +1,196 @@
+"""Unit tests for ``ScheduledScan`` — the safety-net scan orchestrator (MTRNIX-316).
+
+Target-agnostic: exercises the dataclass's ``run()`` method with an in-memory
+``CoordinationStore`` stub + a fake ``FreshnessTarget``. No live services.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from metatron.core import config as config_mod
+from metatron.freshness.scheduled_scan import ScheduledScan
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings() -> None:
+    config_mod._settings = None
+    yield
+    config_mod._settings = None
+
+
+class _FakeTarget:
+    def __init__(self, *, stale_by_ws: dict[str, list[str]]) -> None:
+        self.stale_by_ws = stale_by_ws
+        self.calls: list[tuple[str, datetime, int]] = []
+
+    async def list_stale_candidates(
+        self,
+        workspace_id: str,
+        *,
+        older_than: datetime,
+        limit: int,
+    ) -> list[str]:
+        self.calls.append((workspace_id, older_than, limit))
+        return list(self.stale_by_ws.get(workspace_id, []))
+
+
+class _RaisingTarget:
+    """Raises on the first call — used to verify error swallow."""
+
+    def __init__(self, *, only_ws: str) -> None:
+        self.only_ws = only_ws
+        self.calls: list[str] = []
+
+    async def list_stale_candidates(
+        self,
+        workspace_id: str,
+        *,
+        older_than: datetime,
+        limit: int,
+    ) -> list[str]:
+        self.calls.append(workspace_id)
+        if workspace_id == self.only_ws:
+            raise RuntimeError("target exploded")
+        return []
+
+
+class TestScheduledScanRun:
+    async def test_enqueues_stale_per_workspace(self) -> None:
+        target = _FakeTarget(stale_by_ws={"ws-A": ["rec-1", "rec-2", "rec-3"], "ws-B": []})
+        coord = AsyncMock()
+
+        async def lister() -> list[str]:
+            return ["ws-A", "ws-B"]
+
+        scan = ScheduledScan(
+            target_kind="memory_record",
+            target=target,  # type: ignore[arg-type]
+            coordination=coord,
+            workspace_lister=lister,
+            stale_after_days=30,
+            batch_limit=500,
+        )
+
+        total = await scan.run()
+
+        assert total == 3
+        assert coord.enqueue_job.await_count == 3
+        # Each enqueued job carries the expected shape.
+        for call in coord.enqueue_job.await_args_list:
+            job = call.args[0]
+            assert job.workspace_id == "ws-A"
+            assert job.event_type == "scheduled_scan"
+            assert job.target_kind == "memory_record"
+            assert job.target_id in {"rec-1", "rec-2", "rec-3"}
+            assert "older_than_iso" in job.payload
+
+        # Target called once per workspace with the right batch limit.
+        assert len(target.calls) == 2
+        assert target.calls[0][0] == "ws-A"
+        assert target.calls[0][2] == 500
+        assert target.calls[1][0] == "ws-B"
+
+    async def test_older_than_uses_stale_after_days(self) -> None:
+        target = _FakeTarget(stale_by_ws={"ws-A": ["rec-1"]})
+        coord = AsyncMock()
+
+        async def lister() -> list[str]:
+            return ["ws-A"]
+
+        scan = ScheduledScan(
+            target_kind="memory_record",
+            target=target,  # type: ignore[arg-type]
+            coordination=coord,
+            workspace_lister=lister,
+            stale_after_days=45,
+            batch_limit=100,
+        )
+        await scan.run()
+
+        ws, older_than, _ = target.calls[0]
+        assert ws == "ws-A"
+        delta = datetime.now(UTC) - older_than
+        # 45 days ± ~1 second.
+        assert abs(delta - timedelta(days=45)) < timedelta(seconds=5)
+
+    async def test_empty_workspace_list_returns_zero(self) -> None:
+        target = _FakeTarget(stale_by_ws={})
+        coord = AsyncMock()
+
+        async def lister() -> list[str]:
+            return []
+
+        scan = ScheduledScan(
+            target_kind="memory_record",
+            target=target,  # type: ignore[arg-type]
+            coordination=coord,
+            workspace_lister=lister,
+            stale_after_days=30,
+            batch_limit=500,
+        )
+
+        assert await scan.run() == 0
+        coord.enqueue_job.assert_not_called()
+
+    async def test_lister_error_returns_zero_and_bumps_counter(self) -> None:
+        coord = AsyncMock()
+
+        async def lister() -> list[str]:
+            raise RuntimeError("pg down")
+
+        scan = ScheduledScan(
+            target_kind="memory_record",
+            target=_FakeTarget(stale_by_ws={}),  # type: ignore[arg-type]
+            coordination=coord,
+            workspace_lister=lister,
+            stale_after_days=30,
+            batch_limit=500,
+        )
+
+        assert await scan.run() == 0
+        coord.enqueue_job.assert_not_called()
+
+    async def test_per_workspace_error_is_swallowed(self) -> None:
+        target = _RaisingTarget(only_ws="ws-A")
+        coord = AsyncMock()
+
+        async def lister() -> list[str]:
+            return ["ws-A", "ws-B"]
+
+        scan = ScheduledScan(
+            target_kind="memory_record",
+            target=target,  # type: ignore[arg-type]
+            coordination=coord,
+            workspace_lister=lister,
+            stale_after_days=30,
+            batch_limit=500,
+        )
+
+        # ws-A raises → error counter bumps but ws-B still runs.
+        total = await scan.run()
+
+        assert total == 0
+        # Both workspaces visited.
+        assert target.calls == ["ws-A", "ws-B"]
+
+
+class TestScheduledScanMetrics:
+    async def test_records_enqueued_counter_incremented(self) -> None:
+        """Smoke test: metrics label call does not raise.
+
+        We can't easily read a Prometheus counter in isolation here, but we
+        can assert the hot-path doesn't explode when metrics are wired.
+        """
+        from metatron.freshness import metrics
+
+        # Just verify ``.labels(...).inc(...)`` is a callable noop-safe path.
+        metrics.scheduled_scan_jobs_enqueued.labels(
+            env="development", target_kind="memory_record"
+        ).inc(3)
+        metrics.scheduled_scan_errors.labels(
+            env="development", target_kind="memory_record"
+        ).inc()

--- a/tests/unit/freshness/test_worker_id.py
+++ b/tests/unit/freshness/test_worker_id.py
@@ -1,0 +1,38 @@
+"""Unit tests for ``build_worker_id`` (MTRNIX-316).
+
+Covers shape, uniqueness, and the ``METATRON_FRESHNESS_TEST_WORKER_ID``
+override knob used by the SIGKILL integration test.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from metatron.freshness.worker_id import build_worker_id
+
+
+class TestShape:
+    def test_matches_hostname_pid_uuid_pattern(self) -> None:
+        wid = build_worker_id()
+        # hostname may contain letters, digits, dashes, dots; never colons.
+        assert re.match(r"^[^:]+:\d+:[0-9a-f]{8}$", wid), wid
+
+
+class TestUniqueness:
+    def test_two_calls_differ(self) -> None:
+        a = build_worker_id()
+        b = build_worker_id()
+        assert a != b
+
+
+class TestTestOverride:
+    def test_env_override_returns_verbatim(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_TEST_WORKER_ID", "pinned-test-worker")
+        assert build_worker_id() == "pinned-test-worker"
+
+    def test_empty_override_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("METATRON_FRESHNESS_TEST_WORKER_ID", "")
+        wid = build_worker_id()
+        assert re.match(r"^[^:]+:\d+:[0-9a-f]{8}$", wid), wid

--- a/tests/unit/memory/freshness/test_coordination.py
+++ b/tests/unit/memory/freshness/test_coordination.py
@@ -138,7 +138,9 @@ class TestLocks:
         ok = await store.heartbeat("linker", "rec1", ttl=30, token="tok")
 
         assert ok is True
-        redis.heartbeat_lock.assert_awaited_once_with("freshness:development:linker:rec1", 30, "tok")
+        redis.heartbeat_lock.assert_awaited_once_with(
+            "freshness:development:linker:rec1", 30, "tok"
+        )
 
     async def test_release_uses_token_guard(self) -> None:
         store, redis = _make()

--- a/tests/unit/memory/freshness/test_coordination.py
+++ b/tests/unit/memory/freshness/test_coordination.py
@@ -22,7 +22,7 @@ def _make() -> tuple[CoordinationStore, AsyncMock]:
 
 class TestQueueKeys:
     def test_queue_key_includes_workspace(self) -> None:
-        assert queue_key_for("ws1") == "freshness:queue:ws1"
+        assert queue_key_for("ws1") == "freshness:development:queue:ws1"
 
 
 class TestEnqueue:
@@ -40,7 +40,7 @@ class TestEnqueue:
 
         redis.lpush.assert_awaited_once()
         key, payload = redis.lpush.await_args.args
-        assert key == "freshness:queue:ws1"
+        assert key == "freshness:development:queue:ws1"
         assert '"event_type"' in payload
         assert '"rec1"' in payload
 
@@ -48,30 +48,39 @@ class TestEnqueue:
 class TestDequeue:
     async def test_dequeue_batch_returns_parsed_jobs(self) -> None:
         store, redis = _make()
-        redis.rpop_batch.return_value = [
+        # MTRNIX-316: dequeue now loops LMOVE per item; mock returns items
+        # until None terminates the loop.
+        redis.lmove_rightleft.side_effect = [
             '{"workspace_id":"ws1","event_type":"knowledge_changed",'
             '"target_kind":"memory_record","target_id":"rec1","payload":{}}',
             '{"workspace_id":"ws1","event_type":"content_changed",'
             '"target_kind":"memory_record","target_id":"rec2","payload":{"k":"v"}}',
+            None,
         ]
 
-        jobs = await store.dequeue_batch("ws1", max_items=5)
+        jobs = await store.dequeue_batch("ws1", max_items=5, worker_id="w1")
 
         assert len(jobs) == 2
         assert jobs[0].target_id == "rec1"
         assert jobs[1].event_type == "content_changed"
         assert jobs[1].payload == {"k": "v"}
-        redis.rpop_batch.assert_awaited_once_with("freshness:queue:ws1", 5)
+        # Each call moves from the workspace queue to the worker's processing list.
+        first_call = redis.lmove_rightleft.await_args_list[0].args
+        assert first_call == (
+            "freshness:development:queue:ws1",
+            "freshness:development:processing:w1",
+        )
 
     async def test_dequeue_batch_skips_malformed_entries(self) -> None:
         store, redis = _make()
-        redis.rpop_batch.return_value = [
+        redis.lmove_rightleft.side_effect = [
             "not-json",
             '{"workspace_id":"ws1","event_type":"knowledge_changed",'
             '"target_kind":"memory_record","target_id":"rec1","payload":{}}',
+            None,
         ]
 
-        jobs = await store.dequeue_batch("ws1", max_items=5)
+        jobs = await store.dequeue_batch("ws1", max_items=5, worker_id="w1")
 
         # Malformed entries must be dropped, not raised — the worker cannot
         # afford a poison message to stall the queue.
@@ -85,19 +94,19 @@ class TestDequeue:
         depth = await store.queue_depth("ws1")
 
         assert depth == 42
-        redis.llen.assert_awaited_once_with("freshness:queue:ws1")
+        redis.llen.assert_awaited_once_with("freshness:development:queue:ws1")
 
     async def test_list_active_workspaces_parses_keys(self) -> None:
         store, redis = _make()
         redis.scan_keys.return_value = [
-            "freshness:queue:ws1",
-            "freshness:queue:ws2",
+            "freshness:development:queue:ws1",
+            "freshness:development:queue:ws2",
         ]
 
         ws = await store.list_active_workspaces()
 
         assert sorted(ws) == ["ws1", "ws2"]
-        redis.scan_keys.assert_awaited_once_with("freshness:queue:*")
+        redis.scan_keys.assert_awaited_once_with("freshness:development:queue:*")
 
 
 class TestLocks:
@@ -110,7 +119,7 @@ class TestLocks:
         assert token is not None
         redis.acquire_lock.assert_awaited_once()
         key, ttl, tok = redis.acquire_lock.await_args.args
-        assert key == "freshness:linker:rec1"
+        assert key == "freshness:development:linker:rec1"
         assert ttl == 30
         assert tok == token
 
@@ -129,7 +138,7 @@ class TestLocks:
         ok = await store.heartbeat("linker", "rec1", ttl=30, token="tok")
 
         assert ok is True
-        redis.heartbeat_lock.assert_awaited_once_with("freshness:linker:rec1", 30, "tok")
+        redis.heartbeat_lock.assert_awaited_once_with("freshness:development:linker:rec1", 30, "tok")
 
     async def test_release_uses_token_guard(self) -> None:
         store, redis = _make()
@@ -137,7 +146,7 @@ class TestLocks:
 
         await store.release("linker", "rec1", token="tok")
 
-        redis.release_lock.assert_awaited_once_with("freshness:linker:rec1", "tok")
+        redis.release_lock.assert_awaited_once_with("freshness:development:linker:rec1", "tok")
 
 
 class TestCheckpointsRemoved:

--- a/tests/unit/memory/freshness/test_memory_target_stale_candidates.py
+++ b/tests/unit/memory/freshness/test_memory_target_stale_candidates.py
@@ -1,0 +1,125 @@
+"""Unit tests for ``list_stale_candidates`` (MTRNIX-316).
+
+* ``FreshnessTarget.list_stale_candidates`` — default Protocol behaviour
+  is empty; both concrete adapters inherit it explicitly. KB returns ``[]``;
+  memory delegates to the PG store.
+* ``MemoryTarget.list_stale_candidates`` — thin pass-through.
+* ``MemoryPostgresStore.list_stale_candidates`` — SQL shape covered via a
+  mocked SQLAlchemy engine (no live PG).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from metatron.memory.freshness.target_memory import MemoryTarget
+
+
+class TestMemoryTargetDelegation:
+    async def test_delegates_to_pg_store(self) -> None:
+        pg = AsyncMock()
+        pg.list_stale_candidates.return_value = ["rec-1", "rec-2", "rec-3"]
+
+        target = MemoryTarget(
+            pg_store=pg,
+            qdrant_store_factory=lambda _ws: MagicMock(),
+        )
+        older_than = datetime.now(UTC) - timedelta(days=30)
+
+        out = await target.list_stale_candidates("ws-A", older_than=older_than, limit=10)
+
+        assert out == ["rec-1", "rec-2", "rec-3"]
+        pg.list_stale_candidates.assert_awaited_once_with(
+            "ws-A", older_than=older_than, limit=10
+        )
+
+    async def test_forwards_empty_list(self) -> None:
+        pg = AsyncMock()
+        pg.list_stale_candidates.return_value = []
+
+        target = MemoryTarget(
+            pg_store=pg,
+            qdrant_store_factory=lambda _ws: MagicMock(),
+        )
+        out = await target.list_stale_candidates(
+            "ws-A", older_than=datetime.now(UTC), limit=500
+        )
+
+        assert out == []
+
+
+class TestRawDocumentTargetDefault:
+    async def test_raw_document_target_returns_empty(self) -> None:
+        """KB adapter inherits the default empty list (MTRNIX-316 scope).
+
+        KB-side scheduled scan is deferred to MTRNIX-316-follow.
+        """
+        from metatron.ingestion.freshness.target_raw_document import RawDocumentTarget
+
+        pg = AsyncMock()
+        target = RawDocumentTarget(
+            pg_store=pg,
+            qdrant_factory=lambda _ws: MagicMock(),
+        )
+
+        out = await target.list_stale_candidates(
+            "ws-A", older_than=datetime.now(UTC), limit=10
+        )
+
+        assert out == []
+        # PG not touched — default implementation does not query.
+        pg.get_raw_document_by_id.assert_not_called()
+
+
+class TestMemoryPostgresStoreQueryShape:
+    async def test_list_stale_candidates_query_and_params(self) -> None:
+        """Assert the SQL query binds workspace_id, older_than, limit and
+        filters out terminal statuses.
+        """
+        from metatron.storage.memory_postgres import MemoryPostgresStore
+
+        engine = MagicMock()
+        # Mock engine.begin() context manager.
+        conn = MagicMock()
+        conn.execute = AsyncMock()
+        conn.execute.return_value = MagicMock(
+            fetchall=lambda: [SimpleNamespace(_mapping={"id": "rec-1"})],
+        )
+        # conn.execute returns a mock whose .fetchall() is callable.
+        fetch_result = MagicMock()
+        fetch_result.fetchall.return_value = [("rec-1",), ("rec-2",)]
+        conn.execute.return_value = fetch_result
+
+        # Fake the async context manager `engine.begin()`.
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=conn)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        engine.begin = MagicMock(return_value=cm)
+
+        store = MemoryPostgresStore(engine)
+        older_than = datetime(2026, 1, 1, tzinfo=UTC)
+
+        out = await store.list_stale_candidates(
+            "ws-A", older_than=older_than, limit=42
+        )
+
+        assert out == ["rec-1", "rec-2"]
+        # Verify the execute was called with expected bound parameters.
+        call_args = conn.execute.await_args
+        sql_text = str(call_args.args[0])
+        params: dict[str, Any] = call_args.args[1]
+        assert params == {
+            "ws": "ws-A",
+            "older_than": older_than,
+            "limit": 42,
+        }
+        # Query filters out terminal statuses.
+        assert "stale" in sql_text.lower()
+        assert "superseded" in sql_text.lower()
+        assert "archived" in sql_text.lower()
+        # Orders by updated_at ASC so oldest stale candidates come first.
+        assert "updated_at" in sql_text.lower()
+        assert "asc" in sql_text.lower()

--- a/tests/unit/memory/freshness/test_memory_target_stale_candidates.py
+++ b/tests/unit/memory/freshness/test_memory_target_stale_candidates.py
@@ -32,9 +32,7 @@ class TestMemoryTargetDelegation:
         out = await target.list_stale_candidates("ws-A", older_than=older_than, limit=10)
 
         assert out == ["rec-1", "rec-2", "rec-3"]
-        pg.list_stale_candidates.assert_awaited_once_with(
-            "ws-A", older_than=older_than, limit=10
-        )
+        pg.list_stale_candidates.assert_awaited_once_with("ws-A", older_than=older_than, limit=10)
 
     async def test_forwards_empty_list(self) -> None:
         pg = AsyncMock()
@@ -44,9 +42,7 @@ class TestMemoryTargetDelegation:
             pg_store=pg,
             qdrant_store_factory=lambda _ws: MagicMock(),
         )
-        out = await target.list_stale_candidates(
-            "ws-A", older_than=datetime.now(UTC), limit=500
-        )
+        out = await target.list_stale_candidates("ws-A", older_than=datetime.now(UTC), limit=500)
 
         assert out == []
 
@@ -65,9 +61,7 @@ class TestRawDocumentTargetDefault:
             qdrant_factory=lambda _ws: MagicMock(),
         )
 
-        out = await target.list_stale_candidates(
-            "ws-A", older_than=datetime.now(UTC), limit=10
-        )
+        out = await target.list_stale_candidates("ws-A", older_than=datetime.now(UTC), limit=10)
 
         assert out == []
         # PG not touched — default implementation does not query.
@@ -102,9 +96,7 @@ class TestMemoryPostgresStoreQueryShape:
         store = MemoryPostgresStore(engine)
         older_than = datetime(2026, 1, 1, tzinfo=UTC)
 
-        out = await store.list_stale_candidates(
-            "ws-A", older_than=older_than, limit=42
-        )
+        out = await store.list_stale_candidates("ws-A", older_than=older_than, limit=42)
 
         assert out == ["rec-1", "rec-2"]
         # Verify the execute was called with expected bound parameters.

--- a/tests/unit/memory/freshness/test_producer.py
+++ b/tests/unit/memory/freshness/test_producer.py
@@ -54,7 +54,7 @@ class TestProducer:
 
         redis.lpush.assert_awaited_once()
         key, payload = redis.lpush.await_args.args
-        assert key == "freshness:queue:ws1"
+        assert key == "freshness:development:queue:ws1"
         assert "content_changed" in payload
         assert "rec1" in payload
 

--- a/tests/unit/memory/freshness/test_worker_reclaim_loop.py
+++ b/tests/unit/memory/freshness/test_worker_reclaim_loop.py
@@ -1,0 +1,195 @@
+"""Unit tests for MTRNIX-316 worker hooks: heartbeat + reclaim + scheduled scan.
+
+Covers:
+
+* Startup path — tick_heartbeat, one-shot reclaim, optional legacy drain.
+* Per-iteration — tick_heartbeat every iteration; reclaim every N iterations.
+* Scheduled scan — runs when the timer fires (monkey-patched ``time.monotonic``).
+* ``complete_job`` is called in the job finally, both on success and on error.
+* Graceful shutdown — ``release_worker`` called on CancelledError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from metatron.core.config import get_settings
+from metatron.core.models import FreshnessJob
+from metatron.memory.freshness.worker import (
+    FreshnessWorker,
+    _Pipeline,
+    _run_loop,
+)
+
+
+def _make_worker(**worker_kwargs: object) -> tuple[FreshnessWorker, AsyncMock, AsyncMock]:
+    coordination = AsyncMock()
+    freshness_pg = AsyncMock()
+    decision_engine = AsyncMock()
+
+    linker = AsyncMock()
+    reconciler = AsyncMock()
+    monitor = AsyncMock()
+    curator = AsyncMock()
+    target = MagicMock()
+    target.kind = "memory_record"
+    target.supports_candidate_promotion = True
+    target.get = AsyncMock(return_value=None)
+
+    pipelines = {
+        "memory_record": _Pipeline(
+            linker=linker,
+            reconciler=reconciler,
+            monitor=monitor,
+            curator=curator,
+            target=target,
+        )
+    }
+
+    worker = FreshnessWorker(
+        coordination=coordination,
+        freshness_pg=freshness_pg,
+        decision_engine=decision_engine,
+        pipelines=pipelines,
+        worker_id="test-worker-a",
+        heartbeat_ttl=20,
+        reclaim_interval_iterations=3,
+        scheduled_scan_interval_seconds=60,
+        **worker_kwargs,  # type: ignore[arg-type]
+    )
+    return worker, coordination, freshness_pg
+
+
+def _job(ws: str, rid: str) -> FreshnessJob:
+    return FreshnessJob(
+        workspace_id=ws,
+        event_type="knowledge_changed",
+        target_kind="memory_record",
+        target_id=rid,
+    )
+
+
+class TestHeartbeat:
+    async def test_tick_heartbeat_every_iteration(self) -> None:
+        worker, coord, _fp = _make_worker()
+        coord.list_active_workspaces.return_value = []
+
+        await worker.run_once(max_jobs=1)
+
+        coord.tick_heartbeat.assert_awaited_with("test-worker-a", 20)
+
+
+class TestReclaimPeriodicity:
+    async def test_reclaim_runs_every_N_iterations(self) -> None:
+        worker, coord, _fp = _make_worker()  # N=3
+        coord.list_active_workspaces.return_value = []
+        coord.list_processing_workers.return_value = []
+
+        await worker.run_once(max_jobs=1)  # iter 1 → no reclaim
+        await worker.run_once(max_jobs=1)  # iter 2 → no reclaim
+        await worker.run_once(max_jobs=1)  # iter 3 → reclaim
+
+        # Each iteration calls list_processing_workers via the reclaim helper.
+        # With interval=3, only iteration 3 triggers it.
+        assert coord.list_processing_workers.await_count == 1
+
+    async def test_reclaim_skips_self(self) -> None:
+        worker, coord, _fp = _make_worker()
+        coord.list_active_workspaces.return_value = []
+        coord.list_processing_workers.return_value = ["test-worker-a", "dead-peer"]
+        coord.reclaim_worker_orphans.return_value = 2
+
+        # Run 3 iterations so reclaim fires once.
+        await worker.run_once(1)
+        await worker.run_once(1)
+        await worker.run_once(1)
+
+        # Reclaim called only for the dead peer, never for self.
+        coord.reclaim_worker_orphans.assert_awaited_once_with("dead-peer")
+
+
+class TestCompleteJobFinally:
+    async def test_complete_job_called_on_success(self) -> None:
+        worker, coord, _fp = _make_worker()
+        coord.list_active_workspaces.return_value = ["ws-A"]
+        coord.dequeue_batch.return_value = [_job("ws-A", "rec-1")]
+
+        await worker.run_once(max_jobs=5)
+
+        coord.complete_job.assert_awaited_once()
+        wid, job_arg = coord.complete_job.await_args.args
+        assert wid == "test-worker-a"
+        assert job_arg.target_id == "rec-1"
+
+    async def test_complete_job_called_on_exception(self) -> None:
+        worker, coord, _fp = _make_worker()
+        coord.list_active_workspaces.return_value = ["ws-A"]
+        coord.dequeue_batch.return_value = [_job("ws-A", "rec-1")]
+        # Force a pipeline failure so _process_job raises.
+        pipeline = worker._pipelines["memory_record"]
+        pipeline.linker.run.side_effect = RuntimeError("kaboom")  # type: ignore[attr-defined]
+
+        with pytest.raises(RuntimeError, match="kaboom"):
+            await worker.run_once(max_jobs=5)
+
+        # Even with the raise, complete_job still runs (outer finally).
+        coord.complete_job.assert_awaited_once()
+
+
+class TestScheduledScanTimer:
+    async def test_scan_fires_when_due(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        scanner = AsyncMock()
+        worker, coord, _fp = _make_worker(scheduled_scanners=[scanner])
+        coord.list_active_workspaces.return_value = []
+
+        # First iteration initialises the timer — scan fires immediately
+        # because _last_scan_monotonic defaults to 0.0 and elapsed > 60s
+        # of fake-monotonic.
+        monkeypatch.setattr(
+            "metatron.memory.freshness.worker.time.monotonic",
+            lambda: 100.0,
+        )
+        await worker.run_once(max_jobs=1)
+        scanner.run.assert_awaited_once()
+
+        # Next iteration a few seconds later — should NOT fire again.
+        monkeypatch.setattr(
+            "metatron.memory.freshness.worker.time.monotonic",
+            lambda: 110.0,
+        )
+        await worker.run_once(max_jobs=1)
+        assert scanner.run.await_count == 1
+
+        # Iteration past the next interval — fires again.
+        monkeypatch.setattr(
+            "metatron.memory.freshness.worker.time.monotonic",
+            lambda: 200.0,
+        )
+        await worker.run_once(max_jobs=1)
+        assert scanner.run.await_count == 2
+
+
+class TestGracefulShutdown:
+    async def test_release_worker_on_cancel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When ``_run_loop`` is cancelled, ``release_worker`` runs in finally."""
+        settings = get_settings()
+        monkeypatch.setattr(settings, "freshness_enabled", True)
+        monkeypatch.setattr(settings, "freshness_poll_seconds", 0.01)
+
+        worker, coord, _fp = _make_worker()
+        # Each run_once returns 0 processed → the loop sleeps.
+        worker.run_once = AsyncMock(return_value=0)  # type: ignore[method-assign]
+
+        task = asyncio.create_task(_run_loop(worker))
+        # Let it tick once.
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        coord.release_worker.assert_awaited_with("test-worker-a")

--- a/tests/unit/memory/freshness/test_worker_reclaim_loop.py
+++ b/tests/unit/memory/freshness/test_worker_reclaim_loop.py
@@ -173,9 +173,7 @@ class TestScheduledScanTimer:
 
 
 class TestGracefulShutdown:
-    async def test_release_worker_on_cancel(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_release_worker_on_cancel(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When ``_run_loop`` is cancelled, ``release_worker`` runs in finally."""
         settings = get_settings()
         monkeypatch.setattr(settings, "freshness_enabled", True)

--- a/tests/unit/memory/freshness/test_worker_target_kind_dispatch.py
+++ b/tests/unit/memory/freshness/test_worker_target_kind_dispatch.py
@@ -83,9 +83,7 @@ async def test_unknown_target_kind_drains_queue_without_running_stages() -> None
 async def test_memory_job_routes_to_memory_pipeline() -> None:
     memory = _pipeline_stub("memory_record")
     kb = _pipeline_stub("raw_document")
-    worker, coord, _fpg = _make_worker(
-        pipelines={"memory_record": memory, "raw_document": kb}
-    )
+    worker, coord, _fpg = _make_worker(pipelines={"memory_record": memory, "raw_document": kb})
     coord.dequeue_batch = AsyncMock(
         return_value=[
             FreshnessJob(
@@ -109,9 +107,7 @@ async def test_memory_job_routes_to_memory_pipeline() -> None:
 async def test_kb_job_routes_to_kb_pipeline() -> None:
     memory = _pipeline_stub("memory_record")
     kb = _pipeline_stub("raw_document")
-    worker, coord, _fpg = _make_worker(
-        pipelines={"memory_record": memory, "raw_document": kb}
-    )
+    worker, coord, _fpg = _make_worker(pipelines={"memory_record": memory, "raw_document": kb})
     coord.dequeue_batch = AsyncMock(
         return_value=[
             FreshnessJob(

--- a/tests/unit/storage/test_redis_lmove.py
+++ b/tests/unit/storage/test_redis_lmove.py
@@ -1,0 +1,87 @@
+"""Unit tests for RedisStore LMOVE-family primitives (MTRNIX-316).
+
+Covers ``lmove_rightleft`` (the RPOPLPUSH-style primitive used by the
+freshness processing-list reclaim pattern), ``peek_tail`` (LINDEX key -1),
+and ``lrem`` (remove a serialised job by value on successful processing).
+
+Uses ``AsyncMock`` so no live Redis is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from metatron.storage.redis import RedisStore
+
+
+def _make_store() -> tuple[RedisStore, AsyncMock]:
+    store = RedisStore("redis://localhost:6379/0")
+    fake = AsyncMock()
+    store._client = fake  # type: ignore[assignment]
+    return store, fake
+
+
+class TestLmoveRightLeft:
+    async def test_returns_moved_value(self) -> None:
+        store, client = _make_store()
+        client.lmove.return_value = "a"
+
+        out = await store.lmove_rightleft("queue", "processing")
+
+        assert out == "a"
+        client.lmove.assert_awaited_once_with("queue", "processing", "RIGHT", "LEFT")
+
+    async def test_returns_none_when_source_empty(self) -> None:
+        store, client = _make_store()
+        client.lmove.return_value = None
+
+        out = await store.lmove_rightleft("queue", "processing")
+
+        assert out is None
+
+
+class TestPeekTail:
+    async def test_returns_tail_value(self) -> None:
+        store, client = _make_store()
+        client.lindex.return_value = "tail-value"
+
+        out = await store.peek_tail("queue")
+
+        assert out == "tail-value"
+        client.lindex.assert_awaited_once_with("queue", -1)
+
+    async def test_returns_none_on_missing_key(self) -> None:
+        store, client = _make_store()
+        client.lindex.return_value = None
+
+        out = await store.peek_tail("missing")
+
+        assert out is None
+
+
+class TestLrem:
+    async def test_lrem_default_count_is_one(self) -> None:
+        store, client = _make_store()
+        client.lrem.return_value = 1
+
+        n = await store.lrem("processing", "job-json")
+
+        assert n == 1
+        client.lrem.assert_awaited_once_with("processing", 1, "job-json")
+
+    async def test_lrem_explicit_count(self) -> None:
+        store, client = _make_store()
+        client.lrem.return_value = 2
+
+        n = await store.lrem("processing", "job-json", count=2)
+
+        assert n == 2
+        client.lrem.assert_awaited_once_with("processing", 2, "job-json")
+
+    async def test_lrem_returns_zero_when_no_match(self) -> None:
+        store, client = _make_store()
+        client.lrem.return_value = 0
+
+        n = await store.lrem("processing", "nonexistent")
+
+        assert n == 0


### PR DESCRIPTION
Closes the MTRNIX-304 pre-prod gate. Unblocks flipping \`METATRON_FRESHNESS_ENABLED=true\` in any production environment.

## What ships

### 1. Processing-list reclaim (AC gate)
Replaces lossy atomic \`LPOP × N\` with \`LMOVE RIGHT → LEFT\` into per-worker processing list \`freshness:{env}:processing:{worker_id}\`. On clean completion, \`LREM\` from the list. On SIGKILL mid-batch, the orphaned entries remain — a second worker's reclaim pass (running in the loop + on startup) finds dead workers via missing \`freshness:{env}:heartbeat:{worker_id}\` TTL key, acquires a per-worker \`SET NX EX\` reclaim lock, and \`LMOVE\`s orphans back to the source queue. At-least-once semantics.

### 2. Scheduled scan safety net
New \`ScheduledScan\` module, runs inside the worker loop on a monotonic timer (default 3600s). Enumerates \`memory_records\` with stale \`updated_at\` AND no recent \`machine_events.freshness_job_processed\` row, enqueues \`scheduled_scan\` freshness jobs. Memory-only this ticket; KB deferred to follow-up (noted in \`docs/MEMORY_MCP_FOLLOWUPS.md\`).

### 3. Env-prefixed Redis keys
\`freshness:{env}:queue:{workspace_id}\` / \`freshness:{env}:processing:{worker_id}\` / \`freshness:{env}:heartbeat:{worker_id}\`. \`env\` sourced from existing \`settings.env\` (\`METATRON_ENV\`). Empty/unset → no prefix (backward-compat with Phase A and local dev). One-shot legacy-key drain at worker startup gated by new \`METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP\` (default False).

### 4. Observability
Five new Prometheus counters (labels kept low-cardinality — worker_id is SHA1-truncated):
- \`freshness_orphans_reclaimed_total{env, worker_id_hash}\`
- \`freshness_reclaim_errors_total{env, stage}\`
- \`freshness_scheduled_scan_jobs_enqueued_total{env, target_kind}\`
- \`freshness_scheduled_scan_errors_total{env, target_kind}\`
- \`freshness_legacy_keys_drained_total{env}\`

## Architect spec + plan

- \`docs/superpowers/specs/2026-04-24-freshness-queue-reliability-design.md\` (861521c)
- \`docs/superpowers/plans/2026-04-24-freshness-queue-reliability.md\` (861521c)
- 12 open questions closed with rationale; 15 ordered tasks executed 1:1.

## Test plan

- [x] **AC gate** — \`tests/integration/memory/freshness/test_reclaim_sigkill.py\`: spawn worker via \`subprocess.Popen\`, enqueue N jobs, \`os.kill(pid, SIGKILL)\` mid-batch, start second worker, assert all N jobs eventually transition. Passes in ≤13s on isolated run.
- [x] Integration: scheduled scan rescues records with stale \`updated_at\` and no recent freshness event.
- [x] Integration: env-prefixed keys isolate two simulated environments sharing Redis.
- [x] Unit: 255 tests across \`tests/unit/freshness\`, \`tests/unit/memory/freshness\`, \`tests/unit/storage\`, \`tests/unit/core\`.
- [x] \`make lint\` / \`ruff format --check\` — clean on all 12 touched source files.
- [x] \`make typecheck\` — zero new errors on touched source files.

### Known flake
\`test_reclaim_sigkill.py\` can flake on a full-suite integration run under heavy Ollama load (timeouts), but passes deterministically in isolation and in pair with neighbors. Addressed by generous event-wait timeout (120s). If it becomes chronic in CI, we can pin the SLM used in the test to a lighter-weight local model.

## Hard constraints verified

- \`core/interfaces.py\` — untouched
- \`core/events.py\` — untouched
- No migrations, no PG schema change (Redis is infra)
- Backward compat: \`METATRON_ENV\` unset → byte-identical key shape as Phase A
- Worker starts cleanly on empty \`.env\`
- \`rpop_batch\` legacy shim kept in \`storage/redis.py\` with a deprecation note; zero freshness call sites use it

## Coordination (courtesy)

- New Prometheus counters — Grafana dashboards may want panels
- Redis ≥ 6.2 hard requirement for \`LMOVE\`. docker-compose already uses \`redis:7-alpine\`; a comment was added so future ops don't silently downgrade

## Files (groups)

- **Core config / new settings (6):** \`core/config.py\` + tests
- **Redis primitives (3 new):** \`storage/redis.py\` + tests
- **Freshness infra:**
  - NEW \`freshness/worker_id.py\`, \`freshness/scheduled_scan.py\`
  - Heavily reworked \`freshness/coordination.py\` (env-prefixed keys, heartbeat, LMOVE dequeue, reclaim, legacy drain)
  - \`freshness/targets.py\` (+ \`list_stale_candidates\` protocol method)
  - \`freshness/metrics.py\` (+ 5 counters)
- **Memory target adapter:** \`memory/freshness/target_memory.py\`, \`memory/freshness/worker.py\`
- **PG store:** \`storage/memory_postgres.py\` (+ \`list_workspaces\`, \`list_stale_candidates\`)
- **Tests:** 7 unit files, 3 integration files
- **Docs:** CHANGELOG, 3 module CLAUDE.md files, docker-compose comment