### PR TITLE
docs: rollout note — explicit 'Known unknowns' section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,94 +1,272 @@
 # =============================================================================
 # Metatron Core — Environment Variables
 # Copy to .env and adjust values for your environment.
+#
+# All vars below mirror src/metatron/core/config.py (Settings) plus a few read
+# directly via os.environ in specific modules (MCP server, query-expansion LLM,
+# admin cleanup, ingestion entity resolver). Defaults match codebase defaults.
 # =============================================================================
 
-# --- Connectors & Channels ---
-# Connector credentials (Confluence, Jira, Notion, etc.) and channel tokens
-# (Telegram, Discord, Slack) are now managed via the Connections API / UI
-# and stored encrypted in the database.
-#
-# Legacy env vars (CONFLUENCE_URL, TELEGRAM_BOT_TOKEN, etc.) are still read
-# at startup for one-time migration into the DB. After that migration they
-# can be removed from .env. See storage/migrate_env_connections.py.
-
-# --- Infrastructure ---
-METATRON_ENV=development         # development | staging | production
-METATRON_PORT=8000               # HTTP port for the API server
-METATRON_HOST=0.0.0.0            # Bind address (0.0.0.0 = all interfaces)
-METATRON_LOG_LEVEL=INFO          # DEBUG | INFO | WARNING | ERROR
+# -----------------------------------------------------------------------------
+# Application
+# -----------------------------------------------------------------------------
+METATRON_ENV=development              # development | staging | production
+METATRON_HOST=0.0.0.0                 # bind address (0.0.0.0 = all interfaces)
+METATRON_PORT=8000                    # HTTP port for the API server
+METATRON_LOG_LEVEL=INFO               # DEBUG | INFO | WARNING | ERROR | CRITICAL
 METATRON_SECRET_KEY=change-me-in-production
+CORS_ORIGINS=*                        # comma-separated list, or * for all
 
+# -----------------------------------------------------------------------------
+# Auth (JWT) — optional gate on /api/v1/* endpoints
+# -----------------------------------------------------------------------------
+AUTH_ENABLED=false                    # when true, JWT required on /api/v1/*
+AUTH_PASSWORD=metatron                # password for /auth/login
+
+# -----------------------------------------------------------------------------
+# PostgreSQL — system of record (users, raw_documents, memory, agents, ...)
+# -----------------------------------------------------------------------------
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=metatron
 POSTGRES_USER=metatron
 POSTGRES_PASSWORD=metatron_dev
 
+# -----------------------------------------------------------------------------
+# Qdrant — vector store (dense embeddings + SPLADE sparse vectors)
+# -----------------------------------------------------------------------------
 QDRANT_HOST=localhost
 QDRANT_HTTP_PORT=6333
 QDRANT_GRPC_PORT=6334
+QDRANT_API_KEY=                       # for cloud / authenticated Qdrant
+QDRANT_HTTPS=false
 
+# -----------------------------------------------------------------------------
+# Neo4j — knowledge graph (Document → Chunk → Entity, ALIAS edges)
+# Legacy MEMGRAPH_* aliases for these vars are still accepted for back-compat.
+# -----------------------------------------------------------------------------
 NEO4J_HOST=localhost
 NEO4J_PORT=7687
-NEO4J_USER=                      # empty = no auth (NEO4J_AUTH=none in Docker)
+NEO4J_USER=                           # empty = no auth (NEO4J_AUTH=none in Docker)
 NEO4J_PASSWORD=
 
+# -----------------------------------------------------------------------------
+# Redis — agent session cache + freshness worker locks/heartbeats
+# -----------------------------------------------------------------------------
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0
 REDIS_PASSWORD=
-METATRON_MEMORY_SESSION_TTL=14400  # session memory TTL in seconds (4 hours)
 
-FERNET_KEY=                      # generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-FILE_STORE_PATH=./data/files     # local path for uploaded files
+# -----------------------------------------------------------------------------
+# Encryption — for connector credentials (Fernet, per-workspace)
+# Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# -----------------------------------------------------------------------------
+FERNET_KEY=
 
