### PR TITLE
feat(memory-scopes): Phase 1 — unified knowledge endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- feat(memory-scopes): unified knowledge view in Memory Inspector — new `GET /api/v1/knowledge/records?origin=agent|kb|all` endpoint that fans out across `memory_records` and `raw_documents`. `origin=all` uses `asyncio.gather` with partial-failure semantics (one leg down → 200 + `partial=true`; both down → 503). New L3 module `knowledge/` provides the `RawDocumentReadService` read facade. Zero schema migrations; zero new env vars; no changes to existing memory, MCP, or freshness surfaces. Audit: `docs/superpowers/2026-05-12-memory-scopes-audit.md`.
 - feat(MTRNIX-277): per-agent memory health observability — `GET /api/v1/agents/{id}/memory/health` (viewer+, read-only) returns total ACTIVE / archived counts, 30-day growth timeseries (`growth_timeseries`), unused-record count (`unused_records`), near-duplicate cluster metrics (`duplicate_ratio`, `duplicate_clusters_count`) via SimHash + hamming distance, and source-type distribution. Adds `last_accessed_at` (TIMESTAMPTZ) and `content_simhash` (BIGINT) columns to `memory_records` (migration 021); hybrid search updates `last_accessed_at` fire-and-forget after every result set. Backfill script at `scripts/backfill_memory_simhash.py`. New env vars: `METATRON_MEMORY_STALE_AFTER_DAYS` (30), `METATRON_MEMORY_DUPLICATE_HAMMING_THRESHOLD` (3). Foundation for the W9 memory-health dashboard.
 - feat: Memory snapshot/restore/diff for agent memory (MTRNIX-272, WS1 S4-5).
   `MemorySnapshotService` — JSONL+gzip+SHA256 backups with atomic file write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,8 @@ pytest tests/unit/test_search.py::test_name -v  # single test
 L6  api/            REST + OAI-compat + MCP HTTP mount (FastAPI routes, middleware)
 L5  channels/       [LEGACY] Telegram, Discord, Slack bots — moving out, do NOT extend
 L4  agent/          Intent router, commands, executor (memory_service now a shim -> memory/service.py)
-L3  services        connectors/, llm/, mcp/, memory/, auth/, workspaces/, agents/
+L3  services        connectors/, llm/, mcp/, memory/, auth/, workspaces/, agents/,
+                    knowledge/ — [NEW] read-only facade over raw_documents
                     [INACTIVE] skills/ — engine unimplemented, kept as reserved capability
 L2  processing      ingestion/, retrieval/
                     [OPTIONAL] benchmarker/ — dev-eval tool, may move out of core
