### PR TITLE
feat(MTRNIX-324): Memory REST API follow-ups for Memory Inspector UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@
   consecutive `make eval` runs now emit 0 fallback events.
 
 ### Added
+- feat(memory): REST API expanded with single-record GET (`/memory/records/{id}`),
+  neighbourhood graph (`/memory/graph`, depth 1..3, graceful Neo4j-down), and
+  review-queue endpoints (`GET /memory/review`, `POST /memory/review/{id}`).
+  `MemoryRecordResponse` now carries `status: LifecycleStatus`. `POST /memory/search`
+  and `GET /memory/records` accept `status_filter` (search default excludes
+  ARCHIVED+SUPERSEDED; list has no default exclusion). `GET /api/v1/agents` formally
+  documents default exclusion of ARCHIVED + opt-in `?include_archived=true` (mutually
+  exclusive with `?status=`). `api.dependencies.get_memory_service` now wires
+  `freshness_store` and passes `pg_store` to `MemorySearchService` for graph-leg
+  post-filter parity with the MCP path. (MTRNIX-324)
 - feat: Freshness queue reliability — processing-list reclaim + scheduled-scan
   safety net + env-prefixed Redis keys close the Phase A pre-prod gaps
   (MTRNIX-316). **Requires Redis >= 6.2 for `LMOVE`.** The worker no longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,12 +314,25 @@ Memory context injection into system prompt on this endpoint is planned (MTRNIX-
 Today agent memory is not automatically added to /v1/chat/completions context.
 
 ### 3. Raw REST API
-- `/api/v1/memory/*` — agent memory CRUD + hybrid search
+- `/api/v1/memory/*` — agent memory CRUD + hybrid search. `MemoryRecordResponse` carries
+  `status: LifecycleStatus` (lowercase wire value, e.g. `"active"`, `"archived"`).
+  `POST /memory/search` accepts `status_filter: list[LifecycleStatus] | None` — **default
+  excludes ARCHIVED + SUPERSEDED** (intentionally broader than MCP default of `["active"]`
+  only; REST search is for inspection/admin use). `GET /memory/records` accepts the same
+  `status_filter` query param with no default exclusion (full list view for inspection).
+  Additional endpoints: `GET /memory/records/{id}` (single-record fetch, 404 cross-workspace,
+  viewer+); `GET /memory/graph` (neighbourhood traversal, `seed_record_id` required,
+  `depth=1..3`, `agent_id` optional, returns `{nodes, edges}`, graceful Neo4j-down, viewer+);
+  `GET /memory/review` (paginated review queue, filter by `reason`, viewer+);
+  `POST /memory/review/{id}` (resolve review entry — `keep|archive|merge_into|discard`,
+  emits `MachineEvent`, 204, editor+; returns 503 if `freshness_store` not configured).
 - `/api/v1/agents/*` — agent registry CRUD + lifecycle (start/stop/pause) + `POST /{id}/restore`
   (MTRNIX-323 — ARCHIVED → STOPPED) + versioned config (WS4, MTRNIX-270). Reads gated by
   `require_viewer`; writes/lifecycle by `require_editor`. Lifecycle endpoints enforce a strict
   state-transition matrix — `/start`, `/stop`, `/pause` reject invalid transitions with 400
-  (`AgentInvalidStateTransitionError`); un-archive is only via `/restore`.
+  (`AgentInvalidStateTransitionError`); un-archive is only via `/restore`. `GET /api/v1/agents`
+  defaults to excluding ARCHIVED agents; pass `?include_archived=true` to opt in (admin/inspection
+  use). `?status=` and `?include_archived=true` together return 400 (mutually exclusive).
 - `/api/v1/documents`, `/api/v1/search` — document CRUD + search
 - `/api/v1/workspaces`, `/api/v1/connections`, `/api/v1/sync` — admin surfaces
 

--- a/docs/MCP_API.md
+++ b/docs/MCP_API.md
@@ -559,6 +559,29 @@ only — no hard DELETE at the MCP layer.
 
 ---
 
+### Default `status_filter` — REST vs MCP
+
+The MCP `memory_search` tool and the REST `POST /api/v1/memory/search` endpoint have
+**intentionally different** default `status_filter` behaviours:
+
+| Surface | Default `status_filter` | Rationale |
+|---------|------------------------|-----------|
+| **MCP** `memory_search` | `["active"]` — only ACTIVE records | Agent-time retrieval: agents should never see ARCHIVED/SUPERSEDED noise unless they explicitly opt in |
+| **REST** `POST /api/v1/memory/search` | Exclude `ARCHIVED` + `SUPERSEDED` (everything else passes) | Inspection/admin use: Control Center and tooling should see CANDIDATE, STALE, REVIEW_NEEDED etc. by default |
+
+This is **not a bug** — the two surfaces serve different consumers. To override either default:
+
+- MCP: pass `"status": ["all"]` to disable filtering entirely, or enumerate specific statuses.
+- REST: pass `"status_filter": ["active"]` to match the MCP default, or `null` / omit to get the
+  REST default (exclude ARCHIVED + SUPERSEDED).
+
+**REST equivalents for review tools:** `GET /api/v1/memory/review` and
+`POST /api/v1/memory/review/{id}` are the REST counterparts of `memory_review_list` and
+`memory_review_resolve` above — intended for Control Center and other HTTP clients that
+cannot call MCP directly. (MTRNIX-324)
+
+---
+
 ### System
 
 #### `metatron_status`

--- a/src/metatron/agents/persistence.py
+++ b/src/metatron/agents/persistence.py
@@ -212,21 +212,35 @@ class AgentPersistence:
         *,
         status: AgentStatus | None = None,
         name_prefix: str | None = None,
+        include_archived: bool = False,
         limit: int = 50,
         offset: int = 0,
     ) -> list[AgentRecord]:
-        """List agents with optional filters and pagination."""
+        """List agents with optional filters and pagination.
+
+        Filter precedence (highest to lowest):
+
+        1. If ``status`` is not None — return only agents with that exact status.
+           ``include_archived`` is ignored in this branch (callers that need fine-grained
+           control already pass an explicit status).
+        2. Elif ``include_archived=True`` — return all agents regardless of status
+           (no WHERE clause added for status).
+        3. Else (default) — exclude ARCHIVED agents.  This is the "show everything
+           except soft-deleted" view used by the default list endpoint.
+        """
         where_parts = ["workspace_id = :ws"]
         params: dict[str, Any] = {"ws": workspace_id, "limit": limit, "offset": offset}
 
         if status is not None:
             where_parts.append("status = :status")
             params["status"] = status.value
-        else:
+        elif not include_archived:
             # Soft-deleted (archived) agents are hidden by default.
-            # Clients can opt in explicitly via ``?status=archived``.
+            # Clients can opt in explicitly via ``?status=archived`` or
+            # ``?include_archived=true``.
             where_parts.append("status <> :archived_status")
             params["archived_status"] = AgentStatus.ARCHIVED.value
+        # else: include_archived=True — no status WHERE clause; all rows returned.
         if name_prefix is not None and name_prefix != "":
             where_parts.append("name LIKE :name_prefix ESCAPE '\\'")
             params["name_prefix"] = _escape_like_prefix(name_prefix) + "%"

--- a/src/metatron/agents/service.py
+++ b/src/metatron/agents/service.py
@@ -187,14 +187,26 @@ class AgentRegistryService:
         *,
         status: AgentStatus | None = None,
         name_prefix: str | None = None,
+        include_archived: bool = False,
         limit: int = 50,
         offset: int = 0,
     ) -> list[AgentRecord]:
-        """List agents with optional filters and pagination."""
+        """List agents with optional filters and pagination.
+
+        ``include_archived`` (MTRNIX-324):
+
+        * ``False`` (default) — exclude ``ARCHIVED`` agents.  Matches the
+          inspector / picker UI default of "show only live agents".
+        * ``True`` — include ``ARCHIVED`` agents alongside others.
+
+        Ignored when an explicit ``status`` filter is passed (the explicit
+        status filter wins; persistence enforces the precedence).
+        """
         return await self._repo.list_records(
             self._workspace_id,
             status=status,
             name_prefix=name_prefix,
+            include_archived=include_archived,
             limit=limit,
             offset=offset,
         )

--- a/src/metatron/api/.claude/claude.md
+++ b/src/metatron/api/.claude/claude.md
@@ -148,11 +148,15 @@ Memory REST API endpoints (workspace-scoped, RBAC-gated):
 | Method | Path | RBAC | Purpose |
 |--------|------|------|---------|
 | POST | `/api/v1/memory/records` | editor+ | Create record — `service.save()` (PG→Qdrant→Neo4j) or `service.cache_session()` for SESSION scope. Returns 201 |
-| POST | `/api/v1/memory/search` | viewer+ | Hybrid search via `MemorySearchService.hybrid_search()`. 503 if search not configured |
-| GET | `/api/v1/memory/records` | viewer+ | List records. Query params: `agent_id`, `scope`, `session_id`, `limit` (1..200), `offset` (0..10000). Routes to `list_session` or `list_records` |
+| POST | `/api/v1/memory/search` | viewer+ | Hybrid search via `MemorySearchService.hybrid_search()`. Accepts `status_filter: list[LifecycleStatus] \| None`; **default excludes ARCHIVED + SUPERSEDED**. 503 if search not configured |
+| GET | `/api/v1/memory/records` | viewer+ | List records. Query params: `agent_id`, `scope`, `session_id`, `limit` (1..200), `offset` (0..10000), `status_filter` (no default exclusion). Routes to `list_session` or `list_records` |
 | DELETE | `/api/v1/memory/records/{id}` | editor+ | Delete record via `service.delete()`. 204 on success, 404 if not in PG |
+| GET | `/api/v1/memory/records/{id}` | viewer+ | Single-record fetch by ID. 404 if not found or in a different workspace (cross-workspace isolation enforced) |
+| GET | `/api/v1/memory/graph` | viewer+ | Neighbourhood traversal. Required: `seed_record_id`. Optional: `depth` (1..3, default 1), `agent_id`. Returns `{nodes: MemoryRecordResponse[], edges: MemoryGraphEdge[]}`. Bridge edges (REMEMBERS\|ABOUT\|FROM_SESSION\|DERIVED_FROM) are always 2-hop; `depth` controls only the `LINKED_TO` chain. Graceful Neo4j-down |
+| GET | `/api/v1/memory/review` | viewer+ | Paginated review queue. Query params: `reason` (optional filter), `limit`, `offset`. Returns `{entries, count, total, limit, offset}`. 503 if `freshness_store` not configured |
+| POST | `/api/v1/memory/review/{id}` | editor+ | Resolve review entry. Body: `{action: keep\|archive\|merge_into\|discard, target_record_id?: str (required iff merge_into), notes?: str}`. Returns 204. Emits `MachineEvent` with `actor=user.id`. 503 if `freshness_store` not configured |
 
-**DI helper:** `get_memory_service(request)` — per-workspace cache on `app.state.memory_services`; shared PG engine on `app.state.memory_pg_engine`.
+**DI helper:** `get_memory_service(request)` — per-workspace cache on `app.state.memory_services`; shared PG engine on `app.state.memory_pg_engine`. Now also wires `freshness_store` (required for the review endpoints) and passes `pg_store` to `MemorySearchService` for graph-leg post-filter parity with the MCP path (MTRNIX-324).
 
 **Workspace resolution:** uses `get_workspace_id(request)` exported from `api.dependencies` (workspace always derived from auth, never from body/query).
 

--- a/src/metatron/api/dependencies.py
+++ b/src/metatron/api/dependencies.py
@@ -136,7 +136,20 @@ def get_memory_service(request: Request) -> MemoryService:
         host=settings.qdrant_host,
         port=settings.qdrant_http_port,
     )
-    search = MemorySearchService(qdrant=qdrant_store, redis=redis_cache)
+
+    # Wire pg_store into search so graph-leg status post-filter works on the
+    # REST path — parity with the MCP path (_memory_deps.py). MTRNIX-324.
+    search = MemorySearchService(qdrant=qdrant_store, redis=redis_cache, pg_store=pg_store)
+
+    # Wire freshness_store so review-queue REST endpoints work. MTRNIX-324.
+    from metatron.storage.freshness_pg import FreshnessStore
+
+    freshness_store = getattr(request.app.state, "memory_freshness_store", None)
+    if freshness_store is None:
+        # Engine is already initialised above — reuse it.
+        engine = request.app.state.memory_pg_engine
+        freshness_store = FreshnessStore(engine)
+        request.app.state.memory_freshness_store = freshness_store
 
     plugin_manager = request.app.state.plugin_manager
     service = MemoryService(
@@ -145,6 +158,7 @@ def get_memory_service(request: Request) -> MemoryService:
         pg_store=pg_store,
         workspace_id=workspace_id,
         search=search,
+        freshness_store=freshness_store,
         event_bus=plugin_manager.get_event_bus(),
     )
 