-DEFAULT_WORKSPACE_ID=MTRNIX      # workspace scope for multi-tenant isolation
+# -----------------------------------------------------------------------------
+# File storage & workspace defaults
+# -----------------------------------------------------------------------------
+FILE_STORE_PATH=./data/files
+DEFAULT_WORKSPACE_ID=MTRNIX
 DEFAULT_WORKSPACE_NAME=MTRNIX
-WORKSPACE_PERSISTENCE=neo4j      # neo4j | postgres
+WORKSPACE_PERSISTENCE=neo4j           # neo4j | postgres
 
-# --- LLM ---
-LLM_PROVIDER=ollama              # ollama | deepseek | openrouter | custom
-LLM_FALLBACK_PROVIDER=           # fallback if primary fails (same options)
 
-# Ollama — embeddings + chat (default)
+# =============================================================================
+# LLM Providers
+# =============================================================================
+LLM_PROVIDER=ollama                   # ollama | deepseek | openrouter | custom
+LLM_FALLBACK_PROVIDER=                # fallback if primary fails (same options)
+
+# --- Ollama (embeddings + chat, default provider) ---
 OLLAMA_HOST=http://localhost:11434
-OLLAMA_CHAT_MODEL=llama3.1:8b    # model for routing and chat
-OLLAMA_EMBED_MODEL=nomic-embed-text  # model for embeddings (768d)
+OLLAMA_CHAT_MODEL=llama3.1:8b
+OLLAMA_EMBED_MODEL=nomic-embed-text   # 768-dim default
 
-# Ollama — separate LLM instance (optional, falls back to OLLAMA_HOST)
-OLLAMA_LLM_HOST=                 # separate host for LLM if different from embeddings
+# --- Ollama LLM instance (separate from embeddings, optional) ---
+# If OLLAMA_LLM_HOST is empty, OLLAMA_HOST is reused.
+OLLAMA_LLM_HOST=
 OLLAMA_LLM_PORT=11434
 OLLAMA_LLM_MODEL=llama3
+OLLAMA_NUM_CTX=32768                  # context window for Ollama chat
+OLLAMA_REQUEST_TIMEOUT=               # seconds; empty = library default
 
-# DeepSeek
+# --- DeepSeek ---
 DEEPSEEK_API_KEY=
 DEEPSEEK_MODEL=deepseek-chat
 
-# OpenRouter
+# --- OpenRouter ---
 OPENROUTER_API_KEY=
 OPENROUTER_MODEL=meta-llama/llama-3.1-8b-instruct
 OPENROUTER_APP_NAME=metatron
+OPENROUTER_SITE_URL=
 
-# Custom OpenAI-compatible endpoint
-CUSTOM_LLM_URL=                  # e.g. http://localhost:8080/v1
+# --- Custom OpenAI-compatible endpoint ---
+CUSTOM_LLM_URL=                       # e.g. http://localhost:8080/v1
 CUSTOM_LLM_API_KEY=
 CUSTOM_LLM_MODEL=default
 
-# --- Benchmarker ---
-BENCHMARKER_EMBEDDING_PROXY_URL=http://localhost:8001  # Embedding proxy for benchmarker metrics
+# Auxiliary LLM (query expansion, classifier) timeout
+METATRON_AUX_LLM_TIMEOUT=10           # seconds
 
-# --- OpenAI-Compatible API (Open WebUI) ---
-METATRON_OPENAI_COMPAT_ENABLED=true      # enable /v1/models and /v1/chat/completions
-METATRON_OPENAI_COMPAT_KEY=              # static API key (empty = endpoints disabled)
 
-# --- Search ---
-QUERY_EXPANSION_ENABLED=true     # LLM-based query expansion for better recall
-SEARCH_MAX_TOTAL_CHARS=40000     # max context chars sent to LLM
-SEARCH_MAX_FRAGMENT_CHARS=8000   # max chars per single fragment
-SEARCH_POOL_MULTIPLIER=3         # fetch N× more results than needed, then re-rank
-SEARCH_POOL_MIN=15               # minimum results in candidate pool
-BM25_VOCAB_SIZE=30000            # BM25 sparse index vocabulary size
+# =============================================================================
+# External Consumer Surfaces
+# =============================================================================
 