@@ -58,6 +59,11 @@ L0  core/           Config, Interfaces, Models, Events, Plugin (ZERO upward deps
 ```
 
 `memory/` (L3) is the first-class new module built in WS1. See `src/metatron/memory/.claude/CLAUDE.md`.
+
+`knowledge/` (L3) is a read-only facade over `raw_documents`. It backs the unified
+`/api/v1/knowledge/records` endpoint that merges agent memory and KB documents for the
+Memory Inspector. Does NOT bridge to `memory_records`; sources stay separate at the storage
+layer and are only merged at the view layer. See `src/metatron/knowledge/.claude/CLAUDE.md`.
 Legacy markers reflect the 2026-04 product transition — details and migration plan in `docs/LEGACY.md`.
 
 `freshness/` (L3) is a shared submodule (promoted from `memory/freshness/` in MTRNIX-313) — the
@@ -125,6 +131,10 @@ src/metatron/
 │                              #   memory/freshness/): stages/ (linker, reconciler, monitor,
 │                              #   curator), coordination.py, decision_engine.py, apply_decision.py,
 │                              #   metrics.py, targets.py (FreshnessTarget protocol).
+├── knowledge/                 # L3 — [NEW] Read-only facade over raw_documents.
+│                              #   service.py (RawDocumentReadService) — list/count raw_documents
+│                              #   filtered by workspace_id, backs /api/v1/knowledge/records.
+│                              #   No writes, no ingestion, no bridge to memory_records.
 ├── agents/                    # L3 — Agent Registry (WS4, MTRNIX-270): models.py (AgentRecord,
 │                              #   AgentStatus), service.py (AgentRegistryService), persistence.py
 │                              #   (PG store). CRUD + lifecycle flag + versioned config. Hermes
@@ -357,6 +367,13 @@ Today agent memory is not automatically added to /v1/chat/completions context.
   restored_count}`. 404 if missing, 422 if corrupt.
   `GET /diff?from=<id>&to=<id>&key=source|content_hash` (viewer+) — compare two snapshots of the
   **same agent** (cross-agent → 400). Returns `{added, removed, changed}` record-id lists.
+- `/api/v1/knowledge/records` — unified read view across `memory_records` (origin=agent) and
+  `raw_documents` (origin=kb). Workspace-scoped, `require_viewer`. Query params: `origin=agent|kb|all`
+  (default `all`), `limit`, `offset`. Returns `KnowledgeRecordListResponse` with records tagged
+  `origin: "agent"|"kb"`, plus `partial: bool` and `failed_sources: list[Literal["agent","kb"]]`.
+  `origin=all` fans out via `asyncio.gather`: one leg failing → 200 with `partial=true`; both legs
+  failing → 503. `origin` is endpoint-derived, NOT a DB column. Pagination is approximate under
+  `origin=all` (per-leg fetch + merge + truncate). Backs the Memory Inspector unified view.
 - `/api/v1/documents`, `/api/v1/search` — document CRUD + search
 - `/api/v1/workspaces`, `/api/v1/connections`, `/api/v1/sync` — admin surfaces
 
@@ -408,6 +425,11 @@ Alembic in `migrations/`. Run `make migrate` after pulling. Create new: `make mi
 - Assume "workspace == KB tenant" forever — the agent-era model separates company from agent; `agent_id` is becoming a first-class field in memory records
 - Invest in the **enterprise RBAC plugin** — it is **frozen / DEPRECATED** as of 2026-04-25 (D-014 in the strategy ADR). Its model attaches permissions to ingestion; the correct model attaches permissions to documents/chunks at retrieval time. For multi-team isolation use **workspace isolation** (D-016). Permission Model v2 lives in the backlog with a "first enterprise client" trigger.
 - Treat memory records as flat. The next memory work introduces a `kind` enum (`fact` / `preference` / `pinned`, D-017) — `preference` and `pinned` are always-on, never-vanishing entries injected into the agent prompt without retrieval. New memory features must respect this categorisation; do NOT bury preferences in the same `memory_search` flow as facts.
+- Add an `origin` column to `memory_records` or `raw_documents`. `origin` is endpoint-derived (which
+  source returned the row — `"agent"` vs `"kb"`); it is computed by `/api/v1/knowledge/records` at
+  response time, not stored anywhere. The orthogonal `visibility / lifetime / kind` axes for
+  `memory_records` are planned for later memory-scopes work (separate from the `kind` rollout
+  in MTRNIX-275).
 - Bypass the **Agent Context Assembler** (D-020) once it lands. Both Hermes (via MCP wrapper) and `/v1/chat/completions` will go through one assembler that imposes `<constitution>` / `<preferences>` / `<relevant_memories>` / `<relevant_knowledge>` section boundaries. New consumers must use it; ad-hoc prompt assembly is forbidden.
 
 ## Agent Teams

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -29,6 +29,7 @@ from metatron.api.routes import (
     files,
     graph,
     health,
+    knowledge,
     memory,
     skills,
     snapshots,
@@ -345,6 +346,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(config.router, prefix="/api/v1")
     app.include_router(users.router, prefix="/api/v1")
     app.include_router(memory.router, prefix="/api/v1")
+    app.include_router(knowledge.router, prefix="/api/v1")
     app.include_router(agents.router, prefix="/api/v1")
     app.include_router(snapshots.router, prefix="/api/v1")
 

--- a/src/metatron/api/dependencies.py
+++ b/src/metatron/api/dependencies.py
@@ -14,6 +14,7 @@ from metatron.core.config import Settings  # noqa: TC001 — runtime annotations
 
 if TYPE_CHECKING:
     from metatron.agents.service import AgentRegistryService
+    from metatron.knowledge.service import RawDocumentReadService
     from metatron.memory.health import MemoryHealthService
     from metatron.memory.service import MemoryService
     from metatron.memory.snapshot import MemorySnapshotService
@@ -323,3 +324,44 @@ def get_memory_snapshot_service(request: Request) -> MemorySnapshotService:
     services[workspace_id] = snapshot_service
     request.app.state.memory_snapshot_services = services
     return snapshot_service
+
+
+def get_raw_document_service(request: Request) -> RawDocumentReadService:
+    """Return (and lazily construct) a per-workspace :class:`RawDocumentReadService`.
+
+    Reuses ``app.state.postgres`` (the shared :class:`~metatron.storage.postgres.PostgresStore`
+    initialised in the lifespan) so no new connection pool is created.  If the
+    lifespan store is not yet available — e.g. in isolated test setups — a new
+    ``PostgresStore`` is constructed from ``settings.postgres_dsn``.
+
+    Cached per workspace on ``app.state.raw_document_services`` (same pattern
+    as :func:`get_memory_health_service`).
+    """
+    from metatron.knowledge.service import RawDocumentReadService
+    from metatron.storage.postgres import PostgresStore
+
+    settings: Settings = request.app.state.settings
+    workspace_id = _resolve_workspace_id(request)
+
+    services: dict[str, RawDocumentReadService] = getattr(
+        request.app.state,
+        "raw_document_services",
+        {},
+    )
+    cached = services.get(workspace_id)
+    if cached is not None:
+        return cached
+
+    # Prefer the shared PostgresStore created in lifespan (app.state.postgres).
+    # Fall back to constructing a new one from settings if the lifespan store is
+    # not present (common in minimal test-app setups).
+    pg_store: PostgresStore | None = getattr(request.app.state, "postgres", None)
+    if pg_store is None:
+        pg_store = PostgresStore(settings.postgres_dsn)
+        request.app.state.postgres = pg_store
+
+    service = RawDocumentReadService(pg_store, workspace_id=workspace_id)
+
+    services[workspace_id] = service
+    request.app.state.raw_document_services = services
+    return service

--- a/src/metatron/api/routes/knowledge.py
+++ b/src/metatron/api/routes/knowledge.py
@@ -25,8 +25,11 @@ estimate.  Safe at current scale (< 500 documents).
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime  # noqa: TC003 — pydantic field validation needs runtime resolution
-from enum import Enum
+from datetime import (  # noqa: TC003 — pydantic field validation needs runtime resolution
+    UTC,
+    datetime,
+)
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 import structlog
@@ -39,7 +42,11 @@ from metatron.api.dependencies import (
     get_workspace_id,
 )
 from metatron.auth.dependencies import require_viewer
-from metatron.core.models import LifecycleStatus, RawDocument, User
+from metatron.core.models import (
+    LifecycleStatus,  # noqa: TC001 — pydantic needs runtime
+    RawDocument,  # noqa: TC001 — used in function signatures
+    User,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+)
 from metatron.knowledge.service import (
     RawDocumentReadService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
 )
@@ -57,7 +64,7 @@ router = APIRouter(prefix="/knowledge", tags=["knowledge"])
 # ---------------------------------------------------------------------------
 
 
-class KnowledgeOrigin(str, Enum):
+class KnowledgeOrigin(StrEnum):
     """Origin discriminator for the knowledge endpoint.
 
     ``ALL`` is a query-string sentinel meaning "both sources"; it never appears
@@ -115,8 +122,16 @@ class KnowledgeRecordListResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+
 def _memory_record_to_response(record: Any) -> KnowledgeRecordResponse:
     """Map a :class:`~metatron.core.models.MemoryRecord` to the unified shape."""
+    updated_at: datetime = (
+        getattr(record, "updated_at", None)
+        or getattr(record, "created_at", None)
+        or _EPOCH
+    )
     return KnowledgeRecordResponse(
         id=record.id,
         origin="agent",
@@ -125,7 +140,7 @@ def _memory_record_to_response(record: Any) -> KnowledgeRecordResponse:
         freshness_score=getattr(record, "freshness_score", 0.5) or 0.5,
         source_type=record.source_type or "",
         agent_id=record.agent_id,
-        updated_at=getattr(record, "updated_at", None) or getattr(record, "created_at", None),
+        updated_at=updated_at,
         workspace_id=record.workspace_id,
         tags=list(record.tags) if record.tags else [],
         metadata=dict(record.metadata) if record.metadata else {},
@@ -147,7 +162,7 @@ def _raw_document_to_response(doc: RawDocument) -> KnowledgeRecordResponse:
         freshness_score=doc.freshness_score,
         source_type=doc.connector_type or "",
         agent_id=None,
-        updated_at=doc.updated_at,
+        updated_at=doc.updated_at or _EPOCH,
         workspace_id=doc.workspace_id,
         tags=[],
         metadata=dict(doc.metadata) if doc.metadata else {},
@@ -165,9 +180,9 @@ async def list_knowledge_records(
     user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
     memory_service: Annotated[MemoryService, Depends(get_memory_service)],
     raw_doc_service: Annotated[RawDocumentReadService, Depends(get_raw_document_service)],
-    origin: KnowledgeOrigin = Query(KnowledgeOrigin.ALL),
-    limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0, le=10000),
+    origin: KnowledgeOrigin = Query(KnowledgeOrigin.ALL),  # noqa: B008
+    limit: int = Query(50, ge=1, le=200),  # noqa: B008
+    offset: int = Query(0, ge=0, le=10000),  # noqa: B008
 ) -> KnowledgeRecordListResponse:
     """Unified, paginated view of agent memory + KB documents.
 
@@ -218,7 +233,9 @@ async def list_knowledge_records(
     # --- KB-only path ---
     if origin == KnowledgeOrigin.KB:
         try:
-            kb_records, kb_total = await raw_doc_service.list_records(limit=limit, offset=offset)
+            kb_only_records, kb_only_total = await raw_doc_service.list_records(
+                limit=limit, offset=offset
+            )
         except Exception as exc:
             logger.warning(
                 "route.knowledge.kb_leg_failed",
@@ -227,13 +244,13 @@ async def list_knowledge_records(
             )
             raise HTTPException(status_code=503, detail="knowledge sources unavailable") from exc
 
-        responses = [_raw_document_to_response(d) for d in kb_records]
+        responses = [_raw_document_to_response(d) for d in kb_only_records]
         return KnowledgeRecordListResponse(
             records=responses,
             count=len(responses),
             limit=limit,
             offset=offset,
-            has_more=(offset + limit) < kb_total,
+            has_more=(offset + limit) < kb_only_total,
         )
 
     # --- All (fan-out) path ---
@@ -254,7 +271,7 @@ async def list_knowledge_records(
     kb_records_resp: list[KnowledgeRecordResponse] = []
     kb_total: int = 0
 
-    if isinstance(agent_result, Exception):
+    if isinstance(agent_result, BaseException):
         logger.warning(
             "route.knowledge.partial",
             workspace_id=workspace_id,
@@ -264,9 +281,11 @@ async def list_knowledge_records(
         partial = True
         failed_sources.append("agent")
     else:
-        agent_records, agent_total = agent_result
+        _agent_pair = agent_result  # Any after gather w/ return_exceptions
+        agent_records = _agent_pair[0]
+        agent_total = _agent_pair[1]
 
-    if isinstance(kb_result, Exception):
+    if isinstance(kb_result, BaseException):
         logger.warning(
             "route.knowledge.partial",
             workspace_id=workspace_id,
@@ -276,7 +295,9 @@ async def list_knowledge_records(
         partial = True
         failed_sources.append("kb")
     else:
-        kb_records_resp, kb_total = kb_result
+        _kb_pair = kb_result  # Any after gather w/ return_exceptions
+        kb_records_resp = _kb_pair[0]
+        kb_total = _kb_pair[1]
 
     if partial and len(failed_sources) == 2:
         raise HTTPException(status_code=503, detail="knowledge sources unavailable")
@@ -284,7 +305,7 @@ async def list_knowledge_records(
     # Merge, re-sort by updated_at DESC (approximate — see D-P1-02), truncate.
     combined = agent_records + kb_records_resp
     combined.sort(
-        key=lambda r: r.updated_at if r.updated_at else datetime.min,
+        key=lambda r: r.updated_at,
         reverse=True,
     )
     page = combined[:limit]

--- a/src/metatron/api/routes/knowledge.py
+++ b/src/metatron/api/routes/knowledge.py
@@ -1,0 +1,332 @@
+"""Knowledge REST API — /api/v1/knowledge.
+
+Exposes a unified, paginated view across agent memory (``memory_records``) and
+KB documents (``raw_documents``) under a single endpoint.  The two sources are
+fan-out concurrently under ``origin=all``.
+
+Design decisions (see plan §8 Risks & decisions):
+- ``workspace_id`` is always auth-derived via ``get_workspace_id(request)`` — it
+  is never accepted from the query string or request body (D-P1-01).
+- ``origin=all`` pagination is approximate: each leg fetches up to ``limit`` rows
+  ordered by its own ``updated_at DESC``, then the combined page is re-sorted and
+  truncated.  ``total = agent_total + kb_total`` is therefore an estimate when the
+  two counts are used together with a merged page (D-P1-02).
+- KB rows have no ``tags`` column → always ``[]``.  Do not synthesise from metadata
+  (D-P1-03).
+- KB ``connector_type`` is surfaced as ``source_type`` (D-P1-04).
+- Hybrid search remains memory-only in Phase 1; this endpoint is list/inspect only
+  (D-P1-05).
+
+TODO (R2): for workspaces with >100 k raw_documents, ``count(*)`` becomes slow.
+Consider adding a partial index or switching to ``EXPLAIN (FORMAT JSON) SELECT 1``
+estimate.  Safe at current scale (< 500 documents).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime  # noqa: TC003 — pydantic field validation needs runtime resolution
+from enum import Enum
+from typing import Annotated, Any, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from metatron.api.dependencies import (
+    get_memory_service,
+    get_raw_document_service,
+    get_workspace_id,
+)
+from metatron.auth.dependencies import require_viewer
+from metatron.core.models import LifecycleStatus, RawDocument, User
+from metatron.knowledge.service import (
+    RawDocumentReadService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+)
+from metatron.memory.service import (
+    MemoryService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/knowledge", tags=["knowledge"])
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeOrigin(str, Enum):
+    """Origin discriminator for the knowledge endpoint.
+
+    ``ALL`` is a query-string sentinel meaning "both sources"; it never appears
+    in individual record responses (those always carry ``"agent"`` or ``"kb"``).
+    """
+
+    AGENT = "agent"
+    KB = "kb"
+    ALL = "all"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic v2 schemas
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeRecordResponse(BaseModel):
+    """A single record in the unified knowledge view.
+
+    ``origin`` is endpoint-derived, never stored: ``"agent"`` records come from
+    ``memory_records``; ``"kb"`` records come from ``raw_documents``.
+    ``agent_id`` is ``None`` for KB records.
+    ``tags`` is always ``[]`` for KB records (no tags column on ``raw_documents``).
+    ``source_type`` for KB records is mapped from ``RawDocument.connector_type``
+    (values like ``"confluence"`` / ``"jira"`` are equally meaningful as either name).
+    """
+
+    id: str
+    origin: Literal["agent", "kb"]
+    content: str
+    status: LifecycleStatus
+    freshness_score: float
+    source_type: str
+    agent_id: str | None
+    updated_at: datetime
+    workspace_id: str
+    tags: list[str]
+    metadata: dict[str, Any]
+
+
+class KnowledgeRecordListResponse(BaseModel):
+    """Paginated response for ``GET /knowledge/records``."""
+
+    records: list[KnowledgeRecordResponse]
+    count: int
+    limit: int
+    offset: int
+    has_more: bool
+    partial: bool = False
+    failed_sources: list[Literal["agent", "kb"]] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Mapper helpers
+# ---------------------------------------------------------------------------
+
+
+def _memory_record_to_response(record: Any) -> KnowledgeRecordResponse:
+    """Map a :class:`~metatron.core.models.MemoryRecord` to the unified shape."""
+    return KnowledgeRecordResponse(
+        id=record.id,
+        origin="agent",
+        content=record.content,
+        status=record.status,
+        freshness_score=getattr(record, "freshness_score", 0.5) or 0.5,
+        source_type=record.source_type or "",
+        agent_id=record.agent_id,
+        updated_at=getattr(record, "updated_at", None) or getattr(record, "created_at", None),
+        workspace_id=record.workspace_id,
+        tags=list(record.tags) if record.tags else [],
+        metadata=dict(record.metadata) if record.metadata else {},
+    )
+
+
+def _raw_document_to_response(doc: RawDocument) -> KnowledgeRecordResponse:
+    """Map a :class:`~metatron.core.models.RawDocument` to the unified shape.
+
+    ``connector_type`` → ``source_type`` (D-P1-04).
+    ``tags`` → ``[]`` (no column; D-P1-03).
+    ``agent_id`` → ``None``.
+    """
+    return KnowledgeRecordResponse(
+        id=doc.id,
+        origin="kb",
+        content=doc.content,
+        status=doc.status,
+        freshness_score=doc.freshness_score,
+        source_type=doc.connector_type or "",
+        agent_id=None,
+        updated_at=doc.updated_at,
+        workspace_id=doc.workspace_id,
+        tags=[],
+        metadata=dict(doc.metadata) if doc.metadata else {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/records", response_model=KnowledgeRecordListResponse)
+async def list_knowledge_records(
+    request: Request,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    memory_service: Annotated[MemoryService, Depends(get_memory_service)],
+    raw_doc_service: Annotated[RawDocumentReadService, Depends(get_raw_document_service)],
+    origin: KnowledgeOrigin = Query(KnowledgeOrigin.ALL),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0, le=10000),
+) -> KnowledgeRecordListResponse:
+    """Unified, paginated view of agent memory + KB documents.
+
+    ``workspace_id`` is always auth-derived — never accepted from the query
+    string or request body (D-P1-01).
+
+    Origin routing:
+    - ``origin=agent`` — only ``memory_records``. KB service not called.
+    - ``origin=kb`` — only ``raw_documents``. Memory service not called.
+    - ``origin=all`` (default) — fan out concurrently. On a single-leg failure,
+      returns ``200`` with ``partial=true`` and the other source's rows.  On
+      total failure, returns ``503``.
+
+    Pagination under ``origin=all`` is approximate (D-P1-02): each leg returns
+    up to ``limit`` rows ordered by its own ``updated_at DESC``; the combined page
+    is re-sorted and truncated to ``limit``.  ``total = agent_total + kb_total``.
+    """
+    workspace_id = get_workspace_id(request)
+
+    # --- Agent-only path ---
+    if origin == KnowledgeOrigin.AGENT:
+        try:
+            mem_records, mem_total = await asyncio.gather(
+                memory_service.list_records(
+                    workspace_id,
+                    limit=limit,
+                    offset=offset,
+                ),
+                memory_service.pg_store.count_records(workspace_id),
+            )
+        except Exception as exc:
+            logger.warning(
+                "route.knowledge.agent_leg_failed",
+                workspace_id=workspace_id,
+                error=str(exc),
+            )
+            raise HTTPException(status_code=503, detail="knowledge sources unavailable") from exc
+
+        responses = [_memory_record_to_response(r) for r in mem_records]
+        return KnowledgeRecordListResponse(
+            records=responses,
+            count=len(responses),
+            limit=limit,
+            offset=offset,
+            has_more=(offset + limit) < mem_total,
+        )
+
+    # --- KB-only path ---
+    if origin == KnowledgeOrigin.KB:
+        try:
+            kb_records, kb_total = await raw_doc_service.list_records(limit=limit, offset=offset)
+        except Exception as exc:
+            logger.warning(
+                "route.knowledge.kb_leg_failed",
+                workspace_id=workspace_id,
+                error=str(exc),
+            )
+            raise HTTPException(status_code=503, detail="knowledge sources unavailable") from exc
+
+        responses = [_raw_document_to_response(d) for d in kb_records]
+        return KnowledgeRecordListResponse(
+            records=responses,
+            count=len(responses),
+            limit=limit,
+            offset=offset,
+            has_more=(offset + limit) < kb_total,
+        )
+
+    # --- All (fan-out) path ---
+    results = await asyncio.gather(
+        _fetch_agent_leg(memory_service, workspace_id, limit=limit, offset=offset),
+        _fetch_kb_leg(raw_doc_service, limit=limit, offset=offset),
+        return_exceptions=True,
+    )
+
+    agent_result = results[0]
+    kb_result = results[1]
+
+    partial = False
+    failed_sources: list[Literal["agent", "kb"]] = []
+
+    agent_records: list[KnowledgeRecordResponse] = []
+    agent_total: int = 0
+    kb_records_resp: list[KnowledgeRecordResponse] = []
+    kb_total: int = 0
+
+    if isinstance(agent_result, Exception):
+        logger.warning(
+            "route.knowledge.partial",
+            workspace_id=workspace_id,
+            failed_source="agent",
+            error=str(agent_result),
+        )
+        partial = True
+        failed_sources.append("agent")
+    else:
+        agent_records, agent_total = agent_result
+
+    if isinstance(kb_result, Exception):
+        logger.warning(
+            "route.knowledge.partial",
+            workspace_id=workspace_id,
+            failed_source="kb",
+            error=str(kb_result),
+        )
+        partial = True
+        failed_sources.append("kb")
+    else:
+        kb_records_resp, kb_total = kb_result
+
+    if partial and len(failed_sources) == 2:
+        raise HTTPException(status_code=503, detail="knowledge sources unavailable")
+
+    # Merge, re-sort by updated_at DESC (approximate — see D-P1-02), truncate.
+    combined = agent_records + kb_records_resp
+    combined.sort(
+        key=lambda r: r.updated_at if r.updated_at else datetime.min,
+        reverse=True,
+    )
+    page = combined[:limit]
+    total = agent_total + kb_total
+
+    return KnowledgeRecordListResponse(
+        records=page,
+        count=len(page),
+        limit=limit,
+        offset=offset,
+        has_more=(offset + limit) < total,
+        partial=partial,
+        failed_sources=failed_sources,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-leg fetch helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_agent_leg(
+    service: MemoryService,
+    workspace_id: str,
+    *,
+    limit: int,
+    offset: int,
+) -> tuple[list[KnowledgeRecordResponse], int]:
+    """Fetch agent memory records and total count concurrently."""
+    records, total = await asyncio.gather(
+        service.list_records(workspace_id, limit=limit, offset=offset),
+        service.pg_store.count_records(workspace_id),
+    )
+    return [_memory_record_to_response(r) for r in records], total
+
+
+async def _fetch_kb_leg(
+    service: RawDocumentReadService,
+    *,
+    limit: int,
+    offset: int,
+) -> tuple[list[KnowledgeRecordResponse], int]:
+    """Fetch KB raw_documents and total count concurrently."""
+    raw_docs, total = await service.list_records(limit=limit, offset=offset)
+    return [_raw_document_to_response(d) for d in raw_docs], total

--- a/src/metatron/knowledge/.claude/CLAUDE.md
+++ b/src/metatron/knowledge/.claude/CLAUDE.md
@@ -1,0 +1,32 @@
+# knowledge/
+
+## Purpose
+L3 read-only facade over `raw_documents`. Paired with `memory/service.py` to back the unified
+`GET /api/v1/knowledge/records` endpoint that merges agent memory records and KB documents
+in the Memory Inspector. See `docs/superpowers/2026-05-12-memory-scopes-audit.md` for context.
+
+## What this module is
+- `service.py` — `RawDocumentReadService`: list and count `raw_documents` rows filtered by
+  `workspace_id`. Called by the `knowledge` API route to provide the KB leg of the unified view.
+
+## What this module is NOT
+- Not a writer — no inserts, updates, or deletes to any table
+- Not a bridge to `memory_records` — the two sources are kept separate at storage; merging
+  happens only at the view layer (`/api/v1/knowledge/records`)
+- Not a place for ingestion logic — ingestion lives in `ingestion/`
+- Not a place for freshness logic — freshness lives in `freshness/` and `ingestion/freshness/`
+
+## Layer rules
+- Layer: L3 (services)
+- May import from: `core/` (L0), `storage/` (L1)
+- Must NOT import from: `api/`, `agent/`, `channels/`, `retrieval/`, `ingestion/`, `memory/`
+
+## `origin` field
+`origin` is endpoint-derived — the value `"agent"` or `"kb"` is assigned by the API route
+based on which source returned the row. It is NOT stored in `raw_documents` or `memory_records`.
+Do NOT propose adding an `origin` column to either table.
+
+## Planned work
+Later memory-scopes phases will introduce orthogonal `visibility / lifetime / kind` axes on
+`memory_records`. This module stays read-only on the KB side regardless of those changes.
+Phase 3 details live in `docs/superpowers/2026-05-12-memory-scopes-audit.md` (local, gitignored).

--- a/src/metatron/knowledge/__init__.py
+++ b/src/metatron/knowledge/__init__.py
@@ -1,0 +1,13 @@
+"""L3 read-only facade for KB raw_documents.
+
+Exposes raw_documents to the unified knowledge endpoint without touching
+the existing ingestion or retrieval paths. Write-free by design: all
+mutations go through the ingestion pipeline and connector sync.
+
+Re-exports:
+    RawDocumentReadService
+"""
+
+from metatron.knowledge.service import RawDocumentReadService
+
+__all__ = ["RawDocumentReadService"]

--- a/src/metatron/knowledge/service.py
+++ b/src/metatron/knowledge/service.py
@@ -1,0 +1,82 @@
+"""L3 read-only service for KB raw_documents.
+
+Layer: L3 (services) — same layer as ``memory/service.py``.
+Imports only from L0 (core) and L1 (storage). No writes.
+
+This module is the read-facade half of the unified knowledge endpoint
+(Phase 1, memory-scopes). It deliberately does NOT:
+- Write to raw_documents (that is the ingestion pipeline's job)
+- Merge data with memory_records (the API route does that)
+- Introduce an ``origin`` column (origin is endpoint-derived)
+- Touch freshness lifecycle (that is the freshness worker's job)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from metatron.core.models import RawDocument
+    from metatron.storage.postgres import PostgresStore
+
+logger = structlog.get_logger(__name__)
+
+
+class RawDocumentReadService:
+    """Read-only access to ``raw_documents`` for a single workspace.
+
+    Bound to ``workspace_id`` at construction (same idiom as
+    :class:`~metatron.memory.service.MemoryService`) so the API layer cannot
+    accidentally cross workspace boundaries.
+
+    All reads fan out as a single ``asyncio.gather`` call — concurrency at
+    zero extra complexity.
+    """
+
+    def __init__(
+        self,
+        pg_store: PostgresStore,
+        *,
+        workspace_id: str,
+    ) -> None:
+        self._pg = pg_store
+        self._workspace_id = workspace_id
+
+    async def list_records(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[RawDocument], int]:
+        """Return ``(records, total)`` for the bound workspace.
+
+        Both ``list_raw_documents`` and ``count_raw_documents`` run
+        concurrently via :func:`asyncio.gather`.  ``total`` is the
+        workspace-wide count (not just the current page), enabling
+        correct ``has_more`` computation.
+
+        Args:
+            limit: Page size, forwarded to :meth:`~.storage.postgres.PostgresStore.list_raw_documents`.
+            offset: Zero-based page offset.
+
+        Returns:
+            Tuple of (page records, total workspace record count).
+        """
+        logger.debug(
+            "knowledge.raw_document_read_service.list",
+            workspace_id=self._workspace_id,
+            limit=limit,
+            offset=offset,
+        )
+        records, total = await asyncio.gather(
+            self._pg.list_raw_documents(
+                self._workspace_id,
+                limit=limit,
+                offset=offset,
+            ),
+            self._pg.count_raw_documents(self._workspace_id),
+        )
+        return records, total

--- a/src/metatron/knowledge/service.py
+++ b/src/metatron/knowledge/service.py
@@ -59,7 +59,8 @@ class RawDocumentReadService:
         correct ``has_more`` computation.
 
         Args:
-            limit: Page size, forwarded to :meth:`~.storage.postgres.PostgresStore.list_raw_documents`.
+            limit: Page size, forwarded to
+                :meth:`~metatron.storage.postgres.PostgresStore.list_raw_documents`.
             offset: Zero-based page offset.
 
         Returns:

--- a/src/metatron/memory/.claude/CLAUDE.md
+++ b/src/metatron/memory/.claude/CLAUDE.md
@@ -1,5 +1,8 @@
 # Memory
 
+Companion read facade for KB lives at `src/metatron/knowledge/` (see its CLAUDE.md). The two sources
+are kept separate at storage; only the `/api/v1/knowledge/records` endpoint merges them at the view layer.
+
 ## Overview
 L3 — service layer for agent memory operations. Sits next to `llm/`, `skills/`, `workspaces/`.
 Memory records are stored across four backends (PostgreSQL source-of-truth, Qdrant content,

--- a/src/metatron/storage/postgres.py
+++ b/src/metatron/storage/postgres.py
@@ -1224,6 +1224,61 @@ class PostgresStore:
                 {**updates, "workspace_id": workspace_id, "id": raw_doc_id},
             )
 
+    # --- Raw document list helpers (memory-scopes Phase 1, MTRNIX-memory-scopes) ---
+
+    async def list_raw_documents(
+        self,
+        workspace_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[RawDocument]:
+        """Return paginated raw_documents for a workspace, ordered by updated_at DESC, id ASC.
+
+        Workspace-scoped. Reuses :meth:`_row_to_raw_document` for consistent field mapping.
+        Stable pagination: ``updated_at DESC, id ASC`` ensures deterministic ordering even
+        when multiple rows share the same ``updated_at`` timestamp.
+        """
+        logger.info(
+            "postgres.raw_documents.list",
+            workspace_id=workspace_id,
+            limit=limit,
+            offset=offset,
+        )
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    SELECT * FROM raw_documents
+                    WHERE workspace_id = :workspace_id
+                    ORDER BY updated_at DESC, id ASC
+                    LIMIT :limit OFFSET :offset
+                """),
+                {"workspace_id": workspace_id, "limit": limit, "offset": offset},
+            )
+            return [self._row_to_raw_document(row) for row in result]
+
+    async def count_raw_documents(self, workspace_id: str) -> int:
+        """Return the total number of raw_documents for a workspace.
+
+        Used alongside :meth:`list_raw_documents` to populate ``has_more`` and
+        ``total`` fields in paginated responses. For workspaces with >100 k
+        documents a partial index or ``estimate_count`` should be considered —
+        see TODO in the knowledge route docstring.
+        """
+        logger.info(
+            "postgres.raw_documents.count",
+            workspace_id=workspace_id,
+        )
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT count(*) FROM raw_documents WHERE workspace_id = :workspace_id"
+                ),
+                {"workspace_id": workspace_id},
+            )
+            row = result.first()
+            return int(row._mapping["count"]) if row else 0
+
     # --- Dedup Fingerprints ---
 
     async def batch_load_fingerprints(self, workspace_id: str) -> dict[int, str]:

--- a/tests/unit/api/test_knowledge_routes.py
+++ b/tests/unit/api/test_knowledge_routes.py
@@ -1,0 +1,595 @@
+"""Tests for GET /api/v1/knowledge/records.
+
+Uses a minimal FastAPI app with dependency overrides so the route exercises
+the full request/response stack without touching real stores.
+
+Scenarios mirror the test plan in the Phase 1 plan doc §6.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from metatron.api.dependencies import get_memory_service, get_raw_document_service
+from metatron.api.routes.knowledge import router as knowledge_router
+from metatron.auth.dependencies import get_current_user
+from metatron.core.config import Settings
+from metatron.core.models import (
+    LifecycleStatus,
+    MemoryRecord,
+    MemoryScope,
+    RawDocument,
+    Role,
+    User,
+)
+from metatron.knowledge.service import RawDocumentReadService
+from metatron.memory.service import MemoryService
+
+
+# ---------------------------------------------------------------------------
+# Factories
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: Role = Role.VIEWER) -> User:
+    return User(
+        id="u1",
+        username="tester",
+        email="t@example.com",
+        role=role,
+        workspace_ids=["ws-test"],
+    )
+
+
+def _sample_mem_record(**overrides: Any) -> MemoryRecord:
+    defaults: dict[str, Any] = {
+        "id": "mem-1",
+        "workspace_id": "ws-test",
+        "agent_id": "agent-1",
+        "scope": MemoryScope.PER_AGENT,
+        "source_type": "conversation",
+        "content": "user prefers dark mode",
+        "tags": ["preference"],
+        "importance_score": 0.75,
+        "status": LifecycleStatus.ACTIVE,
+        "freshness_score": 0.8,
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "updated_at": datetime(2026, 1, 2, tzinfo=UTC),
+    }
+    defaults.update(overrides)
+    return MemoryRecord(**defaults)
+
+
+def _sample_raw_doc(**overrides: Any) -> RawDocument:
+    defaults: dict[str, Any] = {
+        "id": "doc-1",
+        "workspace_id": "ws-test",
+        "connector_type": "confluence",
+        "source_id": "page-1",
+        "title": "Engineering Wiki",
+        "content": "We use Python 3.12",
+        "status": LifecycleStatus.ACTIVE,
+        "freshness_score": 0.5,
+        "updated_at": datetime(2026, 1, 3, tzinfo=UTC),
+        "metadata": {},
+    }
+    defaults.update(overrides)
+    return RawDocument(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=False,
+        METATRON_SECRET_KEY="test-secret",
+    )
+
+
+@pytest.fixture
+def mem_service() -> MagicMock:
+    """MemoryService mock with a pg_store sub-mock."""
+    mock = MagicMock(spec=MemoryService)
+    mock.list_records = AsyncMock(return_value=[])
+    mock.pg_store = MagicMock()
+    mock.pg_store.count_records = AsyncMock(return_value=0)
+    return mock
+
+
+@pytest.fixture
+def raw_doc_service() -> AsyncMock:
+    mock = AsyncMock(spec=RawDocumentReadService)
+    mock.list_records = AsyncMock(return_value=([], 0))
+    return mock
+
+
+def _make_client(
+    settings: Settings,
+    mem_service: MagicMock,
+    raw_doc_service: AsyncMock,
+    role: Role = Role.VIEWER,
+) -> TestClient:
+    """Minimal FastAPI app with only the knowledge router wired."""
+    app = FastAPI()
+    app.state.settings = settings
+    app.include_router(knowledge_router, prefix="/api/v1")
+    app.dependency_overrides[get_memory_service] = lambda: mem_service
+    app.dependency_overrides[get_raw_document_service] = lambda: raw_doc_service
+    app.dependency_overrides[get_current_user] = lambda: _make_user(role=role)
+
+    @app.middleware("http")
+    async def _inject_user(request, call_next):  # type: ignore[no-untyped-def]
+        request.state.user = {"workspace_ids": ["ws-test"]}
+        return await call_next(request)
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def client(
+    settings: Settings,
+    mem_service: MagicMock,
+    raw_doc_service: AsyncMock,
+) -> TestClient:
+    return _make_client(settings, mem_service, raw_doc_service)
+
+
+# ---------------------------------------------------------------------------
+# T1 — Empty workspace, origin=all
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyWorkspace:
+    def test_empty_returns_200(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/knowledge/records?origin=all")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["records"] == []
+        assert body["count"] == 0
+        assert body["has_more"] is False
+        assert body["partial"] is False
+        assert body["failed_sources"] == []
+
+
+# ---------------------------------------------------------------------------
+# T2 — Agent-only data, origin=all
+# ---------------------------------------------------------------------------
+
+
+class TestAgentOnlyData:
+    def test_agent_rows_have_correct_origin(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        record = _sample_mem_record()
+        mem_service.list_records = AsyncMock(return_value=[record])
+        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        raw_doc_service.list_records = AsyncMock(return_value=([], 0))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["records"]) == 1
+        assert body["records"][0]["origin"] == "agent"
+
+    def test_sort_order_by_updated_at_desc(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        older = _sample_mem_record(id="old", updated_at=datetime(2025, 1, 1, tzinfo=UTC))
+        newer = _sample_mem_record(id="new", updated_at=datetime(2026, 6, 1, tzinfo=UTC))
+        mem_service.list_records = AsyncMock(return_value=[older, newer])
+        mem_service.pg_store.count_records = AsyncMock(return_value=2)
+        raw_doc_service.list_records = AsyncMock(return_value=([], 0))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records")
+        body = resp.json()
+        ids = [r["id"] for r in body["records"]]
+        assert ids[0] == "new"
+        assert ids[1] == "old"
+
+
+# ---------------------------------------------------------------------------
+# T3 — KB-only data, origin=all
+# ---------------------------------------------------------------------------
+
+
+class TestKbOnlyData:
+    def test_kb_rows_have_correct_shape(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        doc = _sample_raw_doc()
+        mem_service.list_records = AsyncMock(return_value=[])
+        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all")
+        body = resp.json()
+        assert len(body["records"]) == 1
+        rec = body["records"][0]
+        assert rec["origin"] == "kb"
+        assert rec["agent_id"] is None
+        assert rec["tags"] == []
+
+    def test_kb_row_source_type_from_connector_type(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        """T17 — RawDocument.connector_type appears as source_type."""
+        doc = _sample_raw_doc(connector_type="confluence")
+        mem_service.list_records = AsyncMock(return_value=[])
+        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all")
+        body = resp.json()
+        assert body["records"][0]["source_type"] == "confluence"
+
+
+# ---------------------------------------------------------------------------
+# T4 — Both sources populated, origin=all
+# ---------------------------------------------------------------------------
+
+
+class TestBothSources:
+    def test_combined_pagination_math(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        mem_records = [_sample_mem_record(id=f"m{i}") for i in range(3)]
+        kb_docs = [_sample_raw_doc(id=f"d{i}") for i in range(2)]
+        mem_service.list_records = AsyncMock(return_value=mem_records)
+        mem_service.pg_store.count_records = AsyncMock(return_value=3)
+        raw_doc_service.list_records = AsyncMock(return_value=(kb_docs, 2))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?limit=10")
+        body = resp.json()
+        assert len(body["records"]) == 5  # 3 + 2
+        # total from both legs
+        # has_more = (0 + 10) < (3 + 2) = 10 < 5 = False
+        assert body["has_more"] is False
+
+    def test_has_more_true_when_total_exceeds_page(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        mem_records = [_sample_mem_record(id=f"m{i}") for i in range(3)]
+        kb_docs = [_sample_raw_doc(id=f"d{i}") for i in range(3)]
+        # total = 100 + 200 = 300; offset=0; limit=5 → has_more=True
+        mem_service.list_records = AsyncMock(return_value=mem_records)
+        mem_service.pg_store.count_records = AsyncMock(return_value=100)
+        raw_doc_service.list_records = AsyncMock(return_value=(kb_docs, 200))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?limit=5")
+        body = resp.json()
+        assert body["has_more"] is True
+
+
+# ---------------------------------------------------------------------------
+# T5 — origin=agent filter
+# ---------------------------------------------------------------------------
+
+
+class TestOriginAgentFilter:
+    def test_only_agent_leg_called(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        mem_service.list_records = AsyncMock(return_value=[_sample_mem_record()])
+        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=agent")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["records"]) == 1
+        assert body["records"][0]["origin"] == "agent"
+        # KB service was NOT called
+        raw_doc_service.list_records.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# T6 — origin=kb filter
+# ---------------------------------------------------------------------------
+
+
+class TestOriginKbFilter:
+    def test_only_kb_leg_called(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        raw_doc_service.list_records = AsyncMock(return_value=([_sample_raw_doc()], 1))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=kb")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["records"]) == 1
+        assert body["records"][0]["origin"] == "kb"
+        # Memory service list_records was NOT called
+        mem_service.list_records.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# T7 — Pagination propagation
+# ---------------------------------------------------------------------------
+
+
+class TestPagination:
+    def test_pagination_params_forwarded(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        mem_service.list_records = AsyncMock(return_value=[])
+        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        raw_doc_service.list_records = AsyncMock(return_value=([], 0))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?limit=10&offset=20")
+        assert resp.status_code == 200
+        mem_service.list_records.assert_awaited_once()
+        call_kwargs = mem_service.list_records.await_args
+        assert call_kwargs[1]["limit"] == 10
+        assert call_kwargs[1]["offset"] == 20
+
+        raw_doc_service.list_records.assert_awaited_once_with(limit=10, offset=20)
+
+
+# ---------------------------------------------------------------------------
+# T8 — Memory leg raises in origin=all
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailureAgentLeg:
+    def test_agent_leg_failure_returns_partial(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        mem_service.list_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        mem_service.pg_store.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        doc = _sample_raw_doc()
+        raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["partial"] is True
+        assert "agent" in body["failed_sources"]
+        assert len(body["records"]) == 1
+        assert body["records"][0]["origin"] == "kb"
+
+
+# ---------------------------------------------------------------------------
+# T9 — KB leg raises in origin=all
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailureKbLeg:
+    def test_kb_leg_failure_returns_partial(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        record = _sample_mem_record()
+        mem_service.list_records = AsyncMock(return_value=[record])
+        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        raw_doc_service.list_records = AsyncMock(side_effect=RuntimeError("Qdrant timeout"))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["partial"] is True
+        assert "kb" in body["failed_sources"]
+        assert len(body["records"]) == 1
+        assert body["records"][0]["origin"] == "agent"
+
+
+# ---------------------------------------------------------------------------
+# T10 — Both legs raise in origin=all → 503
+# ---------------------------------------------------------------------------
+
+
+class TestBothLegsFailure:
+    def test_both_legs_fail_returns_503(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        mem_service.list_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        mem_service.pg_store.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        raw_doc_service.list_records = AsyncMock(side_effect=RuntimeError("KB down"))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all")
+        assert resp.status_code == 503
+        assert "unavailable" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# T11 — Single leg requested and raises → 503
+# ---------------------------------------------------------------------------
+
+
+class TestSingleLegFailure:
+    def test_agent_leg_requested_and_fails_503(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        mem_service.list_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        mem_service.pg_store.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=agent")
+        assert resp.status_code == 503
+
+    def test_kb_leg_requested_and_fails_503(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        raw_doc_service.list_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=kb")
+        assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# T12 — Workspace isolation (mock-based)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceIsolation:
+    def test_workspace_id_passed_from_auth(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        """The workspace_id passed to the service must match the auth-derived value."""
+        mem_service.list_records = AsyncMock(return_value=[])
+        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        raw_doc_service.list_records = AsyncMock(return_value=([], 0))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        client.get("/api/v1/knowledge/records?origin=agent")
+
+        # The workspace_id injected by the middleware is "ws-test"
+        mem_service.list_records.assert_awaited_once()
+        args, kwargs = mem_service.list_records.await_args
+        # positional first arg is workspace_id
+        assert args[0] == "ws-test"
+
+
+# ---------------------------------------------------------------------------
+# T13 / T14 — RBAC
+# ---------------------------------------------------------------------------
+
+
+class TestRbac:
+    def test_viewer_role_succeeds(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        client = _make_client(settings, mem_service, raw_doc_service, role=Role.VIEWER)
+        resp = client.get("/api/v1/knowledge/records")
+        assert resp.status_code == 200
+
+    def test_auth_disabled_returns_200(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        """With AUTH_ENABLED=false, no credentials → still 200 (mirrors memory routes)."""
+        # The factory already uses AUTH_ENABLED=False settings
+        client = _make_client(settings, mem_service, raw_doc_service)
+        resp = client.get("/api/v1/knowledge/records")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# T15 — limit/offset validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_limit_zero_is_422(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/knowledge/records?limit=0")
+        assert resp.status_code == 422
+
+    def test_limit_over_200_is_422(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/knowledge/records?limit=201")
+        assert resp.status_code == 422
+
+    def test_negative_offset_is_422(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/knowledge/records?offset=-1")
+        assert resp.status_code == 422
+
+    def test_offset_over_10000_is_422(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/knowledge/records?offset=10001")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# T16 — origin validation
+# ---------------------------------------------------------------------------
+
+
+class TestOriginValidation:
+    def test_invalid_origin_is_422(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/knowledge/records?origin=invalid")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# T17 — KB source_type ↔ connector_type mapping (covered in TestKbOnlyData)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# T18 — updated_at round-trip (ISO 8601, offset-aware)
+# ---------------------------------------------------------------------------
+
+
+class TestDatetimeSerialization:
+    def test_updated_at_is_iso8601(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        doc = _sample_raw_doc(updated_at=datetime(2026, 3, 14, 9, 26, 53, tzinfo=UTC))
+        raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=kb")
+        body = resp.json()
+        assert body["records"][0]["updated_at"] == "2026-03-14T09:26:53Z"

--- a/tests/unit/api/test_knowledge_routes.py
+++ b/tests/unit/api/test_knowledge_routes.py
@@ -28,9 +28,8 @@ from metatron.core.models import (
     Role,
     User,
 )
-from metatron.knowledge.service import RawDocumentReadService
-from metatron.memory.service import MemoryService
-
+from metatron.knowledge.service import RawDocumentReadService  # noqa: TC001
+from metatron.memory.service import MemoryService  # noqa: TC001
 
 # ---------------------------------------------------------------------------
 # Factories

--- a/tests/unit/knowledge/test_raw_document_read_service.py
+++ b/tests/unit/knowledge/test_raw_document_read_service.py
@@ -9,7 +9,7 @@ Tests verify that the service:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/unit/knowledge/test_raw_document_read_service.py
+++ b/tests/unit/knowledge/test_raw_document_read_service.py
@@ -1,0 +1,171 @@
+"""Unit tests for RawDocumentReadService (L3 read facade).
+
+Tests verify that the service:
+- Passes the bound workspace_id to both PG methods
+- Propagates limit+offset correctly
+- Returns the correct (records, total) tuple
+- Fans out both PG calls concurrently via asyncio.gather
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from metatron.core.models import LifecycleStatus, RawDocument
+from metatron.knowledge.service import RawDocumentReadService
+from metatron.storage.postgres import PostgresStore
+
+
+def _make_raw_doc(*, workspace_id: str = "ws-test", doc_id: str = "doc-1") -> RawDocument:
+    return RawDocument(
+        id=doc_id,
+        workspace_id=workspace_id,
+        connector_type="confluence",
+        source_id="page-1",
+        title="Test page",
+        content="Hello world",
+        status=LifecycleStatus.ACTIVE,
+        freshness_score=0.5,
+    )
+
+
+@pytest.fixture
+def pg_store() -> AsyncMock:
+    mock = AsyncMock(spec=PostgresStore)
+    return mock
+
+
+@pytest.fixture
+def service(pg_store: AsyncMock) -> RawDocumentReadService:
+    return RawDocumentReadService(pg_store, workspace_id="ws-test")
+
+
+# ---------------------------------------------------------------------------
+# RDR1 — workspace_id is forwarded to list_raw_documents
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceBinding:
+    async def test_list_passes_bound_workspace_id(
+        self,
+        service: RawDocumentReadService,
+        pg_store: AsyncMock,
+    ) -> None:
+        pg_store.list_raw_documents.return_value = []
+        pg_store.count_raw_documents.return_value = 0
+
+        await service.list_records(limit=50, offset=0)
+
+        pg_store.list_raw_documents.assert_awaited_once_with(
+            "ws-test",
+            limit=50,
+            offset=0,
+        )
+
+    async def test_count_passes_bound_workspace_id(
+        self,
+        service: RawDocumentReadService,
+        pg_store: AsyncMock,
+    ) -> None:
+        pg_store.list_raw_documents.return_value = []
+        pg_store.count_raw_documents.return_value = 7
+
+        await service.list_records(limit=50, offset=0)
+
+        pg_store.count_raw_documents.assert_awaited_once_with("ws-test")
+
+
+# ---------------------------------------------------------------------------
+# RDR2 — returns (records, total) tuple
+# ---------------------------------------------------------------------------
+
+
+class TestReturnShape:
+    async def test_returns_records_and_total(
+        self,
+        service: RawDocumentReadService,
+        pg_store: AsyncMock,
+    ) -> None:
+        doc = _make_raw_doc()
+        pg_store.list_raw_documents.return_value = [doc]
+        pg_store.count_raw_documents.return_value = 42
+
+        records, total = await service.list_records()
+
+        assert len(records) == 1
+        assert records[0].id == "doc-1"
+        assert total == 42
+
+    async def test_empty_workspace(
+        self,
+        service: RawDocumentReadService,
+        pg_store: AsyncMock,
+    ) -> None:
+        pg_store.list_raw_documents.return_value = []
+        pg_store.count_raw_documents.return_value = 0
+
+        records, total = await service.list_records()
+
+        assert records == []
+        assert total == 0
+
+
+# ---------------------------------------------------------------------------
+# RDR3 — pagination propagates
+# ---------------------------------------------------------------------------
+
+
+class TestPagination:
+    async def test_limit_and_offset_propagate(
+        self,
+        service: RawDocumentReadService,
+        pg_store: AsyncMock,
+    ) -> None:
+        pg_store.list_raw_documents.return_value = []
+        pg_store.count_raw_documents.return_value = 100
+
+        await service.list_records(limit=5, offset=10)
+
+        pg_store.list_raw_documents.assert_awaited_once_with(
+            "ws-test",
+            limit=5,
+            offset=10,
+        )
+
+    async def test_default_pagination(
+        self,
+        service: RawDocumentReadService,
+        pg_store: AsyncMock,
+    ) -> None:
+        pg_store.list_raw_documents.return_value = []
+        pg_store.count_raw_documents.return_value = 0
+
+        await service.list_records()
+
+        pg_store.list_raw_documents.assert_awaited_once_with(
+            "ws-test",
+            limit=50,
+            offset=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# RDR4 — both PG calls are awaited (concurrent fan-out smoke test)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentFanOut:
+    async def test_both_pg_calls_are_awaited(
+        self,
+        service: RawDocumentReadService,
+        pg_store: AsyncMock,
+    ) -> None:
+        pg_store.list_raw_documents.return_value = [_make_raw_doc()]
+        pg_store.count_raw_documents.return_value = 1
+
+        await service.list_records(limit=10, offset=0)
+
+        assert pg_store.list_raw_documents.await_count == 1
+        assert pg_store.count_raw_documents.await_count == 1


### PR DESCRIPTION
## Summary

Adds the new read-only endpoint `GET /api/v1/knowledge/records?origin=agent|kb|all` that fans out across `memory_records` (agent memory) and `raw_documents` (KB) and returns a unified, paginated shape. This unblocks the Hermes pilot's Memory Inspector, which today only sees `memory_records` while 491 KB documents (Confluence + Jira) live in `raw_documents` and remain invisible.

Phase 1 is purely **additive**:
- New module `src/metatron/knowledge/` with `RawDocumentReadService` (L3 read facade).
- Two new methods on `PostgresStore`: `list_raw_documents`, `count_raw_documents`.
- New route `src/metatron/api/routes/knowledge.py`, wired in `api/app.py`.
- New DI helper `get_raw_document_service`.
- **Zero schema migrations.** All needed columns (`status`, `freshness_score`, `updated_at`) already exist on both tables.
- **Zero changes** to `/api/v1/memory/*`, MCP tools, `/v1/chat/completions`.

`workspace_id` is auth-derived (not a query parameter). `origin=all` does an `asyncio.gather(..., return_exceptions=True)` fan-out: one leg failing returns 200 with `partial=true`; both failing returns 503. `origin` is endpoint-derived and **not** stored — no new column anywhere (Phase 3 will introduce the proper `visibility / lifetime / kind` axes per ADR §3).

Frontend changes ship in mtrnix/metatronui#29 (paired branch).

Local context: `docs/superpowers/2026-05-12-memory-scopes-audit.md` + `docs/superpowers/plans/2026-05-12-memory-scopes-phase1-plan.md` (both gitignored).

## Test plan

- [ ] `make lint` green
- [ ] `make typecheck` green
- [ ] `make test` — 24 new route tests + 7 service tests, all green
- [ ] `GET /api/v1/knowledge/records?origin=all` returns 200 with mixed agent + KB rows
- [ ] `GET /api/v1/knowledge/records?origin=agent` returns only agent rows
- [ ] `GET /api/v1/knowledge/records?origin=kb` returns only KB rows
- [ ] Workspace isolation: request as workspace A never returns workspace B rows
- [ ] Partial failure: one leg failing → 200 with `partial=true`; both failing → 503
- [ ] Existing `/api/v1/memory/records` response is byte-identical