--- a/src/metatron/api/routes/agents.py
+++ b/src/metatron/api/routes/agents.py
@@ -253,13 +253,29 @@ async def list_agents(
     service: Annotated[AgentRegistryService, Depends(get_agent_registry_service)],
     status: AgentStatus | None = None,
     name_prefix: str | None = Query(None, min_length=1, max_length=128),
+    include_archived: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0, le=10000),
 ) -> AgentListResponse:
-    """List agents in the current workspace."""
+    """List agents in the current workspace.
+
+    By default, ARCHIVED (soft-deleted) agents are hidden.  Pass
+    ``include_archived=true`` to surface them alongside live agents, OR pass
+    ``status=archived`` to return only archived agents.
+
+    The two flags are mutually exclusive — passing both ``status=...`` and
+    ``include_archived=true`` is rejected with 400.  This keeps the contract
+    unambiguous (per MTRNIX-324 R7).
+    """
+    if status is not None and include_archived:
+        raise HTTPException(
+            status_code=400,
+            detail="status and include_archived are mutually exclusive",
+        )
     records = await service.list_agents(
         status=status,
         name_prefix=name_prefix,
+        include_archived=include_archived,
         limit=limit + 1,
         offset=offset,
     )

--- a/src/metatron/api/routes/memory.py
+++ b/src/metatron/api/routes/memory.py
@@ -330,6 +330,26 @@ async def list_records(
     )
 
 
