### PR TITLE
окfeat(MTRNIX-330): snapshot record batch read for diff UI

### DIFF
--- a/src/metatron/api/routes/snapshots.py
+++ b/src/metatron/api/routes/snapshots.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from metatron.api.dependencies import get_memory_snapshot_service
 from metatron.api.routes.agents import MemorySnapshotResponse, _snapshot_to_response
+from metatron.api.routes.memory import MemoryRecordResponse, _record_to_response
 from metatron.auth.dependencies import require_editor, require_viewer
 from metatron.core.exceptions import (
     MemoryNotFoundError,
@@ -31,6 +32,8 @@ from metatron.memory.snapshot import (
     DiffKey,
     MemorySnapshotService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
 )
+
+_MAX_RECORD_IDS_PER_REQUEST = 200
 
 logger = structlog.get_logger(__name__)
 
@@ -54,6 +57,14 @@ class SnapshotDiffResponse(BaseModel):
     added: list[str]
     removed: list[str]
     changed: list[str]
+
+
+class SnapshotRecordsResponse(BaseModel):
+    """Response body for ``GET /snapshots/{id}/records``."""
+
+    snapshot_id: str
+    records: list[MemoryRecordResponse]
+    count: int
 
 
 @router.post(
@@ -126,4 +137,50 @@ async def diff_snapshots(
         added=diff.added,
         removed=diff.removed,
         changed=diff.changed,
+    )
+
+
+@router.get(
+    "/{snapshot_id}/records",
+    response_model=SnapshotRecordsResponse,
+)
+async def read_snapshot_records(
+    snapshot_id: str,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    snap_service: Annotated[MemorySnapshotService, Depends(get_memory_snapshot_service)],
+    ids: Annotated[
+        list[str],
+        Query(
+            alias="ids",
+            min_length=1,
+            max_length=_MAX_RECORD_IDS_PER_REQUEST,
+        ),
+    ],
+) -> SnapshotRecordsResponse:
+    """Resolve record ids inside a snapshot back to full records.
+
+    Built for the diff UI: ``GET /snapshots/diff`` returns id lists; the FE
+    lazily fetches full records on expand. Records are read from the
+    snapshot file (SHA-256 verified), **not** from live memory — a record
+    that was deleted between the two diffed snapshots no longer exists
+    under ``GET /memory/records/{id}``, but it does still exist inside
+    the older snapshot.
+
+    ``ids`` is required (1..200 ids per request). There is no
+    "give me everything" mode on this endpoint — a consumer that needs
+    the full snapshot must drive it from a diff / list call and pass
+    explicit ids. Unknown ids are silently dropped — the caller already
+    knows what it asked for and can surface the gap if needed.
+    """
+    try:
+        records = await snap_service.read_records(snapshot_id, ids=ids)
+    except MemoryNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+    except SnapshotCorruptError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+    response_records = [_record_to_response(rec) for rec in records]
+    return SnapshotRecordsResponse(
+        snapshot_id=snapshot_id,
+        records=response_records,
+        count=len(response_records),
     )

--- a/src/metatron/memory/snapshot.py
+++ b/src/metatron/memory/snapshot.py
@@ -719,3 +719,47 @@ class MemorySnapshotService:
             self._read_snapshot_file_sync, source, sidecar, snapshot.content_hash
         )
         return records
+
+    async def read_records(
+        self,
+        snapshot_id: str,
+        *,
+        ids: list[str] | None = None,
+    ) -> list[MemoryRecord]:
+        """Read records from a snapshot file, optionally filtered by id.
+
+        Built for the diff-UI flow: ``GET /snapshots/diff`` returns only id
+        lists, and the FE lazily resolves visible ids to full records.
+        Reading from the snapshot file (rather than ``GET /memory/records``)
+        is mandatory — ``removed`` records may no longer exist in live
+        memory, and ``changed`` records would return the *current* version
+        instead of the snapshot-time version.
+
+        Service-level contract:
+
+        * ``ids=None`` returns every record in the file. The HTTP route
+          does NOT expose this mode — it is kept only for in-process /
+          test callers.
+        * ``ids=[]`` returns an empty list (distinct from ``None``).
+        * Unknown ids are silently dropped — the caller already knows
+          what it asked for and can surface the gap if needed.
+
+        File is SHA-256 verified by :meth:`_load_records` before parsing.
+        """
+        snapshot = await self.get(snapshot_id)
+        records = await self._load_records(snapshot)
+        if ids is None:
+            returned = records
+        else:
+            wanted = set(ids)
+            returned = [r for r in records if r.id in wanted]
+        logger.info(
+            "snapshot_service.records_read",
+            workspace_id=self._workspace_id,
+            agent_id=snapshot.agent_id,
+            snapshot_id=snapshot.id,
+            requested_ids_count=len(ids) if ids is not None else None,
+            returned_count=len(returned),
+            file_record_count=len(records),
+        )
+        return returned

--- a/tests/unit/api/test_snapshot_routes.py
+++ b/tests/unit/api/test_snapshot_routes.py
@@ -31,7 +31,15 @@ from metatron.core.exceptions import (
     SnapshotCorruptError,
     SnapshotOverflowError,
 )
-from metatron.core.models import MemorySnapshot, Role, User
+from metatron.core.models import (
+    LifecycleStatus,
+    MemoryKind,
+    MemoryRecord,
+    MemoryScope,
+    MemorySnapshot,
+    Role,
+    User,
+)
 from metatron.memory.service import MemoryService
 from metatron.memory.snapshot import MemorySnapshotService, SnapshotDiff
 
@@ -485,3 +493,111 @@ class TestDiff:
     ) -> None:
         response = client.get("/api/v1/snapshots/diff?from=a&to=b&key=invalid")
         assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /snapshots/{id}/records
