### PR TITLE
fix(MTRNIX-313): KB sync_downstream_stores resolves UUID → source_id

### DIFF
--- a/src/metatron/ingestion/freshness/target_raw_document.py
+++ b/src/metatron/ingestion/freshness/target_raw_document.py
@@ -233,13 +233,36 @@ class RawDocumentTarget:
         pipeline never fails solely because a derived store is momentarily
         unavailable. PG remains the source of truth; a later retry will
         re-sync the payload.
+
+        ``target_id`` is the ``raw_documents.id`` (UUID), but Qdrant chunk
+        payloads and Neo4j ``:Document`` nodes are keyed by ``doc_label`` =
+        ``raw_documents.source_id`` (Confluence page id, Jira issue key, etc.).
+        We resolve the source_id before calling the downstream stores
+        (MTRNIX-313 follow-up — without this, the downstream sync was a
+        silent no-op because no chunks/nodes match a UUID doc_label).
         """
+        doc = await self._pg.get_raw_document_by_id(workspace_id, target_id)
+        if doc is None:
+            logger.debug(
+                "freshness.raw_document_target.sync_downstream_no_record",
+                workspace_id=workspace_id,
+                target_id=target_id,
+            )
+            return
+        doc_label = doc.source_id
+        if not doc_label:
+            logger.warning(
+                "freshness.raw_document_target.missing_source_id",
+                workspace_id=workspace_id,
+                target_id=target_id,
+            )
+            return
         payload = {"status": status.value, "freshness_score": freshness_score}
         try:
             qdrant = await self._resolve_qdrant(workspace_id)
             await qdrant.update_payload_by_doc_label(
                 workspace_id=workspace_id,
-                doc_label=target_id,
+                doc_label=doc_label,
                 payload=payload,
             )
         except Exception:
@@ -247,16 +270,20 @@ class RawDocumentTarget:
                 "freshness.raw_document_target.qdrant_payload_sync_failed",
                 workspace_id=workspace_id,
                 target_id=target_id,
+                doc_label=doc_label,
                 exc_info=True,
             )
         try:
             from metatron.storage.raw_document_graph import set_raw_document_status
 
-            await asyncio.to_thread(set_raw_document_status, workspace_id, target_id, status.value)
+            await asyncio.to_thread(
+                set_raw_document_status, workspace_id, doc_label, status.value
+            )
         except Exception:
             logger.debug(
                 "freshness.raw_document_target.neo4j_status_skipped",
                 workspace_id=workspace_id,
                 target_id=target_id,
+                doc_label=doc_label,
                 exc_info=True,
             )

--- a/tests/unit/ingestion/freshness/test_target_raw_document.py
+++ b/tests/unit/ingestion/freshness/test_target_raw_document.py
@@ -116,34 +116,99 @@ async def test_update_lifecycle_ignores_append_tag() -> None:
     assert "append_tag" not in kwargs
 
 
+def _pg_with_doc(*, raw_doc_id: str, source_id: str) -> MagicMock:
+    """Build a pg_store mock whose ``get_raw_document_by_id`` returns a
+    minimal RawDocument carrying the given ``source_id``."""
+    pg = MagicMock()
+    pg.get_raw_document_by_id = AsyncMock(
+        return_value=RawDocument(
+            id=raw_doc_id,
+            workspace_id="ws",
+            connector_type="confluence",
+            source_id=source_id,
+            title="t",
+            content="c",
+        )
+    )
+    return pg
+
+
 async def test_sync_downstream_stores_writes_qdrant_payload() -> None:
+    """Happy path — target_id (UUID) resolves to source_id, payload sent to
+    Qdrant with the resolved ``doc_label`` (MTRNIX-313 fix)."""
     qdrant = MagicMock()
     qdrant.update_payload_by_doc_label = AsyncMock()
-    t = RawDocumentTarget(pg_store=MagicMock(), qdrant_factory=lambda _ws: qdrant)
+    pg = _pg_with_doc(raw_doc_id="uuid-abc-123", source_id="3834017")
+    t = RawDocumentTarget(pg_store=pg, qdrant_factory=lambda _ws: qdrant)
 
     await t.sync_downstream_stores(
         "ws",
-        "doc-1",
+        "uuid-abc-123",
         status=LifecycleStatus.ARCHIVED,
         freshness_score=0.0,
     )
 
     qdrant.update_payload_by_doc_label.assert_awaited_once_with(
         workspace_id="ws",
-        doc_label="doc-1",
+        doc_label="3834017",
         payload={"status": "archived", "freshness_score": 0.0},
     )
+
+
+async def test_sync_downstream_stores_translates_uuid_to_source_id() -> None:
+    """Regression for MTRNIX-313 silent no-op bug.
+
+    Pre-fix code passed ``target_id`` (raw_documents.id UUID) directly to
+    ``update_payload_by_doc_label``. But Qdrant chunk payloads are keyed by
+    ``doc_label = source_id`` (Confluence page id, Jira issue key) — so the
+    UUID matched zero chunks and the whole sync was a silent no-op. This
+    test pins the resolution: UUID → source_id translation must happen.
+    """
+    qdrant = MagicMock()
+    qdrant.update_payload_by_doc_label = AsyncMock()
+    pg = _pg_with_doc(raw_doc_id="2e87390316a54ea78c149d8f6ba1d892", source_id="MTRNIX-69")
+    t = RawDocumentTarget(pg_store=pg, qdrant_factory=lambda _ws: qdrant)
+
+    await t.sync_downstream_stores(
+        "ws",
+        "2e87390316a54ea78c149d8f6ba1d892",
+        status=LifecycleStatus.STALE,
+        freshness_score=0.25,
+    )
+
+    pg.get_raw_document_by_id.assert_awaited_once_with("ws", "2e87390316a54ea78c149d8f6ba1d892")
+    call_kwargs = qdrant.update_payload_by_doc_label.await_args.kwargs
+    assert call_kwargs["doc_label"] == "MTRNIX-69"
+    assert call_kwargs["doc_label"] != "2e87390316a54ea78c149d8f6ba1d892"
+
+
+async def test_sync_downstream_stores_skips_when_record_missing() -> None:
+    qdrant = MagicMock()
+    qdrant.update_payload_by_doc_label = AsyncMock()
+    pg = MagicMock()
+    pg.get_raw_document_by_id = AsyncMock(return_value=None)
+    t = RawDocumentTarget(pg_store=pg, qdrant_factory=lambda _ws: qdrant)
+
+    await t.sync_downstream_stores(
+        "ws",
+        "missing-uuid",
+        status=LifecycleStatus.STALE,
+        freshness_score=0.25,
+    )
+
+    qdrant.update_payload_by_doc_label.assert_not_awaited()
 
 
 async def test_sync_downstream_stores_swallows_qdrant_errors() -> None:
     qdrant = MagicMock()
     qdrant.update_payload_by_doc_label = AsyncMock(side_effect=RuntimeError("qdrant down"))
-    t = RawDocumentTarget(pg_store=MagicMock(), qdrant_factory=lambda _ws: qdrant)
+    pg = _pg_with_doc(raw_doc_id="uuid-1", source_id="doc-1")
+    t = RawDocumentTarget(pg_store=pg, qdrant_factory=lambda _ws: qdrant)
 
     # Must not raise — best-effort invariant.
     await t.sync_downstream_stores(
         "ws",
-        "doc-1",
+        "uuid-1",
         status=LifecycleStatus.ARCHIVED,
         freshness_score=0.0,
     )


### PR DESCRIPTION
## Bug

\`RawDocumentTarget.sync_downstream_stores\` (shipped in MTRNIX-313 Phase B) was passing \`target_id\` — which is \`raw_documents.id\` (UUID) — directly to \`update_payload_by_doc_label\` and \`set_raw_document_status\`. Both downstream calls expect \`doc_label\` = \`raw_documents.source_id\` (Confluence page id, Jira issue key). UUID never matches a real \`doc_label\` → silent no-op.

## Impact

\`METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED=true\` is **useless in production** until this fix lands. The Qdrant \`must_not\` filter on \`status\` would never exclude anything because Qdrant payloads never received the lifecycle status the worker wrote to PG.

## How discovered

Surfaced during MTRNIX-319 ad-hoc KB testing (post-merge follow-up). Walked one Confluence doc through the worker pipeline:
- ✅ PG: \`raw_documents.status\` transitioned \`active → stale\`
- ❌ Qdrant: chunk payload \`status\` field still missing
- ❌ Neo4j: \`:Document.status\` not set

The bug never bit before because:
1. KB freshness flag-off by default
2. KB filter flag-off by default
3. Nobody ever ran the worker against real \`raw_documents\` data

Today was the first such run. We were the lucky finders.

## Fix

In \`sync_downstream_stores\`:
1. Fetch the raw_document by id via existing \`get_raw_document_by_id\`
2. Extract \`source_id\`
3. Use \`source_id\` as the \`doc_label\` argument for both Qdrant and Neo4j calls
4. Skip gracefully on missing record or missing source_id (defensive)

## Tests

- \`test_sync_downstream_stores_writes_qdrant_payload\` — happy path now uses real RawDocument with source_id
- **NEW** \`test_sync_downstream_stores_translates_uuid_to_source_id\` — explicit regression pinning the UUID → source_id translation
- **NEW** \`test_sync_downstream_stores_skips_when_record_missing\` — defensive path
- Existing \`test_sync_downstream_stores_swallows_qdrant_errors\` — adapted to new shape

13/13 tests pass.

## No-impact areas

- \`update_lifecycle\` (PG) is unaffected — it correctly takes UUID. Bug was only in the downstream sync.
- Memory side (\`MemoryTarget\`) is unaffected — it never had this bug because memory record id IS the Qdrant point id by design (no source_id translation needed).