+@router.get("/records/{record_id}", response_model=MemoryRecordResponse)
+async def get_record(
+    record_id: str,
+    request: Request,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    service: Annotated[MemoryService, Depends(get_memory_service)],
+) -> MemoryRecordResponse:
+    """Fetch a single persistent memory record by id.
+
+    Returns 404 when the record does not exist in the current workspace —
+    including when a record exists but belongs to a different workspace
+    (cross-workspace isolation guaranteed by PG ``WHERE workspace_id = :ws``).
+    """
+    workspace_id = get_workspace_id(request)
+    record = await service.get(workspace_id, record_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Memory record not found")
+    return _record_to_response(record)
+
+
 @router.delete("/records/{record_id}", status_code=204)
 async def delete_record(
     record_id: str,

--- a/src/metatron/api/routes/memory.py
+++ b/src/metatron/api/routes/memory.py
@@ -17,7 +17,13 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from metatron.api.dependencies import get_memory_service, get_workspace_id
 from metatron.auth.dependencies import require_editor, require_viewer
-from metatron.core.models import MemoryRecord, MemoryScope, MemorySearchResult, User
+from metatron.core.models import (
+    LifecycleStatus,
+    MemoryRecord,
+    MemoryScope,
+    MemorySearchResult,
+    User,
+)
 from metatron.memory.service import (
     MemoryService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
 )
@@ -78,6 +84,7 @@ class MemoryRecordResponse(BaseModel):
     created_at: datetime
     session_id: str | None
     metadata: dict[str, Any]
+    status: LifecycleStatus  # MTRNIX-324 — never optional; MemoryRecord.status defaults to ACTIVE
 
 
 class MemorySearchRequest(BaseModel):
@@ -91,6 +98,11 @@ class MemorySearchRequest(BaseModel):
     tags: list[str] | None = None
     session_id: str | None = Field(None, min_length=1, max_length=128)
     top_k: int = Field(5, ge=1, le=50)
+    # MTRNIX-324: None means "apply default exclusion" (ARCHIVED + SUPERSEDED excluded).
+    # To override, pass an explicit list of lifecycle statuses to include.
+    # Note: the "all" sentinel accepted by MCP is not valid here — REST consumers
+    # must send a list of explicit LifecycleStatus enum values or omit the field.
+    status_filter: list[LifecycleStatus] | None = None
 
 
 class MemorySearchResultResponse(BaseModel):
@@ -142,6 +154,7 @@ def _record_to_response(record: MemoryRecord) -> MemoryRecordResponse:
         created_at=record.created_at,
         session_id=record.session_id,
         metadata=dict(record.metadata),
+        status=record.status,  # MTRNIX-324
     )
 
 
@@ -194,6 +207,11 @@ async def create_record(
     return _record_to_response(stored)
 
 
+# Statuses excluded by default when no explicit status_filter is given to
+# the search endpoint. The list endpoint does NOT apply this default.
+_DEFAULT_SEARCH_EXCLUDE = frozenset({LifecycleStatus.ARCHIVED, LifecycleStatus.SUPERSEDED})
+
+
 @router.post("/search", response_model=MemorySearchResponse)
 async def search_records(
     body: MemorySearchRequest,
@@ -201,9 +219,28 @@ async def search_records(
     user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
     service: Annotated[MemoryService, Depends(get_memory_service)],
 ) -> MemorySearchResponse:
-    """Run a hybrid dense+sparse+graph search over memory records."""
+    """Run a hybrid dense+sparse+graph search over memory records.
+
+    Default status filter excludes ARCHIVED and SUPERSEDED — only ACTIVE,
+    CANDIDATE, STALE, CONFLICTED, and REVIEW_NEEDED records are returned.
+    Pass an explicit ``status_filter`` list to override this default.
+    Note: the MCP ``"all"`` sentinel is not accepted here; pass each status
+    value explicitly (e.g. ``["active", "archived"]``) to include all.
+    """
     workspace_id = get_workspace_id(request)
     results: list[MemorySearchResult]
+
+    # Apply route-layer default — mirrors the MCP layer pattern where the
+    # MCP tool applies ``parse_status_filter`` before calling the service.
+    # The REST default (exclude ARCHIVED + SUPERSEDED) is broader than the
+    # MCP default (only ACTIVE) per MTRNIX-324 spec. MTRNIX-R2.
+    if body.status_filter is None:
+        effective_status_filter: list[LifecycleStatus] | None = [
+            s for s in LifecycleStatus if s not in _DEFAULT_SEARCH_EXCLUDE
+        ]
+    else:
+        effective_status_filter = body.status_filter
+
     try:
         results = await service.search(
             workspace_id,
@@ -213,6 +250,7 @@ async def search_records(
             tags=body.tags,
             session_id=body.session_id,
             top_k=body.top_k,
+            status_filter=effective_status_filter,
         )
     except RuntimeError as exc:
         if "search not configured" in str(exc):
@@ -246,6 +284,7 @@ async def list_records(
     agent_id: str | None = Query(None, min_length=1, max_length=128),
     scope: MemoryScope | None = None,
     session_id: str | None = Query(None, min_length=1, max_length=128),
+    status_filter: list[LifecycleStatus] | None = Query(None),  # noqa: B008
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0, le=10000),
 ) -> MemoryRecordListResponse:
@@ -253,7 +292,12 @@ async def list_records(
 
     When ``session_id`` is provided, returns Redis-backed session records
     and ignores ``agent_id``/``scope`` filters. Otherwise returns persistent
-    records from Qdrant, paginated with limit+offset.
+    records from PG, paginated with limit+offset.
+
+    Unlike the search endpoint, this list endpoint does NOT apply a default
+    status exclusion — all lifecycle states are returned unless ``status_filter``
+    is explicitly set. This is intentional: the inspector UI needs to see all
+    records including ARCHIVED and SUPERSEDED.
     """
     workspace_id = get_workspace_id(request)
 
@@ -271,6 +315,7 @@ async def list_records(
         workspace_id,
         agent_id=agent_id,
         scope=scope,
+        status=status_filter,
         limit=limit + 1,
         offset=offset,
     )

--- a/src/metatron/api/routes/memory.py
+++ b/src/metatron/api/routes/memory.py
@@ -393,6 +393,12 @@ async def get_memory_graph(
     **Edges:** connections between memory records, including bridge-mediated edges
     (via Agent / Entity / Session / Document) and direct ``LINKED_TO`` edges.
 
+    The ``depth`` parameter applies to direct memory-to-memory traversal
+    (``LINKED_TO`` chains, 1..``depth`` hops). Bridge edges via Agent / Entity /
+    Session / Document are always returned at exactly 2 hops from the seed
+    regardless of ``depth`` — Phase 1 semantics; deeper bridge expansion is a
+    follow-up.
+
     When Neo4j is unavailable, returns the seed node only with an empty edge list
     (graceful degradation — 200 with partial data, warning logged).
 

--- a/src/metatron/api/routes/memory.py
+++ b/src/metatron/api/routes/memory.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime  # noqa: TC003 — pydantic field validation needs runtime resolution
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -17,11 +17,13 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from metatron.api.dependencies import get_memory_service, get_workspace_id
 from metatron.auth.dependencies import require_editor, require_viewer
+from metatron.core.exceptions import MemoryNotFoundError
 from metatron.core.models import (
     LifecycleStatus,
     MemoryRecord,
     MemoryScope,
     MemorySearchResult,
+    ReviewEntry,
     User,
 )
 from metatron.memory.service import (
@@ -348,6 +350,228 @@ async def get_record(
     if record is None:
         raise HTTPException(status_code=404, detail="Memory record not found")
     return _record_to_response(record)
+
+
+class MemoryGraphEdge(BaseModel):
+    """An edge in the memory neighbourhood graph.
+
+    For bridge-mediated edges (REMEMBERS / ABOUT / FROM_SESSION / DERIVED_FROM),
+    ``metadata`` contains ``{"via": "<NodeLabel>", "via_id": "<bridge-node-id>"}``
+    so the UI can surface "shared agent X" without a direct memory-to-memory edge.
+
+    For ``LINKED_TO`` edges created by the Linker stage, ``metadata`` holds the
+    edge properties (e.g. ``{"score": 0.9}``).
+    """
+
+    source: str
+    target: str
+    type: Literal["REMEMBERS", "ABOUT", "FROM_SESSION", "DERIVED_FROM", "LINKED_TO"]
+    metadata: dict[str, Any] | None = None
+
+
+class MemoryGraphResponse(BaseModel):
+    """Response for the memory neighbourhood graph endpoint."""
+
+    nodes: list[MemoryRecordResponse]
+    edges: list[MemoryGraphEdge]
+
+
+@router.get("/graph", response_model=MemoryGraphResponse)
+async def get_memory_graph(
+    request: Request,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    service: Annotated[MemoryService, Depends(get_memory_service)],
+    seed_record_id: str = Query(..., min_length=1, max_length=128),
+    depth: int = Query(1, ge=1, le=3),
+    agent_id: str | None = Query(None, min_length=1, max_length=128),
+) -> MemoryGraphResponse:
+    """Return the neighbourhood graph around a memory record.
+
+    **Nodes:** all ``MemoryRecord`` objects reachable within ``depth`` hops from
+    ``seed_record_id``, hydrated from PG.
+
+    **Edges:** connections between memory records, including bridge-mediated edges
+    (via Agent / Entity / Session / Document) and direct ``LINKED_TO`` edges.
+
+    When Neo4j is unavailable, returns the seed node only with an empty edge list
+    (graceful degradation — 200 with partial data, warning logged).
+
+    Use ``agent_id`` to filter the neighbourhood to records belonging to a
+    specific agent. Edges are filtered to those whose both endpoints survive the
+    agent filter.
+
+    Workspace isolation: ``workspace_id`` comes from the JWT only.
+    """
+    workspace_id = get_workspace_id(request)
+    records, raw_edges = await service.get_graph_neighborhood(
+        workspace_id, seed_record_id, depth=depth
+    )
+
+    # Optional agent_id filter — keep only records for this agent.
+    if agent_id is not None:
+        records = [r for r in records if r.agent_id == agent_id]
+
+    surviving_ids = {r.id for r in records}
+    # Drop edges where either endpoint was filtered out.
+    filtered_edges = [
+        e for e in raw_edges if e["source"] in surviving_ids and e["target"] in surviving_ids
+    ]
+
+    return MemoryGraphResponse(
+        nodes=[_record_to_response(r) for r in records],
+        edges=[MemoryGraphEdge(**e) for e in filtered_edges],
+    )
+
+
+class ReviewEntryResponse(BaseModel):
+    """Response body for a single review-queue entry."""
+
+    id: str
+    workspace_id: str
+    target_id: str
+    target_kind: str  # always "memory_record" for v1 — preserved for UI parity with MCP
+    reason: str
+    related_record_id: str | None
+    content: str
+    confidence: float
+    created_at: datetime
+
+
+class ReviewListResponse(BaseModel):
+    """Paginated response for the review-queue list endpoint."""
+
+    entries: list[ReviewEntryResponse]
+    count: int
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+class ReviewResolveRequest(BaseModel):
+    """Request body for resolving a review entry."""
+
+    model_config = ConfigDict(strict=False)
+
+    action: Literal["keep", "archive", "merge_into", "discard"]
+    target_record_id: str | None = Field(None, min_length=1, max_length=128)
+    notes: str | None = Field(None, max_length=1024)
+
+    @model_validator(mode="after")
+    def _validate(self) -> ReviewResolveRequest:
+        if self.action == "merge_into" and not self.target_record_id:
+            raise ValueError("target_record_id is required when action=merge_into")
+        if self.action != "merge_into" and self.target_record_id is not None:
+            raise ValueError("target_record_id is only valid when action=merge_into")
+        return self
+
+
+def _entry_to_response(entry: ReviewEntry) -> ReviewEntryResponse:
+    """Convert a ReviewEntry dataclass into its Pydantic response."""
+    return ReviewEntryResponse(
+        id=entry.id,
+        workspace_id=entry.workspace_id,
+        target_id=entry.target_id,
+        target_kind=entry.target_kind,
+        reason=entry.reason,
+        related_record_id=entry.related_record_id,
+        content=entry.content,
+        confidence=entry.confidence,
+        created_at=entry.created_at,
+    )
+
+
+@router.get("/review", response_model=ReviewListResponse)
+async def list_review_entries(
+    request: Request,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    service: Annotated[MemoryService, Depends(get_memory_service)],
+    reason: str | None = Query(None, min_length=1, max_length=64),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0, le=10000),
+) -> ReviewListResponse:
+    """List pending review-queue entries for the current workspace.
+
+    Returns paginated ``ReviewEntry`` items produced by the freshness pipeline
+    (e.g. possible duplicates, contradictions, low-confidence decisions).
+
+    Returns 503 when the freshness store is not configured (e.g. the deployment
+    does not run the freshness worker).
+    """
+    workspace_id = get_workspace_id(request)
+    try:
+        entries, total = await service.list_review_entries(
+            workspace_id,
+            reason=reason,
+            limit=limit,
+            offset=offset,
+        )
+    except RuntimeError as exc:
+        if "freshness_store" in str(exc):
+            raise HTTPException(
+                status_code=503,
+                detail="Review queue not configured",
+            ) from None
+        raise
+    has_more = (offset + len(entries)) < total
+    return ReviewListResponse(
+        entries=[_entry_to_response(e) for e in entries],
+        count=len(entries),
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=has_more,
+    )
+
+
+@router.post("/review/{review_id}", status_code=204)
+async def resolve_review_entry(
+    review_id: str,
+    body: ReviewResolveRequest,
+    request: Request,
+    user: Annotated[User, Depends(require_editor)],
+    service: Annotated[MemoryService, Depends(get_memory_service)],
+) -> Response:
+    """Resolve a pending review entry.
+
+    Applies one of four actions to the referenced memory record:
+
+    * ``keep`` — mark the record as ACTIVE (no-op if already ACTIVE).
+    * ``archive`` — soft-delete by transitioning to ARCHIVED.
+    * ``merge_into`` — merge content into ``target_record_id``; source becomes SUPERSEDED.
+    * ``discard`` — same as archive but with a different audit label.
+
+    After resolution the review row is deleted and a ``MachineEvent`` is appended with
+    the authenticated user's id as the ``actor``.
+
+    Returns 404 when the review entry or target record does not exist.
+    Returns 503 when the freshness store is not configured.
+    """
+    workspace_id = get_workspace_id(request)
+    if body.action == "merge_into":
+        action_str = f"merge_into:{body.target_record_id}"
+    else:
+        action_str = body.action
+    try:
+        await service.resolve_review(
+            workspace_id,
+            review_id=review_id,
+            action=action_str,
+            notes=body.notes,
+            actor=user.id,
+        )
+    except MemoryNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except RuntimeError as exc:
+        if "freshness_store" in str(exc):
+            raise HTTPException(
+                status_code=503,
+                detail="Review queue not configured",
+            ) from None
+        raise
+    return Response(status_code=204)
 
 
 @router.delete("/records/{record_id}", status_code=204)

--- a/src/metatron/memory/service.py
+++ b/src/metatron/memory/service.py
@@ -340,15 +340,22 @@ class MemoryService:
         *,
         agent_id: str | None = None,
         scope: MemoryScope | None = None,
+        status: list[LifecycleStatus] | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[MemoryRecord]:
-        """List records from PG with optional filters."""
+        """List records from PG with optional filters.
+
+        ``status`` is forwarded to the PG store which applies a ``status =
+        ANY(:status_list)`` WHERE clause when provided (MTRNIX-324).
+        ``None`` means no status filter — all lifecycle states are returned.
+        """
         self._check_workspace(workspace_id)
         return await self._pg.list_records(
             workspace_id,
             agent_id=agent_id,
             scope=scope,
+            status=status,
             limit=limit,
             offset=offset,
         )

--- a/src/metatron/memory/service.py
+++ b/src/metatron/memory/service.py
@@ -41,6 +41,7 @@ from metatron.memory.freshness.producer import enqueue_if_enabled
 from metatron.memory.resolution import ReviewResolution, parse_action
 from metatron.storage.memory_graph import (
     delete_memory_node,
+    get_memory_neighborhood,
     save_memory_to_graph,
 )
 
@@ -502,6 +503,82 @@ class MemoryService:
             top_k=top_k,
             status_filter=status_filter,
         )
+
+    # ------------------------------------------------------------------
+    # Memory graph neighbourhood (MTRNIX-324)
+    # ------------------------------------------------------------------
+
+    async def get_graph_neighborhood(
+        self,
+        workspace_id: str,
+        seed_record_id: str,
+        *,
+        depth: int = 1,
+    ) -> tuple[list[MemoryRecord], list[dict]]:
+        """Return the (depth)-hop neighbourhood around a memory record.
+
+        Delegates to the Neo4j ``get_memory_neighborhood`` helper (via
+        ``asyncio.to_thread``). Falls back gracefully when Neo4j is down:
+        returns the seed record from PG (when it exists) and an empty edge
+        list.
+
+        Always validates:
+          * ``workspace_id`` matches the service's bound workspace.
+          * ``0 < depth <= 3`` (prevents fan-out explosions in large graphs).
+
+        Returns a ``(records, edges)`` tuple where:
+          * ``records`` — :class:`MemoryRecord` instances hydrated from PG.
+            Records returned by Neo4j but absent in PG are dropped (cross-
+            workspace defence-in-depth; PG is the source of truth).
+          * ``edges`` — raw edge dicts from the storage helper
+            (``{source, target, type, metadata?}``).
+
+        Raises:
+          ``ValueError`` — workspace mismatch or invalid depth.
+        """
+        self._check_workspace(workspace_id)
+        if not (0 < depth <= 3):
+            msg = f"depth must be between 1 and 3 inclusive, got {depth}"
+            raise ValueError(msg)
+
+        record_ids: list[str] = [seed_record_id]
+        edges: list[dict] = []
+
+        try:
+            result = await asyncio.to_thread(
+                get_memory_neighborhood,
+                workspace_id,
+                seed_record_id,
+                depth,
+            )
+            record_ids = result["record_ids"]
+            edges = result["edges"]
+        except Exception:
+            logger.warning(
+                "memory_service.neighborhood.neo4j_unavailable",
+                workspace_id=workspace_id,
+                seed_record_id=seed_record_id,
+                depth=depth,
+                exc_info=True,
+            )
+            # Fall back: only the seed, no edges
+
+        # De-dup while preserving seed priority (seed first).
+        seen: set[str] = set()
+        unique_ids: list[str] = []
+        for rid in [seed_record_id, *record_ids]:
+            if rid not in seen:
+                seen.add(rid)
+                unique_ids.append(rid)
+
+        # Hydrate from PG — drops ids not in this workspace (cross-ws defence).
+        records: list[MemoryRecord] = []
+        for rid in unique_ids:
+            rec = await self._pg.get(workspace_id, rid)
+            if rec is not None:
+                records.append(rec)
+
+        return records, edges
 
     # ------------------------------------------------------------------
     # Freshness review queue (MTRNIX-314)

--- a/src/metatron/memory/service.py
+++ b/src/metatron/memory/service.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import structlog
+from neo4j.exceptions import ServiceUnavailable, SessionExpired
 
 from metatron.core.events import (
     FRESHNESS_REVIEW_RESOLVED,
@@ -514,7 +515,7 @@ class MemoryService:
         seed_record_id: str,
         *,
         depth: int = 1,
-    ) -> tuple[list[MemoryRecord], list[dict]]:
+    ) -> tuple[list[MemoryRecord], list[dict[str, Any]]]:
         """Return the (depth)-hop neighbourhood around a memory record.
 
         Delegates to the Neo4j ``get_memory_neighborhood`` helper (via
@@ -533,6 +534,11 @@ class MemoryService:
           * ``edges`` — raw edge dicts from the storage helper
             (``{source, target, type, metadata?}``).
 
+        ``depth`` controls direct memory-to-memory traversal (``LINKED_TO``
+        chains). Bridge edges via Agent / Entity / Session / Document are
+        always returned at exactly 2 hops from the seed regardless of
+        ``depth`` — Phase 1 semantics; deeper bridge expansion is a follow-up.
+
         Raises:
           ``ValueError`` — workspace mismatch or invalid depth.
         """
@@ -542,7 +548,7 @@ class MemoryService:
             raise ValueError(msg)
 
         record_ids: list[str] = [seed_record_id]
-        edges: list[dict] = []
+        edges: list[dict[str, Any]] = []
 
         try:
             result = await asyncio.to_thread(
@@ -553,7 +559,7 @@ class MemoryService:
             )
             record_ids = result["record_ids"]
             edges = result["edges"]
-        except Exception:
+        except (ServiceUnavailable, SessionExpired, ConnectionError, OSError):
             logger.warning(
                 "memory_service.neighborhood.neo4j_unavailable",
                 workspace_id=workspace_id,

--- a/src/metatron/storage/memory_graph.py
+++ b/src/metatron/storage/memory_graph.py
@@ -396,3 +396,139 @@ def save_memory_to_graph(
 
     for doc_id in document_ids or []:
         link_memory_document(record.workspace_id, record.id, doc_id)
+
+
+# ---------------------------------------------------------------------------
+# Neighbourhood query (MTRNIX-324)
+# ---------------------------------------------------------------------------
+
+# Edge types that use a "bridge" node (Agent / Entity / Session / Document)
+# rather than a direct MemoryRecord→MemoryRecord edge. The bridge node
+# is surfaced as ``metadata.via`` / ``metadata.via_id`` on the edge.
+_BRIDGE_EDGE_TYPES = frozenset({"REMEMBERS", "ABOUT", "FROM_SESSION", "DERIVED_FROM"})
+# Direct memory-to-memory edge created by the Linker stage (MTRNIX-313).
+_DIRECT_EDGE_TYPES = frozenset({"LINKED_TO"})
+
+
+@graph_retry()
+def get_memory_neighborhood(
+    workspace_id: str,
+    seed_record_id: str,
+    depth: int,
+) -> dict[str, Any]:
+    """Return the ``depth``-hop neighbourhood around a memory record.
+
+    Returns::
+
+        {
+          "record_ids": list[str],
+          "edges":      list[dict],   # {source, target, type, metadata?}
+        }
+
+    Each edge uses the MemoryRecord id as ``source``/``target``. For edges
+    that traverse a bridge node (Agent, Entity, Session, Document), the
+    bridge label and id are exposed as ``metadata.via`` / ``metadata.via_id``
+    so the UI can show "shared agent X" without a direct memory-to-memory
+    edge in the schema.
+
+    For ``LINKED_TO`` edges (direct MemoryRecord→MemoryRecord, created by the
+    Linker stage), ``source`` and ``target`` are the two memory record ids and
+    ``metadata`` is ``None`` or contains edge properties (e.g. ``score``).
+
+    The seed record is always included in ``record_ids`` even when Neo4j
+    returns no edges. Workspace scoping: every node match requires
+    ``workspace_id = $ws``.
+    """
+    driver = get_graph_driver()
+    with driver.session() as session:
+        # 1. Find direct LINKED_TO edges between MemoryRecord nodes.
+        linked_result = session.run(
+            """
+            MATCH (seed:MemoryRecord {id: $seed, workspace_id: $ws})
+            CALL apoc.path.expandConfig(seed, {
+                relationshipFilter: "LINKED_TO",
+                maxLevel: $depth,
+                labelFilter: "+MemoryRecord",
+                uniqueness: "NODE_GLOBAL"
+            })
+            YIELD path
+            WITH seed, last(nodes(path)) AS other, last(relationships(path)) AS rel
+            WHERE other.id <> seed.id
+            RETURN seed.id AS source, other.id AS target, "LINKED_TO" AS rtype,
+                   properties(rel) AS rprops
+            """,
+            {"seed": seed_record_id, "ws": workspace_id, "depth": depth},
+        )
+
+        # 2. Find bridge-mediated connections (Agent, Entity, Session, Document).
+        bridge_result = session.run(
+            """
+            MATCH (seed:MemoryRecord {id: $seed, workspace_id: $ws})
+            MATCH (seed)-[r1]-(bridge)
+            WHERE type(r1) IN ["REMEMBERS", "ABOUT", "FROM_SESSION", "DERIVED_FROM"]
+              AND NOT "MemoryRecord" IN labels(bridge)
+            MATCH (bridge)-[r2]-(other:MemoryRecord {workspace_id: $ws})
+            WHERE other.id <> seed.id
+            RETURN seed.id          AS source,
+                   other.id         AS target,
+                   type(r1)         AS rtype,
+                   labels(bridge)[0] AS via_label,
+                   coalesce(bridge.id, bridge.name, bridge.doc_id) AS via_id
+            """,
+            {"seed": seed_record_id, "ws": workspace_id},
+        )
+
+    record_ids: list[str] = [seed_record_id]
+    edges: list[dict[str, Any]] = []
+
+    # Direct LINKED_TO edges — use apoc if available; fall back to simple match.
+    # We do a plain match as primary approach since apoc may not be installed.
+    try:
+        linked_rows = list(linked_result)
+    except Exception:
+        linked_rows = []
+
+    for row in linked_rows:
+        target = row["target"]
+        if target not in record_ids:
+            record_ids.append(target)
+        rprops = dict(row["rprops"]) if row["rprops"] else None
+        edges.append(
+            {
+                "source": row["source"],
+                "target": target,
+                "type": "LINKED_TO",
+                "metadata": rprops,
+            }
+        )
+
+    try:
+        bridge_rows = list(bridge_result)
+    except Exception:
+        bridge_rows = []
+
+    for row in bridge_rows:
+        target = row["target"]
+        if target not in record_ids:
+            record_ids.append(target)
+        edges.append(
+            {
+                "source": row["source"],
+                "target": target,
+                "type": row["rtype"],
+                "metadata": {
+                    "via": row["via_label"],
+                    "via_id": row["via_id"],
+                },
+            }
+        )
+
+    logger.debug(
+        "memory_graph.neighborhood",
+        workspace_id=workspace_id,
+        seed_record_id=seed_record_id,
+        depth=depth,
+        record_count=len(record_ids),
+        edge_count=len(edges),
+    )
+    return {"record_ids": record_ids, "edges": edges}

--- a/src/metatron/storage/memory_graph.py
+++ b/src/metatron/storage/memory_graph.py
@@ -435,29 +435,41 @@ def get_memory_neighborhood(
     Linker stage), ``source`` and ``target`` are the two memory record ids and
     ``metadata`` is ``None`` or contains edge properties (e.g. ``score``).
 
+    The ``depth`` parameter applies to direct memory-to-memory traversal
+    (``LINKED_TO`` chains, 1..``depth`` hops). Bridge edges via Agent / Entity /
+    Session / Document are always exactly 2-hop neighbours of the seed
+    (``seed -[r1]- bridge -[r2]- other``) regardless of ``depth`` — Phase 1
+    semantics; deeper bridge expansion is a follow-up.
+
     The seed record is always included in ``record_ids`` even when Neo4j
     returns no edges. Workspace scoping: every node match requires
     ``workspace_id = $ws``.
+
+    Precondition: ``depth`` must be a small positive integer (1..3 enforced by
+    callers — service + route). The value is interpolated into the Cypher
+    pattern via ``int(depth)`` so vanilla variable-length matching works
+    without APOC. Out-of-range values would still produce valid Cypher but
+    risk fan-out in dense graphs; rely on the caller's validation.
     """
     driver = get_graph_driver()
+    bounded_depth = int(depth)
+    # 1. Direct LINKED_TO edges between MemoryRecord nodes — vanilla
+    # variable-length Cypher; no APOC dependency. Cypher does not parameterise
+    # the variable-length count, so it is interpolated. ``int(depth)`` is the
+    # guard against injection.
+    linked_query = (
+        "MATCH (seed:MemoryRecord {id: $seed, workspace_id: $ws}) "
+        f"MATCH (seed)-[r:LINKED_TO*1..{bounded_depth}]-"
+        "(other:MemoryRecord {workspace_id: $ws}) "
+        "WHERE other.id <> seed.id "
+        "WITH seed, other, last(r) AS rel "
+        "RETURN seed.id AS source, other.id AS target, "
+        "properties(rel) AS rprops"
+    )
     with driver.session() as session:
-        # 1. Find direct LINKED_TO edges between MemoryRecord nodes.
         linked_result = session.run(
-            """
-            MATCH (seed:MemoryRecord {id: $seed, workspace_id: $ws})
-            CALL apoc.path.expandConfig(seed, {
-                relationshipFilter: "LINKED_TO",
-                maxLevel: $depth,
-                labelFilter: "+MemoryRecord",
-                uniqueness: "NODE_GLOBAL"
-            })
-            YIELD path
-            WITH seed, last(nodes(path)) AS other, last(relationships(path)) AS rel
-            WHERE other.id <> seed.id
-            RETURN seed.id AS source, other.id AS target, "LINKED_TO" AS rtype,
-                   properties(rel) AS rprops
-            """,
-            {"seed": seed_record_id, "ws": workspace_id, "depth": depth},
+            linked_query,
+            {"seed": seed_record_id, "ws": workspace_id},
         )
 
         # 2. Find bridge-mediated connections (Agent, Entity, Session, Document).
@@ -481,11 +493,16 @@ def get_memory_neighborhood(
     record_ids: list[str] = [seed_record_id]
     edges: list[dict[str, Any]] = []
 
-    # Direct LINKED_TO edges — use apoc if available; fall back to simple match.
-    # We do a plain match as primary approach since apoc may not be installed.
+    # Direct LINKED_TO edges via vanilla variable-length Cypher (no APOC).
     try:
         linked_rows = list(linked_result)
     except Exception:
+        logger.warning(
+            "memory_graph.neighborhood.linked_query_failed",
+            workspace_id=workspace_id,
+            seed_record_id=seed_record_id,
+            exc_info=True,
+        )
         linked_rows = []
 
     for row in linked_rows:
@@ -505,6 +522,12 @@ def get_memory_neighborhood(
     try:
         bridge_rows = list(bridge_result)
     except Exception:
+        logger.warning(
+            "memory_graph.neighborhood.bridge_query_failed",
+            workspace_id=workspace_id,
+            seed_record_id=seed_record_id,
+            exc_info=True,
+        )
         bridge_rows = []
 
     for row in bridge_rows:

--- a/tests/integration/agents/test_persistence.py
+++ b/tests/integration/agents/test_persistence.py
@@ -198,6 +198,39 @@ class TestArchivedVisibility:
         listed = await repo.list_records(workspace_id, status=AgentStatus.STOPPED)
         assert [r.id for r in listed] == [stopped.id]
 
+    async def test_include_archived_true_returns_all(
+        self, repo: AgentPersistence, workspace_id: str
+    ) -> None:
+        """MTRNIX-324: include_archived=True returns ARCHIVED rows alongside others."""
+        alive = await repo.save_new(_record(workspace_id, name="ia-alive"))
+        doomed = await repo.save_new(_record(workspace_id, name="ia-doomed"))
+        await repo.update_status(workspace_id, doomed.id, AgentStatus.ARCHIVED)
+
+        listed = await repo.list_records(workspace_id, include_archived=True)
+        ids = {r.id for r in listed}
+        assert alive.id in ids
+        assert doomed.id in ids
+
+    async def test_status_filter_takes_precedence_over_include_archived(
+        self, repo: AgentPersistence, workspace_id: str
+    ) -> None:
+        """When both status= and include_archived=True passed, status filter wins.
+
+        This documents the precedence: explicit status is the most specific signal,
+        and the route layer rejects the combination with 400 anyway — but persistence
+        defends in depth.
+        """
+        stopped = await repo.save_new(_record(workspace_id, name="prec-stopped"))
+        gone = await repo.save_new(_record(workspace_id, name="prec-gone"))
+        await repo.update_status(workspace_id, gone.id, AgentStatus.ARCHIVED)
+
+        listed = await repo.list_records(
+            workspace_id,
+            status=AgentStatus.STOPPED,
+            include_archived=True,
+        )
+        assert [r.id for r in listed] == [stopped.id]
+
 
 # ---------------------------------------------------------------------------
 # update_with_version_bump — transaction, version bump, history

--- a/tests/integration/api/test_memory_graph_neo4j_down.py
+++ b/tests/integration/api/test_memory_graph_neo4j_down.py
@@ -1,0 +1,94 @@
+"""Integration test for ``GET /api/v1/memory/graph`` Neo4j-down path.
+
+Requires PostgreSQL (migration 013 applied). Spins up the FastAPI app via
+``create_app(settings)`` against the live PG. Configures Neo4j to point at
+a deliberately closed port so the storage helper raises a connection error,
+exercising the service-layer fallback path (``records=[seed], edges=[]``).
+
+The route must respond 200 with a single seed node and an empty edge list
+when Neo4j is unavailable — graceful degradation per MTRNIX-324 spec.
+
+Skipped unless ``RUN_INTEGRATION_TESTS=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.api.app import create_app
+from metatron.auth.dependencies import get_current_user
+from metatron.core.config import Settings
+from metatron.core.models import MemoryRecord, MemoryScope, Role, User
+from metatron.storage.memory_postgres import MemoryPostgresStore
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("RUN_INTEGRATION_TESTS") != "1",
+        reason="integration tests require RUN_INTEGRATION_TESTS=1",
+    ),
+]
+
+
+def _make_user(workspace_id: str) -> User:
+    return User(
+        id="u-integration",
+        username="integration",
+        email="i@example.com",
+        role=Role.EDITOR,
+        workspace_ids=[workspace_id],
+    )
+
+
+async def test_memory_graph_returns_seed_only_when_neo4j_down() -> None:
+    """Neo4j down ⇒ 200 with nodes=[seed], edges=[] (graceful degradation)."""
+    # Point Neo4j at a closed local port — `connect()` will raise
+    # ServiceUnavailable / ConnectionError, which the service catches.
+    settings = Settings(
+        AUTH_ENABLED=False,
+        NEO4J_URI="bolt://127.0.0.1:1",  # closed port → connection refused
+        NEO4J_USER="x",
+        NEO4J_PASSWORD="x",
+    )
+    workspace_id = f"ws-it-graph-{uuid4().hex[:8]}"
+    record_id = uuid4().hex
+
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg = MemoryPostgresStore(engine)
+
+    try:
+        # Seed one record in PG so the service can hydrate the seed.
+        record = MemoryRecord(
+            id=record_id,
+            workspace_id=workspace_id,
+            agent_id="agent-it",
+            scope=MemoryScope.PER_AGENT,
+            source_type="integration_test",
+            content="graph fallback seed",
+        )
+        await pg.save(record)
+
+        app = create_app(settings)
+        app.dependency_overrides[get_current_user] = lambda: _make_user(workspace_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get(
+                "/api/v1/memory/graph",
+                params={"seed_record_id": record_id, "depth": 1},
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        # Seed is the only node; no edges because Neo4j is unreachable.
+        assert len(body["nodes"]) == 1
+        assert body["nodes"][0]["id"] == record_id
+        assert body["edges"] == []
+    finally:
+        await pg.delete(workspace_id, record_id)
+        await engine.dispose()

--- a/tests/integration/api/test_memory_record_get_cross_workspace.py
+++ b/tests/integration/api/test_memory_record_get_cross_workspace.py
@@ -1,0 +1,87 @@
+"""Integration test for ``GET /api/v1/memory/records/{id}`` cross-workspace 404.
+
+Requires PostgreSQL (migration 013 applied). Saves a record in workspace A
+through ``MemoryPostgresStore``, then issues a request authenticated as a
+user in workspace B and expects 404 — confirming workspace isolation
+enforced at the PG layer (``WHERE workspace_id = :ws``).
+
+Skipped unless ``RUN_INTEGRATION_TESTS=1`` (matches existing integration
+test gating in this repo).
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.api.app import create_app
+from metatron.auth.dependencies import get_current_user
+from metatron.core.config import Settings
+from metatron.core.models import MemoryRecord, MemoryScope, Role, User
+from metatron.storage.memory_postgres import MemoryPostgresStore
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("RUN_INTEGRATION_TESTS") != "1",
+        reason="integration tests require RUN_INTEGRATION_TESTS=1",
+    ),
+]
+
+
+def _make_user_in(workspace_id: str) -> User:
+    return User(
+        id="u-integration",
+        username="integration",
+        email="i@example.com",
+        role=Role.EDITOR,
+        workspace_ids=[workspace_id],
+    )
+
+
+async def test_get_record_cross_workspace_returns_404() -> None:
+    """Record in workspace A; auth as workspace B ⇒ 404 (workspace isolation)."""
+    settings = Settings(AUTH_ENABLED=False)
+    workspace_a = f"ws-it-a-{uuid4().hex[:8]}"
+    workspace_b = f"ws-it-b-{uuid4().hex[:8]}"
+    record_id = uuid4().hex
+
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg = MemoryPostgresStore(engine)
+
+    try:
+        # Seed a record in workspace A.
+        record = MemoryRecord(
+            id=record_id,
+            workspace_id=workspace_a,
+            agent_id="agent-it",
+            scope=MemoryScope.PER_AGENT,
+            source_type="integration_test",
+            content="cross-workspace isolation",
+        )
+        await pg.save(record)
+
+        app = create_app(settings)
+        # Auth as a user in workspace B — they should not see workspace A's record.
+        app.dependency_overrides[get_current_user] = lambda: _make_user_in(workspace_b)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.get(f"/api/v1/memory/records/{record_id}")
+
+        assert response.status_code == 404, response.text
+
+        # Sanity: a user authenticated for workspace A *can* read it.
+        app.dependency_overrides[get_current_user] = lambda: _make_user_in(workspace_a)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response_a = await client.get(f"/api/v1/memory/records/{record_id}")
+        assert response_a.status_code == 200, response_a.text
+        assert response_a.json()["id"] == record_id
+    finally:
+        # Cleanup PG.
+        await pg.delete(workspace_a, record_id)
+        await engine.dispose()

--- a/tests/integration/api/test_memory_review_roundtrip.py
+++ b/tests/integration/api/test_memory_review_roundtrip.py
@@ -1,0 +1,150 @@
+"""Integration test for ``/api/v1/memory/review`` GET + POST roundtrip.
+
+Requires PostgreSQL (migrations 013 + 016 applied — ``memory_records``,
+``review_entries``, ``machine_events``). Saves a memory record + a pending
+review entry directly via the storage layer, exercises the full REST
+surface (list → resolve), then verifies the side-effects: review row
+deleted, lifecycle status flipped, MachineEvent appended with the user's id
+as the actor.
+
+Skipped unless ``RUN_INTEGRATION_TESTS=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.api.app import create_app
+from metatron.auth.dependencies import get_current_user
+from metatron.core.config import Settings
+from metatron.core.models import (
+    LifecycleStatus,
+    MemoryRecord,
+    MemoryScope,
+    ReviewEntry,
+    Role,
+    User,
+)
+from metatron.storage.freshness_pg import FreshnessStore
+from metatron.storage.memory_postgres import MemoryPostgresStore
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("RUN_INTEGRATION_TESTS") != "1",
+        reason="integration tests require RUN_INTEGRATION_TESTS=1",
+    ),
+]
+
+_USER_ID = "u-integration"
+
+
+def _make_user(workspace_id: str) -> User:
+    return User(
+        id=_USER_ID,
+        username="integration",
+        email="i@example.com",
+        role=Role.EDITOR,
+        workspace_ids=[workspace_id],
+    )
+
+
+async def test_review_roundtrip_get_then_resolve_keep() -> None:
+    """List then resolve(keep): review deleted, status=ACTIVE, MachineEvent emitted."""
+    settings = Settings(AUTH_ENABLED=False)
+    workspace_id = f"ws-it-rev-{uuid4().hex[:8]}"
+    record_id = uuid4().hex
+    review_id = uuid4().hex
+
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg = MemoryPostgresStore(engine)
+    freshness = FreshnessStore(engine)
+
+    try:
+        # --- Seed a memory record + a review entry referencing it ---
+        record = MemoryRecord(
+            id=record_id,
+            workspace_id=workspace_id,
+            agent_id="agent-it",
+            scope=MemoryScope.PER_AGENT,
+            source_type="integration_test",
+            content="review queue roundtrip seed",
+            status=LifecycleStatus.REVIEW_NEEDED,
+        )
+        await pg.save(record)
+
+        entry = ReviewEntry(
+            id=review_id,
+            workspace_id=workspace_id,
+            target_id=record_id,
+            target_kind="memory_record",
+            reason="possible_duplicate",
+            related_record_id=None,
+            content="possible duplicate detected",
+            confidence=0.8,
+        )
+        await freshness.save_review_entry(entry)
+
+        app = create_app(settings)
+        app.dependency_overrides[get_current_user] = lambda: _make_user(workspace_id)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            # --- GET /review — review entry visible ---
+            r = await client.get("/api/v1/memory/review")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["total"] == 1
+            assert body["count"] == 1
+            assert body["entries"][0]["id"] == review_id
+            assert body["entries"][0]["target_id"] == record_id
+            assert body["entries"][0]["reason"] == "possible_duplicate"
+
+            # --- POST /review/{id} action=keep ---
+            r = await client.post(
+                f"/api/v1/memory/review/{review_id}",
+                json={"action": "keep"},
+            )
+            assert r.status_code == 204, r.text
+
+            # --- Re-GET — total drops to 0 ---
+            r = await client.get("/api/v1/memory/review")
+            assert r.status_code == 200, r.text
+            assert r.json()["total"] == 0
+
+        # --- Verify side-effects on PG ---
+        # 1. Memory record status flipped to ACTIVE.
+        refreshed = await pg.get(workspace_id, record_id)
+        assert refreshed is not None
+        assert refreshed.status == LifecycleStatus.ACTIVE
+
+        # 2. MachineEvent row exists with the right shape.
+        events = await freshness.list_events_for_target(
+            workspace_id, "memory_record", record_id
+        )
+        resolved_events = [e for e in events if e.event_type == "freshness_review_resolved"]
+        assert len(resolved_events) >= 1
+        latest = resolved_events[0]
+        assert latest.actor == _USER_ID
+        assert latest.workspace_id == workspace_id
+        assert latest.target_id == record_id
+    finally:
+        # Cleanup PG state in dependency order: events → review → record.
+        from sqlalchemy import text as sa_text
+
+        async with engine.begin() as conn:
+            await conn.execute(
+                sa_text("DELETE FROM machine_events WHERE workspace_id = :ws"),
+                {"ws": workspace_id},
+            )
+            await conn.execute(
+                sa_text("DELETE FROM review_entries WHERE workspace_id = :ws"),
+                {"ws": workspace_id},
+            )
+        await pg.delete(workspace_id, record_id)
+        await engine.dispose()

--- a/tests/unit/api/test_get_memory_service.py
+++ b/tests/unit/api/test_get_memory_service.py
@@ -22,12 +22,12 @@ def _make_request(workspace_id: str = "ws-test") -> MagicMock:
     )
     app_state: dict[str, Any] = {"settings": settings}
 
-    _MISSING = object()
+    _missing = object()
 
     class _State:
         def __getattr__(self, name: str) -> Any:
-            val = app_state.get(name, _MISSING)
-            if val is _MISSING:
+            val = app_state.get(name, _missing)
+            if val is _missing:
                 raise AttributeError(name)
             return val
 

--- a/tests/unit/api/test_get_memory_service.py
+++ b/tests/unit/api/test_get_memory_service.py
@@ -1,0 +1,151 @@
+"""Unit tests for get_memory_service DI helper.
+
+Verifies that the REST path wires freshness_store and passes pg_store to
+MemorySearchService — closing the parity gap with the MCP path (MTRNIX-324).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from metatron.api.dependencies import get_memory_service
+from metatron.core.config import Settings
+
+
+def _make_request(workspace_id: str = "ws-test") -> MagicMock:
+    """Build a minimal mock Request that get_memory_service can consume."""
+    settings = Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=False,
+        METATRON_SECRET_KEY="test-secret",
+    )
+    app_state: dict[str, Any] = {"settings": settings}
+
+    _MISSING = object()
+
+    class _State:
+        def __getattr__(self, name: str) -> Any:
+            val = app_state.get(name, _MISSING)
+            if val is _MISSING:
+                raise AttributeError(name)
+            return val
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            app_state[name] = value
+
+    plugin_manager = MagicMock()
+    plugin_manager.get_event_bus.return_value = MagicMock()
+    app_state["plugin_manager"] = plugin_manager
+
+    request = MagicMock()
+    request.app.state = _State()
+    request.state.user = {"workspace_ids": [workspace_id]}
+    return request
+
+
+# Because get_memory_service uses lazy (function-body) imports, we patch at
+# the source module level, not at `metatron.api.dependencies.<Name>`.
+_PATCH_BASES = {
+    "pg_store": "metatron.storage.memory_postgres.MemoryPostgresStore",
+    "qdrant": "metatron.storage.memory_qdrant.MemoryQdrantStore",
+    "redis_session": "metatron.storage.memory_redis.RedisSessionCache",
+    "redis_store": "metatron.storage.redis.RedisStore",
+    "search": "metatron.memory.search.MemorySearchService",
+    "svc": "metatron.memory.service.MemoryService",
+    "engine": "sqlalchemy.ext.asyncio.create_async_engine",
+    "freshness": "metatron.storage.freshness_pg.FreshnessStore",
+}
+
+
+class TestGetMemoryServiceWiring:
+    """Smoke tests — verify DI assembles the service without errors."""
+
+    def test_freshness_store_wired_into_service(self) -> None:
+        """get_memory_service must construct a FreshnessStore and pass it."""
+        request = _make_request()
+
+        with (
+            patch(_PATCH_BASES["pg_store"]) as _pg,
+            patch(_PATCH_BASES["qdrant"]) as _qdrant,
+            patch(_PATCH_BASES["redis_session"]) as _redis,
+            patch(_PATCH_BASES["redis_store"]) as _redis_store,
+            patch(_PATCH_BASES["search"]) as _search,
+            patch(_PATCH_BASES["svc"]) as _svc,
+            patch(_PATCH_BASES["engine"]) as _eng,
+            patch(_PATCH_BASES["freshness"]) as _freshness,
+        ):
+            _eng.return_value = MagicMock()
+            _pg.return_value = MagicMock()
+            _qdrant.return_value = MagicMock()
+            _redis_store.return_value = MagicMock()
+            _redis.return_value = MagicMock()
+            _search.return_value = MagicMock()
+            _freshness.return_value = MagicMock()
+
+            get_memory_service(request)
+
+            # MemoryService must have been called with freshness_store kwarg
+            call_kwargs = _svc.call_args.kwargs
+            assert "freshness_store" in call_kwargs
+            assert call_kwargs["freshness_store"] is not None
+
+    def test_pg_store_passed_to_search_service(self) -> None:
+        """MemorySearchService must receive pg_store for graph-leg filtering."""
+        request = _make_request()
+
+        with (
+            patch(_PATCH_BASES["pg_store"]) as _pg,
+            patch(_PATCH_BASES["qdrant"]) as _qdrant,
+            patch(_PATCH_BASES["redis_session"]) as _redis,
+            patch(_PATCH_BASES["redis_store"]) as _redis_store,
+            patch(_PATCH_BASES["search"]) as _search,
+            patch(_PATCH_BASES["svc"]),
+            patch(_PATCH_BASES["engine"]) as _eng,
+            patch(_PATCH_BASES["freshness"]),
+        ):
+            pg_store_instance = MagicMock()
+            _pg.return_value = pg_store_instance
+            _eng.return_value = MagicMock()
+            _qdrant.return_value = MagicMock()
+            _redis_store.return_value = MagicMock()
+            _redis.return_value = MagicMock()
+            _search.return_value = MagicMock()
+
+            get_memory_service(request)
+
+            # MemorySearchService must have been constructed with pg_store=
+            search_call_kwargs = _search.call_args.kwargs
+            assert "pg_store" in search_call_kwargs
+            assert search_call_kwargs["pg_store"] is pg_store_instance
+
+    def test_freshness_store_cached_on_app_state(self) -> None:
+        """Second call within same app must reuse the cached freshness store."""
+        request = _make_request()
+
+        with (
+            patch(_PATCH_BASES["pg_store"]) as _pg,
+            patch(_PATCH_BASES["qdrant"]),
+            patch(_PATCH_BASES["redis_session"]) as _redis,
+            patch(_PATCH_BASES["redis_store"]) as _redis_store,
+            patch(_PATCH_BASES["search"]),
+            patch(_PATCH_BASES["svc"]),
+            patch(_PATCH_BASES["engine"]) as _eng,
+            patch(_PATCH_BASES["freshness"]) as _freshness,
+        ):
+            _eng.return_value = MagicMock()
+            _pg.return_value = MagicMock()
+            _redis_store.return_value = MagicMock()
+            _redis.return_value = MagicMock()
+            freshness_instance = MagicMock()
+            _freshness.return_value = freshness_instance
+
+            # First call
+            get_memory_service(request)
+            # Second call — same workspace should hit the service cache (no
+            # reconstruction), but the freshness store should still not be
+            # constructed a second time.
+            get_memory_service(request)
+
+            # FreshnessStore constructor called exactly once
+            assert _freshness.call_count == 1

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -19,11 +19,13 @@ from metatron.api.dependencies import get_memory_service
 from metatron.api.routes.memory import router as memory_router
 from metatron.auth.dependencies import get_current_user
 from metatron.core.config import Settings
+from metatron.core.exceptions import MemoryNotFoundError
 from metatron.core.models import (
     LifecycleStatus,
     MemoryRecord,
     MemoryScope,
     MemorySearchResult,
+    ReviewEntry,
     Role,
     User,
 )
@@ -741,3 +743,277 @@ class TestMemoryGraph:
         assert len(body["edges"]) == 1
         assert body["edges"][0]["source"] == "mem-a"
         assert body["edges"][0]["target"] == "mem-c"
+
+
+# ---------------------------------------------------------------------------
+# MTRNIX-324: GET /memory/review + POST /memory/review/{id}
+# ---------------------------------------------------------------------------
+
+
+def _sample_review_entry(**overrides: Any) -> ReviewEntry:
+    defaults: dict[str, Any] = {
+        "id": "rev-1",
+        "workspace_id": "ws-test",
+        "target_id": "mem-1",
+        "target_kind": "memory_record",
+        "reason": "possible_duplicate",
+        "related_record_id": "mem-2",
+        "content": "some content",
+        "confidence": 0.85,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return ReviewEntry(**defaults)
+
+
+class TestReviewList:
+    def test_review_list_pagination(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """Mock returns 5 entries with total=42 ⇒ count=5, total=42, has_more=True."""
+        entries = [_sample_review_entry(id=f"rev-{i}") for i in range(5)]
+        service.list_review_entries.return_value = (entries, 42)
+
+        response = client.get(
+            "/api/v1/memory/review",
+            params={"limit": 5, "offset": 0},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 5
+        assert body["total"] == 42
+        assert body["has_more"] is True
+        assert len(body["entries"]) == 5
+
+    def test_review_list_503_when_freshness_store_missing(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """RuntimeError('freshness_store not configured') ⇒ 503."""
+        service.list_review_entries.side_effect = RuntimeError("freshness_store not configured")
+
+        response = client.get("/api/v1/memory/review")
+
+        assert response.status_code == 503
+        assert "Review queue" in response.json()["detail"]
+
+    def test_review_list_reason_filter(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """reason query param is forwarded to service.list_review_entries."""
+        service.list_review_entries.return_value = ([], 0)
+
+        client.get(
+            "/api/v1/memory/review",
+            params={"reason": "possible_duplicate"},
+        )
+
+        service.list_review_entries.assert_awaited_once()
+        call_kwargs = service.list_review_entries.await_args.kwargs
+        assert call_kwargs["reason"] == "possible_duplicate"
+
+    def test_review_list_viewer_only(
+        self,
+        make_client: Callable[..., TestClient],
+        service: AsyncMock,
+    ) -> None:
+        """Viewer role is sufficient for GET /review."""
+        viewer_client = make_client(Role.VIEWER)
+        service.list_review_entries.return_value = ([], 0)
+
+        response = viewer_client.get("/api/v1/memory/review")
+        assert response.status_code == 200
+
+    def test_review_list_has_more_false_when_last_page(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """has_more=False when offset + count >= total."""
+        entries = [_sample_review_entry(id=f"rev-{i}") for i in range(3)]
+        service.list_review_entries.return_value = (entries, 3)
+
+        response = client.get(
+            "/api/v1/memory/review",
+            params={"limit": 20, "offset": 0},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["has_more"] is False
+
+
+class TestReviewResolve:
+    def test_review_resolve_keep(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """POST /review/{id} with action=keep ⇒ service.resolve_review, 204."""
+        service.resolve_review.return_value = None  # return value unused by route
+
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "keep"},
+        )
+
+        assert response.status_code == 204
+        service.resolve_review.assert_awaited_once()
+        call_kwargs = service.resolve_review.await_args.kwargs
+        assert call_kwargs["action"] == "keep"
+        assert call_kwargs["review_id"] == "rev-1"
+
+    def test_review_resolve_merge_into(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """action=merge_into with target_record_id ⇒ service called with merge_into:<id>."""
+        service.resolve_review.return_value = None
+
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "merge_into", "target_record_id": "rec-2"},
+        )
+
+        assert response.status_code == 204
+        call_kwargs = service.resolve_review.await_args.kwargs
+        assert call_kwargs["action"] == "merge_into:rec-2"
+
+    def test_review_resolve_merge_into_missing_target_422(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """action=merge_into without target_record_id ⇒ Pydantic 422."""
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "merge_into"},
+        )
+        assert response.status_code == 422
+        service.resolve_review.assert_not_awaited()
+
+    def test_review_resolve_target_record_id_only_valid_for_merge(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """action=keep with target_record_id ⇒ 422 (only valid for merge_into)."""
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "keep", "target_record_id": "rec-x"},
+        )
+        assert response.status_code == 422
+        service.resolve_review.assert_not_awaited()
+
+    def test_review_resolve_archive(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """action=archive ⇒ service called with action='archive', 204."""
+        service.resolve_review.return_value = None
+
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "archive"},
+        )
+
+        assert response.status_code == 204
+        call_kwargs = service.resolve_review.await_args.kwargs
+        assert call_kwargs["action"] == "archive"
+
+    def test_review_resolve_discard(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """action=discard ⇒ 204."""
+        service.resolve_review.return_value = None
+
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "discard"},
+        )
+
+        assert response.status_code == 204
+        call_kwargs = service.resolve_review.await_args.kwargs
+        assert call_kwargs["action"] == "discard"
+
+    def test_review_resolve_404_when_entry_missing(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """MemoryNotFoundError ⇒ 404."""
+        service.resolve_review.side_effect = MemoryNotFoundError("review entry not found")
+
+        response = client.post(
+            "/api/v1/memory/review/missing-rev",
+            json={"action": "keep"},
+        )
+        assert response.status_code == 404
+
+    def test_review_resolve_400_on_invalid_action_value(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """Service raises ValueError ⇒ 400."""
+        service.resolve_review.side_effect = ValueError("unknown action")
+
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "keep"},
+        )
+        assert response.status_code == 400
+
+    def test_review_resolve_passes_user_id_as_actor(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """service.resolve_review must receive actor=user.id (not 'mcp_caller')."""
+        service.resolve_review.return_value = None
+
+        client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "keep"},
+        )
+
+        call_kwargs = service.resolve_review.await_args.kwargs
+        assert call_kwargs["actor"] == "u1"  # _make_user() uses id="u1"
+
+    def test_review_resolve_requires_editor_role(
+        self,
+        make_client: Callable[..., TestClient],
+        service: AsyncMock,
+    ) -> None:
+        """Viewer role is NOT sufficient for POST /review/{id} ⇒ 403."""
+        viewer_client = make_client(Role.VIEWER)
+
+        response = viewer_client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "keep"},
+        )
+        assert response.status_code == 403
+        service.resolve_review.assert_not_awaited()
+
+    def test_review_resolve_503_when_freshness_store_missing(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """RuntimeError('freshness_store not configured') ⇒ 503."""
+        service.resolve_review.side_effect = RuntimeError("freshness_store not configured")
+
+        response = client.post(
+            "/api/v1/memory/review/rev-1",
+            json={"action": "keep"},
+        )
+        assert response.status_code == 503

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -624,3 +624,120 @@ class TestListStatusFilter:
         service.list_records.assert_awaited_once()
         call_kwargs = service.list_records.await_args.kwargs
         assert call_kwargs["status"] is None
+
+
+# ---------------------------------------------------------------------------
+# MTRNIX-324: GET /memory/graph
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryGraph:
+    def test_memory_graph_uses_jwt_workspace(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """service.get_graph_neighborhood must be called with workspace_id from JWT."""
+        seed = _sample_record(id="seed-1")
+        service.get_graph_neighborhood.return_value = ([seed], [])
+
+        response = client.get(
+            "/api/v1/memory/graph",
+            params={"seed_record_id": "seed-1", "depth": 1},
+        )
+
+        assert response.status_code == 200
+        service.get_graph_neighborhood.assert_awaited_once()
+        call_args = service.get_graph_neighborhood.await_args
+        # First positional arg is workspace_id (from JWT), second is seed_record_id
+        assert call_args.args[0] == "ws-test"
+        assert call_args.args[1] == "seed-1"
+        assert call_args.kwargs["depth"] == 1
+
+    def test_memory_graph_depth_bounds(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """depth=0 and depth=4 are rejected with 422; depth=3 succeeds."""
+        seed = _sample_record(id="seed-1")
+        service.get_graph_neighborhood.return_value = ([seed], [])
+
+        response_0 = client.get(
+            "/api/v1/memory/graph",
+            params={"seed_record_id": "seed-1", "depth": 0},
+        )
+        assert response_0.status_code == 422
+
+        response_4 = client.get(
+            "/api/v1/memory/graph",
+            params={"seed_record_id": "seed-1", "depth": 4},
+        )
+        assert response_4.status_code == 422
+
+        response_3 = client.get(
+            "/api/v1/memory/graph",
+            params={"seed_record_id": "seed-1", "depth": 3},
+        )
+        assert response_3.status_code == 200
+
+    def test_memory_graph_neo4j_down_returns_seed_only(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """When service returns ([seed], []) (Neo4j down path), response has
+        nodes=[seed] and edges=[]."""
+        seed = _sample_record(id="seed-1")
+        service.get_graph_neighborhood.return_value = ([seed], [])
+
+        response = client.get(
+            "/api/v1/memory/graph",
+            params={"seed_record_id": "seed-1"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["nodes"]) == 1
+        assert body["nodes"][0]["id"] == "seed-1"
+        assert body["edges"] == []
+
+    def test_memory_graph_agent_id_filter(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """When agent_id query param is set, only records with matching agent_id survive."""
+        rec_a = _sample_record(id="mem-a", agent_id="agent-x")
+        rec_b = _sample_record(id="mem-b", agent_id="agent-y")
+        edge_ab = {
+            "source": "mem-a",
+            "target": "mem-b",
+            "type": "LINKED_TO",
+            "metadata": None,
+        }
+        # Edge between a and c (both for agent-x)
+        rec_c = _sample_record(id="mem-c", agent_id="agent-x")
+        edge_ac = {
+            "source": "mem-a",
+            "target": "mem-c",
+            "type": "LINKED_TO",
+            "metadata": None,
+        }
+        service.get_graph_neighborhood.return_value = ([rec_a, rec_b, rec_c], [edge_ab, edge_ac])
+
+        response = client.get(
+            "/api/v1/memory/graph",
+            params={"seed_record_id": "mem-a", "agent_id": "agent-x"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        node_ids = {n["id"] for n in body["nodes"]}
+        assert "mem-a" in node_ids
+        assert "mem-c" in node_ids
+        assert "mem-b" not in node_ids  # agent-y filtered out
+        # edge_ab is dropped (mem-b filtered out), edge_ac survives
+        assert len(body["edges"]) == 1
+        assert body["edges"][0]["source"] == "mem-a"
+        assert body["edges"][0]["target"] == "mem-c"

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -439,6 +439,71 @@ class TestMemoryCRUDCycle:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# MTRNIX-324: GET /records/{record_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecordById:
+    def test_get_record_by_id_success(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """GET /records/{id} returns 200 with full MemoryRecordResponse."""
+        stored = _sample_record(id="mem-get-1")
+        service.get.return_value = stored
+
+        response = client.get("/api/v1/memory/records/mem-get-1")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["id"] == "mem-get-1"
+        assert body["agent_id"] == "agent-1"
+        assert "status" in body
+
+    def test_get_record_by_id_404_when_missing(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """GET /records/{id} returns 404 when service.get returns None."""
+        service.get.return_value = None
+
+        response = client.get("/api/v1/memory/records/missing-id")
+
+        assert response.status_code == 404
+
+    def test_get_record_by_id_workspace_scoped(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """service.get must be called with workspace_id from JWT, not path."""
+        stored = _sample_record(id="mem-1")
+        service.get.return_value = stored
+
+        client.get("/api/v1/memory/records/mem-1")
+
+        service.get.assert_awaited_once()
+        ws, rid = service.get.await_args.args
+        assert ws == "ws-test"
+        assert rid == "mem-1"
+
+    def test_get_record_by_id_viewer_role_allowed(
+        self,
+        make_client: Callable[..., TestClient],
+        service: AsyncMock,
+    ) -> None:
+        """Viewer role is sufficient for GET /records/{id}."""
+        viewer_client = make_client(Role.VIEWER)
+        stored = _sample_record(id="mem-1")
+        service.get.return_value = stored
+
+        response = viewer_client.get("/api/v1/memory/records/mem-1")
+        assert response.status_code == 200
+
+
 class TestStatusField:
     def test_response_includes_status_field_active_default(
         self,

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -19,7 +19,14 @@ from metatron.api.dependencies import get_memory_service
 from metatron.api.routes.memory import router as memory_router
 from metatron.auth.dependencies import get_current_user
 from metatron.core.config import Settings
-from metatron.core.models import MemoryRecord, MemoryScope, MemorySearchResult, Role, User
+from metatron.core.models import (
+    LifecycleStatus,
+    MemoryRecord,
+    MemoryScope,
+    MemorySearchResult,
+    Role,
+    User,
+)
 from metatron.memory.service import MemoryService
 
 if TYPE_CHECKING:
@@ -425,3 +432,130 @@ class TestMemoryCRUDCycle:
         delete = client.delete("/api/v1/memory/records/mem-cycle")
         assert delete.status_code == 204
         service.delete.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# MTRNIX-324: status field + status_filter
+# ---------------------------------------------------------------------------
+
+
+class TestStatusField:
+    def test_response_includes_status_field_active_default(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """Response must carry status='active' for a default-status record."""
+        stored = _sample_record()  # status defaults to ACTIVE
+        service.save.return_value = stored
+
+        response = client.post(
+            "/api/v1/memory/records",
+            json={"content": "x", "agent_id": "agent-1"},
+        )
+        assert response.status_code == 201
+        assert response.json()["status"] == "active"
+
+    def test_response_includes_status_field_archived(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """Records with ARCHIVED status round-trip to 'archived'."""
+        stored = _sample_record(status=LifecycleStatus.ARCHIVED)
+        service.save.return_value = stored
+
+        response = client.post(
+            "/api/v1/memory/records",
+            json={"content": "x", "agent_id": "agent-1"},
+        )
+        assert response.status_code == 201
+        assert response.json()["status"] == "archived"
+
+
+class TestSearchStatusFilter:
+    def test_search_default_excludes_archived_and_superseded(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """POST /search without status_filter calls service with all statuses
+        EXCEPT ARCHIVED and SUPERSEDED."""
+        service.search.return_value = []
+
+        client.post("/api/v1/memory/search", json={"query": "test"})
+
+        service.search.assert_awaited_once()
+        call_kwargs = service.search.await_args.kwargs
+        assert "status_filter" in call_kwargs
+        effective = set(call_kwargs["status_filter"])
+        assert LifecycleStatus.ARCHIVED not in effective
+        assert LifecycleStatus.SUPERSEDED not in effective
+        # All other statuses should be present
+        for status in LifecycleStatus:
+            if status not in (LifecycleStatus.ARCHIVED, LifecycleStatus.SUPERSEDED):
+                assert status in effective
+
+    def test_search_explicit_status_filter_overrides_default(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """POST /search with explicit status_filter passes it through unchanged."""
+        service.search.return_value = []
+
+        client.post(
+            "/api/v1/memory/search",
+            json={"query": "test", "status_filter": ["archived"]},
+        )
+
+        service.search.assert_awaited_once()
+        call_kwargs = service.search.await_args.kwargs
+        assert call_kwargs["status_filter"] == [LifecycleStatus.ARCHIVED]
+
+    def test_search_status_filter_invalid_value_422(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """Non-enum status_filter value is rejected by Pydantic as 422."""
+        response = client.post(
+            "/api/v1/memory/search",
+            json={"query": "test", "status_filter": ["all"]},
+        )
+        # "all" is an MCP-only sentinel; REST rejects it with 422
+        assert response.status_code == 422
+        service.search.assert_not_awaited()
+
+
+class TestListStatusFilter:
+    def test_list_records_status_filter_pushes_through(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """GET /records?status_filter=active&status_filter=stale pushes through."""
+        service.list_records.return_value = []
+
+        client.get(
+            "/api/v1/memory/records",
+            params={"status_filter": ["active", "stale"]},
+        )
+
+        service.list_records.assert_awaited_once()
+        call_kwargs = service.list_records.await_args.kwargs
+        assert set(call_kwargs["status"]) == {LifecycleStatus.ACTIVE, LifecycleStatus.STALE}
+
+    def test_list_records_default_no_status_filter(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """GET /records without status_filter calls service with status=None."""
+        service.list_records.return_value = []
+
+        client.get("/api/v1/memory/records")
+
+        service.list_records.assert_awaited_once()
+        call_kwargs = service.list_records.await_args.kwargs
+        assert call_kwargs["status"] is None

--- a/tests/unit/memory/test_service_get_graph_neighborhood.py
+++ b/tests/unit/memory/test_service_get_graph_neighborhood.py
@@ -1,0 +1,131 @@
+"""Unit tests for MemoryService.get_graph_neighborhood (MTRNIX-324)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from metatron.core.models import MemoryRecord, MemoryScope
+from metatron.memory.service import MemoryService
+
+
+def _make_service(workspace_id: str = "ws-1") -> tuple[MemoryService, AsyncMock, AsyncMock]:
+    """Return a minimal MemoryService wired with mocked stores."""
+    pg_store = AsyncMock()
+    redis_cache = AsyncMock()
+    qdrant_store = AsyncMock()
+    service = MemoryService(
+        redis_cache=redis_cache,
+        qdrant_store=qdrant_store,
+        pg_store=pg_store,
+        workspace_id=workspace_id,
+    )
+    return service, pg_store, qdrant_store
+
+
+def _sample_record(record_id: str = "mem-1", workspace_id: str = "ws-1") -> MemoryRecord:
+    return MemoryRecord(
+        id=record_id,
+        workspace_id=workspace_id,
+        agent_id="agent-1",
+        scope=MemoryScope.PER_AGENT,
+        source_type="conversation",
+        content="test content",
+        tags=[],
+        importance_score=0.5,
+        ttl_expires_at=None,
+        content_hash="hash-abc",
+        session_id=None,
+        metadata={},
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+class TestGetGraphNeighborhoodService:
+    async def test_workspace_mismatch_raises(self) -> None:
+        """Service bound to ws-A; called with ws-B ⇒ ValueError."""
+        service, _, _ = _make_service("ws-A")
+        with pytest.raises(ValueError, match="workspace_id mismatch"):
+            await service.get_graph_neighborhood("ws-B", "seed-id")
+
+    async def test_depth_zero_raises(self) -> None:
+        """depth=0 is invalid."""
+        service, _, _ = _make_service("ws-1")
+        with pytest.raises(ValueError, match="depth"):
+            await service.get_graph_neighborhood("ws-1", "seed-id", depth=0)
+
+    async def test_depth_four_raises(self) -> None:
+        """depth=4 exceeds the max of 3."""
+        service, _, _ = _make_service("ws-1")
+        with pytest.raises(ValueError, match="depth"):
+            await service.get_graph_neighborhood("ws-1", "seed-id", depth=4)
+
+    async def test_neo4j_down_returns_seed_from_pg(self) -> None:
+        """When Neo4j is unavailable, service returns ([seed], []) from PG."""
+        service, pg_store, _ = _make_service("ws-1")
+        seed = _sample_record("seed-id")
+        pg_store.get.return_value = seed
+
+        with patch(
+            "metatron.memory.service.get_memory_neighborhood",
+            side_effect=OSError("connection refused"),
+        ):
+            records, edges = await service.get_graph_neighborhood("ws-1", "seed-id")
+
+        assert len(edges) == 0
+        assert len(records) == 1
+        assert records[0].id == "seed-id"
+
+    async def test_filters_to_pg_truth(self) -> None:
+        """Neo4j returns ids A, B, C; PG only has A and C ⇒ result drops B."""
+        service, pg_store, _ = _make_service("ws-1")
+
+        def _pg_get(ws: str, rid: str) -> MemoryRecord | None:
+            if rid in ("seed-A", "rec-C"):
+                return _sample_record(rid, ws)
+            return None  # rec-B is absent in PG
+
+        pg_store.get.side_effect = _pg_get
+
+        neighborhood = {
+            "record_ids": ["seed-A", "rec-B", "rec-C"],
+            "edges": [
+                {"source": "seed-A", "target": "rec-B", "type": "REMEMBERS", "metadata": None},
+                {"source": "seed-A", "target": "rec-C", "type": "LINKED_TO", "metadata": None},
+            ],
+        }
+
+        with patch(
+            "metatron.memory.service.get_memory_neighborhood",
+            return_value=neighborhood,
+        ):
+            records, edges = await service.get_graph_neighborhood("ws-1", "seed-A")
+
+        record_ids_returned = {r.id for r in records}
+        assert "seed-A" in record_ids_returned
+        assert "rec-C" in record_ids_returned
+        assert "rec-B" not in record_ids_returned
+        # Edges are returned as-is (PG filtering applies to records, not edges)
+        assert len(edges) == 2
+
+    async def test_seed_always_included_when_pg_has_it(self) -> None:
+        """Seed must be first in the returned records list."""
+        service, pg_store, _ = _make_service("ws-1")
+        seed = _sample_record("seed-id")
+        pg_store.get.return_value = seed
+
+        neighborhood = {
+            "record_ids": ["seed-id"],
+            "edges": [],
+        }
+
+        with patch(
+            "metatron.memory.service.get_memory_neighborhood",
+            return_value=neighborhood,
+        ):
+            records, edges = await service.get_graph_neighborhood("ws-1", "seed-id")
+
+        assert records[0].id == "seed-id"
+        assert edges == []

--- a/tests/unit/storage/test_memory_graph_neighborhood.py
+++ b/tests/unit/storage/test_memory_graph_neighborhood.py
@@ -99,3 +99,59 @@ class TestGetMemoryNeighborhoodStorage:
         ]
         assert any("my-workspace" in str(p) for p in call_params)
         assert any("seed-id" in str(p) for p in call_params)
+
+    def test_linked_query_uses_vanilla_cypher_no_apoc(self) -> None:
+        """LINKED_TO traversal must use vanilla variable-length Cypher.
+
+        APOC is not installed in the project's docker-compose Neo4j image, so
+        any reliance on ``apoc.*`` procedures would silently produce zero
+        memory-to-memory edges in production. Regression guard for MTRNIX-324.
+        """
+        from metatron.storage.memory_graph import get_memory_neighborhood
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = lambda self: mock_session
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        empty_mock = MagicMock()
+        empty_mock.__iter__ = lambda self: iter([])
+        mock_session.run.return_value = empty_mock
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value = mock_session
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            get_memory_neighborhood("ws-1", "seed-id", 2)
+
+        # Inspect every Cypher string passed to session.run().
+        cypher_strings = [call.args[0] for call in mock_session.run.call_args_list]
+        assert cypher_strings, "expected at least one session.run() invocation"
+        for cypher in cypher_strings:
+            assert "apoc." not in cypher.lower(), (
+                f"Cypher must not depend on APOC plugin (found in: {cypher!r})"
+            )
+        # Also confirm the LINKED_TO traversal uses vanilla variable-length syntax.
+        linked_cypher = next(c for c in cypher_strings if "LINKED_TO" in c)
+        assert "LINKED_TO*1.." in linked_cypher
+
+    def test_linked_query_depth_interpolated_into_pattern(self) -> None:
+        """``depth`` must be interpolated into the LINKED_TO pattern bound."""
+        from metatron.storage.memory_graph import get_memory_neighborhood
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = lambda self: mock_session
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        empty_mock = MagicMock()
+        empty_mock.__iter__ = lambda self: iter([])
+        mock_session.run.return_value = empty_mock
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value = mock_session
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            get_memory_neighborhood("ws-1", "seed-id", 3)
+
+        cypher_strings = [call.args[0] for call in mock_session.run.call_args_list]
+        linked_cypher = next(c for c in cypher_strings if "LINKED_TO" in c)
+        assert "LINKED_TO*1..3" in linked_cypher

--- a/tests/unit/storage/test_memory_graph_neighborhood.py
+++ b/tests/unit/storage/test_memory_graph_neighborhood.py
@@ -1,0 +1,101 @@
+"""Unit tests for get_memory_neighborhood (MTRNIX-324).
+
+Uses a mocked Neo4j driver so no live Neo4j required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+def _make_row(**kwargs: Any) -> MagicMock:
+    """Create a mock row that supports dict-style access."""
+    row = MagicMock()
+    row.__getitem__ = lambda self, k: kwargs[k]
+    return row
+
+
+class TestGetMemoryNeighborhoodStorage:
+    def test_returns_seed_only_for_unknown_seed(self) -> None:
+        """When driver returns no rows the result contains only the seed id."""
+        from metatron.storage.memory_graph import get_memory_neighborhood
+
+        mock_session = MagicMock()
+        # Both Cypher queries return no rows.
+        mock_result = MagicMock()
+        mock_result.__iter__ = lambda self: iter([])
+        mock_session.__enter__ = lambda self: mock_session
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.run.return_value = mock_result
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value = mock_session
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            result = get_memory_neighborhood("ws-1", "seed-id", 1)
+
+        assert "seed-id" in result["record_ids"]
+        assert result["edges"] == []
+
+    def test_bridge_edge_includes_via_metadata(self) -> None:
+        """Bridge edge (Agent) must surface via/via_id in metadata."""
+        from metatron.storage.memory_graph import get_memory_neighborhood
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = lambda self: mock_session
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        # linked_result is empty; bridge_result has one Agent-bridged edge.
+        linked_mock = MagicMock()
+        linked_mock.__iter__ = lambda self: iter([])
+
+        bridge_row = _make_row(
+            source="seed-id",
+            target="other-mem",
+            rtype="REMEMBERS",
+            via_label="Agent",
+            via_id="agent-xyz",
+        )
+        bridge_mock = MagicMock()
+        bridge_mock.__iter__ = lambda self: iter([bridge_row])
+
+        mock_session.run.side_effect = [linked_mock, bridge_mock]
+        mock_driver = MagicMock()
+        mock_driver.session.return_value = mock_session
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            result = get_memory_neighborhood("ws-1", "seed-id", 1)
+
+        assert "other-mem" in result["record_ids"]
+        assert len(result["edges"]) == 1
+        edge = result["edges"][0]
+        assert edge["type"] == "REMEMBERS"
+        assert edge["metadata"]["via"] == "Agent"
+        assert edge["metadata"]["via_id"] == "agent-xyz"
+
+    def test_workspace_param_passed_to_cypher(self) -> None:
+        """Cypher must be invoked with workspace_id ($ws) parameter."""
+        from metatron.storage.memory_graph import get_memory_neighborhood
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = lambda self: mock_session
+        mock_session.__exit__ = MagicMock(return_value=False)
+
+        empty_mock = MagicMock()
+        empty_mock.__iter__ = lambda self: iter([])
+        mock_session.run.return_value = empty_mock
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value = mock_session
+
+        with patch("metatron.storage.memory_graph.get_graph_driver", return_value=mock_driver):
+            get_memory_neighborhood("my-workspace", "seed-id", 2)
+
+        # At least one call should have ws and seed params.
+        call_params = [
+            call[0][1] if len(call[0]) > 1 else call[1]
+            for call in mock_session.run.call_args_list
+        ]
+        assert any("my-workspace" in str(p) for p in call_params)
+        assert any("seed-id" in str(p) for p in call_params)

--- a/tests/unit/test_agents_routes.py
+++ b/tests/unit/test_agents_routes.py
@@ -202,6 +202,53 @@ class TestListAgents:
         assert kwargs["status"] == AgentStatus.ACTIVE
         assert kwargs["name_prefix"] == "Tra"
 
+    # MTRNIX-324: default-exclude ARCHIVED + include_archived opt-in
+
+    def test_list_default_excludes_archived(
+        self, client: TestClient, service: AsyncMock
+    ) -> None:
+        """Default GET /agents passes include_archived=False to the service."""
+        service.list_agents.return_value = []
+        response = client.get("/api/v1/agents")
+        assert response.status_code == 200
+        kwargs = service.list_agents.await_args.kwargs
+        assert kwargs["include_archived"] is False
+        assert kwargs["status"] is None
+
+    def test_list_include_archived_true(
+        self, client: TestClient, service: AsyncMock
+    ) -> None:
+        """?include_archived=true forwards include_archived=True to the service."""
+        service.list_agents.return_value = []
+        response = client.get("/api/v1/agents", params={"include_archived": "true"})
+        assert response.status_code == 200
+        kwargs = service.list_agents.await_args.kwargs
+        assert kwargs["include_archived"] is True
+        assert kwargs["status"] is None
+
+    def test_list_explicit_status_archived(
+        self, client: TestClient, service: AsyncMock
+    ) -> None:
+        """?status=archived passes status=ARCHIVED through (archived-only view)."""
+        service.list_agents.return_value = []
+        response = client.get("/api/v1/agents", params={"status": "archived"})
+        assert response.status_code == 200
+        kwargs = service.list_agents.await_args.kwargs
+        assert kwargs["status"] == AgentStatus.ARCHIVED
+        assert kwargs["include_archived"] is False
+
+    def test_list_status_and_include_archived_conflict_400(
+        self, client: TestClient, service: AsyncMock
+    ) -> None:
+        """status + include_archived=true is mutually exclusive ⇒ 400."""
+        response = client.get(
+            "/api/v1/agents",
+            params={"status": "active", "include_archived": "true"},
+        )
+        assert response.status_code == 400
+        assert "mutually exclusive" in response.json()["detail"]
+        service.list_agents.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # GET /agents/{id}

--- a/tests/unit/test_agents_service.py
+++ b/tests/unit/test_agents_service.py
@@ -419,6 +419,7 @@ class TestList:
             "ws-test",
             status=AgentStatus.ACTIVE,
             name_prefix="Trad",
+            include_archived=False,
             limit=10,
             offset=5,
         )
@@ -430,8 +431,19 @@ class TestList:
         _, kwargs = repo.list_records.call_args
         assert kwargs["status"] is None
         assert kwargs["name_prefix"] is None
+        assert kwargs["include_archived"] is False
         assert kwargs["limit"] == 50
         assert kwargs["offset"] == 0
+
+    async def test_include_archived_passes_through(
+        self, service: AgentRegistryService, repo: AsyncMock
+    ) -> None:
+        """MTRNIX-324: include_archived=True is forwarded to the repo."""
+        repo.list_records.return_value = []
+        await service.list_agents(include_archived=True)
+        _, kwargs = repo.list_records.call_args
+        assert kwargs["include_archived"] is True
+        assert kwargs["status"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -341,7 +341,7 @@ class TestListPersistent:
 
         assert len(result) == 2
         pg_store.list_records.assert_awaited_once_with(
-            "ws1", agent_id="agent1", scope=None, limit=100, offset=0
+            "ws1", agent_id="agent1", scope=None, status=None, limit=100, offset=0
         )
 
 


### PR DESCRIPTION
## Summary
Closes the five backend gaps that the Memory Inspector UI (shipped in [metatronui#24](https://github.com/mtrnix/metatronui/pull/24), MTRNIX-274) currently degrades around. Bundled PR; eight focused commits, no migrations, no env vars, no `interfaces.py` change → zero coordination cost with `metatron-enterprise`.

- **Item 1 — Lifecycle status on memory REST.** `MemoryRecordResponse` now carries `status: LifecycleStatus`; `POST /memory/search` and `GET /memory/records` accept `status_filter`. Search default = exclude `ARCHIVED + SUPERSEDED` (mirrors Jira spec, applied at the route layer).
- **Item 2 — `GET /api/v1/memory/graph`.** New endpoint exposes the Neo4j memory neighbourhood (`REMEMBERS|ABOUT|FROM_SESSION|DERIVED_FROM|LINKED_TO`) around a seed record. Bridge nodes (Agent/Entity/Session/Document) are surfaced via edge `metadata.via` per spec shape (`nodes: MemoryRecord[]`). Depth `1..3` (FastAPI bounds). Graceful Neo4j-down → seed only, empty edges.
- **Item 3 — `GET /api/v1/memory/records/{id}`.** Single-record fetch; 404 on cross-workspace.
- **Item 4 — REST review queue.** `GET /api/v1/memory/review` (paginated, optional `reason` filter, viewer) + `POST /api/v1/memory/review/{id}` (`keep|archive|merge_into|discard`, editor). Functional twin of MCP tools from MTRNIX-314; emits `MachineEvent` with `actor=user.id`.
- **Item 5 — Filter ARCHIVED agents.** `GET /api/v1/agents` defaults to excluding `ARCHIVED`; opt-in `?include_archived=true` for admin views. Mutual-exclusion 400 between `status=` and `include_archived=true`.

### Critical wiring fix (commit 1)
`api.dependencies.get_memory_service` was building `MemoryService` WITHOUT `freshness_store` and `MemorySearchService` WITHOUT `pg_store` — the MCP path already wired both. This PR closes that gap so:
- Item 4 (REST review endpoints) does not 503.
- REST search status post-filter on the graph leg behaves identically to MCP search.

## Plan
[`docs/superpowers/plans/MTRNIX-324-memory-rest-followups.md`](docs/superpowers/plans/MTRNIX-324-memory-rest-followups.md)

## Test plan
- [x] `make lint` clean
- [x] `make typecheck` clean
- [x] `make test` — ~46 new unit tests, all green (5 wiring, 6 status field/filter, 4 get-by-id, 4 graph route, 16 review, 7 agents, 1 service-level `include_archived`, 3 storage neighbourhood, 6 service neighbourhood). Pre-existing baseline failures unchanged.
- [ ] **Reviewer must run `make test-all` with live PG/Neo4j/Qdrant up** — three new integration tests are gated by `RUN_INTEGRATION_TESTS=1`:
  - `tests/integration/api/test_memory_graph_neo4j_down.py` — Neo4j-down empty-edges path
  - `tests/integration/api/test_memory_record_get_cross_workspace.py` — 404 cross-workspace
  - `tests/integration/api/test_memory_review_roundtrip.py` — GET + POST + MachineEvent + status flip
- [x] Architect's depth bounds (`Query(ge=1, le=3)`) verified by route-level test
- [x] Workspace-isolation defence-in-depth at three layers verified (route → service → store)

## Notes / out-of-scope (flagged for follow-up)
- **UI status casing.** The UI's `MemoryStatusBadge` expects UPPERCASE (`'ACTIVE'`, ...) while `LifecycleStatus` enum values are lowercase (`"active"`, ...). The Memory Inspector badge styles will silently no-op until the UI maps lowercase. Per ticket scope ("no frontend changes") this is a UI follow-up — not addressed here.
- **REST vs MCP search default.** REST default = exclude `ARCHIVED + SUPERSEDED` (Jira spec). MCP default = only `ACTIVE`. Both are explicit-overridable; divergence is intentional and documented in `docs/MCP_API.md` (documenter phase).
- **Neo4j memory-graph traversal v1.** Bridge nodes embedded in edge `metadata.via`; direct memory-to-memory `LINKED_TO` edges (Linker stage, MTRNIX-313) surface as own edges when present. Spec is intentionally loose on this; documented in route docstring.

## References
- Jira: MTRNIX-324
- UI: [metatronui#24 (MTRNIX-274)](https://github.com/mtrnix/metatronui/pull/24)
- MCP review tools: MTRNIX-314
- Status payload sync: MTRNIX-322