### PR TITLE
feat(MTRNIX-272): memory snapshot/restore/diff (WS1 S4-5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ docs/superpowers/
 # Data
 /data/
 
+# Logs
+/logs/
+
 # Testing
 .pytest_cache/
 eval_results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## [Unreleased]
 
 ### Added
+- feat: Memory snapshot/restore/diff for agent memory (MTRNIX-272, WS1 S4-5).
+  `MemorySnapshotService` — JSONL+gzip+SHA256 backups with atomic file write
+  (tmp+rename for both gzip and sidecar). Pre-reset and pre-restore auto-snapshots
+  guarantee an undo point before any destructive operation. Restore uses a single
+  `MemoryPostgresStore.replace_for_agent` transaction (DELETE+INSERT) with best-effort
+  Qdrant+Neo4j repopulation (PG remains source of truth). New REST endpoints:
+  `POST /api/v1/agents/{id}/reset` (auto pre_reset snapshot → wipe, 413/422/500-with-snapshot-id),
+  `POST /api/v1/agents/{id}/snapshots` (manual snapshot, 201),
+  `GET /api/v1/agents/{id}/snapshots` (list newest-first),
+  `POST /api/v1/snapshots/{id}/restore` (checksum verify → pre_restore snapshot → transactional replace),
+  `GET /api/v1/snapshots/diff` (same-agent comparison, `key=source|content_hash`).
+  New events: `MEMORY_SNAPSHOT_CREATED` (`snapshot_id`, `trigger`, `record_count`),
+  `MEMORY_RESTORED` (`snapshot_id`, `record_count`, `pre_restore_snapshot_id`).
+  New env vars: `METATRON_SNAPSHOT_DIR` (./data/snapshots), `METATRON_SNAPSHOT_MAX_FILE_BYTES` (256 MiB).
 - docs: strategy ADR `docs/adr/2026-04-25-metatron-strategy.md` —
   authoritative snapshot of architectural decisions and pre-pilot plan
   (Memory Quality Layer with `kind=fact|preference|pinned`, Agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,8 @@ Graph extraction is decoupled from sync (process_all_unsynced_graphs, graph-proc
 - METATRON_FRESHNESS_KB_SEARCH_FILTER_ENABLED (false) — retrieval-side ARCHIVED/SUPERSEDED filter pushdown; when on, recall channels combine the filter with `access_filter` via `_combine_filters`
 - METATRON_FRESHNESS_WEIGHT (0.0) — scoring weight for the `freshness` signal in `compute_signal_score`; default 0.0 keeps the formula numerically identical to Phase A
 - METATRON_FRESHNESS_KB_STALE_AFTER_DAYS (90) — KB stale threshold in days (higher than memory's 30 because KB documents age more slowly)
+- METATRON_SNAPSHOT_DIR (./data/snapshots) — root directory for memory snapshot files (MTRNIX-272)
+- METATRON_SNAPSHOT_MAX_FILE_BYTES (268435456) — per-file size cap (256 MiB) for snapshot exports; exceeded → 413 (MTRNIX-272)
 - See core/config.py for full list
 
 ## External Agent Integration Surfaces
@@ -333,6 +335,18 @@ Today agent memory is not automatically added to /v1/chat/completions context.
   (`AgentInvalidStateTransitionError`); un-archive is only via `/restore`. `GET /api/v1/agents`
   defaults to excluding ARCHIVED agents; pass `?include_archived=true` to opt in (admin/inspection
   use). `?status=` and `?include_archived=true` together return 400 (mutually exclusive).
+  Memory snapshot endpoints (MTRNIX-272, editor+ unless noted):
+  `POST /{id}/reset` — wipe agent memory; auto `pre_reset` snapshot taken first; returns
+  `{snapshot_id, deleted_count}`. 413 on >10k overflow, 422 on corrupt snapshot, 500 with
+  `snapshot_id` in detail when wipe fails after snapshot succeeds (operator can restore).
+  `POST /{id}/snapshots` — manual snapshot, body `{label?: str}`, returns snapshot record (201).
+  413 on overflow, 422 on corrupt. `GET /{id}/snapshots` (viewer+) — list snapshots newest-first.
+- `/api/v1/snapshots/*` — cross-snapshot operations (MTRNIX-272):
+  `POST /{id}/restore` (editor+) — SHA-256 verify → auto `pre_restore` snapshot → transactional
+  PG replace → best-effort Qdrant+Neo4j repopulation. Returns `{snapshot_id, pre_restore_snapshot,
+  restored_count}`. 404 if missing, 422 if corrupt.
+  `GET /diff?from=<id>&to=<id>&key=source|content_hash` (viewer+) — compare two snapshots of the
+  **same agent** (cross-agent → 400). Returns `{added, removed, changed}` record-id lists.
 - `/api/v1/documents`, `/api/v1/search` — document CRUD + search
 - `/api/v1/workspaces`, `/api/v1/connections`, `/api/v1/sync` — admin surfaces
 

--- a/docs/superpowers/plans/2026-05-02-ws1-snapshot-restore-diff.md
+++ b/docs/superpowers/plans/2026-05-02-ws1-snapshot-restore-diff.md
@@ -171,9 +171,13 @@ class SnapshotDiff:
 5. PG transaction:
    - `DELETE FROM memory_records WHERE workspace_id = :ws AND agent_id = :ag`
    - `INSERT` each record from the snapshot in the same transaction.
-6. Best-effort Qdrant: `qdrant_store.delete_by_agent(agent_id)` then
-   `qdrant_store.upsert(record)` per record (re-embeds).
-7. Best-effort Neo4j: `delete_agent_memories(...)` then `save_memory_to_graph(...)`.
+6. Best-effort downstream cleanup — per-id deletes for both stores, driven by
+   the authoritative `deleted_ids` returned from the PG `DELETE … RETURNING`:
+   `qdrant_store.delete(rid)` and `delete_memory_node(workspace_id, rid)` per
+   id. Avoids the over-delete bug Qdrant's `delete_by_agent` is known for and
+   keeps the cleanup symmetric with `MemoryService.reset`.
+7. Best-effort repopulation: per-record `qdrant_store.upsert(record)`
+   (re-embeds via the embedding provider) and `save_memory_to_graph(...)`.
 8. Emit `MEMORY_RESTORED` with `{workspace_id, agent_id, snapshot_id, count}`.
 
 ### `diff(from_id, to_id, key)`
@@ -260,17 +264,28 @@ fixture style).
 
 ## Risks and follow-ups
 
-- **Re-embedding cost on restore** — pulls the embedding provider for every
-  record. For an agent with thousands of records this can take seconds-to-minutes.
-  Acceptable for v1; revisit only if a customer reports slow restores.
+- **Synchronous restore + per-record re-embed** — `restore()` awaits N
+  sequential `qdrant.upsert` (re-embed) and N `to_thread(save_memory_to_graph)`
+  calls. Realistic HTTP timeouts (30-60s) will fire well before completion for
+  agents with more than a few hundred records. Follow-up: move downstream
+  repopulation to a background task and return 202 + job id, or use a batch
+  upsert path.
+- **No per-(workspace, agent) lock on restore** — concurrent restores for the
+  same agent are PG-safe but Qdrant/Neo4j repop can interleave. Acceptable for
+  v1 (admin-only endpoint, low concurrency); follow-up adds a Redis lock if
+  multi-tenant restores ever start happening from a UI.
 - **No retention/cleanup** — snapshots accumulate on disk forever. Tracked as
-  follow-up: add `expires_at` column + cron sweep.
+  follow-up: add `expires_at` column + cron sweep, AND a startup orphan-file
+  reaper that removes files under `snapshot_dir/{ws}/{ag}/` not present in
+  `memory_snapshots` (covers the hard-crash window between gzip rename and
+  PG row commit).
 - **No PG/Qdrant/Neo4j atomicity** — same as the rest of `MemoryService`. PG is
   source of truth; if Qdrant/Neo4j re-population fails midway the next search
   query may miss some records until a re-save fixes it. Documented, not fixed
   in v1.
 - **10k record cap on `create()`** — `pg_store.list_records` is called once;
-  paginate when this becomes real.
+  service refuses with `SnapshotOverflowError` (HTTP 413) when an agent
+  exceeds the cap. Paginate when this becomes real.
 
 ## Out of scope
 

--- a/docs/superpowers/plans/2026-05-02-ws1-snapshot-restore-diff.md
+++ b/docs/superpowers/plans/2026-05-02-ws1-snapshot-restore-diff.md
@@ -1,0 +1,283 @@
+# WS1 S4-5: Memory snapshot / restore / diff (MTRNIX-272)
+
+**Date:** 2026-05-02
+**Branch:** `feature/MTRNIX-272`
+**Sprint:** W5 (May 5-9)
+**Stage:** WS1 stages 4-5
+
+## Goal
+
+Enterprise-grade backup/restore for agent memory with integrity checks. Three
+user-visible capabilities:
+
+1. **Reset** an agent's memory with an automatic pre-reset snapshot.
+2. **Snapshot/restore** an agent's memory as JSONL+gzip with SHA-256 integrity.
+3. **Diff** two snapshots of the same agent.
+
+## What's already in place
+
+- `migrations/versions/013_memory_system.py` — `memory_snapshots` table:
+  `id, workspace_id, agent_id, label, trigger, record_count, content_hash,
+  size_bytes, storage_path, created_at` + index `(workspace_id, agent_id)`.
+- `core/models.py:379` — `MemorySnapshot` dataclass.
+- `storage/memory_postgres.py:664-731` — `MemoryPostgresStore.save_snapshot /
+  get_snapshot / delete_snapshot / list_snapshots` (metadata CRUD).
+- `core/events.py:48-49` — `MEMORY_SNAPSHOT_CREATED`, `MEMORY_RESTORED` constants
+  with documented payload shape.
+- `core/exceptions.py:71` — `SnapshotCorruptError(AgentMemoryError)`.
+- `core/interfaces.py:388-401` — `MemoryStoreInterface.create_snapshot /
+  restore_snapshot` ABC methods (currently unimplemented).
+- `MemoryService.reset(ws, *, agent_id, scope)` — `DELETE … RETURNING id` in PG
+  + per-id Qdrant + Neo4j cleanup, emits `MEMORY_RESET`.
+
+**No new alembic migration is needed.**
+
+## What's missing — this PR
+
+1. `memory/snapshot.py` (new, L3) — `MemorySnapshotService` orchestrator and
+   file IO helpers.
+2. `api/routes/snapshots.py` (new, L6) — `/api/v1/snapshots/{id}/restore` and
+   `/api/v1/snapshots/diff`.
+3. Extensions to `api/routes/agents.py` (L6) — `/{id}/reset`, `/{id}/snapshots`
+   POST + GET.
+4. `api/dependencies.py` — `get_memory_snapshot_service(request)`.
+5. Two new `Settings` fields — snapshot dir + max file size.
+6. Wiring in `api/app.py` — include the new router.
+7. Unit tests (snapshot service round-trip, checksum tampering, workspace
+   isolation, diff semantics, route RBAC + cross-workspace defence).
+
+## Design decisions (confirmed in conversation)
+
+| # | Decision |
+|---|---|
+| 1 | "Bulk soft-delete" = call existing `MemoryService.reset(agent_id=…)`. PG hard-delete + per-id Qdrant + Neo4j cleanup. Reversible only via the auto-snapshot taken immediately before. |
+| 2 | Restore = transaction replace: PG `BEGIN; DELETE … WHERE agent_id=…; INSERT …; COMMIT;` + best-effort Qdrant/Neo4j re-population. Conflicting `id`s do not occur (we just deleted them); use plain `INSERT`. |
+| 3 | Embeddings are NOT in the snapshot. Restore re-embeds via `MemoryQdrantStore.upsert(record)`. Pro: portable across embedding model versions. Con: slower restore (acceptable — bounded by record count, not record size). |
+| 4 | Diff: same-agent only. `from.workspace_id == to.workspace_id == auth.workspace_id` and `from.agent_id == to.agent_id` enforced server-side; otherwise 400. |
+| 5 | `expires_at` retention: deferred. Keep schema as-is; cron pruning is a follow-up. |
+
+## Layer map
+
+```
+L6  api/routes/snapshots.py            (new)
+L6  api/routes/agents.py               (extend with /reset, /snapshots)
+L6  api/dependencies.py                (add get_memory_snapshot_service)
+L6  api/app.py                         (mount new router)
+L3  memory/snapshot.py                 (new — service + file IO)
+L3  memory/__init__.py                 (re-export)
+L1  storage/memory_postgres.py         (already done — no changes)
+L0  core/config.py                     (add 2 fields)
+L0  core/events.py                     (already done — no changes)
+L0  core/exceptions.py                 (already done — no changes)
+L0  core/models.py                     (already done — no changes)
+```
+
+No upward imports introduced. `memory/snapshot.py` depends on `core/`, `storage/`,
+and the existing `memory/service.py`.
+
+## File format
+
+```
+data/snapshots/{workspace_id}/{agent_id}/{snapshot_id}.jsonl.gz
+data/snapshots/{workspace_id}/{agent_id}/{snapshot_id}.sha256
+```
+
+- `*.jsonl.gz` — gzip-wrapped JSON-Lines.
+  - **Line 1 = manifest:**
+    ```json
+    {"_kind": "manifest", "version": 1, "workspace_id": "...",
+     "agent_id": "...", "snapshot_id": "...", "created_at": "ISO-8601",
+     "trigger": "manual|pre_reset|pre_restore", "label": "...",
+     "record_count": N}
+    ```
+  - **Lines 2..N+1 = `MemoryRecord` JSON** (one per line, lifecycle fields
+    included: `status`, `verification_state`, `superseded_by`, `valid_from`,
+    `valid_until`, `evidence_count`, `freshness_score`, `content_hash`).
+- `*.sha256` — single line: `<hex digest>  <basename>.jsonl.gz`. Sidecar so the
+  checksum can be verified before reading the gzip body.
+
+The `MemorySnapshot.content_hash` column stores the same SHA-256 (semantically
+"file checksum", not "memory record content hash" — tracked across the codebase
+under the existing column name to avoid a migration).
+
+## Service API — `memory/snapshot.py`
+
+```python
+class MemorySnapshotService:
+    def __init__(
+        self,
+        memory_service: MemoryService,
+        pg_store: MemoryPostgresStore,
+        *,
+        workspace_id: str,
+        snapshot_dir: Path,
+        event_bus: EventBus | None = None,
+        max_file_bytes: int = 256 * 1024 * 1024,
+    ) -> None: ...
+
+    async def create(
+        self, agent_id: str, *, label: str = "", trigger: str = "manual"
+    ) -> MemorySnapshot: ...
+    async def restore(self, snapshot_id: str) -> tuple[MemorySnapshot, int]: ...
+        # returns (auto_pre_restore_snapshot, restored_count)
+    async def get(self, snapshot_id: str) -> MemorySnapshot: ...     # raises MemoryNotFoundError
+    async def list(self, agent_id: str) -> list[MemorySnapshot]: ...
+    async def diff(
+        self, from_id: str, to_id: str, *, key: str = "source"
+    ) -> SnapshotDiff: ...
+        # key in {"source", "content_hash"}
+```
+
+`SnapshotDiff` dataclass:
+
+```python
+@dataclass
+class SnapshotDiff:
+    from_id: str
+    to_id: str
+    key: str
+    added: list[str]     # record ids present only in `to`
+    removed: list[str]   # record ids present only in `from`
+    changed: list[str]   # same key, different content_hash
+```
+
+## Workflow details
+
+### `create(agent_id, label, trigger)`
+
+1. `pg_store.list_records(workspace_id, agent_id=agent_id, limit=10_000)` —
+   pull **all** records for the agent. (Caveat: snapshots over 10k records will
+   need pagination — note as TODO; not in v1 scope.)
+2. Build manifest dict + serialize records as JSONL.
+3. Stream to a temporary file on disk via `gzip.open(..., "wt")`, computing
+   SHA-256 of the **compressed bytes** as we write.
+4. Reject if `tmp.stat().st_size > max_file_bytes` → raise `SnapshotCorruptError`
+   (admin-tunable safety cap).
+5. Atomic rename to final path `{snapshot_dir}/{ws}/{agent_id}/{snapshot_id}.jsonl.gz`.
+6. Write `.sha256` sidecar.
+7. `pg_store.save_snapshot(MemorySnapshot(...))`.
+8. Emit `MEMORY_SNAPSHOT_CREATED` with `{workspace_id, agent_id, snapshot_id, trigger}`.
+
+### `restore(snapshot_id)`
+
+1. `pg_store.get_snapshot(workspace_id, snapshot_id)` → 404 → `MemoryNotFoundError`.
+2. Verify checksum:
+   - Read sidecar `.sha256`. If missing, fall back to recomputing from `.jsonl.gz`.
+   - Recompute SHA-256 of the `.jsonl.gz` bytes; compare with stored
+     `content_hash` AND the sidecar (when present).
+   - Mismatch → `SnapshotCorruptError`.
+3. Read+verify the manifest (line 1) — workspace/agent must match the row.
+4. Take `pre_restore` auto-snapshot of current state via `self.create(...)`.
+5. PG transaction:
+   - `DELETE FROM memory_records WHERE workspace_id = :ws AND agent_id = :ag`
+   - `INSERT` each record from the snapshot in the same transaction.
+6. Best-effort Qdrant: `qdrant_store.delete_by_agent(agent_id)` then
+   `qdrant_store.upsert(record)` per record (re-embeds).
+7. Best-effort Neo4j: `delete_agent_memories(...)` then `save_memory_to_graph(...)`.
+8. Emit `MEMORY_RESTORED` with `{workspace_id, agent_id, snapshot_id, count}`.
+
+### `diff(from_id, to_id, key)`
+
+1. Load both `MemorySnapshot` rows. Both must be in the auth workspace AND same
+   `agent_id` → otherwise raise `ValueError` (route maps to 400).
+2. Verify both file checksums (defense in depth — diff must not silently consume
+   tampered snapshots).
+3. Stream-read each file, build `dict[key_value, content_hash]` mappings.
+   - For `key="source"`, the key is `f"{record.source_type}:{record.metadata.get('source_id', '')}"`
+     when source_id present; falls back to `record.id` when empty (so records
+     without a source still appear in the diff but only match by id).
+   - For `key="content_hash"`, the key is `record.content_hash` itself; "changed"
+     never fires (it's tautological).
+4. Compute `added` / `removed` / `changed` as documented above.
+5. Return `SnapshotDiff` — endpoint serializes to JSON.
+
+## REST endpoints
+
+| Method | Path | RBAC | Notes |
+|---|---|---|---|
+| POST | `/api/v1/agents/{id}/reset` | editor+ | Creates `pre_reset` snapshot, then calls `MemoryService.reset(agent_id=id)`. Returns `{snapshot_id, deleted_count}`. |
+| POST | `/api/v1/agents/{id}/snapshots` | editor+ | Body `{label?: str}`. Returns the created `MemorySnapshot`. |
+| GET | `/api/v1/agents/{id}/snapshots` | viewer+ | Returns `{snapshots: [...], count}` (newest first, no pagination in v1 — list is bounded by usage). |
+| POST | `/api/v1/snapshots/{id}/restore` | editor+ | Returns `{auto_snapshot_id, restored_count}`. |
+| GET | `/api/v1/snapshots/diff?from=<id>&to=<id>&key=source\|content_hash` | viewer+ | 400 on cross-agent or unknown id. |
+
+All endpoints derive `workspace_id` from auth (never body/query). Cross-workspace
+snapshot ids return 404 (`MemoryNotFoundError` from PG store).
+
+## Configuration
+
+```python
+# core/config.py
+snapshot_dir: str = Field(
+    "./data/snapshots", alias="METATRON_SNAPSHOT_DIR"
+)
+snapshot_max_file_bytes: int = Field(
+    256 * 1024 * 1024, alias="METATRON_SNAPSHOT_MAX_FILE_BYTES"
+)
+```
+
+256 MiB cap is generous (handful of MB per 10k records typical) — protects
+against runaway disk consumption from bug or hostile content.
+
+## Error model
+
+| Failure | Raised | HTTP |
+|---|---|---|
+| Snapshot id not in workspace | `MemoryNotFoundError` | 404 |
+| File missing on disk | `SnapshotCorruptError` | 422 |
+| Checksum mismatch | `SnapshotCorruptError` | 422 |
+| Workspace mismatch in manifest | `SnapshotCorruptError` | 422 |
+| Diff across agents | `ValueError` | 400 |
+| File exceeds cap | `SnapshotCorruptError` | 422 |
+| Agent does not exist (for `/reset`) | `AgentNotFoundError` | 404 |
+
+## Test plan — unit only (no live services)
+
+1. **`test_snapshot_service_create_roundtrip`** — create snapshot → manifest +
+   N records on disk → SHA-256 matches stored `content_hash`.
+2. **`test_snapshot_service_restore_roundtrip`** — create → reset → restore →
+   PG state matches the snapshot.
+3. **`test_snapshot_service_restore_creates_auto_pre_restore_snapshot`** — verify
+   there are now 2 snapshot rows with `trigger=pre_restore` for the second.
+4. **`test_snapshot_service_restore_rejects_tampered_file`** — flip a byte in
+   the gzip body → `SnapshotCorruptError`.
+5. **`test_snapshot_service_restore_rejects_workspace_mismatch_in_manifest`**.
+6. **`test_snapshot_service_diff_added_removed_changed`** — fixture with
+   3 records in `from`, 3 in `to` (1 same, 1 changed-content, 1 added, 1 removed).
+7. **`test_snapshot_service_diff_rejects_cross_agent`**.
+8. **`test_snapshot_service_workspace_isolation`** — service bound to ws_A
+   refuses to create/restore for snapshot rows owned by ws_B (404).
+9. **`test_routes_reset_creates_snapshot_and_deletes`** — RBAC + happy path
+   via TestClient with an in-memory fake of `MemoryService` + `MemorySnapshotService`.
+10. **`test_routes_restore_workspace_cross_leak`** — a foreign workspace id in
+    the URL never resolves to another workspace's data.
+11. **`test_routes_diff_400_on_cross_agent`**.
+12. **`test_routes_rbac_viewer_blocked_from_writes`**.
+
+Tests live in `tests/unit/memory/test_snapshot_service.py` and
+`tests/unit/api/test_snapshot_routes.py` (mirrors existing `test_memory_routes.py`
+fixture style).
+
+## Risks and follow-ups
+
+- **Re-embedding cost on restore** — pulls the embedding provider for every
+  record. For an agent with thousands of records this can take seconds-to-minutes.
+  Acceptable for v1; revisit only if a customer reports slow restores.
+- **No retention/cleanup** — snapshots accumulate on disk forever. Tracked as
+  follow-up: add `expires_at` column + cron sweep.
+- **No PG/Qdrant/Neo4j atomicity** — same as the rest of `MemoryService`. PG is
+  source of truth; if Qdrant/Neo4j re-population fails midway the next search
+  query may miss some records until a re-save fixes it. Documented, not fixed
+  in v1.
+- **10k record cap on `create()`** — `pg_store.list_records` is called once;
+  paginate when this becomes real.
+
+## Out of scope
+
+- New alembic migration (table already exists).
+- Cross-agent diff (separate endpoint when needed).
+- Retention/cleanup of old snapshots.
+- MCP tool exposure (REST only for v1; MCP tools follow when external agents
+  need them).
+- Snapshot encryption at rest (deferred until any customer/compliance ask
+  triggers it).

--- a/src/metatron/api/.claude/claude.md
+++ b/src/metatron/api/.claude/claude.md
@@ -108,6 +108,19 @@ Uses Neo4j directly (neo4j driver). Handles `ServiceUnavailable`/`SessionExpired
 `GET/POST /api/v1/skills` — list / create skills
 `GET/PUT/DELETE /api/v1/skills/{id}` — read / update / delete
 
+### `routes/snapshots.py`
+Cross-snapshot REST endpoints (MTRNIX-272). Listing and creation live under `/agents/{id}/snapshots`
+so agent context is explicit; these routes cover operations where the snapshot id is the primary key.
+
+| Method | Path | RBAC | Purpose |
+|--------|------|------|---------|
+| POST | `/api/v1/snapshots/{id}/restore` | editor+ | SHA-256 verify → auto `pre_restore` snapshot → PG `BEGIN; DELETE; INSERT; COMMIT` → best-effort Qdrant+Neo4j. Returns `{snapshot_id, pre_restore_snapshot, restored_count}`. 404 if missing, 422 if corrupt |
+| GET | `/api/v1/snapshots/diff` | viewer+ | Compare two snapshots of the **same** agent via `?from=<id>&to=<id>&key=source\|content_hash`. Cross-agent → 400. Returns `{from_snapshot_id, to_snapshot_id, key, added, removed, changed}` |
+
+DI helper: `get_memory_snapshot_service(request)` — lazily constructs `MemorySnapshotService` per workspace, shares PG engine with `get_memory_service`.
+
+**Workspace isolation:** snapshot id is resolved through the authenticated workspace — a snapshot id from another workspace resolves to 404.
+
 ### `routes/workspaces.py`
 `GET/POST /api/v1/workspaces` — list / create workspaces
 `GET/PUT/DELETE /api/v1/workspaces/{id}` — read / update / delete
@@ -161,6 +174,21 @@ Memory REST API endpoints (workspace-scoped, RBAC-gated):
 **Workspace resolution:** uses `get_workspace_id(request)` exported from `api.dependencies` (workspace always derived from auth, never from body/query).
 
 **Schemas:** pydantic v2 request/response models live inline in `routes/memory.py` per codebase convention.
+
+### `routes/agents.py`
+Agent registry REST endpoints + memory snapshot sub-routes (MTRNIX-270, MTRNIX-272, MTRNIX-323):
+
+Agent CRUD and lifecycle endpoints follow the pattern from `agents/service.py`. Memory snapshot
+endpoints added in MTRNIX-272:
+
+| Method | Path | RBAC | Purpose |
+|--------|------|------|---------|
+| POST | `/api/v1/agents/{id}/reset` | editor+ | Wipe agent memory. Auto `pre_reset` snapshot before wipe. Returns `{snapshot_id, deleted_count}`. 413 on >10k overflow, 422 if snapshot corrupt, 500 with `snapshot_id` in `detail` when wipe fails after snapshot succeeds |
+| POST | `/api/v1/agents/{id}/snapshots` | editor+ | Manual snapshot. Body `{label?: str}`. Returns `MemorySnapshotResponse` (201). 413 on overflow, 422 if corrupt |
+| GET | `/api/v1/agents/{id}/snapshots` | viewer+ | List snapshots for agent, newest-first. Returns `{snapshots, count}` |
+
+Response models: `MemorySnapshotResponse` (id, workspace_id, agent_id, label, trigger, record_count, content_hash, size_bytes, storage_path, created_at); `MemorySnapshotListResponse` ({snapshots, count}).
+Helper `_snapshot_to_response` converts `MemorySnapshot` core model to the response shape.
 
 ### `routes/dashboard/__init__.py`
 Aggregates 3 sub-routers under `/api/v1/dashboard`.

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -31,6 +31,7 @@ from metatron.api.routes import (
     health,
     memory,
     skills,
+    snapshots,
     sync,
     users,
     workspaces,
@@ -345,6 +346,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(users.router, prefix="/api/v1")
     app.include_router(memory.router, prefix="/api/v1")
     app.include_router(agents.router, prefix="/api/v1")
+    app.include_router(snapshots.router, prefix="/api/v1")
 
     from metatron.api.routes.finops import router as finops_router
 

--- a/src/metatron/api/dependencies.py
+++ b/src/metatron/api/dependencies.py
@@ -15,6 +15,7 @@ from metatron.core.config import Settings  # noqa: TC001 — runtime annotations
 if TYPE_CHECKING:
     from metatron.agents.service import AgentRegistryService
     from metatron.memory.service import MemoryService
+    from metatron.memory.snapshot import MemorySnapshotService
 
 
 async def get_settings(request: Request) -> Settings:
@@ -211,3 +212,65 @@ def get_agent_registry_service(request: Request) -> AgentRegistryService:
     services[workspace_id] = service
     request.app.state.agent_registry_services = services
     return service
+
+
+def get_memory_snapshot_service(request: Request) -> MemorySnapshotService:
+    """Return (and lazily construct) a per-workspace :class:`MemorySnapshotService`.
+
+    Shares the PostgreSQL async engine / ``MemoryPostgresStore`` with
+    :func:`get_memory_service` so a single connection pool serves both. The
+    Qdrant store is workspace-scoped (collection name embeds the workspace),
+    so we construct it inline — same pattern as :func:`get_memory_service`.
+    """
+    from pathlib import Path
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from metatron.memory.snapshot import MemorySnapshotService
+    from metatron.storage.memory_postgres import MemoryPostgresStore
+    from metatron.storage.memory_qdrant import MemoryQdrantStore
+
+    settings: Settings = request.app.state.settings
+    workspace_id = _resolve_workspace_id(request)
+
+    services: dict[str, MemorySnapshotService] = getattr(
+        request.app.state,
+        "memory_snapshot_services",
+        {},
+    )
+    cached = services.get(workspace_id)
+    if cached is not None:
+        return cached
+
+    pg_store: MemoryPostgresStore | None = getattr(
+        request.app.state,
+        "memory_pg_store",
+        None,
+    )
+    if pg_store is None:
+        engine = getattr(request.app.state, "memory_pg_engine", None)
+        if engine is None:
+            engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+            request.app.state.memory_pg_engine = engine
+        pg_store = MemoryPostgresStore(engine)
+        request.app.state.memory_pg_store = pg_store
+
+    qdrant_store = MemoryQdrantStore(
+        workspace_id=workspace_id,
+        host=settings.qdrant_host,
+        port=settings.qdrant_http_port,
+    )
+
+    plugin_manager = request.app.state.plugin_manager
+    snapshot_service = MemorySnapshotService(
+        pg_store=pg_store,
+        qdrant_store=qdrant_store,
+        workspace_id=workspace_id,
+        snapshot_dir=Path(settings.snapshot_dir),
+        max_file_bytes=settings.snapshot_max_file_bytes,
+        event_bus=plugin_manager.get_event_bus(),
+    )
+
+    services[workspace_id] = snapshot_service
+    request.app.state.memory_snapshot_services = services
+    return snapshot_service

--- a/src/metatron/api/routes/agents.py
+++ b/src/metatron/api/routes/agents.py
@@ -41,7 +41,7 @@ from metatron.api.dependencies import (
     get_memory_snapshot_service,
 )
 from metatron.auth.dependencies import require_editor, require_viewer
-from metatron.core.exceptions import SnapshotCorruptError
+from metatron.core.exceptions import SnapshotCorruptError, SnapshotOverflowError
 from metatron.core.models import (
     MemorySnapshot,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
     User,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
@@ -470,13 +470,12 @@ async def reset_agent_memory(
             label="auto pre-reset snapshot",
             trigger=SnapshotTrigger.PRE_RESET,
         )
+    except SnapshotOverflowError as exc:
+        # >10k-records guard or on-disk size cap. 413 — request can't be
+        # fulfilled until pagination / size-aware export ships.
+        raise HTTPException(status_code=413, detail=str(exc)) from None
     except SnapshotCorruptError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from None
-    except RuntimeError as exc:
-        # Triggered by the >10k-records overflow guard. 413 is the closest
-        # match — semantically the request can't be fulfilled until paginated
-        # snapshots ship.
-        raise HTTPException(status_code=413, detail=str(exc)) from None
 
     try:
         deleted = await mem_service.reset(reg_service.workspace_id, agent_id=agent_id)
@@ -571,10 +570,10 @@ async def create_agent_snapshot(
             label=body.label,
             trigger=SnapshotTrigger.MANUAL,
         )
+    except SnapshotOverflowError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from None
     except SnapshotCorruptError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from None
-    except RuntimeError as exc:
-        raise HTTPException(status_code=413, detail=str(exc)) from None
     return _snapshot_to_response(snapshot)
 
 

--- a/src/metatron/api/routes/agents.py
+++ b/src/metatron/api/routes/agents.py
@@ -35,9 +35,24 @@ from metatron.agents.service import (
     AgentNotFoundError,
     AgentRegistryService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
 )
-from metatron.api.dependencies import get_agent_registry_service
+from metatron.api.dependencies import (
+    get_agent_registry_service,
+    get_memory_service,
+    get_memory_snapshot_service,
+)
 from metatron.auth.dependencies import require_editor, require_viewer
-from metatron.core.models import User  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+from metatron.core.exceptions import SnapshotCorruptError
+from metatron.core.models import (
+    MemorySnapshot,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+    User,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+)
+from metatron.memory.service import (
+    MemoryService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+)
+from metatron.memory.snapshot import (
+    MemorySnapshotService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+    SnapshotTrigger,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -413,6 +428,177 @@ async def restore_agent(
     except AgentNameConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from None
     return _agent_to_response(record)
+
+
+class ResetAgentMemoryResponse(BaseModel):
+    """Response body for ``POST /agents/{id}/reset``."""
+
+    snapshot_id: str
+    deleted_count: int
+
+
+@router.post(
+    "/{agent_id}/reset",
+    response_model=ResetAgentMemoryResponse,
+    status_code=200,
+)
+async def reset_agent_memory(
+    agent_id: str,
+    user: Annotated[User, Depends(require_editor)],  # noqa: ARG001
+    reg_service: Annotated[AgentRegistryService, Depends(get_agent_registry_service)],
+    mem_service: Annotated[MemoryService, Depends(get_memory_service)],
+    snap_service: Annotated[MemorySnapshotService, Depends(get_memory_snapshot_service)],
+) -> ResetAgentMemoryResponse:
+    """Wipe an agent's memory after taking an automatic ``pre_reset`` snapshot.
+
+    Pre-snapshot is created first — if it fails, the reset never happens, so
+    operators always have an undo point.
+
+    If the wipe itself fails *after* the snapshot was committed, the response
+    is a 500 whose ``detail`` includes the snapshot id so the operator can
+    recover via ``POST /api/v1/snapshots/{snapshot_id}/restore`` rather than
+    being left with an orphaned snapshot row.
+    """
+    try:
+        await reg_service.get_agent(agent_id)  # 404 if unknown
+    except AgentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+
+    try:
+        snapshot = await snap_service.create(
+            agent_id,
+            label="auto pre-reset snapshot",
+            trigger=SnapshotTrigger.PRE_RESET,
+        )
+    except SnapshotCorruptError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+    except RuntimeError as exc:
+        # Triggered by the >10k-records overflow guard. 413 is the closest
+        # match — semantically the request can't be fulfilled until paginated
+        # snapshots ship.
+        raise HTTPException(status_code=413, detail=str(exc)) from None
+
+    try:
+        deleted = await mem_service.reset(reg_service.workspace_id, agent_id=agent_id)
+    except Exception as exc:
+        # The pre_reset snapshot succeeded but the wipe failed — the system
+        # is in a partially-consistent state. Surface the snapshot id so the
+        # operator can either retry the reset or restore from the snapshot.
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "message": (
+                    "reset failed after pre_reset snapshot was taken; "
+                    "use the snapshot id to restore or retry"
+                ),
+                "snapshot_id": snapshot.id,
+                "error": str(exc),
+            },
+        ) from exc
+
+    return ResetAgentMemoryResponse(
+        snapshot_id=snapshot.id,
+        deleted_count=deleted,
+    )
+
+
+class CreateSnapshotRequest(BaseModel):
+    """Request body for creating a manual memory snapshot."""
+
+    model_config = ConfigDict(strict=False)
+
+    label: str = Field("", max_length=256)
+
+
+class MemorySnapshotResponse(BaseModel):
+    """Response shape for a single :class:`MemorySnapshot`."""
+
+    id: str
+    workspace_id: str
+    agent_id: str
+    label: str
+    trigger: str
+    record_count: int
+    content_hash: str
+    size_bytes: int
+    storage_path: str
+    created_at: datetime
+
+
+class MemorySnapshotListResponse(BaseModel):
+    """Response shape for listing snapshots for an agent."""
+
+    snapshots: list[MemorySnapshotResponse]
+    count: int
+
+
+def _snapshot_to_response(snapshot: MemorySnapshot) -> MemorySnapshotResponse:
+    return MemorySnapshotResponse(
+        id=snapshot.id,
+        workspace_id=snapshot.workspace_id,
+        agent_id=snapshot.agent_id,
+        label=snapshot.label,
+        trigger=snapshot.trigger,
+        record_count=snapshot.record_count,
+        content_hash=snapshot.content_hash,
+        size_bytes=snapshot.size_bytes,
+        storage_path=snapshot.storage_path,
+        created_at=snapshot.created_at,
+    )
+
+
+@router.post(
+    "/{agent_id}/snapshots",
+    response_model=MemorySnapshotResponse,
+    status_code=201,
+)
+async def create_agent_snapshot(
+    agent_id: str,
+    body: CreateSnapshotRequest,
+    user: Annotated[User, Depends(require_editor)],  # noqa: ARG001
+    reg_service: Annotated[AgentRegistryService, Depends(get_agent_registry_service)],
+    snap_service: Annotated[MemorySnapshotService, Depends(get_memory_snapshot_service)],
+) -> MemorySnapshotResponse:
+    """Take a manual snapshot of the agent's current memory."""
+    try:
+        await reg_service.get_agent(agent_id)
+    except AgentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+
+    try:
+        snapshot = await snap_service.create(
+            agent_id,
+            label=body.label,
+            trigger=SnapshotTrigger.MANUAL,
+        )
+    except SnapshotCorruptError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+    except RuntimeError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from None
+    return _snapshot_to_response(snapshot)
+
+
+@router.get(
+    "/{agent_id}/snapshots",
+    response_model=MemorySnapshotListResponse,
+)
+async def list_agent_snapshots(
+    agent_id: str,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    reg_service: Annotated[AgentRegistryService, Depends(get_agent_registry_service)],
+    snap_service: Annotated[MemorySnapshotService, Depends(get_memory_snapshot_service)],
+) -> MemorySnapshotListResponse:
+    """List snapshots for an agent, newest first."""
+    try:
+        await reg_service.get_agent(agent_id)
+    except AgentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+
+    snapshots = await snap_service.list_snapshots(agent_id)
+    return MemorySnapshotListResponse(
+        snapshots=[_snapshot_to_response(s) for s in snapshots],
+        count=len(snapshots),
+    )
 
 
 @router.get(

--- a/src/metatron/api/routes/snapshots.py
+++ b/src/metatron/api/routes/snapshots.py
@@ -21,7 +21,11 @@ from pydantic import BaseModel
 from metatron.api.dependencies import get_memory_snapshot_service
 from metatron.api.routes.agents import MemorySnapshotResponse, _snapshot_to_response
 from metatron.auth.dependencies import require_editor, require_viewer
-from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.exceptions import (
+    MemoryNotFoundError,
+    SnapshotCorruptError,
+    SnapshotOverflowError,
+)
 from metatron.core.models import User  # noqa: TC001 — FastAPI Annotated DI needs runtime import
 from metatron.memory.snapshot import (
     DiffKey,
@@ -74,6 +78,12 @@ async def restore_snapshot(
         pre_restore, restored = await snap_service.restore(snapshot_id)
     except MemoryNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from None
+    except SnapshotOverflowError as exc:
+        # The auto pre_restore snapshot tripped the overflow guard — the
+        # agent's current memory exceeds the per-snapshot cap, or the file
+        # cap was lowered after the original snapshot was written. The
+        # restore is aborted before any state changes.
+        raise HTTPException(status_code=413, detail=str(exc)) from None
     except SnapshotCorruptError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from None
     return RestoreSnapshotResponse(

--- a/src/metatron/api/routes/snapshots.py
+++ b/src/metatron/api/routes/snapshots.py
@@ -1,0 +1,119 @@
+"""Snapshot REST API — /api/v1/snapshots (MTRNIX-272).
+
+Endpoints for restoring and diffing memory snapshots. Listing and creation
+live under ``/api/v1/agents/{id}/snapshots`` so the agent context is always
+explicit. The cross-snapshot operations live here because the snapshot id is
+the natural primary key.
+
+Workspace is always derived from the authenticated user — never accepted from
+the request body or query string. A snapshot id from another workspace
+resolves to 404.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from metatron.api.dependencies import get_memory_snapshot_service
+from metatron.api.routes.agents import MemorySnapshotResponse, _snapshot_to_response
+from metatron.auth.dependencies import require_editor, require_viewer
+from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.models import User  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+from metatron.memory.snapshot import (
+    DiffKey,
+    MemorySnapshotService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/snapshots", tags=["snapshots"])
+
+
+class RestoreSnapshotResponse(BaseModel):
+    """Response body for ``POST /snapshots/{id}/restore``."""
+
+    snapshot_id: str
+    pre_restore_snapshot: MemorySnapshotResponse
+    restored_count: int
+
+
+class SnapshotDiffResponse(BaseModel):
+    """Response body for ``GET /snapshots/diff``."""
+
+    from_snapshot_id: str
+    to_snapshot_id: str
+    key: str
+    added: list[str]
+    removed: list[str]
+    changed: list[str]
+
+
+@router.post(
+    "/{snapshot_id}/restore",
+    response_model=RestoreSnapshotResponse,
+)
+async def restore_snapshot(
+    snapshot_id: str,
+    user: Annotated[User, Depends(require_editor)],  # noqa: ARG001
+    snap_service: Annotated[MemorySnapshotService, Depends(get_memory_snapshot_service)],
+) -> RestoreSnapshotResponse:
+    """Replace the agent's memory with the contents of the snapshot.
+
+    Steps (see :class:`MemorySnapshotService.restore`):
+
+    1. Verify SHA-256 of the snapshot file.
+    2. Take an automatic ``pre_restore`` snapshot of current state.
+    3. PG ``BEGIN; DELETE; INSERT; COMMIT``.
+    4. Best-effort Qdrant + Neo4j cleanup and re-population.
+    """
+    try:
+        pre_restore, restored = await snap_service.restore(snapshot_id)
+    except MemoryNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+    except SnapshotCorruptError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+    return RestoreSnapshotResponse(
+        snapshot_id=snapshot_id,
+        pre_restore_snapshot=_snapshot_to_response(pre_restore),
+        restored_count=restored,
+    )
+
+
+@router.get("/diff", response_model=SnapshotDiffResponse)
+async def diff_snapshots(
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    snap_service: Annotated[MemorySnapshotService, Depends(get_memory_snapshot_service)],
+    from_snapshot_id: Annotated[str, Query(alias="from", min_length=1, max_length=128)],
+    to_snapshot_id: Annotated[str, Query(alias="to", min_length=1, max_length=128)],
+    key: Literal["source", "content_hash"] = "source",
+) -> SnapshotDiffResponse:
+    """Compare two snapshots of the same agent.
+
+    Returns ``added`` / ``removed`` / ``changed`` record-id lists. Both
+    snapshots must belong to the bound workspace AND share the same
+    ``agent_id`` — cross-agent diffs return 400.
+    """
+    try:
+        diff = await snap_service.diff(
+            from_snapshot_id,
+            to_snapshot_id,
+            key=DiffKey(key),
+        )
+    except MemoryNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+    except SnapshotCorruptError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    return SnapshotDiffResponse(
+        from_snapshot_id=diff.from_snapshot_id,
+        to_snapshot_id=diff.to_snapshot_id,
+        key=diff.key,
+        added=diff.added,
+        removed=diff.removed,
+        changed=diff.changed,
+    )

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -82,6 +82,13 @@ class Settings(BaseSettings):
     memory_search_session_weight: float = Field(0.1, alias="METATRON_MEMORY_SEARCH_SESSION_WEIGHT")
     memory_search_top_k_multiplier: int = Field(3, alias="METATRON_MEMORY_SEARCH_TOP_K_MULTIPLIER")
 
+    # --- Memory snapshots (WS1 stages 4-5, MTRNIX-272) ---
+    snapshot_dir: str = Field("./data/snapshots", alias="METATRON_SNAPSHOT_DIR")
+    snapshot_max_file_bytes: int = Field(
+        256 * 1024 * 1024,
+        alias="METATRON_SNAPSHOT_MAX_FILE_BYTES",
+    )
+
     # --- Fast search profile (metatron_search_fast MCP tool) ---
     search_fast_top_k: int = Field(10, alias="METATRON_SEARCH_FAST_TOP_K")
     search_fast_include_metadata: bool = Field(

--- a/src/metatron/core/events.py
+++ b/src/metatron/core/events.py
@@ -40,8 +40,10 @@ SYNC_FAILED = "sync_failed"
 #   memory_stored            -> {"workspace_id", "agent_id", "record_id", "scope"}
 #   memory_deleted           -> {"workspace_id", "agent_id", "record_id"}
 #   memory_reset             -> {"workspace_id", "agent_id", "scope", "count"}
-#   memory_snapshot_created  -> {"workspace_id", "agent_id", "snapshot_id", "trigger"}
-#   memory_restored          -> {"workspace_id", "agent_id", "snapshot_id", "count"}
+#   memory_snapshot_created  -> {"workspace_id", "agent_id", "snapshot_id",
+#                                "trigger", "record_count"}
+#   memory_restored          -> {"workspace_id", "agent_id", "snapshot_id",
+#                                "record_count", "pre_restore_snapshot_id"}
 MEMORY_STORED = "memory_stored"
 MEMORY_DELETED = "memory_deleted"
 MEMORY_RESET = "memory_reset"

--- a/src/metatron/core/exceptions.py
+++ b/src/metatron/core/exceptions.py
@@ -69,7 +69,17 @@ class MemoryNotFoundError(AgentMemoryError):
 
 
 class SnapshotCorruptError(AgentMemoryError):
-    """Snapshot content hash mismatch or unreadable payload."""
+    """Snapshot integrity failure — checksum mismatch, manifest mismatch,
+    or malformed JSON.  Reserved strictly for tampered / unreadable payloads;
+    payload-too-large conditions raise :class:`SnapshotOverflowError` instead.
+    """
+
+
+class SnapshotOverflowError(AgentMemoryError):
+    """Snapshot operation cannot proceed because the payload is too large —
+    either the on-disk gzip size exceeds ``METATRON_SNAPSHOT_MAX_FILE_BYTES``
+    or the agent currently has more memory records than the per-snapshot
+    pagination cap. Mapped to HTTP 413 by the routes."""
 
 
 class FreshnessError(MetatronError):

--- a/src/metatron/memory/.claude/CLAUDE.md
+++ b/src/metatron/memory/.claude/CLAUDE.md
@@ -58,6 +58,33 @@ kwarg — when None, the graph-leg post-filter is skipped (safe legacy default).
 
 `MemorySearchWeights` — frozen dataclass (dense=0.6, graph=0.3, session=0.1, top_k_multiplier=3).
 
+### `snapshot.py`
+`MemorySnapshotService` — JSONL+gzip+SHA256 backup/restore for agent memory (MTRNIX-272, WS1 S4-5).
+L3 service. PG is the source of truth; Qdrant and Neo4j are best-effort during restore.
+
+Constructor: `MemorySnapshotService(pg_store, qdrant_store, workspace_id, snapshot_dir, *, max_file_bytes, event_bus?)`
+
+Public methods:
+- `create(agent_id, *, label, trigger) -> MemorySnapshot` — atomic write of gzip+sidecar (tmp+os.replace), calls `pg_store.save_snapshot`. 413-style `RuntimeError` on >10k records; `SnapshotCorruptError` on hash mismatch.
+- `restore(snapshot_id) -> tuple[MemorySnapshot, int]` — returns `(pre_restore_snapshot, restored_count)`. SHA-256 verify → auto `pre_restore` snapshot → `pg_store.replace_for_agent` → best-effort Qdrant+Neo4j repopulation.
+- `get(snapshot_id) -> MemorySnapshot` — fetch snapshot metadata from PG (404 → `MemoryNotFoundError`).
+- `list_snapshots(agent_id) -> list[MemorySnapshot]` — newest-first listing from PG.
+- `diff(from_id, to_id, *, key) -> SnapshotDiff` — compare two snapshots of the same agent. Cross-agent → `ValueError`.
+
+File layout: `{snapshot_dir}/{workspace_id}/{agent_id}/{snapshot_id}.jsonl.gz` + sidecar `{snapshot_id}.sha256`.
+Gzip body is self-describing: line 1 = JSON manifest (`version`, `snapshot_id`, `agent_id`, `workspace_id`, `record_count`, `created_at`); lines 2..N = serialised `MemoryRecord` JSON.
+
+Helper types (also re-exported from `__init__.py`):
+- `SnapshotTrigger(StrEnum)` — `manual | pre_reset | pre_restore`; written to `memory_snapshots.trigger`.
+- `DiffKey(StrEnum)` — `source | content_hash`; controls which field is used as the diff key.
+- `SnapshotDiff(dataclass)` — `from_snapshot_id, to_snapshot_id, key, added, removed, changed` (all id lists).
+
+Key invariants:
+- File writes are atomic (tmp file + `os.replace`) for both gzip and sidecar.
+- `MemoryPostgresStore.replace_for_agent` runs in a single transaction (DELETE + INSERT).
+- Qdrant/Neo4j failures on restore are logged at WARNING and never propagate — PG remains source of truth.
+- Events emitted: `MEMORY_SNAPSHOT_CREATED` (`snapshot_id`, `trigger`, `record_count`) and `MEMORY_RESTORED` (`snapshot_id`, `record_count`, `pre_restore_snapshot_id`).
+
 ### `freshness/` — MTRNIX-304 Phase A
 
 Background lifecycle maintenance for agent memory records. Feature-flagged via
@@ -135,4 +162,4 @@ thin re-export shims for backward compatibility; import from
   (e.g. an MCP-layer `session_boost` signal — see `mcp/tools/memory_search.py`).
 
 ## Public Surface
-`MemoryService`, `MemorySearchService`, `MemorySearchWeights` — re-exported from `__init__.py`.
+`MemoryService`, `MemorySearchService`, `MemorySearchWeights`, `MemorySnapshotService`, `SnapshotDiff`, `SnapshotTrigger`, `DiffKey` — re-exported from `__init__.py`.

--- a/src/metatron/memory/__init__.py
+++ b/src/metatron/memory/__init__.py
@@ -9,11 +9,21 @@ from metatron.memory.assembler import AgentContextAssembler
 from metatron.memory.search import MemorySearchService, MemorySearchWeights
 from metatron.memory.serde import record_from_qdrant_payload
 from metatron.memory.service import MemoryService
+from metatron.memory.snapshot import (
+    DiffKey,
+    MemorySnapshotService,
+    SnapshotDiff,
+    SnapshotTrigger,
+)
 
 __all__ = [
     "AgentContextAssembler",
+    "DiffKey",
     "MemoryService",
     "MemorySearchService",
     "MemorySearchWeights",
+    "MemorySnapshotService",
+    "SnapshotDiff",
+    "SnapshotTrigger",
     "record_from_qdrant_payload",
 ]

--- a/src/metatron/memory/snapshot.py
+++ b/src/metatron/memory/snapshot.py
@@ -10,8 +10,13 @@ Snapshot file layout (under ``settings.snapshot_dir``):
     {workspace_id}/{agent_id}/{snapshot_id}.sha256
 
 The gzip body is self-describing — line 1 is a manifest, lines 2..N are
-serialised :class:`MemoryRecord` JSON. The sidecar holds the SHA-256 hex digest
+serialised :class:`MemoryRecord` JSON.  The sidecar holds the SHA-256 hex digest
 so callers can verify integrity before reading the gzip body.
+
+**Embeddings are intentionally NOT stored in the snapshot.** On restore each
+record goes through :meth:`MemoryQdrantStore.upsert` which re-embeds via the
+configured embedding provider — keeps the file portable across embedding-model
+versions at the cost of a slower restore.
 
 PG is the source of truth — Qdrant + Neo4j are best-effort during restore.
 A failure populating downstream stores is logged but never fails the restore;
@@ -35,7 +40,11 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from metatron.core.events import MEMORY_RESTORED, MEMORY_SNAPSHOT_CREATED
-from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.exceptions import (
+    MemoryNotFoundError,
+    SnapshotCorruptError,
+    SnapshotOverflowError,
+)
 from metatron.core.models import (
     LifecycleStatus,
     MemoryKind,
@@ -44,7 +53,7 @@ from metatron.core.models import (
     MemorySnapshot,
 )
 from metatron.storage.memory_graph import (
-    delete_agent_memories as _graph_delete_agent_memories,
+    delete_memory_node as _graph_delete_memory_node,
 )
 from metatron.storage.memory_graph import (
     save_memory_to_graph as _graph_save_memory,
@@ -180,9 +189,10 @@ def _record_from_json(payload: dict[str, Any]) -> MemoryRecord:
 def _diff_key(record: MemoryRecord, key: DiffKey) -> str:
     """Compute the diff key for a record per the chosen strategy.
 
-    The two strategies use distinct prefixes (``src::`` vs ``id::``) so a
-    record whose ``source_type`` happens to be the literal string ``"id"``
-    cannot collide with a fallback-keyed record.
+    Three distinct prefixes are emitted (``hash::`` for ``CONTENT_HASH``;
+    ``src::`` and ``id::`` for ``SOURCE``) so a record whose ``source_type``
+    happens to be the literal string ``"id"`` or ``"hash"`` cannot collide
+    with a fallback-keyed record.
     """
     if key == DiffKey.CONTENT_HASH:
         return f"hash::{record.content_hash or record.id}"
@@ -300,7 +310,7 @@ class MemorySnapshotService:
         size = tmp_path.stat().st_size
         if size > self._max_file_bytes:
             tmp_path.unlink(missing_ok=True)
-            raise SnapshotCorruptError(
+            raise SnapshotOverflowError(
                 f"snapshot exceeds {self._max_file_bytes} bytes (got {size})"
             )
 
@@ -343,7 +353,7 @@ class MemorySnapshotService:
                 hasher.update(chunk)
                 size += len(chunk)
                 if size > self._max_file_bytes:
-                    raise SnapshotCorruptError(
+                    raise SnapshotOverflowError(
                         f"snapshot exceeds {self._max_file_bytes} bytes — refusing to read"
                     )
         actual = hasher.hexdigest()
@@ -419,7 +429,7 @@ class MemorySnapshotService:
             limit=_LIST_PAGE_LIMIT + 1,
         )
         if len(records) > _LIST_PAGE_LIMIT:
-            raise RuntimeError(
+            raise SnapshotOverflowError(
                 f"snapshot would exceed {_LIST_PAGE_LIMIT} records "
                 f"(found at least {len(records)} for agent {agent_id!r}) — "
                 "pagination not yet supported"
@@ -517,6 +527,20 @@ class MemorySnapshotService:
           7. Emit ``MEMORY_RESTORED``.
 
         Returns ``(pre_restore_snapshot, restored_count)``.
+
+        Caveats (see follow-up issues for the v2 fixes):
+
+        * **Sequential, synchronous** — Qdrant ``upsert`` (re-embeds via the
+          embedding provider) and Neo4j ``save_memory_to_graph`` run one
+          record at a time.  A few hundred records is fine over a typical
+          HTTP request; tens of thousands will exceed the gateway timeout.
+          Track via the planned async-restore follow-up.
+        * **No per-(workspace, agent) lock** — concurrent restores for the
+          same agent are safe in PG (transactional replace) but downstream
+          stores can interleave, leaving Qdrant/Neo4j temporarily showing a
+          mixture of both restores until the next memory write reconciles.
+          Operator-facing endpoint, low real-world concurrency; if needed,
+          gate behind a Redis lock keyed on ``(workspace_id, agent_id)``.
         """
         snapshot = await self.get(snapshot_id)
 
@@ -572,6 +596,10 @@ class MemorySnapshotService:
 
         # 6. Best-effort downstream stores. We never fail the restore here —
         # PG is the source of truth and search is reconciled lazily.
+        # Both Qdrant and Neo4j use per-id deletes from the authoritative
+        # ``deleted_ids`` returned by PG ``DELETE … RETURNING`` — matches the
+        # pattern in ``MemoryService.reset`` and avoids the over-delete bug
+        # of Qdrant's ``delete_by_agent``.
         for rid in deleted_ids:
             try:
                 await self._qdrant.delete(rid)
@@ -579,16 +607,12 @@ class MemorySnapshotService:
                 logger.warning(
                     "snapshot_service.qdrant_delete_failed", record_id=rid, exc_info=True
                 )
-        try:
-            await asyncio.to_thread(
-                _graph_delete_agent_memories, self._workspace_id, snapshot.agent_id
-            )
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "snapshot_service.graph_delete_failed",
-                agent_id=snapshot.agent_id,
-                exc_info=True,
-            )
+            try:
+                await asyncio.to_thread(_graph_delete_memory_node, self._workspace_id, rid)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "snapshot_service.graph_delete_failed", record_id=rid, exc_info=True
+                )
 
         for record in records:
             try:

--- a/src/metatron/memory/snapshot.py
+++ b/src/metatron/memory/snapshot.py
@@ -1,0 +1,697 @@
+"""MemorySnapshotService — JSONL+gzip backup/restore for agent memory (MTRNIX-272).
+
+L3 service. Wraps :class:`MemoryPostgresStore` (metadata + transactional replace),
+:class:`MemoryQdrantStore` (re-embedding on restore), and the Neo4j memory graph
+helpers (best-effort cleanup + re-population).
+
+Snapshot file layout (under ``settings.snapshot_dir``):
+
+    {workspace_id}/{agent_id}/{snapshot_id}.jsonl.gz
+    {workspace_id}/{agent_id}/{snapshot_id}.sha256
+
+The gzip body is self-describing — line 1 is a manifest, lines 2..N are
+serialised :class:`MemoryRecord` JSON. The sidecar holds the SHA-256 hex digest
+so callers can verify integrity before reading the gzip body.
+
+PG is the source of truth — Qdrant + Neo4j are best-effort during restore.
+A failure populating downstream stores is logged but never fails the restore;
+the next memory write or scheduled scan reconciles them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from metatron.core.events import MEMORY_RESTORED, MEMORY_SNAPSHOT_CREATED
+from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.models import (
+    LifecycleStatus,
+    MemoryKind,
+    MemoryRecord,
+    MemoryScope,
+    MemorySnapshot,
+)
+from metatron.storage.memory_graph import (
+    delete_agent_memories as _graph_delete_agent_memories,
+)
+from metatron.storage.memory_graph import (
+    save_memory_to_graph as _graph_save_memory,
+)
+
+if TYPE_CHECKING:
+    from metatron.core.events import EventBus
+    from metatron.storage.memory_postgres import MemoryPostgresStore
+    from metatron.storage.memory_qdrant import MemoryQdrantStore
+
+logger = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+_MANIFEST_VERSION = 1
+_LIST_PAGE_LIMIT = 10_000
+
+
+class SnapshotTrigger(StrEnum):
+    """How a snapshot came to be — written to ``memory_snapshots.trigger``."""
+
+    MANUAL = "manual"
+    PRE_RESET = "pre_reset"
+    PRE_RESTORE = "pre_restore"
+
+
+class DiffKey(StrEnum):
+    """Diff key strategy used by :meth:`MemorySnapshotService.diff`."""
+
+    SOURCE = "source"
+    CONTENT_HASH = "content_hash"
+
+
+@dataclass
+class SnapshotDiff:
+    """Result of comparing two snapshots of the same agent.
+
+    ``added``     — record ids present in ``to`` but not ``from``.
+    ``removed``   — record ids present in ``from`` but not ``to``.
+    ``changed``   — same diff key but different ``content_hash``. Always empty
+                    when ``key=content_hash`` (tautological).
+    """
+
+    from_snapshot_id: str = ""
+    to_snapshot_id: str = ""
+    key: str = DiffKey.SOURCE.value
+    added: list[str] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    changed: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()
+
+
+def _from_iso(raw: Any) -> datetime | None:
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=UTC)
+    return datetime.fromisoformat(str(raw))
+
+
+def _record_to_json(record: MemoryRecord) -> dict[str, Any]:
+    """Serialise MemoryRecord (incl. lifecycle fields) to a JSON-friendly dict."""
+    return {
+        "id": record.id,
+        "workspace_id": record.workspace_id,
+        "agent_id": record.agent_id,
+        "scope": record.scope.value,
+        "kind": record.kind.value,
+        "source_type": record.source_type,
+        "content": record.content,
+        "tags": list(record.tags),
+        "importance_score": record.importance_score,
+        "ttl_expires_at": _iso(record.ttl_expires_at),
+        "content_hash": record.content_hash,
+        "session_id": record.session_id,
+        "metadata": dict(record.metadata),
+        "created_at": _iso(record.created_at),
+        "updated_at": _iso(record.updated_at),
+        "status": record.status.value,
+        "freshness_score": record.freshness_score,
+        "superseded_by": record.superseded_by,
+        "valid_from": _iso(record.valid_from),
+        "valid_until": _iso(record.valid_until),
+        "evidence_count": record.evidence_count,
+        "verification_state": record.verification_state,
+    }
+
+
+def _record_from_json(payload: dict[str, Any]) -> MemoryRecord:
+    """Inverse of :func:`_record_to_json`. Tolerates missing optional fields."""
+    return MemoryRecord(
+        id=str(payload["id"]),
+        workspace_id=str(payload["workspace_id"]),
+        agent_id=str(payload["agent_id"]),
+        scope=MemoryScope(payload.get("scope", MemoryScope.PER_AGENT.value)),
+        kind=MemoryKind(payload.get("kind", MemoryKind.FACT.value)),
+        source_type=str(payload.get("source_type", "")),
+        content=str(payload.get("content", "")),
+        tags=list(payload.get("tags") or []),
+        importance_score=float(payload.get("importance_score", 0.5)),
+        ttl_expires_at=_from_iso(payload.get("ttl_expires_at")),
+        content_hash=str(payload.get("content_hash", "")),
+        created_at=_from_iso(payload.get("created_at")) or datetime.now(UTC),
+        session_id=payload.get("session_id"),
+        metadata=dict(payload.get("metadata") or {}),
+        status=LifecycleStatus(payload.get("status", LifecycleStatus.ACTIVE.value)),
+        freshness_score=float(payload.get("freshness_score", 0.5)),
+        superseded_by=payload.get("superseded_by"),
+        valid_from=_from_iso(payload.get("valid_from")),
+        valid_until=_from_iso(payload.get("valid_until")),
+        evidence_count=int(payload.get("evidence_count", 0)),
+        verification_state=payload.get("verification_state"),
+        updated_at=_from_iso(payload.get("updated_at")),
+    )
+
+
+def _diff_key(record: MemoryRecord, key: DiffKey) -> str:
+    """Compute the diff key for a record per the chosen strategy.
+
+    The two strategies use distinct prefixes (``src::`` vs ``id::``) so a
+    record whose ``source_type`` happens to be the literal string ``"id"``
+    cannot collide with a fallback-keyed record.
+    """
+    if key == DiffKey.CONTENT_HASH:
+        return f"hash::{record.content_hash or record.id}"
+    # SOURCE — fall back to id when the source pair is unset so unscoped
+    # records still appear in the diff (matched only by exact id).
+    source_id = (record.metadata or {}).get("source_id") or ""
+    if record.source_type and source_id:
+        return f"src::{record.source_type}:{source_id}"
+    return f"id::{record.id}"
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class MemorySnapshotService:
+    """Per-workspace orchestrator for snapshot/restore/diff operations."""
+
+    def __init__(
+        self,
+        pg_store: MemoryPostgresStore,
+        qdrant_store: MemoryQdrantStore,
+        *,
+        workspace_id: str,
+        snapshot_dir: Path | str,
+        event_bus: EventBus | None = None,
+        max_file_bytes: int = 256 * 1024 * 1024,
+    ) -> None:
+        self._pg = pg_store
+        self._qdrant = qdrant_store
+        self._workspace_id = workspace_id
+        self._snapshot_dir = Path(snapshot_dir)
+        self._event_bus = event_bus
+        self._max_file_bytes = max_file_bytes
+        self._warned_no_bus = False
+
+    @property
+    def workspace_id(self) -> str:
+        return self._workspace_id
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _agent_dir(self, agent_id: str) -> Path:
+        return self._snapshot_dir / self._workspace_id / agent_id
+
+    def _file_path(self, agent_id: str, snapshot_id: str) -> Path:
+        return self._agent_dir(agent_id) / f"{snapshot_id}.jsonl.gz"
+
+    def _sha_path(self, agent_id: str, snapshot_id: str) -> Path:
+        return self._agent_dir(agent_id) / f"{snapshot_id}.sha256"
+
+    async def _emit(self, name: str, payload: dict[str, Any]) -> None:
+        if self._event_bus is None:
+            if not self._warned_no_bus:
+                logger.warning(
+                    "event_bus_not_wired",
+                    service="MemorySnapshotService",
+                    workspace_id=self._workspace_id,
+                )
+                self._warned_no_bus = True
+            return
+        try:
+            await self._event_bus.emit(name, payload)
+        except Exception:  # noqa: BLE001 — event delivery is best-effort
+            logger.warning("snapshot_service.bus_emit_failed", event=name, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # File IO (sync, run via to_thread)
+    # ------------------------------------------------------------------
+
+    def _write_snapshot_file_sync(
+        self,
+        target: Path,
+        manifest: dict[str, Any],
+        records: list[MemoryRecord],
+    ) -> tuple[str, int]:
+        """Write the gzip body atomically. Returns (sha256_hex, size_bytes).
+
+        Streams to a tmp file in the same directory, then atomic-renames so a
+        crash mid-write never leaves a half-finished snapshot under the final
+        name. SHA-256 is computed over the gzip bytes (i.e. the on-disk body),
+        not the JSONL plaintext, so callers can verify integrity by hashing
+        the file alone.
+        """
+        target.parent.mkdir(parents=True, exist_ok=True)
+        hasher = hashlib.sha256()
+        size = 0
+
+        # delete=False: we close, hash, then atomically rename.
+        with tempfile.NamedTemporaryFile(
+            dir=str(target.parent),
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as raw:
+            tmp_path = Path(raw.name)
+            try:
+                with gzip.GzipFile(fileobj=raw, mode="wb", mtime=0) as gz:
+                    payload = json.dumps(manifest, ensure_ascii=False) + "\n"
+                    gz.write(payload.encode("utf-8"))
+                    for record in records:
+                        line = json.dumps(_record_to_json(record), ensure_ascii=False) + "\n"
+                        gz.write(line.encode("utf-8"))
+                raw.flush()
+                # fsync is inside the try so a failing fsync still triggers
+                # tmp cleanup — otherwise we'd leak a partial file on disk.
+                os.fsync(raw.fileno())
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
+
+        size = tmp_path.stat().st_size
+        if size > self._max_file_bytes:
+            tmp_path.unlink(missing_ok=True)
+            raise SnapshotCorruptError(
+                f"snapshot exceeds {self._max_file_bytes} bytes (got {size})"
+            )
+
+        # Compute SHA-256 over the on-disk gzip bytes.
+        with tmp_path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(64 * 1024), b""):
+                hasher.update(chunk)
+        digest = hasher.hexdigest()
+
+        # Atomic rename of the gzip body.
+        os.replace(tmp_path, target)
+        # Sidecar path mirrors :meth:`_sha_path` — strip the full ``.jsonl.gz``
+        # suffix pair so the cleanup path on PG-save failure finds the same
+        # file we wrote here.
+        sidecar = target.with_name(target.name.replace(".jsonl.gz", ".sha256"))
+        # Atomic sidecar write — write to ``.tmp`` next to the final name and
+        # rename. A crash between the gzip rename and the sidecar rename leaves
+        # NO half-written sidecar; the read path treats a missing sidecar as
+        # "verify against the PG-row checksum only" (still mandatory).
+        tmp_sidecar = sidecar.with_name(sidecar.name + ".tmp")
+        tmp_sidecar.write_text(f"{digest}  {target.name}\n", encoding="utf-8")
+        os.replace(tmp_sidecar, sidecar)
+        return digest, size
+
+    def _read_snapshot_file_sync(
+        self,
+        source: Path,
+        sidecar: Path,
+        expected_digest: str,
+    ) -> tuple[dict[str, Any], list[MemoryRecord]]:
+        """Verify SHA-256 then read manifest + records from the gzip body."""
+        if not source.is_file():
+            raise SnapshotCorruptError(f"snapshot file missing: {source}")
+
+        # Recompute digest on the raw gzip bytes.
+        hasher = hashlib.sha256()
+        size = 0
+        with source.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(64 * 1024), b""):
+                hasher.update(chunk)
+                size += len(chunk)
+                if size > self._max_file_bytes:
+                    raise SnapshotCorruptError(
+                        f"snapshot exceeds {self._max_file_bytes} bytes — refusing to read"
+                    )
+        actual = hasher.hexdigest()
+
+        if expected_digest and actual != expected_digest:
+            raise SnapshotCorruptError(
+                f"snapshot checksum mismatch: expected {expected_digest!r}, got {actual!r}"
+            )
+
+        # Cross-check sidecar when present (defence in depth — protects against
+        # a tampered ``memory_snapshots.content_hash`` row paired with an
+        # equally tampered file).
+        if sidecar.is_file():
+            try:
+                first_token = sidecar.read_text(encoding="utf-8").strip().split()[0]
+            except Exception as exc:
+                raise SnapshotCorruptError(f"sidecar unreadable: {exc}") from exc
+            if first_token != actual:
+                raise SnapshotCorruptError(
+                    f"sidecar checksum mismatch: sidecar={first_token!r} actual={actual!r}"
+                )
+
+        # Now read the body.
+        manifest: dict[str, Any] | None = None
+        records: list[MemoryRecord] = []
+        with gzip.open(source, "rt", encoding="utf-8") as gz:
+            for raw_line in gz:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise SnapshotCorruptError(f"snapshot has invalid JSON: {exc}") from exc
+                if manifest is None:
+                    if obj.get("_kind") != "manifest":
+                        raise SnapshotCorruptError("snapshot is missing manifest line")
+                    manifest = obj
+                else:
+                    records.append(_record_from_json(obj))
+
+        if manifest is None:
+            raise SnapshotCorruptError("snapshot is empty")
+        return manifest, records
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def create(
+        self,
+        agent_id: str,
+        *,
+        label: str = "",
+        trigger: SnapshotTrigger | str = SnapshotTrigger.MANUAL,
+    ) -> MemorySnapshot:
+        """Export current memory for ``agent_id`` to a JSONL+gzip file.
+
+        ``label`` is a free-form name surfaced in the UI / Jira logs.
+        ``trigger`` records *why* the snapshot was taken — set automatically by
+        :meth:`reset` and :meth:`restore` to ``pre_reset`` / ``pre_restore``.
+        """
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        trigger_str = trigger.value if isinstance(trigger, SnapshotTrigger) else str(trigger)
+
+        # +1 sentinel so we can detect overflow vs an exact match. Pagination
+        # for snapshots > 10k records is a planned follow-up; until it lands,
+        # we refuse rather than silently truncate the export.
+        records = await self._pg.list_records(
+            self._workspace_id,
+            agent_id=agent_id,
+            limit=_LIST_PAGE_LIMIT + 1,
+        )
+        if len(records) > _LIST_PAGE_LIMIT:
+            raise RuntimeError(
+                f"snapshot would exceed {_LIST_PAGE_LIMIT} records "
+                f"(found at least {len(records)} for agent {agent_id!r}) — "
+                "pagination not yet supported"
+            )
+
+        snapshot = MemorySnapshot(
+            workspace_id=self._workspace_id,
+            agent_id=agent_id,
+            label=label,
+            trigger=trigger_str,
+            record_count=len(records),
+            created_at=datetime.now(UTC),
+        )
+        target = self._file_path(agent_id, snapshot.id)
+        manifest = {
+            "_kind": "manifest",
+            "version": _MANIFEST_VERSION,
+            "snapshot_id": snapshot.id,
+            "workspace_id": snapshot.workspace_id,
+            "agent_id": snapshot.agent_id,
+            "label": snapshot.label,
+            "trigger": snapshot.trigger,
+            "record_count": snapshot.record_count,
+            "created_at": _iso(snapshot.created_at),
+        }
+
+        digest, size = await asyncio.to_thread(
+            self._write_snapshot_file_sync, target, manifest, records
+        )
+        snapshot.content_hash = digest
+        snapshot.size_bytes = size
+        # Store a path relative to the snapshot root. The actual file path is
+        # always reconstructed from :meth:`_file_path` on read; this column is
+        # informational (UI / log breadcrumbs / future cleanup tooling). Using
+        # a relative form keeps the row valid if the deployment moves
+        # ``METATRON_SNAPSHOT_DIR`` to a new mount.
+        snapshot.storage_path = f"{self._workspace_id}/{snapshot.agent_id}/{snapshot.id}.jsonl.gz"
+
+        try:
+            await self._pg.save_snapshot(snapshot)
+        except Exception:
+            # Roll back the file write so we don't leave an orphan on disk.
+            target.unlink(missing_ok=True)
+            self._sha_path(agent_id, snapshot.id).unlink(missing_ok=True)
+            raise
+
+        await self._emit(
+            MEMORY_SNAPSHOT_CREATED,
+            {
+                "workspace_id": self._workspace_id,
+                "agent_id": agent_id,
+                "snapshot_id": snapshot.id,
+                "trigger": snapshot.trigger,
+                "record_count": snapshot.record_count,
+            },
+        )
+        logger.info(
+            "snapshot_service.created",
+            workspace_id=self._workspace_id,
+            agent_id=agent_id,
+            snapshot_id=snapshot.id,
+            trigger=snapshot.trigger,
+            record_count=snapshot.record_count,
+            size_bytes=size,
+        )
+        return snapshot
+
+    async def get(self, snapshot_id: str) -> MemorySnapshot:
+        """Fetch a snapshot row by id. 404 → :class:`MemoryNotFoundError`."""
+        row = await self._pg.get_snapshot(self._workspace_id, snapshot_id)
+        if row is None:
+            raise MemoryNotFoundError(f"snapshot not found: {snapshot_id}")
+        return row
+
+    async def list_snapshots(self, agent_id: str) -> list[MemorySnapshot]:
+        """List snapshots for an agent, newest first.
+
+        Named ``list_snapshots`` rather than ``list`` so it does not shadow
+        the built-in ``list`` inside type annotations on sibling methods.
+        """
+        return await self._pg.list_snapshots(self._workspace_id, agent_id)
+
+    async def restore(self, snapshot_id: str) -> tuple[MemorySnapshot, int]:
+        """Restore the given snapshot.
+
+        Steps:
+          1. Look up the snapshot row (workspace-scoped — 404 leaks nothing).
+          2. Verify SHA-256 of the file against the stored ``content_hash``
+             (and the sidecar when present).
+          3. Sanity-check the manifest matches the row.
+          4. Take an automatic ``pre_restore`` snapshot of the current agent
+             state — gives the operator a one-step undo.
+          5. PG ``BEGIN; DELETE … WHERE agent_id = ?; INSERT …; COMMIT``.
+          6. Best-effort downstream cleanup + repopulation in Qdrant + Neo4j.
+          7. Emit ``MEMORY_RESTORED``.
+
+        Returns ``(pre_restore_snapshot, restored_count)``.
+        """
+        snapshot = await self.get(snapshot_id)
+
+        # Always derive the file path from the canonical layout, not the
+        # ``storage_path`` column — defence against a tampered PG row.
+        # The manifest + checksum checks would catch a swap, but reading
+        # an attacker-chosen path is a needless first-step risk.
+        source = self._file_path(snapshot.agent_id, snapshot.id)
+        sidecar = self._sha_path(snapshot.agent_id, snapshot.id)
+
+        manifest, records = await asyncio.to_thread(
+            self._read_snapshot_file_sync, source, sidecar, snapshot.content_hash
+        )
+
+        if (
+            manifest.get("workspace_id") != snapshot.workspace_id
+            or manifest.get("agent_id") != snapshot.agent_id
+            or manifest.get("snapshot_id") != snapshot.id
+        ):
+            raise SnapshotCorruptError(
+                "manifest does not match snapshot row "
+                f"(row=({snapshot.workspace_id}, {snapshot.agent_id}, {snapshot.id}), "
+                f"manifest=({manifest.get('workspace_id')}, "
+                f"{manifest.get('agent_id')}, {manifest.get('snapshot_id')}))"
+            )
+        if manifest.get("record_count") != len(records):
+            raise SnapshotCorruptError(
+                f"manifest record_count={manifest.get('record_count')} but "
+                f"file contains {len(records)} records"
+            )
+
+        # 4. Pre-restore auto-snapshot (skipped silently when there's nothing
+        # to back up — first restore on a fresh agent has zero records).
+        pre_restore = await self.create(
+            snapshot.agent_id,
+            label=f"pre-restore of {snapshot.id}",
+            trigger=SnapshotTrigger.PRE_RESTORE,
+        )
+
+        # 5. Transactional replace in PG. ``replace_for_agent`` raises
+        # ValueError if any record has a mismatched workspace_id / agent_id —
+        # that means the file passed checksum + manifest checks but still
+        # contains foreign records. Surface this as a corruption error rather
+        # than a generic 500.
+        try:
+            deleted_ids, inserted_count = await self._pg.replace_for_agent(
+                self._workspace_id, snapshot.agent_id, records
+            )
+        except ValueError as exc:
+            raise SnapshotCorruptError(
+                f"snapshot file contains records with mismatched workspace/agent: {exc}"
+            ) from exc
+
+        # 6. Best-effort downstream stores. We never fail the restore here —
+        # PG is the source of truth and search is reconciled lazily.
+        for rid in deleted_ids:
+            try:
+                await self._qdrant.delete(rid)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "snapshot_service.qdrant_delete_failed", record_id=rid, exc_info=True
+                )
+        try:
+            await asyncio.to_thread(
+                _graph_delete_agent_memories, self._workspace_id, snapshot.agent_id
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "snapshot_service.graph_delete_failed",
+                agent_id=snapshot.agent_id,
+                exc_info=True,
+            )
+
+        for record in records:
+            try:
+                await self._qdrant.upsert(record)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "snapshot_service.qdrant_upsert_failed", record_id=record.id, exc_info=True
+                )
+            try:
+                await asyncio.to_thread(_graph_save_memory, record)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "snapshot_service.graph_save_failed", record_id=record.id, exc_info=True
+                )
+
+        await self._emit(
+            MEMORY_RESTORED,
+            {
+                "workspace_id": self._workspace_id,
+                "agent_id": snapshot.agent_id,
+                "snapshot_id": snapshot.id,
+                "record_count": inserted_count,
+                "pre_restore_snapshot_id": pre_restore.id,
+            },
+        )
+        logger.info(
+            "snapshot_service.restored",
+            workspace_id=self._workspace_id,
+            agent_id=snapshot.agent_id,
+            snapshot_id=snapshot.id,
+            restored=inserted_count,
+            pre_restore_snapshot_id=pre_restore.id,
+        )
+        return pre_restore, inserted_count
+
+    async def diff(
+        self,
+        from_snapshot_id: str,
+        to_snapshot_id: str,
+        *,
+        key: DiffKey | str = DiffKey.SOURCE,
+    ) -> SnapshotDiff:
+        """Compare two snapshots of the same agent.
+
+        Both snapshots must be in the bound workspace and share an
+        ``agent_id``. Mismatches raise :class:`ValueError` (route maps to 400).
+        """
+        if from_snapshot_id == to_snapshot_id:
+            raise ValueError("diff requires two distinct snapshot ids")
+        try:
+            key_kind = DiffKey(key) if not isinstance(key, DiffKey) else key
+        except ValueError as exc:
+            raise ValueError(f"unknown diff key: {key!r}") from exc
+
+        from_snap = await self.get(from_snapshot_id)
+        to_snap = await self.get(to_snapshot_id)
+        if from_snap.agent_id != to_snap.agent_id:
+            raise ValueError(
+                "diff requires same-agent snapshots "
+                f"(from.agent_id={from_snap.agent_id!r}, to.agent_id={to_snap.agent_id!r})"
+            )
+
+        from_records = await self._load_records(from_snap)
+        to_records = await self._load_records(to_snap)
+
+        # key -> (record_id, content_hash)
+        def _index(records: list[MemoryRecord]) -> dict[str, tuple[str, str]]:
+            out: dict[str, tuple[str, str]] = {}
+            for rec in records:
+                out[_diff_key(rec, key_kind)] = (rec.id, rec.content_hash or "")
+            return out
+
+        from_idx = _index(from_records)
+        to_idx = _index(to_records)
+
+        added: list[str] = sorted(rid for k, (rid, _h) in to_idx.items() if k not in from_idx)
+        removed: list[str] = sorted(rid for k, (rid, _h) in from_idx.items() if k not in to_idx)
+        changed: list[str] = []
+        if key_kind == DiffKey.SOURCE:
+            for k, (rid, h) in to_idx.items():
+                prior = from_idx.get(k)
+                if prior is not None and prior[1] != h:
+                    changed.append(rid)
+            changed.sort()
+
+        return SnapshotDiff(
+            from_snapshot_id=from_snapshot_id,
+            to_snapshot_id=to_snapshot_id,
+            key=key_kind.value,
+            added=added,
+            removed=removed,
+            changed=changed,
+        )
+
+    async def _load_records(self, snapshot: MemorySnapshot) -> list[MemoryRecord]:
+        """Read+verify+parse a snapshot file. Used by :meth:`diff`.
+
+        Path is derived from canonical layout (not ``snapshot.storage_path``)
+        to match :meth:`restore` — see the comment there.
+        """
+        source = self._file_path(snapshot.agent_id, snapshot.id)
+        sidecar = self._sha_path(snapshot.agent_id, snapshot.id)
+        _manifest, records = await asyncio.to_thread(
+            self._read_snapshot_file_sync, source, sidecar, snapshot.content_hash
+        )
+        return records

--- a/src/metatron/storage/.claude/claude.md
+++ b/src/metatron/storage/.claude/claude.md
@@ -245,6 +245,7 @@ Class: `MemoryPostgresStore(engine: AsyncEngine)`
 - `delete_snapshot(workspace_id, snapshot_id) -> bool` — delete, returns True if existed
 - `get_snapshot(workspace_id, snapshot_id) -> MemorySnapshot | None`
 - `list_snapshots(workspace_id, agent_id) -> list[MemorySnapshot]`
+- `replace_for_agent(workspace_id, agent_id, records) -> tuple[list[str], int]` — single-transaction DELETE + bulk INSERT used by snapshot restore (MTRNIX-272). Returns `(deleted_ids, inserted_count)`. Validates each record's `workspace_id`/`agent_id` before opening the transaction; raises `ValueError` on mismatch.
 
 ### `freshness_pg.py`
 PostgreSQL store for freshness pipeline machinery — review queue (`review_entries`)

--- a/src/metatron/storage/memory_postgres.py
+++ b/src/metatron/storage/memory_postgres.py
@@ -616,6 +616,96 @@ class MemoryPostgresStore:
         logger.info("memory_pg.reset", workspace_id=workspace_id, count=count)
         return count, ids
 
+    async def replace_for_agent(
+        self,
+        workspace_id: str,
+        agent_id: str,
+        records: list[MemoryRecord],
+    ) -> tuple[list[str], int]:
+        """Atomically wipe and re-insert all memory rows for an agent (MTRNIX-272).
+
+        Used by snapshot restore. Runs DELETE + N×INSERT in a single
+        transaction so a failure mid-way leaves PG in its prior state.
+
+        ``records`` may carry lifecycle columns (``status``, ``freshness_score``,
+        …); all are written back verbatim so a restore preserves the snapshot's
+        lifecycle state, not just the basic fields.
+
+        Returns ``(deleted_ids, inserted_count)``.
+        """
+        for r in records:
+            if r.workspace_id != workspace_id or r.agent_id != agent_id:
+                msg = (
+                    "replace_for_agent: record workspace/agent mismatch "
+                    f"(record={r.id} ws={r.workspace_id!r} agent={r.agent_id!r}, "
+                    f"target ws={workspace_id!r} agent={agent_id!r})"
+                )
+                raise ValueError(msg)
+
+        async with self._engine.begin() as conn:
+            del_result = await conn.execute(
+                text(
+                    "DELETE FROM memory_records "
+                    "WHERE workspace_id = :ws AND agent_id = :agent_id "
+                    "RETURNING id"
+                ),
+                {"ws": workspace_id, "agent_id": agent_id},
+            )
+            deleted_ids = [str(r[0]) for r in del_result.fetchall()]
+
+            if records:
+                await conn.execute(
+                    text(
+                        f"""
+                        INSERT INTO memory_records ({_RECORD_COLUMNS})
+                        VALUES (:id, :workspace_id, :agent_id, :scope, :kind,
+                                :source_type, :content, CAST(:tags AS jsonb),
+                                :importance_score, :ttl_expires_at, :content_hash,
+                                :session_id, CAST(:metadata AS jsonb),
+                                :created_at, :updated_at,
+                                :status, :freshness_score, :superseded_by,
+                                :valid_from, :valid_until,
+                                :evidence_count, :verification_state)
+                        """
+                    ),
+                    [
+                        {
+                            "id": r.id,
+                            "workspace_id": r.workspace_id,
+                            "agent_id": r.agent_id,
+                            "scope": r.scope.value,
+                            "kind": r.kind.value,
+                            "source_type": r.source_type,
+                            "content": r.content,
+                            "tags": json.dumps(r.tags),
+                            "importance_score": r.importance_score,
+                            "ttl_expires_at": r.ttl_expires_at,
+                            "content_hash": r.content_hash,
+                            "session_id": r.session_id,
+                            "metadata": json.dumps(r.metadata),
+                            "created_at": r.created_at,
+                            "updated_at": r.updated_at or r.created_at,
+                            "status": r.status.value,
+                            "freshness_score": r.freshness_score,
+                            "superseded_by": r.superseded_by,
+                            "valid_from": r.valid_from,
+                            "valid_until": r.valid_until,
+                            "evidence_count": r.evidence_count,
+                            "verification_state": r.verification_state,
+                        }
+                        for r in records
+                    ],
+                )
+
+        logger.info(
+            "memory_pg.replaced_for_agent",
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            deleted=len(deleted_ids),
+            inserted=len(records),
+        )
+        return deleted_ids, len(records)
+
     # ------------------------------------------------------------------
     # Dedup + TTL
     # ------------------------------------------------------------------

--- a/tests/unit/api/test_snapshot_routes.py
+++ b/tests/unit/api/test_snapshot_routes.py
@@ -26,7 +26,11 @@ from metatron.api.routes.agents import router as agents_router
 from metatron.api.routes.snapshots import router as snapshots_router
 from metatron.auth.dependencies import get_current_user
 from metatron.core.config import Settings
-from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.exceptions import (
+    MemoryNotFoundError,
+    SnapshotCorruptError,
+    SnapshotOverflowError,
+)
 from metatron.core.models import MemorySnapshot, Role, User
 from metatron.memory.service import MemoryService
 from metatron.memory.snapshot import MemorySnapshotService, SnapshotDiff
@@ -204,7 +208,7 @@ class TestResetAgent:
         snap_service: AsyncMock,
     ) -> None:
         reg_service.get_agent.return_value = _sample_agent()
-        snap_service.create.side_effect = RuntimeError(
+        snap_service.create.side_effect = SnapshotOverflowError(
             "snapshot would exceed 10000 records (found at least 10001 for agent 'agent-1')"
         )
 
@@ -300,13 +304,31 @@ class TestCreateSnapshot:
         snap_service: AsyncMock,
     ) -> None:
         reg_service.get_agent.return_value = _sample_agent()
-        snap_service.create.side_effect = RuntimeError("would exceed 10000 records")
+        snap_service.create.side_effect = SnapshotOverflowError("would exceed 10000 records")
 
         response = client.post(
             "/api/v1/agents/agent-1/snapshots",
             json={"label": "manual"},
         )
         assert response.status_code == 413
+
+    def test_unrelated_runtime_error_still_500(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        # A bare RuntimeError (not SnapshotOverflowError) should NOT be
+        # silently mapped to 413 — it must surface as 500. Guards against
+        # the over-broad ``except RuntimeError`` flagged in PR review.
+        reg_service.get_agent.return_value = _sample_agent()
+        snap_service.create.side_effect = RuntimeError("disk full or other bug")
+
+        response = client.post(
+            "/api/v1/agents/agent-1/snapshots",
+            json={"label": "manual"},
+        )
+        assert response.status_code == 500
 
     def test_422_on_corrupt(
         self,
@@ -389,6 +411,22 @@ class TestRestoreSnapshot:
         snap_service.restore.side_effect = SnapshotCorruptError("bad checksum")
         response = client.post("/api/v1/snapshots/bad/restore")
         assert response.status_code == 422
+
+    def test_413_when_pre_restore_snapshot_overflows(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        # restore() internally takes a pre_restore snapshot. If the agent's
+        # current memory grew past the per-snapshot cap since the original
+        # snapshot was taken, that internal create() raises
+        # SnapshotOverflowError — must surface as 413 rather than 500.
+        snap_service.restore.side_effect = SnapshotOverflowError(
+            "snapshot would exceed 10000 records"
+        )
+        response = client.post("/api/v1/snapshots/snap-1/restore")
+        assert response.status_code == 413
+        assert "10000" in response.json()["detail"]
 
     def test_viewer_blocked(self, make_client: Callable[..., TestClient]) -> None:
         client = make_client(Role.VIEWER)

--- a/tests/unit/api/test_snapshot_routes.py
+++ b/tests/unit/api/test_snapshot_routes.py
@@ -1,0 +1,449 @@
+"""Tests for snapshot REST endpoints (MTRNIX-272).
+
+Covers /api/v1/agents/{id}/reset, /api/v1/agents/{id}/snapshots POST + GET,
+/api/v1/snapshots/{id}/restore, and /api/v1/snapshots/diff. Uses dependency
+overrides so no real PG / Qdrant / FS access happens.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from metatron.agents.models import AgentRecord, AgentStatus
+from metatron.agents.service import AgentNotFoundError, AgentRegistryService
+from metatron.api.dependencies import (
+    get_agent_registry_service,
+    get_memory_service,
+    get_memory_snapshot_service,
+)
+from metatron.api.routes.agents import router as agents_router
+from metatron.api.routes.snapshots import router as snapshots_router
+from metatron.auth.dependencies import get_current_user
+from metatron.core.config import Settings
+from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.models import MemorySnapshot, Role, User
+from metatron.memory.service import MemoryService
+from metatron.memory.snapshot import MemorySnapshotService, SnapshotDiff
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=False,
+        METATRON_SECRET_KEY="test-secret",
+    )
+
+
+def _make_user(role: Role = Role.EDITOR) -> User:
+    return User(
+        id="u1",
+        username="tester",
+        email="t@example.com",
+        role=role,
+        workspace_ids=["ws-test"],
+    )
+
+
+def _sample_agent() -> AgentRecord:
+    return AgentRecord(
+        id="agent-1",
+        workspace_id="ws-test",
+        name="Trader",
+        status=AgentStatus.STOPPED,
+        model="gpt-4",
+        config_version=1,
+        current_config={
+            "name": "Trader",
+            "model": "gpt-4",
+            "capabilities": [],
+            "tools": [],
+            "memory_bindings": {},
+            "budget": {},
+        },
+        created_by="u1",
+        created_at=datetime(2026, 5, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+
+
+def _sample_snapshot(
+    snapshot_id: str = "snap-1",
+    *,
+    agent_id: str = "agent-1",
+    trigger: str = "manual",
+    record_count: int = 3,
+) -> MemorySnapshot:
+    return MemorySnapshot(
+        id=snapshot_id,
+        workspace_id="ws-test",
+        agent_id=agent_id,
+        label="snap label",
+        trigger=trigger,
+        record_count=record_count,
+        content_hash="deadbeef",
+        size_bytes=1024,
+        storage_path=f"/tmp/{snapshot_id}.jsonl.gz",
+        created_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def reg_service() -> AsyncMock:
+    return AsyncMock(spec=AgentRegistryService)
+
+
+@pytest.fixture
+def mem_service() -> AsyncMock:
+    return AsyncMock(spec=MemoryService)
+
+
+@pytest.fixture
+def snap_service() -> AsyncMock:
+    return AsyncMock(spec=MemorySnapshotService)
+
+
+@pytest.fixture
+def make_client(
+    settings: Settings,
+    reg_service: AsyncMock,
+    mem_service: AsyncMock,
+    snap_service: AsyncMock,
+) -> Callable[..., TestClient]:
+    def _factory(role: Role = Role.EDITOR) -> TestClient:
+        app = FastAPI()
+        app.state.settings = settings
+        app.include_router(agents_router, prefix="/api/v1")
+        app.include_router(snapshots_router, prefix="/api/v1")
+        app.dependency_overrides[get_agent_registry_service] = lambda: reg_service
+        app.dependency_overrides[get_memory_service] = lambda: mem_service
+        app.dependency_overrides[get_memory_snapshot_service] = lambda: snap_service
+        app.dependency_overrides[get_current_user] = lambda: _make_user(role=role)
+
+        @app.middleware("http")
+        async def _inject_user(request, call_next):  # type: ignore[no-untyped-def]
+            request.state.user = {"workspace_ids": ["ws-test"]}
+            return await call_next(request)
+
+        return TestClient(app, raise_server_exceptions=False)
+
+    return _factory
+
+
+@pytest.fixture
+def client(make_client: Callable[..., TestClient]) -> TestClient:
+    return make_client(Role.EDITOR)
+
+
+# ---------------------------------------------------------------------------
+# POST /agents/{id}/reset
+# ---------------------------------------------------------------------------
+
+
+class TestResetAgent:
+    def test_creates_pre_reset_snapshot_then_resets(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        mem_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.return_value = _sample_agent()
+        snapshot = _sample_snapshot(trigger="pre_reset")
+        snap_service.create.return_value = snapshot
+        mem_service.reset.return_value = 7
+
+        response = client.post("/api/v1/agents/agent-1/reset")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"snapshot_id": snapshot.id, "deleted_count": 7}
+        snap_service.create.assert_awaited_once()
+        mem_service.reset.assert_awaited_once()
+        # Snapshot is created BEFORE reset so a snapshot failure never leaves
+        # state wiped without backup.
+        assert snap_service.create.await_args.args[0] == "agent-1"
+
+    def test_404_when_agent_unknown(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        mem_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.side_effect = AgentNotFoundError("nope")
+
+        response = client.post("/api/v1/agents/agent-x/reset")
+
+        assert response.status_code == 404
+        snap_service.create.assert_not_awaited()
+        mem_service.reset.assert_not_awaited()
+
+    def test_viewer_blocked(
+        self,
+        make_client: Callable[..., TestClient],
+    ) -> None:
+        client = make_client(Role.VIEWER)
+        response = client.post("/api/v1/agents/agent-1/reset")
+        assert response.status_code == 403
+
+    def test_413_when_snapshot_overflows(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        mem_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.return_value = _sample_agent()
+        snap_service.create.side_effect = RuntimeError(
+            "snapshot would exceed 10000 records (found at least 10001 for agent 'agent-1')"
+        )
+
+        response = client.post("/api/v1/agents/agent-1/reset")
+
+        assert response.status_code == 413
+        assert "10000" in response.json()["detail"]
+        # No reset happens when the snapshot fails.
+        mem_service.reset.assert_not_awaited()
+
+    def test_422_when_snapshot_corrupt(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        mem_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.return_value = _sample_agent()
+        snap_service.create.side_effect = SnapshotCorruptError("file too big")
+
+        response = client.post("/api/v1/agents/agent-1/reset")
+
+        assert response.status_code == 422
+        mem_service.reset.assert_not_awaited()
+
+    def test_500_carries_snapshot_id_when_reset_fails(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        mem_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        # Pre-snapshot succeeds, then the wipe blows up. Operator must see
+        # the snapshot id in the error so they can recover via /restore.
+        reg_service.get_agent.return_value = _sample_agent()
+        snapshot = _sample_snapshot(trigger="pre_reset")
+        snap_service.create.return_value = snapshot
+        mem_service.reset.side_effect = RuntimeError("PG connection lost")
+
+        response = client.post("/api/v1/agents/agent-1/reset")
+
+        assert response.status_code == 500
+        detail = response.json()["detail"]
+        assert detail["snapshot_id"] == snapshot.id
+        assert "PG connection lost" in detail["error"]
+        assert "use the snapshot id" in detail["message"]
+
+
+# ---------------------------------------------------------------------------
+# POST /agents/{id}/snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSnapshot:
+    def test_201_returns_snapshot(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.return_value = _sample_agent()
+        snap_service.create.return_value = _sample_snapshot()
+
+        response = client.post(
+            "/api/v1/agents/agent-1/snapshots",
+            json={"label": "manual"},
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["id"] == "snap-1"
+        assert body["agent_id"] == "agent-1"
+        assert body["trigger"] == "manual"
+
+    def test_404_when_agent_unknown(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.side_effect = AgentNotFoundError("nope")
+
+        response = client.post(
+            "/api/v1/agents/agent-x/snapshots",
+            json={"label": "manual"},
+        )
+
+        assert response.status_code == 404
+
+    def test_413_on_overflow(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.return_value = _sample_agent()
+        snap_service.create.side_effect = RuntimeError("would exceed 10000 records")
+
+        response = client.post(
+            "/api/v1/agents/agent-1/snapshots",
+            json={"label": "manual"},
+        )
+        assert response.status_code == 413
+
+    def test_422_on_corrupt(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.return_value = _sample_agent()
+        snap_service.create.side_effect = SnapshotCorruptError("oversize")
+
+        response = client.post(
+            "/api/v1/agents/agent-1/snapshots",
+            json={"label": "manual"},
+        )
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /agents/{id}/snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestListSnapshots:
+    def test_lists_newest_first(
+        self,
+        client: TestClient,
+        reg_service: AsyncMock,
+        snap_service: AsyncMock,
+    ) -> None:
+        reg_service.get_agent.return_value = _sample_agent()
+        snap_service.list_snapshots.return_value = [
+            _sample_snapshot("snap-2"),
+            _sample_snapshot("snap-1"),
+        ]
+
+        response = client.get("/api/v1/agents/agent-1/snapshots")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 2
+        assert [s["id"] for s in body["snapshots"]] == ["snap-2", "snap-1"]
+
+
+# ---------------------------------------------------------------------------
+# POST /snapshots/{id}/restore
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreSnapshot:
+    def test_returns_pre_restore_and_count(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        pre_restore = _sample_snapshot("snap-pre", trigger="pre_restore")
+        snap_service.restore.return_value = (pre_restore, 5)
+
+        response = client.post("/api/v1/snapshots/snap-1/restore")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["snapshot_id"] == "snap-1"
+        assert body["restored_count"] == 5
+        assert body["pre_restore_snapshot"]["id"] == "snap-pre"
+
+    def test_404_when_snapshot_missing(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.restore.side_effect = MemoryNotFoundError("no")
+        response = client.post("/api/v1/snapshots/missing/restore")
+        assert response.status_code == 404
+
+    def test_422_when_corrupt(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.restore.side_effect = SnapshotCorruptError("bad checksum")
+        response = client.post("/api/v1/snapshots/bad/restore")
+        assert response.status_code == 422
+
+    def test_viewer_blocked(self, make_client: Callable[..., TestClient]) -> None:
+        client = make_client(Role.VIEWER)
+        response = client.post("/api/v1/snapshots/snap-1/restore")
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /snapshots/diff
+# ---------------------------------------------------------------------------
+
+
+class TestDiff:
+    def test_200_with_diff_payload(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.diff.return_value = SnapshotDiff(
+            from_snapshot_id="a",
+            to_snapshot_id="b",
+            key="source",
+            added=["r2"],
+            removed=["r1"],
+            changed=["r3"],
+        )
+        response = client.get("/api/v1/snapshots/diff?from=a&to=b")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["added"] == ["r2"]
+        assert body["removed"] == ["r1"]
+        assert body["changed"] == ["r3"]
+        assert body["key"] == "source"
+
+    def test_400_on_cross_agent(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.diff.side_effect = ValueError("same-agent only")
+        response = client.get("/api/v1/snapshots/diff?from=a&to=b")
+        assert response.status_code == 400
+
+    def test_404_when_snapshot_missing(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.diff.side_effect = MemoryNotFoundError("no")
+        response = client.get("/api/v1/snapshots/diff?from=a&to=b")
+        assert response.status_code == 404
+
+    def test_invalid_key_rejected_by_pydantic(
+        self,
+        client: TestClient,
+    ) -> None:
+        response = client.get("/api/v1/snapshots/diff?from=a&to=b&key=invalid")
+        assert response.status_code == 422

--- a/tests/unit/memory/test_snapshot_service.py
+++ b/tests/unit/memory/test_snapshot_service.py
@@ -13,7 +13,11 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
-from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.exceptions import (
+    MemoryNotFoundError,
+    SnapshotCorruptError,
+    SnapshotOverflowError,
+)
 from metatron.core.models import (
     LifecycleStatus,
     MemoryKind,
@@ -186,11 +190,13 @@ class TestCreate:
         service, pg, _ = service_factory(max_file_bytes=10)
         pg.list_records.return_value = [_record("r1", content="x" * 10_000)]
 
-        with pytest.raises(SnapshotCorruptError, match="exceeds"):
+        # Oversize is an "overflow" condition, not corruption — see
+        # SnapshotOverflowError vs SnapshotCorruptError split in core/exceptions.
+        with pytest.raises(SnapshotOverflowError, match="exceeds"):
             await service.create("agent1")
         pg.save_snapshot.assert_not_awaited()
 
-    async def test_workspace_mismatch_raises(self, service_factory) -> None:
+    async def test_create_rejects_empty_agent_id(self, service_factory) -> None:
         service, _, _ = service_factory(workspace_id="ws1")
         with pytest.raises(ValueError, match="agent_id is required"):
             await service.create("")
@@ -199,7 +205,7 @@ class TestCreate:
         service, pg, _ = service_factory()
         # Service requests limit=10001 to detect overflow; mock returns 10001.
         pg.list_records.return_value = [_record(f"r{i}") for i in range(10_001)]
-        with pytest.raises(RuntimeError, match="exceed"):
+        with pytest.raises(SnapshotOverflowError, match="exceed"):
             await service.create("agent1")
         pg.save_snapshot.assert_not_awaited()
 

--- a/tests/unit/memory/test_snapshot_service.py
+++ b/tests/unit/memory/test_snapshot_service.py
@@ -1,0 +1,461 @@
+"""Tests for MemorySnapshotService (MTRNIX-272)."""
+
+from __future__ import annotations
+
+import gzip
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from metatron.core.exceptions import MemoryNotFoundError, SnapshotCorruptError
+from metatron.core.models import (
+    LifecycleStatus,
+    MemoryKind,
+    MemoryRecord,
+    MemoryScope,
+    MemorySnapshot,
+)
+from metatron.memory.snapshot import (
+    DiffKey,
+    MemorySnapshotService,
+    SnapshotTrigger,
+)
+
+
+def _record(
+    record_id: str,
+    *,
+    agent_id: str = "agent1",
+    workspace_id: str = "ws1",
+    content: str = "",
+    content_hash: str = "",
+    source_type: str = "",
+    source_id: str = "",
+) -> MemoryRecord:
+    return MemoryRecord(
+        id=record_id,
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        scope=MemoryScope.PER_AGENT,
+        kind=MemoryKind.FACT,
+        source_type=source_type,
+        content=content or f"content of {record_id}",
+        tags=["t1"],
+        importance_score=0.7,
+        content_hash=content_hash or f"hash-of-{record_id}",
+        created_at=datetime(2026, 5, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 1, tzinfo=UTC),
+        metadata={"source_id": source_id} if source_id else {},
+        status=LifecycleStatus.ACTIVE,
+    )
+
+
+def _snapshot_row(
+    *,
+    snapshot_id: str,
+    agent_id: str,
+    workspace_id: str,
+    storage_path: str,
+    content_hash: str,
+    record_count: int,
+    label: str = "",
+    trigger: str = SnapshotTrigger.MANUAL.value,
+    size_bytes: int = 0,
+) -> MemorySnapshot:
+    return MemorySnapshot(
+        id=snapshot_id,
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        label=label,
+        trigger=trigger,
+        record_count=record_count,
+        content_hash=content_hash,
+        size_bytes=size_bytes,
+        storage_path=storage_path,
+        created_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def service_factory(tmp_path: Path):
+    """Build a MemorySnapshotService with mocked pg/qdrant stores."""
+
+    def _make(
+        workspace_id: str = "ws1",
+        max_file_bytes: int = 256 * 1024 * 1024,
+    ) -> tuple[MemorySnapshotService, AsyncMock, AsyncMock]:
+        pg = AsyncMock()
+        qdrant = AsyncMock()
+        # Default: no records in PG.
+        pg.list_records.return_value = []
+        # Default: save_snapshot returns the input untouched.
+        pg.save_snapshot.side_effect = lambda s: s
+        # Default: replace_for_agent reports no deletes, the inserted count.
+        pg.replace_for_agent.side_effect = lambda ws, ag, recs: ([], len(recs))
+        service = MemorySnapshotService(
+            pg_store=pg,
+            qdrant_store=qdrant,
+            workspace_id=workspace_id,
+            snapshot_dir=tmp_path,
+            max_file_bytes=max_file_bytes,
+        )
+        return service, pg, qdrant
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    async def test_writes_jsonl_gz_and_sidecar(self, service_factory, tmp_path: Path) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1"), _record("r2")]
+
+        snapshot = await service.create("agent1", label="manual snap")
+
+        target = tmp_path / "ws1" / "agent1" / f"{snapshot.id}.jsonl.gz"
+        sidecar = tmp_path / "ws1" / "agent1" / f"{snapshot.id}.sha256"
+        assert target.is_file()
+        assert sidecar.is_file()
+        assert snapshot.record_count == 2
+        assert snapshot.size_bytes > 0
+        assert snapshot.content_hash, "content_hash must be set"
+        # Sidecar starts with the same digest.
+        assert sidecar.read_text(encoding="utf-8").startswith(snapshot.content_hash)
+
+    async def test_writes_manifest_as_first_line(self, service_factory, tmp_path: Path) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1")]
+
+        snapshot = await service.create("agent1")
+
+        # storage_path is relative to the snapshot root since MTRNIX-272 v2.
+        target = tmp_path / snapshot.storage_path
+        with gzip.open(target, "rt", encoding="utf-8") as fh:
+            lines = fh.readlines()
+        assert len(lines) == 2  # manifest + 1 record
+        manifest = json.loads(lines[0])
+        assert manifest["_kind"] == "manifest"
+        assert manifest["agent_id"] == "agent1"
+        assert manifest["workspace_id"] == "ws1"
+        assert manifest["snapshot_id"] == snapshot.id
+        assert manifest["record_count"] == 1
+        body = json.loads(lines[1])
+        assert body["id"] == "r1"
+        assert body["status"] == "active"
+
+    async def test_persists_metadata_row(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = []
+
+        snapshot = await service.create("agent1", trigger=SnapshotTrigger.PRE_RESET)
+
+        pg.save_snapshot.assert_awaited_once()
+        saved = pg.save_snapshot.await_args.args[0]
+        assert saved.id == snapshot.id
+        assert saved.agent_id == "agent1"
+        assert saved.workspace_id == "ws1"
+        assert saved.trigger == SnapshotTrigger.PRE_RESET.value
+        assert saved.content_hash == snapshot.content_hash
+
+    async def test_rolls_back_file_when_pg_save_fails(
+        self, service_factory, tmp_path: Path
+    ) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1")]
+        pg.save_snapshot.side_effect = RuntimeError("pg down")
+
+        with pytest.raises(RuntimeError, match="pg down"):
+            await service.create("agent1")
+
+        # No leftover gzip + sidecar.
+        agent_dir = tmp_path / "ws1" / "agent1"
+        assert not any(agent_dir.glob("*.jsonl.gz"))
+        assert not any(agent_dir.glob("*.sha256"))
+
+    async def test_rejects_oversized_file(self, service_factory) -> None:
+        service, pg, _ = service_factory(max_file_bytes=10)
+        pg.list_records.return_value = [_record("r1", content="x" * 10_000)]
+
+        with pytest.raises(SnapshotCorruptError, match="exceeds"):
+            await service.create("agent1")
+        pg.save_snapshot.assert_not_awaited()
+
+    async def test_workspace_mismatch_raises(self, service_factory) -> None:
+        service, _, _ = service_factory(workspace_id="ws1")
+        with pytest.raises(ValueError, match="agent_id is required"):
+            await service.create("")
+
+    async def test_refuses_when_pg_returns_more_than_10k(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        # Service requests limit=10001 to detect overflow; mock returns 10001.
+        pg.list_records.return_value = [_record(f"r{i}") for i in range(10_001)]
+        with pytest.raises(RuntimeError, match="exceed"):
+            await service.create("agent1")
+        pg.save_snapshot.assert_not_awaited()
+
+    async def test_emits_snapshot_created_event(self, service_factory) -> None:
+        bus = AsyncMock()
+        service, pg, _ = service_factory()
+        # Inject the bus after construction for terseness.
+        service._event_bus = bus
+        pg.list_records.return_value = [_record("r1")]
+
+        snapshot = await service.create("agent1")
+
+        bus.emit.assert_awaited_once()
+        event_name, payload = bus.emit.await_args.args
+        assert event_name == "memory_snapshot_created"
+        assert payload == {
+            "workspace_id": "ws1",
+            "agent_id": "agent1",
+            "snapshot_id": snapshot.id,
+            "trigger": SnapshotTrigger.MANUAL.value,
+            "record_count": 1,
+        }
+
+
+# ---------------------------------------------------------------------------
+# get / list
+# ---------------------------------------------------------------------------
+
+
+class TestGetList:
+    async def test_get_404(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.get_snapshot.return_value = None
+
+        with pytest.raises(MemoryNotFoundError):
+            await service.get("missing-id")
+
+    async def test_get_workspace_scoped(self, service_factory) -> None:
+        service, pg, _ = service_factory(workspace_id="ws1")
+        pg.get_snapshot.return_value = None
+
+        with pytest.raises(MemoryNotFoundError):
+            await service.get("snap-from-other-ws")
+
+        # PG store was queried with the bound workspace id (cross-ws lookup
+        # is the PG store's responsibility, but we assert the service passes
+        # the right workspace).
+        pg.get_snapshot.assert_awaited_once_with("ws1", "snap-from-other-ws")
+
+    async def test_list_delegates_to_pg(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_snapshots.return_value = []
+        await service.list_snapshots("agent1")
+        pg.list_snapshots.assert_awaited_once_with("ws1", "agent1")
+
+
+# ---------------------------------------------------------------------------
+# restore
+# ---------------------------------------------------------------------------
+
+
+class TestRestore:
+    async def test_round_trip(self, service_factory) -> None:
+        service, pg, qdrant = service_factory()
+        records = [_record("r1"), _record("r2")]
+        pg.list_records.return_value = records
+
+        snapshot = await service.create("agent1", label="initial")
+
+        # Reset pg fixture to act as the read-back target for restore.
+        pg.list_records.return_value = []  # no records before restore (state was reset)
+        pg.get_snapshot.return_value = snapshot
+
+        pre_restore, restored = await service.restore(snapshot.id)
+
+        assert restored == 2
+        assert pre_restore.trigger == SnapshotTrigger.PRE_RESTORE.value
+        # PG.replace_for_agent was called with the original record list.
+        pg.replace_for_agent.assert_awaited()
+        ws, ag, recs = pg.replace_for_agent.await_args.args
+        assert ws == "ws1"
+        assert ag == "agent1"
+        assert sorted(r.id for r in recs) == ["r1", "r2"]
+        # Qdrant upsert called per restored record.
+        assert qdrant.upsert.await_count == 2
+
+    async def test_404_when_snapshot_missing(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.get_snapshot.return_value = None
+
+        with pytest.raises(MemoryNotFoundError):
+            await service.restore("missing")
+
+    async def test_rejects_tampered_file(self, service_factory, tmp_path: Path) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1")]
+        snapshot = await service.create("agent1")
+        pg.get_snapshot.return_value = snapshot
+
+        # Flip a byte deep into the gzip body.
+        target = tmp_path / snapshot.storage_path
+        data = bytearray(target.read_bytes())
+        data[-1] ^= 0xFF
+        target.write_bytes(bytes(data))
+
+        with pytest.raises(SnapshotCorruptError):
+            await service.restore(snapshot.id)
+
+    async def test_rejects_workspace_mismatch_in_manifest(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1")]
+        snapshot = await service.create("agent1")
+
+        # Forge a sibling row that lies about the workspace.
+        forged = _snapshot_row(
+            snapshot_id=snapshot.id,
+            agent_id=snapshot.agent_id,
+            workspace_id="ws-other",  # mismatch
+            storage_path=snapshot.storage_path,
+            content_hash=snapshot.content_hash,
+            record_count=snapshot.record_count,
+        )
+        pg.get_snapshot.return_value = forged
+
+        with pytest.raises(SnapshotCorruptError, match="manifest"):
+            await service.restore(snapshot.id)
+
+    async def test_replace_value_error_becomes_corrupt(self, service_factory) -> None:
+        # If the snapshot file passed checksum + manifest but somehow contains
+        # records with foreign workspace/agent (defence in depth), the service
+        # surfaces this as a corruption error so the route returns 422.
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1")]
+        snapshot = await service.create("agent1")
+        pg.get_snapshot.return_value = snapshot
+        pg.replace_for_agent.side_effect = ValueError("workspace/agent mismatch")
+
+        with pytest.raises(SnapshotCorruptError, match="mismatched"):
+            await service.restore(snapshot.id)
+
+    async def test_emits_memory_restored_event(self, service_factory) -> None:
+        bus = AsyncMock()
+        service, pg, _ = service_factory()
+        service._event_bus = bus
+        pg.list_records.return_value = [_record("r1"), _record("r2")]
+        snapshot = await service.create("agent1")
+        pg.get_snapshot.return_value = snapshot
+        pg.replace_for_agent.side_effect = lambda ws, ag, recs: ([], len(recs))
+
+        bus.emit.reset_mock()
+        await service.restore(snapshot.id)
+
+        # Two emits — pre_restore create, then restored.
+        events = [call.args[0] for call in bus.emit.await_args_list]
+        assert "memory_snapshot_created" in events
+        assert "memory_restored" in events
+        restored_payload = next(
+            call.args[1] for call in bus.emit.await_args_list if call.args[0] == "memory_restored"
+        )
+        assert set(restored_payload.keys()) == {
+            "workspace_id",
+            "agent_id",
+            "snapshot_id",
+            "record_count",
+            "pre_restore_snapshot_id",
+        }
+        assert restored_payload["record_count"] == 2
+
+    async def test_pre_restore_snapshot_recorded(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1")]
+        snapshot = await service.create("agent1")
+        pg.get_snapshot.return_value = snapshot
+        # After create, list_records is reused; reset it to model 'current'
+        # state captured by the pre-restore snapshot.
+        pg.list_records.return_value = [_record("current-r")]
+
+        await service.restore(snapshot.id)
+
+        # save_snapshot called twice — initial + pre_restore.
+        assert pg.save_snapshot.await_count == 2
+        triggers = [call.args[0].trigger for call in pg.save_snapshot.await_args_list]
+        assert triggers == [SnapshotTrigger.MANUAL.value, SnapshotTrigger.PRE_RESTORE.value]
+
+
+# ---------------------------------------------------------------------------
+# diff
+# ---------------------------------------------------------------------------
+
+
+class TestDiff:
+    async def _make_two_snapshots(
+        self,
+        service_factory,
+        from_records: list[MemoryRecord],
+        to_records: list[MemoryRecord],
+    ) -> tuple[MemorySnapshotService, AsyncMock, MemorySnapshot, MemorySnapshot]:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = from_records
+        from_snap = await service.create("agent1", label="from")
+        pg.list_records.return_value = to_records
+        to_snap = await service.create("agent1", label="to")
+        # diff() will call get() for both ids — set a mapping side_effect.
+        snapshots = {from_snap.id: from_snap, to_snap.id: to_snap}
+        pg.get_snapshot.side_effect = lambda ws, sid: snapshots.get(sid)
+        return service, pg, from_snap, to_snap
+
+    async def test_added_removed_changed_by_source(self, service_factory) -> None:
+        # from: r1(unchanged), r2(will-be-changed), r3(will-be-removed)
+        # to:   r1(unchanged), r2_v2(content_hash differs but same source),
+        #       r4(added)
+        from_records = [
+            _record("r1", source_type="conv", source_id="s1", content_hash="h1"),
+            _record("r2", source_type="conv", source_id="s2", content_hash="h2"),
+            _record("r3", source_type="conv", source_id="s3", content_hash="h3"),
+        ]
+        to_records = [
+            _record("r1", source_type="conv", source_id="s1", content_hash="h1"),
+            _record("r2_v2", source_type="conv", source_id="s2", content_hash="h2-changed"),
+            _record("r4", source_type="conv", source_id="s4", content_hash="h4"),
+        ]
+        service, _pg, from_snap, to_snap = await self._make_two_snapshots(
+            service_factory, from_records, to_records
+        )
+
+        diff = await service.diff(from_snap.id, to_snap.id, key=DiffKey.SOURCE)
+
+        assert diff.added == ["r4"]
+        assert diff.removed == ["r3"]
+        assert diff.changed == ["r2_v2"]
+
+    async def test_changed_empty_when_keying_by_content_hash(self, service_factory) -> None:
+        from_records = [_record("r1", content_hash="h1")]
+        to_records = [_record("r2", content_hash="h2")]
+        service, _pg, from_snap, to_snap = await self._make_two_snapshots(
+            service_factory, from_records, to_records
+        )
+
+        diff = await service.diff(from_snap.id, to_snap.id, key=DiffKey.CONTENT_HASH)
+
+        assert diff.added == ["r2"]
+        assert diff.removed == ["r1"]
+        assert diff.changed == []  # tautological
+
+    async def test_rejects_cross_agent(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = []
+        a1 = await service.create("agent1")
+        a2 = await service.create("agent2")
+        snapshots = {a1.id: a1, a2.id: a2}
+        pg.get_snapshot.side_effect = lambda ws, sid: snapshots.get(sid)
+
+        with pytest.raises(ValueError, match="same-agent"):
+            await service.diff(a1.id, a2.id)
+
+    async def test_rejects_same_id(self, service_factory) -> None:
+        service, _, _ = service_factory()
+        with pytest.raises(ValueError, match="distinct"):
+            await service.diff("snap-x", "snap-x")

--- a/tests/unit/test_memory_postgres.py
+++ b/tests/unit/test_memory_postgres.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from metatron.core.models import MemoryRecord, MemoryScope, MemorySnapshot
 from metatron.storage.memory_postgres import MemoryPostgresStore
 
@@ -308,6 +310,57 @@ class TestReset:
         sql_text = str(conn.execute.call_args.args[0])
         assert "scope" in sql_text
         assert "RETURNING id" in sql_text
+
+
+# ===========================================================================
+# replace_for_agent (MTRNIX-272)
+# ===========================================================================
+
+
+class TestReplaceForAgent:
+    async def test_atomic_delete_and_insert(self) -> None:
+        store, engine = _make_store()
+        conn = AsyncMock()
+        delete_result = MagicMock()
+        deleted_row = MagicMock()
+        deleted_row.__getitem__ = lambda self, i: "id-old"
+        delete_result.fetchall.return_value = [deleted_row]
+        insert_result = MagicMock()
+        conn.execute.side_effect = [delete_result, insert_result]
+        engine.begin.return_value = _FakeCtx(conn)
+
+        records = [_sample_record(id="id-new")]
+        deleted_ids, inserted = await store.replace_for_agent("ws1", "agent1", records)
+
+        assert deleted_ids == ["id-old"]
+        assert inserted == 1
+        # Two execute calls: DELETE, then INSERT.
+        assert conn.execute.await_count == 2
+        delete_sql = str(conn.execute.await_args_list[0].args[0])
+        insert_sql = str(conn.execute.await_args_list[1].args[0])
+        assert "DELETE FROM memory_records" in delete_sql
+        assert "INSERT INTO memory_records" in insert_sql
+
+    async def test_skips_insert_when_no_records(self) -> None:
+        store, engine = _make_store()
+        conn = AsyncMock()
+        delete_result = MagicMock()
+        delete_result.fetchall.return_value = []
+        conn.execute.return_value = delete_result
+        engine.begin.return_value = _FakeCtx(conn)
+
+        deleted_ids, inserted = await store.replace_for_agent("ws1", "agent1", [])
+
+        assert deleted_ids == []
+        assert inserted == 0
+        # Only the DELETE ran.
+        assert conn.execute.await_count == 1
+
+    async def test_rejects_workspace_or_agent_mismatch(self) -> None:
+        store, _ = _make_store()
+        bad = _sample_record(workspace_id="ws-other")
+        with pytest.raises(ValueError, match="workspace/agent mismatch"):
+            await store.replace_for_agent("ws1", "agent1", [bad])
 
 
 # ===========================================================================


### PR DESCRIPTION
MemorySnapshotService — JSONL+gzip+SHA256 backup/restore for agent memory. Atomic file write (tmp+rename for both gzip and sidecar), pre-reset/pre-restore auto-snapshots, transactional PG replace via MemoryPostgresStore.replace_for_agent, best-effort Qdrant + Neo4j re-population. REST endpoints under /api/v1/agents/{id}/{reset,snapshots} and /api/v1/snapshots/{id}/restore + /diff. Same-agent diff only. RuntimeError on >10k overflow -> 413; SnapshotCorruptError -> 422; reset failure after pre_reset snapshot returns 500 with snapshot_id in detail for operator recovery. Storage path is relative to METATRON_SNAPSHOT_DIR.

Also: add /logs/ to .gitignore.