-EMBEDDING_CACHE_TTL=3600         # embedding cache TTL in seconds
-EMBEDDING_CACHE_MAXSIZE=2048     # max cached embeddings
+# --- MCP server (Hermes / Cursor / Claude Desktop / OpenClaw / custom MCP) ---
+# Mounted at /mcp on the API. METATRON_MCP_TRANSPORT/HOST/PORT are read by
+# `python -m metatron.mcp` standalone runner; the API mount uses streamable-http.
+METATRON_MCP_API_KEY=                 # bearer token; empty = MCP requires no auth
+METATRON_MCP_TRANSPORT=stdio          # stdio | streamable-http
+METATRON_MCP_HOST=127.0.0.1           # for streamable-http transport
+METATRON_MCP_PORT=8765                # for streamable-http transport
+
+# --- OpenAI-compatible API (OpenWebUI / LibreChat / OAI clients) ---
+# RAG-backed completions (NOT a raw LLM proxy).
+METATRON_OPENAI_COMPAT_ENABLED=true   # enable /v1/models and /v1/chat/completions
+METATRON_OPENAI_COMPAT_KEY=           # static API key fallback (empty = use mtk_* user keys)
+
+# --- OpenWebUI bundled chat sync (current chat front-end) ---
+METATRON_OPENWEBUI_URL=               # bundled OpenWebUI URL (for user sync)
+METATRON_OPENWEBUI_METATRON_URL=      # external Metatron URL for OpenWebUI Direct Connections
+
+
+# =============================================================================
+# Search Pipeline (KB hybrid RAG)
+# =============================================================================
+
+# --- Feature toggles ---
+QUERY_EXPANSION_ENABLED=true          # LLM-based query expansion
+RERANKER_ENABLED=true                 # bge-reranker-v2-m3 cross-encoder
+QUERY_CLASSIFIER_ENABLED=true         # hybrid rule+LLM query classifier
+HYDE_ENABLED=false                    # HyDE for short/vague queries
+ADAPTIVE_RRF_ENABLED=false            # adaptive RRF fusion (regresses metrics, off)
+ENABLE_SEMANTIC_MATCHING=true         # semantic entity matching in resolver
+METATRON_HIERARCHICAL_CHUNKING_ENABLED=true
+
+# --- HyDE tuning ---
+HYDE_MAX_WORDS=4                      # max query word count to trigger HyDE
+HYDE_TIMEOUT=8                        # HyDE LLM timeout (seconds)
+
+# --- General search budget ---
+SEARCH_MAX_TOTAL_CHARS=40000          # max context chars sent to LLM
+SEARCH_MAX_FRAGMENT_CHARS=8000        # max chars per single fragment
+SEARCH_POOL_MULTIPLIER=3              # fetch N× more results than needed
+SEARCH_POOL_MIN=15                    # minimum candidate pool size
+
+# --- Per-channel recall limits ---
+RECALL_TOP_N_DENSE=30
+RECALL_TOP_N_EXACT=10
+RECALL_TOP_N_METADATA=10
+RECALL_TOP_N_GRAPH=5
+RECALL_GRAPH_MAX_DEPTH=2
+
+# --- RRF / Adaptive RRF ---
+RRF_K_LOW=20
+RRF_K_HIGH=80
+RRF_OVERLAP_THRESHOLD_LOW=0.2
+RRF_OVERLAP_THRESHOLD_HIGH=0.7
+
+# --- LLM context budget for answer generation ---
+LLM_CONTEXT_MAX_TOKENS=10000
+LLM_ANSWER_RESERVE_TOKENS=1500
+
+# --- Sparse retrieval ---
+# SPLADE replaces BM25 by default. BM25 is the fallback when SPLADE_ENABLED=false.
+SPLADE_ENABLED=true
+SPLADE_MODEL=naver/splade-cocondenser-ensembledistil
+SPLADE_MAX_LENGTH=256
+SPLADE_SERVICE_URL=                   # optional remote SPLADE service URL
+BM25_VOCAB_SIZE=30000                 # BM25 fallback vocabulary size
+
+# --- Embedding cache & ingest concurrency ---
+EMBEDDING_CACHE_TTL=3600              # seconds
+EMBEDDING_CACHE_MAXSIZE=2048
+INGEST_EMBED_CONCURRENCY=2            # caps ingest-path embedding calls (queries are not throttled)
+
+# --- Graph extraction ---
+GRAPH_EXTRACTION_ENABLED=true
+GRAPH_EXTRACTION_WORKERS=1
+GRAPH_EXTRACTION_MIN_CHARS=100
+
+
+# =============================================================================
+# Agent Memory (WS1)
+# =============================================================================
+METATRON_MEMORY_SESSION_TTL=14400     # session memory TTL (seconds; 4h)
+METATRON_MEMORY_SEARCH_DENSE_WEIGHT=0.6
+METATRON_MEMORY_SEARCH_GRAPH_WEIGHT=0.3
+METATRON_MEMORY_SEARCH_SESSION_WEIGHT=0.1
+METATRON_MEMORY_SEARCH_TOP_K_MULTIPLIER=3
+
+# --- Fast search profile (metatron_search_fast MCP tool) ---
+METATRON_SEARCH_FAST_TOP_K=10
+METATRON_SEARCH_FAST_INCLUDE_METADATA=true
+
+
+# =============================================================================
+# Freshness Pipeline — Phase A (Agent Memory, MTRNIX-304)
+# Master flag is OFF by default. When false, the producer is a no-op and
+# `python -m metatron.memory.freshness` exits immediately.
+# =============================================================================
+METATRON_FRESHNESS_ENABLED=false
+METATRON_FRESHNESS_POLL_SECONDS=2.0
+METATRON_FRESHNESS_MAX_JOBS_PER_ITERATION=20
+METATRON_FRESHNESS_LOCK_TTL_SECONDS=30
+METATRON_FRESHNESS_STALE_AFTER_DAYS=30
+METATRON_FRESHNESS_DECISION_CONFIDENCE_THRESHOLD=0.7
+METATRON_FRESHNESS_LINKER_THRESHOLD=0.6
+METATRON_FRESHNESS_RECONCILER_THRESHOLD=0.85
+METATRON_FRESHNESS_BACKOFF_BASE_SECONDS=2.0
+METATRON_FRESHNESS_BACKOFF_MAX_SECONDS=60.0
+METATRON_FRESHNESS_MAX_CONSECUTIVE_ERRORS=10
+
+# --- Freshness SLM (DecisionEngine) ---
+# When METATRON_FRESHNESS_LLM_API_BASE_URL is set, provider auto-switches to "custom".
+METATRON_FRESHNESS_LLM_MODEL=qwen2.5-4b-instruct-q4
+METATRON_FRESHNESS_LLM_PROVIDER=
+METATRON_FRESHNESS_LLM_API_BASE_URL=
+METATRON_FRESHNESS_LLM_API_KEY=
+
+# --- Freshness queue reliability (MTRNIX-316) ---
+METATRON_FRESHNESS_HEARTBEAT_TTL_SECONDS=20
+METATRON_FRESHNESS_RECLAIM_INTERVAL_ITERATIONS=30
+METATRON_FRESHNESS_SCHEDULED_SCAN_ENABLED=true
+METATRON_FRESHNESS_SCHEDULED_SCAN_INTERVAL_SECONDS=3600
+METATRON_FRESHNESS_SCAN_BATCH_LIMIT=500
+METATRON_FRESHNESS_DRAIN_LEGACY_AT_STARTUP=false
+
+
+# =============================================================================
+# KB Freshness — Phase B (MTRNIX-313)
+# Requires METATRON_FRESHNESS_ENABLED=true.
+# =============================================================================
+METATRON_FRESHNESS_KB_ENABLED=false
+METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED=false   # retrieval-side ARCHIVED/SUPERSEDED filter
+METATRON_FRESHNESS_WEIGHT=0.0                       # scoring weight for freshness signal (0=off)
+METATRON_FRESHNESS_KB_STALE_AFTER_DAYS=90           # higher than memory's 30 (KB ages slower)
+
+
+# =============================================================================
+# Misc / Ops
+# =============================================================================
+ALLOW_CLEANUP=false                   # gate destructive /api/v1/admin/cleanup* endpoints
+
+# --- Benchmarker (dev eval tool, optional) ---
+BENCHMARKER_EMBEDDING_PROXY_URL=http://localhost:8001
+
+
+# =============================================================================
+# Legacy connector / channel env vars (transitional)
+# -----------------------------------------------------------------------------
+# Connector credentials (CONFLUENCE_*, JIRA_*, NOTION_TOKEN, GITHUB_TOKEN,
+# GDRIVE_*, SLACK_HISTORY_*) and channel tokens (TELEGRAM_BOT_TOKEN,
+# DISCORD_TOKEN, SLACK_BOT_TOKEN) are now managed via the Connections API/UI
+# and stored Fernet-encrypted in PostgreSQL.
+#
+# `storage/migrate_env_connections.py` reads them at startup for a one-time DB
+# migration. After that, they can be removed from .env.
+# Channels (Telegram/Discord/Slack) are scheduled for removal — see docs/LEGACY.md.
+# =============================================================================

