### PR TITLE
docs: PR #95 aftermath — KB filter validation + UUID→source_id fix recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@
   exist in both v1.3 and v1.4 stay within ±0.01.
 
 ### Fixed
+- fix: KB freshness sync_downstream_stores resolves UUID → source_id
+  (MTRNIX-313 follow-up, PR #95). `RawDocumentTarget.sync_downstream_stores`
+  was passing the freshness job's `target_id` (raw_documents.id UUID)
+  directly to `update_payload_by_doc_label` and
+  `set_raw_document_status`. Both downstream stores key by
+  `doc_label = raw_documents.source_id` (Confluence page id, Jira issue
+  key) — UUID never matched a real chunk or `:Document` node, so every
+  worker-driven KB lifecycle transition was a silent no-op on Qdrant
+  and Neo4j. Net effect: `METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED=true`
+  was useless before this fix; the retrieval `must_not` filter had
+  nothing to filter because Qdrant payloads never received the
+  lifecycle status. Surfaced during MTRNIX-319 ad-hoc KB validation.
+  Fix fetches the raw_document, extracts source_id, uses it as the
+  doc_label argument. End-to-end validation: doc-02 query MRR 1.000 →
+  0.000 when the expected document is transitioned to ARCHIVED.
 - fix: Eval driver event-loop reuse (MTRNIX-323 §1). `scripts/run_eval.py`
   now wraps the entire run in a single `asyncio.run()`, calling
   `clear_store_cache()` immediately before to flush any stray async

--- a/docs/ROLLOUT_NOTES_2026-04-24.md
+++ b/docs/ROLLOUT_NOTES_2026-04-24.md
@@ -36,8 +36,8 @@ These features are in the codebase but gated off. Flipping them requires explici
 | Flag | Default | What flipping does | Pre-flip gate |
 |---|---|---|---|
 | `METATRON_FRESHNESS_ENABLED` | `false` | Starts the memory freshness worker | Run worker on staging ≥15 min on empty queue first |
-| `METATRON_FRESHNESS_KB_ENABLED` | `false` | Enables the KB (raw_documents) freshness pipeline | Requires `FRESHNESS_ENABLED=true`. Run `make eval-compare` with/without to gauge drift |
-| `METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED` | `false` | Push-down ARCHIVED/SUPERSEDED filter into document retrieval | Run `make eval-compare`; ±0.5 pp NDCG band |
+| `METATRON_FRESHNESS_KB_ENABLED` | `false` | Enables the KB (raw_documents) freshness pipeline. End-to-end validated 2026-04-25 (PR #95 fixed a UUID/source_id bug discovered during validation). | Requires `FRESHNESS_ENABLED=true`. Run `make eval-compare` with/without to gauge drift |
+| `METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED` | `false` | Push-down ARCHIVED/SUPERSEDED filter into document retrieval. Validated end-to-end on a single archived doc — filtered correctly. STALE docs are deliberately NOT excluded (only ARCHIVED + SUPERSEDED); STALE rank-downgrade requires `FRESHNESS_WEIGHT > 0`. | Run `make eval-compare`; ±0.5 pp NDCG band |
 | `METATRON_FRESHNESS_WEIGHT` | `0.0` | Adds a freshness signal to the scoring formula | Any value > 0 changes rankings; grid-search weights first |
 | `HYDE_ENABLED` | `false` | HyDE for short/vague queries | Currently regresses eval, off by default |
 | `ADAPTIVE_RRF_ENABLED` | `false` | Adaptive RRF fusion | Currently regresses eval, off by default |

--- a/src/metatron/ingestion/.claude/claude.md
+++ b/src/metatron/ingestion/.claude/claude.md
@@ -112,7 +112,20 @@ Files:
   `similarity_search` deduplicates by `doc_label`, and
   `sync_downstream_stores` mirrors `(status, freshness_score)` onto every
   chunk payload via `AsyncQdrantVectorStore.update_payload_by_doc_label` plus
-  the `:Document.status` property via `set_raw_document_status`.
+  the `:Document.status` property via `set_raw_document_status`. Both
+  downstream calls key by `doc_label = raw_documents.source_id` (the
+  Confluence page id, Jira issue key, etc.), so the adapter resolves the
+  freshness job's `target_id` (the raw_documents.id UUID) to the
+  `source_id` via PG before invoking either store (PR #95 — the original
+  Phase B implementation passed UUID directly and the downstream sync
+  was a silent no-op).
+- **Monitor age-gate (KB-only).** On the first FreshnessMonitor run for
+  a raw_document (`last_freshness_run_at IS NULL`), the stage only
+  stamps the timestamp and returns — it does not transition to STALE
+  even if the staleness predicate fires. The next run actually
+  transitions. This is a defensive gate to avoid en-masse STALE
+  flagging at Phase B rollout. Memory records preserve Phase A
+  behaviour: STALE fires on the first run across the threshold.
 
 All behaviour is gated by `METATRON_FRESHNESS_KB_ENABLED`; when off, neither
 the producer nor the adapter is exercised by core code paths.


### PR DESCRIPTION
Documentation catch-up after PR #95 (the silent-no-op fix in RawDocumentTarget.sync_downstream_stores landed earlier tonight) and the end-to-end KB filter validation that followed.

- CHANGELOG entry under Fixed
- ROLLOUT_NOTES table updated (KB_ENABLED + KB_SEARCH_FILTER rows now describe validation status + STALE-not-excluded design)
- ingestion/.claude/CLAUDE.md — RawDocumentTarget docstring explains the UUID→source_id resolution + Monitor age-gate gotcha (first-touch only stamps, second touch transitions)

No code changes.