+# ---------------------------------------------------------------------------
+
+
+def _memory_record(record_id: str = "r1") -> MemoryRecord:
+    return MemoryRecord(
+        id=record_id,
+        workspace_id="ws-test",
+        agent_id="agent-1",
+        scope=MemoryScope.PER_AGENT,
+        kind=MemoryKind.FACT,
+        source_type="conv",
+        content=f"content of {record_id}",
+        tags=["t1"],
+        importance_score=0.5,
+        content_hash=f"hash-{record_id}",
+        created_at=datetime(2026, 5, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 1, tzinfo=UTC),
+        status=LifecycleStatus.ACTIVE,
+    )
+
+
+class TestReadSnapshotRecords:
+    def test_returns_records_for_given_ids(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.read_records.return_value = [
+            _memory_record("r1"),
+            _memory_record("r3"),
+        ]
+
+        response = client.get("/api/v1/snapshots/snap-1/records?ids=r1&ids=r3")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["snapshot_id"] == "snap-1"
+        assert body["count"] == 2
+        assert [r["id"] for r in body["records"]] == ["r1", "r3"]
+        # Service was called with the parsed id list and the snapshot id.
+        snap_service.read_records.assert_awaited_once_with("snap-1", ids=["r1", "r3"])
+
+    def test_422_when_ids_missing(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        # ids is required — there is no "give me everything" mode on the
+        # HTTP surface. A consumer that wants the full snapshot must drive
+        # it from a diff or list-records call and pass explicit ids.
+        # FastAPI/Pydantic raises 422 for missing required query params.
+        response = client.get("/api/v1/snapshots/snap-1/records")
+
+        assert response.status_code == 422
+        snap_service.read_records.assert_not_awaited()
+
+    def test_rejects_too_many_ids(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        # Cap protects bandwidth + per-request payload size; an FE that needs
+        # more must page through batches. Pydantic max_length validation kicks
+        # in before the route body, so this is a 422 (validation error).
+        many = "&".join(f"ids=r{i}" for i in range(201))
+        response = client.get(f"/api/v1/snapshots/snap-1/records?{many}")
+
+        assert response.status_code == 422
+        snap_service.read_records.assert_not_awaited()
+
+    def test_404_when_snapshot_missing(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.read_records.side_effect = MemoryNotFoundError("no")
+
+        response = client.get("/api/v1/snapshots/missing/records?ids=r1")
+
+        assert response.status_code == 404
+
+    def test_422_when_corrupt(
+        self,
+        client: TestClient,
+        snap_service: AsyncMock,
+    ) -> None:
+        snap_service.read_records.side_effect = SnapshotCorruptError("bad checksum")
+
+        response = client.get("/api/v1/snapshots/bad/records?ids=r1")
+
+        assert response.status_code == 422
+
+    def test_viewer_allowed(
+        self,
+        make_client: Callable[..., TestClient],
+        snap_service: AsyncMock,
+    ) -> None:
+        # Read-only — viewer can resolve snapshot record content for diff UI.
+        snap_service.read_records.return_value = [_memory_record("r1")]
+        viewer_client = make_client(Role.VIEWER)
+
+        response = viewer_client.get("/api/v1/snapshots/snap-1/records?ids=r1")
+
+        assert response.status_code == 200

--- a/tests/unit/memory/test_snapshot_service.py
+++ b/tests/unit/memory/test_snapshot_service.py
@@ -465,3 +465,88 @@ class TestDiff:
         service, _, _ = service_factory()
         with pytest.raises(ValueError, match="distinct"):
             await service.diff("snap-x", "snap-x")
+
+
+# ---------------------------------------------------------------------------
+# read_records
+# ---------------------------------------------------------------------------
+
+
+class TestReadRecords:
+    async def test_returns_all_records_when_ids_omitted(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1"), _record("r2"), _record("r3")]
+        snap = await service.create("agent1")
+        pg.get_snapshot.return_value = snap
+
+        records = await service.read_records(snap.id)
+
+        assert sorted(r.id for r in records) == ["r1", "r2", "r3"]
+
+    async def test_filters_by_ids(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1"), _record("r2"), _record("r3")]
+        snap = await service.create("agent1")
+        pg.get_snapshot.return_value = snap
+
+        records = await service.read_records(snap.id, ids=["r1", "r3"])
+
+        assert sorted(r.id for r in records) == ["r1", "r3"]
+
+    async def test_unknown_ids_silently_skipped(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1"), _record("r2")]
+        snap = await service.create("agent1")
+        pg.get_snapshot.return_value = snap
+
+        # Asking for a mix of present + absent ids returns only the present ones.
+        # Caller decides how to surface the gap (the diff UI already knows
+        # which ids it asked for).
+        records = await service.read_records(snap.id, ids=["r1", "ghost"])
+
+        assert [r.id for r in records] == ["r1"]
+
+    async def test_empty_id_filter_returns_empty_list(self, service_factory) -> None:
+        # Distinguishes "give me everything" (ids=None) from "give me nothing"
+        # (ids=[]) — important so an FE that built an empty filter list does
+        # not accidentally pull the whole snapshot.
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1"), _record("r2")]
+        snap = await service.create("agent1")
+        pg.get_snapshot.return_value = snap
+
+        records = await service.read_records(snap.id, ids=[])
+
+        assert records == []
+
+    async def test_404_when_snapshot_missing(self, service_factory) -> None:
+        service, pg, _ = service_factory()
+        pg.get_snapshot.return_value = None
+
+        with pytest.raises(MemoryNotFoundError):
+            await service.read_records("missing-id")
+
+    async def test_rejects_tampered_file(self, service_factory, tmp_path: Path) -> None:
+        # Same SHA-256 path as restore/diff — a tampered file must not be
+        # exposed via read_records either.
+        service, pg, _ = service_factory()
+        pg.list_records.return_value = [_record("r1")]
+        snap = await service.create("agent1")
+        pg.get_snapshot.return_value = snap
+
+        target = tmp_path / snap.storage_path
+        data = bytearray(target.read_bytes())
+        data[-1] ^= 0xFF
+        target.write_bytes(bytes(data))
+
+        with pytest.raises(SnapshotCorruptError):
+            await service.read_records(snap.id)
+
+    async def test_workspace_scoped(self, service_factory) -> None:
+        service, pg, _ = service_factory(workspace_id="ws1")
+        pg.get_snapshot.return_value = None
+
+        with pytest.raises(MemoryNotFoundError):
+            await service.read_records("snap-from-other-ws")
+
+        pg.get_snapshot.assert_awaited_once_with("ws1", "snap-from-other-ws")


### PR DESCRIPTION
Add GET /api/v1/snapshots/{snapshot_id}/records?ids=... so the diff UI can lazily resolve record ids returned by /snapshots/diff back to full records — read from the snapshot file (SHA-256 verified), not from live memory, since `removed` records may no longer exist live and `changed` ones would return the current version instead of the snapshot-time one.

- MemorySnapshotService.read_records(snapshot_id, *, ids=None) — public wrapper around the existing _load_records; in-process callers may pass ids=None for "everything".
- Route requires `ids` (1..200 per request, Pydantic min_length/max_length). No "all" mode on HTTP — paginate from a diff/list call instead.
- viewer+ RBAC; 404 on missing/cross-workspace, 422 on corrupt file.
- Reuses MemoryRecordResponse + _record_to_response from routes/memory so FE can render snapshot records with the same component as live records.

Tests: 13 new (7 service + 6 route) covering happy path, id filter, unknown-id drop, missing-snapshot, tampered file, workspace isolation, required-ids 422, max-ids 422, viewer-allowed.