--- a/docs/ROLLOUT_NOTES_2026-04-24.md
+++ b/docs/ROLLOUT_NOTES_2026-04-24.md
@@ -65,6 +65,19 @@ Smoke covered by `tests/integration/api/test_openai_compat_smoke.py` (MTRNIX-323
 - Recall channels refactor (~March 31) introduced a documented −6–8% on eval metrics. Accepted trade-off for cleaner architecture; will be revisited once WS1 lands end-to-end.
 - `recall_dense_async` previously returned `[]` silently under heavy concurrent sync load. Fixed in PR #88 (`2026-04-23`), but older snapshots of develop may still show it.
 
+## Known unknowns (untested surfaces)
+
+These are areas we did **not** validate during the MTRNIX-319 gate. Treat them as "unproven" rather than "broken" — code paths exist, unit tests cover them, but no live-environment evidence yet.
+
+| Surface | Why not tested | Risk if you flip / use it | Mitigation |
+| --- | --- | --- | --- |
+| Hermes as a real MCP client | Their LLM provider was rate-limited during validation | Hermes-specific argument tokenisation may garble parameters (we saw this once with `workspace_id` → `<\|"\|>MTRNIX<\|"\|>`); MCP transport itself was validated via direct Python client | Validate via Hermes once their LLM is back; transport-side fix would be theirs |
+| `FRESHNESS_ENABLED=true` under sustained production load | Only ran ~15 min dry-run on 20 records | Worker SLM (DecisionEngine) latency under hundreds-per-minute QPS unknown; backoff thresholds unproven | Run a 24h soak on staging with real producer traffic before flipping in prod |
+| `FRESHNESS_KB_ENABLED=true` on the full 475-doc corpus | Validated end-to-end on 1 document; bulk batch performance unknown | Qdrant `update_payload_by_doc_label` × 475 + Ollama for DecisionEngine × 475 may saturate; no failure mode observed but also no observation | Roll out staged: 50 docs → 200 → all. Watch `freshness_qdrant_sync_failed_total` and Ollama queue |
+| Multi-worker reclaim in a docker-compose deploy | Logic validated via `test_reclaim_sigkill.py` (subprocess), not in a real two-container setup | Heartbeat + reclaim lock interaction across true network boundary unproven | Spin up 2 worker containers for one staging soak; watch `freshness_orphans_reclaimed_total` |
+| `make eval-compare` with `KB_ENABLED=true` after corpus naturally ages | Only ran with `KB_STALE_AFTER_DAYS=0` (artificial all-stale) | Mass STALE/SUPERSEDED transitions over days/weeks may shift retrieval distribution unpredictably | Re-run eval weekly post-flip; track aggregate metric drift |
+| Real-life integration patterns of the consuming team | They haven't started yet | Unknown unknowns — first day of integration is when the real bugs show up | Be available for the first week, expect to file follow-up tickets |
+
 ## Operational setup
 
 ### Required services


### PR DESCRIPTION
Today's hand-off note had 'Known issues' (broken-but-workaround) but was missing 'Known unknowns' (not-tested). They're different: one says "this is broken, here's the workaround", the other says "we never tried this, here's the risk if you do".

Adding a 6-row table covering: Hermes MCP path, sustained freshness load, full-corpus KB enablement, multi-worker reclaim in docker-compose, KB-enabled eval drift over time, real-life consuming team patterns.

No code changes.