### PR TITLE
feat(MTRNIX-332): force_full param for connection sync trigger

### DIFF
--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -546,6 +546,16 @@ async def trigger_sync(
     request: Request,
     background_tasks: BackgroundTasks,
     workspace_id: str | None = Query(None),
+    force_full: bool = Query(
+        False,
+        description=(
+            "Bypass the incremental sync watermark and refetch from the "
+            "connector as if syncing for the first time. Use to force a "
+            "one-off full resync (e.g. when the watermark has drifted "
+            "past the most recent remote update). The successful sync "
+            "still advances the watermark to NOW."
+        ),
+    ),
 ) -> dict[str, str]:
     """Trigger a manual sync for a DB-based connection.
 
@@ -554,6 +564,10 @@ async def trigger_sync(
     task is destroyed before reaching its finally block (API restart,
     CancelledError, hung LLM call). The background task then UPDATEs
     this row on completion or failure.
+
+    ``force_full=true`` bypasses the incremental sync watermark so the
+    connector performs a full fetch. The watermark is still advanced on
+    success — this is a one-off reset, not a flag flip.
     """
     import uuid
 
@@ -575,6 +589,19 @@ async def trigger_sync(
 
     if not conn.get("enabled", True):
         raise HTTPException(status_code=400, detail="Connection is disabled")
+
+    # Best-effort guard against duplicate concurrent syncs. Two POSTs in quick
+    # succession otherwise spawn two BackgroundTasks that fetch+embed+graph the
+    # same payload in parallel — wasteful in general, expensive with
+    # ``force_full=true``. This check is racy (no atomic CAS — between the read
+    # above and the status update below another request can slip through) but
+    # closes the common double-click / retry case. A race-free version requires
+    # a conditional UPDATE on ``connections.status`` and is a separate ticket.
+    if conn.get("status") == "syncing":
+        raise HTTPException(
+            status_code=409,
+            detail="Sync already in progress for this connection",
+        )
 
     # Mark connection as syncing
     await store.update_connection_status(connection_id, status="syncing")
@@ -605,6 +632,7 @@ async def trigger_sync(
         workspace_id=ws_id,
         store=store,
         event_bus=event_bus,
+        force_full=force_full,
     )
 
     return {
@@ -648,12 +676,18 @@ async def _run_connection_sync(
     workspace_id: str,
     store: PostgresStore,
     event_bus: EventBus | None = None,
+    force_full: bool = False,
 ) -> None:
     """Run sync for a DB-based connection. Async background task.
 
     Expects a `sync_logs` row with id=sync_id already inserted by
     `trigger_sync` with status='running'. Updates that row on
     completion, failure, or exception.
+
+    ``force_full=True`` bypasses the persistent sync_state cursor (the
+    connector receives ``since=None`` and performs a full refetch). The
+    cursor is still stamped on success — this is a one-off reset, not a
+    permanent mode flip.
     """
     import time
     from datetime import UTC, datetime
@@ -690,7 +724,16 @@ async def _run_connection_sync(
         from metatron.connectors.sync_state import SyncState
 
         sync_state = SyncState()
-        since = sync_state.get_last_sync(workspace_id, connector_type)
+        if force_full:
+            since = None
+            logger.info(
+                "sync.force_full",
+                sync_id=sync_id,
+                connector_type=connector_type,
+                workspace_id=workspace_id,
+            )
+        else:
+            since = sync_state.get_last_sync(workspace_id, connector_type)
         documents = await connector.fetch(workspace_id, since=since)
         documents_fetched = len(documents)
 
@@ -699,6 +742,8 @@ async def _run_connection_sync(
             sync_id=sync_id,
             connector_type=connector_type,
             documents=documents_fetched,
+            since=since.isoformat() if since else None,
+            force_full=force_full,
         )
 
         # Phase 1: Persist raw documents to PostgreSQL (source of truth)

--- a/tests/unit/test_connections_sync.py
+++ b/tests/unit/test_connections_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -143,3 +144,162 @@ async def test_run_connection_sync_marks_failed_on_exception(store, seeded_ids):
         assert any("Jira 500" in e for e in row.errors)
         assert conn.status == "error"
         assert "Jira 500" in (conn.error_message or "")
+
+
+# ---------------------------------------------------------------------------
+# force_full flag (MTRNIX-332)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_connection_sync_force_full_bypasses_sync_state(store, seeded_ids):
+    """force_full=True must pass since=None to fetch and skip SyncState read."""
+    ws, cid = seeded_ids
+    sync_id = f"sync_force_{uuid4().hex[:10]}"
+    await store.create_sync_log(sync_id, ws, cid, "jira")
+
+    # SyncState would normally return a stale cursor — verify we ignore it.
+    stale_cursor = datetime(2099, 1, 1, tzinfo=UTC)
+    mock_sync_state = MagicMock()
+    mock_sync_state.get_last_sync = MagicMock(return_value=stale_cursor)
+    mock_sync_state.set_last_sync = MagicMock()
+
+    fake_connector = MagicMock()
+    fake_connector.source_role = "task_tracker"
+    fake_connector.configure = AsyncMock()
+    fake_connector.fetch = AsyncMock(return_value=[])
+
+    fake_registry = MagicMock()
+    fake_registry.create.return_value = fake_connector
+
+    with (
+        patch("metatron.api.routes.connections._get_registry", return_value=fake_registry),
+        patch("metatron.connectors.sync_state.SyncState", return_value=mock_sync_state),
+        patch(
+            "metatron.ingestion.pipeline.ingest_documents",
+            AsyncMock(
+                return_value=MagicMock(
+                    documents_new=0,
+                    documents_updated=0,
+                    documents_skipped=0,
+                    errors=[],
+                )
+            ),
+        ),
+    ):
+        await _run_connection_sync(
+            sync_id=sync_id,
+            connection_id=cid,
+            connector_type="jira",
+            config={"url": "http://x", "username": "u", "api_token": "t", "project_key": "P"},
+            workspace_id=ws,
+            store=store,
+            event_bus=None,
+            force_full=True,
+        )
+
+    # The whole point: fetch was called with since=None despite the stale cursor.
+    fake_connector.fetch.assert_awaited_once()
+    call_kwargs = fake_connector.fetch.await_args.kwargs
+    assert call_kwargs.get("since") is None, (
+        f"force_full=True must pass since=None, got {call_kwargs.get('since')!r}"
+    )
+    # SyncState.get_last_sync must NOT have been called — we bypass it entirely.
+    mock_sync_state.get_last_sync.assert_not_called()
+
+
+async def test_run_connection_sync_default_reads_sync_state(store, seeded_ids):
+    """force_full=False (default) keeps the cursor read — regression guard."""
+    ws, cid = seeded_ids
+    sync_id = f"sync_default_{uuid4().hex[:10]}"
+    await store.create_sync_log(sync_id, ws, cid, "jira")
+
+    cursor = datetime(2026, 5, 1, tzinfo=UTC)
+    mock_sync_state = MagicMock()
+    mock_sync_state.get_last_sync = MagicMock(return_value=cursor)
+    mock_sync_state.set_last_sync = MagicMock()
+
+    fake_connector = MagicMock()
+    fake_connector.source_role = "task_tracker"
+    fake_connector.configure = AsyncMock()
+    fake_connector.fetch = AsyncMock(return_value=[])
+
+    fake_registry = MagicMock()
+    fake_registry.create.return_value = fake_connector
+
+    with (
+        patch("metatron.api.routes.connections._get_registry", return_value=fake_registry),
+        patch("metatron.connectors.sync_state.SyncState", return_value=mock_sync_state),
+        patch(
+            "metatron.ingestion.pipeline.ingest_documents",
+            AsyncMock(
+                return_value=MagicMock(
+                    documents_new=0,
+                    documents_updated=0,
+                    documents_skipped=0,
+                    errors=[],
+                )
+            ),
+        ),
+    ):
+        await _run_connection_sync(
+            sync_id=sync_id,
+            connection_id=cid,
+            connector_type="jira",
+            config={"url": "http://x", "username": "u", "api_token": "t", "project_key": "P"},
+            workspace_id=ws,
+            store=store,
+            event_bus=None,
+            # force_full omitted — defaults to False
+        )
+
+    fake_connector.fetch.assert_awaited_once()
+    assert fake_connector.fetch.await_args.kwargs.get("since") == cursor
+    mock_sync_state.get_last_sync.assert_called_once_with(ws, "jira")
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-sync guard (MTRNIX-332)
+# ---------------------------------------------------------------------------
+
+
+async def test_trigger_sync_returns_409_when_connection_is_syncing(seeded_ids):
+    """A POST /sync/ against a connection with status='syncing' returns 409.
+
+    Best-effort guard (racy — see route comment). Verifies the common case:
+    operator hits the button twice in a row, second hit is rejected.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from metatron.api.routes.connections import router as connections_router
+
+    ws, cid = seeded_ids
+
+    # Mock the store so get_connection_decrypted returns a syncing connection.
+    mock_store = MagicMock()
+    mock_store.get_connection_decrypted = AsyncMock(
+        return_value={
+            "id": cid,
+            "workspace_id": ws,
+            "connector_type": "jira",
+            "config": {"url": "http://x", "username": "u", "api_token": "t", "project_key": "P"},
+            "status": "syncing",  # already running
+            "enabled": True,
+        }
+    )
+    mock_store.create_sync_log = AsyncMock()
+    mock_store.update_connection_status = AsyncMock()
+
+    app = FastAPI()
+    app.state.settings = MagicMock(fernet_key="x" * 44, default_workspace_id=ws)
+    app.state.postgres = mock_store
+    app.include_router(connections_router, prefix="/api/v1")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post(f"/api/v1/connections/{cid}/sync/?force_full=true")
+
+    assert resp.status_code == 409
+    assert "already in progress" in resp.json()["detail"].lower()
+    # Crucially: no sync log written, no status change, no background task.
+    mock_store.create_sync_log.assert_not_awaited()
+    mock_store.update_connection_status.assert_not_awaited()


### PR DESCRIPTION
Adds POST /api/v1/connections/{id}/sync/?force_full=true which bypasses the incremental sync watermark so the connector receives since=None and performs a full refetch. Use case: operator needs a one-off resync after the watermark has drifted past the most recent remote update (cursor-trap diagnostic / recovery path).

Also adds a best-effort 409 Conflict guard when the connection is already in status='syncing' — prevents concurrent BackgroundTasks from duplicating fetch + embed + graph extraction. The check is racy (no atomic CAS); a race-free version is a separate ticket.

The successful sync still advances the watermark on completion — this is a one-off reset, not a permanent mode flip.