### PR TITLE
fix(MTRNIX-332): migrate sync cursor to PG + sub-minute Jira post-filter

### DIFF
--- a/src/metatron/api/routes/admin.py
+++ b/src/metatron/api/routes/admin.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel
 
+from metatron.core.config import Settings
+from metatron.storage.postgres import PostgresStore
 from metatron.storage.cleanup import (
     ALLOW_CLEANUP,
     CleanupError,
@@ -99,9 +101,18 @@ class ReindexResponse(BaseModel):
 
 @router.post("/reindex", response_model=ReindexResponse)
 async def trigger_reindex(
+    request: Request,
     x_confirm_reindex: str | None = Header(None),
 ) -> ReindexResponse:
     """Trigger full reindex: reset sync flags and clear Neo4j graph.
+
+    **GLOBAL operation — affects EVERY workspace in this deployment.** There
+    is no per-workspace scoping; ``connections.last_synced_at`` is NULL'd for
+    all rows and ``raw_documents`` qdrant/graph flags are reset across the
+    whole table. On a multi-tenant deployment this triggers a re-embed and
+    re-graph storm on every tenant simultaneously. The ``X-Confirm-Reindex:
+    yes`` header is the only safety net — operators must understand the
+    blast radius. Per-workspace reindex is a separate follow-up.
 
     Does NOT require ALLOW_CLEANUP. After calling this, trigger sync from UI
     to re-ingest all documents with current settings (e.g. SPLADE vectors).
@@ -128,31 +139,28 @@ async def trigger_reindex(
 
     # 1. Reset PG sync state — clear connections.last_synced_at AND
     # raw_documents.{qdrant,graph}_synced flags in a single transaction so
-    # we don't keep two parallel engines for adjacent UPDATEs (MTRNIX-332).
+    # we use one connection from the pool (MTRNIX-332).
     # Next sync starts from since=None (full fetch).
+    store: PostgresStore | None = getattr(request.app.state, "postgres", None)
+    if store is None:
+        settings: Settings = request.app.state.settings
+        store = PostgresStore(settings.postgres_dsn)
+        request.app.state.postgres = store
     try:
         from sqlalchemy import text
 
-        from metatron.core.config import Settings
-        from metatron.storage.postgres import PostgresStore
-
-        settings = Settings()
-        store = PostgresStore(settings.postgres_dsn)
-        try:
-            async with store._engine.begin() as conn:
-                await conn.execute(text("UPDATE connections SET last_synced_at = NULL"))
-                r = await conn.execute(
-                    text(
-                        "UPDATE raw_documents "
-                        "SET qdrant_synced = false, qdrant_synced_at = NULL, "
-                        "    graph_synced = false, graph_synced_at = NULL"
-                    )
+        async with store._engine.begin() as conn:
+            await conn.execute(text("UPDATE connections SET last_synced_at = NULL"))
+            r = await conn.execute(
+                text(
+                    "UPDATE raw_documents "
+                    "SET qdrant_synced = false, qdrant_synced_at = NULL, "
+                    "    graph_synced = false, graph_synced_at = NULL"
                 )
-                docs_reset = r.rowcount
-            sync_state_cleared = True
-            logger.info("admin.reindex.pg_reset_done", docs_reset=docs_reset)
-        finally:
-            await store.close()
+            )
+            docs_reset = r.rowcount
+        sync_state_cleared = True
+        logger.info("admin.reindex.pg_reset_done", docs_reset=docs_reset)
     except Exception as e:
         logger.warning("admin.reindex.pg_reset_error", error=str(e))
 

--- a/src/metatron/api/routes/admin.py
+++ b/src/metatron/api/routes/admin.py
@@ -107,10 +107,12 @@ async def trigger_reindex(
     to re-ingest all documents with current settings (e.g. SPLADE vectors).
 
     Steps:
-    1. Reset sync state (forces full fetch from connectors)
-    2. Reset qdrant_synced=false for all raw_documents
-    3. Reset graph_synced=false for all raw_documents
-    4. Clear Neo4j graph (DETACH DELETE all nodes)
+    1. Reset PG sync state in a single transaction:
+       - connections.last_synced_at = NULL (forces full fetch on next sync)
+       - raw_documents.qdrant_synced = false
+       - raw_documents.graph_synced = false
+    1b. Best-effort: clear legacy file-based SyncState (rolling-deploy guard).
+    2. Clear Neo4j graph (DETACH DELETE all nodes).
 
     Requires header X-Confirm-Reindex: yes
     """
@@ -124,45 +126,53 @@ async def trigger_reindex(
     graph_cleared = False
     sync_state_cleared = False
 
-    # 1. Reset sync state
-    try:
-        from metatron.connectors.sync_state import SyncState
-
-        ss = SyncState()
-        # Clear all known workspace+connector combos
-        for key in list(ss._state.keys()):
-            parts = key.split(":", 1)
-            if len(parts) == 2:
-                ss.clear(parts[0], parts[1])
-        sync_state_cleared = True
-        logger.info("admin.reindex.sync_state_cleared")
-    except Exception as e:
-        logger.warning("admin.reindex.sync_state_error", error=str(e))
-
-    # 2. Reset qdrant_synced + graph_synced in raw_documents
+    # 1. Reset PG sync state — clear connections.last_synced_at AND
+    # raw_documents.{qdrant,graph}_synced flags in a single transaction so
+    # we don't keep two parallel engines for adjacent UPDATEs (MTRNIX-332).
+    # Next sync starts from since=None (full fetch).
     try:
         from sqlalchemy import text
 
         from metatron.core.config import Settings
         from metatron.storage.postgres import PostgresStore
 
-        s = Settings()
-        store = PostgresStore(s.postgres_dsn)
-        async with store._engine.begin() as conn:
-            r = await conn.execute(
-                text(
-                    "UPDATE raw_documents "
-                    "SET qdrant_synced = false, qdrant_synced_at = NULL, "
-                    "    graph_synced = false, graph_synced_at = NULL"
+        settings = Settings()
+        store = PostgresStore(settings.postgres_dsn)
+        try:
+            async with store._engine.begin() as conn:
+                await conn.execute(text("UPDATE connections SET last_synced_at = NULL"))
+                r = await conn.execute(
+                    text(
+                        "UPDATE raw_documents "
+                        "SET qdrant_synced = false, qdrant_synced_at = NULL, "
+                        "    graph_synced = false, graph_synced_at = NULL"
+                    )
                 )
-            )
-            docs_reset = r.rowcount
-        await store.close()
-        logger.info("admin.reindex.docs_reset", count=docs_reset)
+                docs_reset = r.rowcount
+            sync_state_cleared = True
+            logger.info("admin.reindex.pg_reset_done", docs_reset=docs_reset)
+        finally:
+            await store.close()
     except Exception as e:
-        logger.warning("admin.reindex.docs_reset_error", error=str(e))
+        logger.warning("admin.reindex.pg_reset_error", error=str(e))
 
-    # 3. Clear Neo4j graph
+    # 1b. Best-effort: clear legacy file-based SyncState (no-op if file is
+    # not present or already empty; survives mid-rollout deployments).
+    # TODO(MTRNIX-332 follow-up): drop after one release cycle along with
+    # sync_state.py + test_incremental_sync.py.
+    try:
+        from metatron.connectors.sync_state import SyncState
+
+        ss = SyncState()
+        for key in list(ss._state.keys()):
+            parts = key.split(":", 1)
+            if len(parts) == 2:
+                ss.clear(parts[0], parts[1])
+        logger.info("admin.reindex.legacy_sync_state_cleared")
+    except Exception as e:
+        logger.warning("admin.reindex.legacy_sync_state_error", error=str(e))
+
+    # 2. Clear Neo4j graph
     try:
         from metatron.storage.neo4j_graph import get_graph_driver
 

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -719,6 +719,15 @@ async def _run_connection_sync(
     from metatron.ingestion.pipeline import ingest_documents
 
     start_time = time.perf_counter()
+    # Capture the wall-clock instant BEFORE the remote fetch. The cursor must
+    # be stamped with this value (not datetime.now() in the finally block) so
+    # any source-side update that happens DURING fetch+ingest+graph is still
+    # captured by the next sync. Otherwise, a long sync (Confluence/Jira can
+    # take minutes) silently drops every doc whose `updated` falls inside
+    # that window (MTRNIX-332 review B1). Re-fetching one doc next time
+    # (content_hash dedup makes it cheap) is strictly better than losing one
+    # forever.
+    fetch_started_at = datetime.now(UTC)
     status = "failed"
     documents_fetched = 0
     documents_new = 0
@@ -921,17 +930,16 @@ async def _run_connection_sync(
             logger.warning("sync.log_failed", sync_id=sync_id, error=str(e))
 
         # Update connection status. The cursor (last_synced_at) is advanced
-        # ONLY on success/partial — a failed fetch must NOT move the cursor
-        # forward, or documents updated between the last successful sync and
-        # the failed one are lost forever (MTRNIX-332 B1). Passing
-        # ``last_synced_at=None`` means "leave the column unchanged" — see
-        # ``update_connection_status`` for the conditional SET clause.
+        # ONLY on success/partial, and stamped with ``fetch_started_at`` (NOT
+        # ``now()``) — see the explanation at the top of this function.
+        # Passing ``last_synced_at=None`` means "leave the column unchanged"
+        # — see ``update_connection_status`` for the conditional SET clause.
         try:
             await store.update_connection_status(
                 connection_id,
                 status=final_conn_status,
                 error_message=error_msg,
-                last_synced_at=(datetime.now(UTC) if status in ("success", "partial") else None),
+                last_synced_at=(fetch_started_at if status in ("success", "partial") else None),
             )
         except Exception as e:
             logger.warning(
@@ -939,12 +947,6 @@ async def _run_connection_sync(
                 connection_id=connection_id,
                 error=str(e),
             )
-
-        # Cursor advancement happens via update_connection_status above
-        # (connections.last_synced_at = NOW). The legacy file-based
-        # SyncState write has been removed (MTRNIX-332) — it was unreliable
-        # under multi-replica / read-only-FS deployments and PG is now the
-        # single source of truth for the incremental cursor.
 
         # Emit SYNC_COMPLETED for cache invalidation and plugin hooks
         if event_bus is not None:

--- a/src/metatron/api/routes/connections.py
+++ b/src/metatron/api/routes/connections.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import asdict
+from datetime import datetime
 from typing import Any
 
 import structlog
@@ -623,6 +624,22 @@ async def trigger_sync(
     pm = getattr(request.app.state, "plugin_manager", None)
     event_bus = pm.get_event_bus() if pm is not None else None
 
+    # PG cursor for incremental fetch (MTRNIX-332). ``get_connection_decrypted``
+    # returns ``last_synced_at`` as an ISO string (or None for freshly-created
+    # connections); the connector's ``fetch`` expects ``datetime | None`` so we
+    # parse here at the boundary.
+    last_synced_iso = conn.get("last_synced_at")
+    last_synced_dt: datetime | None = None
+    if last_synced_iso:
+        try:
+            last_synced_dt = datetime.fromisoformat(last_synced_iso)
+        except (ValueError, TypeError):
+            logger.warning(
+                "sync.cursor_parse_failed",
+                connection_id=connection_id,
+                raw=last_synced_iso,
+            )
+
     background_tasks.add_task(
         _run_connection_sync,
         sync_id=sync_id,
@@ -633,6 +650,7 @@ async def trigger_sync(
         store=store,
         event_bus=event_bus,
         force_full=force_full,
+        last_synced_at=last_synced_dt,
     )
 
     return {
@@ -677,6 +695,7 @@ async def _run_connection_sync(
     store: PostgresStore,
     event_bus: EventBus | None = None,
     force_full: bool = False,
+    last_synced_at: datetime | None = None,
 ) -> None:
     """Run sync for a DB-based connection. Async background task.
 
@@ -684,10 +703,15 @@ async def _run_connection_sync(
     `trigger_sync` with status='running'. Updates that row on
     completion, failure, or exception.
 
-    ``force_full=True`` bypasses the persistent sync_state cursor (the
-    connector receives ``since=None`` and performs a full refetch). The
-    cursor is still stamped on success — this is a one-off reset, not a
-    permanent mode flip.
+    ``last_synced_at`` is the cursor for incremental fetch — read from
+    ``connections.last_synced_at`` by the caller. ``None`` means "no
+    prior sync" (fresh connection) and the connector performs a full
+    fetch. After successful sync, the cursor is advanced by
+    ``update_connection_status`` in the finally block.
+
+    ``force_full=True`` ignores ``last_synced_at`` entirely and performs
+    a full refetch. The cursor is still stamped on success — this is a
+    one-off reset, not a permanent mode flip.
     """
     import time
     from datetime import UTC, datetime
@@ -721,9 +745,10 @@ async def _run_connection_sync(
 
         await connector.configure(connection_obj, config)
 
-        from metatron.connectors.sync_state import SyncState
-
-        sync_state = SyncState()
+        # Incremental cursor from PG (connections.last_synced_at). For a
+        # freshly-created connection this is NULL → ``since=None`` → full
+        # fetch (correct: nothing has been ingested yet). The cursor is
+        # advanced in the finally block via update_connection_status.
         if force_full:
             since = None
             logger.info(
@@ -733,7 +758,7 @@ async def _run_connection_sync(
                 workspace_id=workspace_id,
             )
         else:
-            since = sync_state.get_last_sync(workspace_id, connector_type)
+            since = last_synced_at
         documents = await connector.fetch(workspace_id, since=since)
         documents_fetched = len(documents)
 
@@ -895,13 +920,18 @@ async def _run_connection_sync(
         except Exception as e:
             logger.warning("sync.log_failed", sync_id=sync_id, error=str(e))
 
-        # Update connection status
+        # Update connection status. The cursor (last_synced_at) is advanced
+        # ONLY on success/partial — a failed fetch must NOT move the cursor
+        # forward, or documents updated between the last successful sync and
+        # the failed one are lost forever (MTRNIX-332 B1). Passing
+        # ``last_synced_at=None`` means "leave the column unchanged" — see
+        # ``update_connection_status`` for the conditional SET clause.
         try:
             await store.update_connection_status(
                 connection_id,
                 status=final_conn_status,
                 error_message=error_msg,
-                last_synced_at=datetime.now(UTC),
+                last_synced_at=(datetime.now(UTC) if status in ("success", "partial") else None),
             )
         except Exception as e:
             logger.warning(
@@ -910,15 +940,11 @@ async def _run_connection_sync(
                 error=str(e),
             )
 
-        # Persist sync timestamp so next sync is incremental (not full)
-        if status in ("success", "partial"):
-            try:
-                from metatron.connectors.sync_state import SyncState
-
-                sync_state = SyncState()
-                sync_state.set_last_sync(workspace_id, connector_type)
-            except Exception as e:
-                logger.warning("sync.state_save.error", error=str(e))
+        # Cursor advancement happens via update_connection_status above
+        # (connections.last_synced_at = NOW). The legacy file-based
+        # SyncState write has been removed (MTRNIX-332) — it was unreliable
+        # under multi-replica / read-only-FS deployments and PG is now the
+        # single source of truth for the incremental cursor.
 
         # Emit SYNC_COMPLETED for cache invalidation and plugin hooks
         if event_bus is not None:

--- a/src/metatron/connectors/_filter.py
+++ b/src/metatron/connectors/_filter.py
@@ -1,0 +1,49 @@
+"""Shared sub-minute cursor filter for connectors (MTRNIX-332).
+
+JQL (Jira) and CQL (Confluence) both support only minute-resolution date
+filters (``yyyy-MM-dd HH:mm``). When the cursor is, say, ``22:09:40``, the
+server-side filter ``>= "22:09"`` (Jira) or ``> "22:09"`` (Confluence) still
+matches docs updated 22:09:00-22:09:59 — so a doc updated in the same minute
+as the cursor stamp gets re-emitted on every sync until the cursor's minute
+advances past it. This module gives the connectors a precise post-filter
+they can apply with the raw item's ``updated`` field to drop those boundary
+docs.
+
+Both helpers are defensive: a missing or unparseable timestamp returns the
+"keep" verdict (``True``) — safer to over-fetch one extra doc than to
+silently lose it through a partially-typed dict from Atlassian's API.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def parse_iso_timestamp(raw: Any) -> datetime | None:
+    """Parse an ISO8601 timestamp (with ``Z`` or numeric offset) to UTC-aware
+    ``datetime``. Returns ``None`` if the input is missing, not a string, or
+    unparseable."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def is_strictly_after(raw_timestamp: Any, since: datetime | None) -> bool:
+    """Return ``True`` if the parsed timestamp is strictly greater than the
+    cursor.
+
+    Returns ``True`` (= keep the doc) when ``since`` is ``None`` (initial
+    sync), the timestamp is missing, or the timestamp is unparseable. Only
+    drops the doc when we are *certain* its update predates or equals the
+    cursor.
+    """
+    if since is None:
+        return True
+    ts = parse_iso_timestamp(raw_timestamp)
+    if ts is None:
+        return True
+    return ts > since

--- a/src/metatron/connectors/confluence.py
+++ b/src/metatron/connectors/confluence.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import structlog
 
+from metatron.connectors._filter import is_strictly_after
 from metatron.connectors.confluence_processing import process_confluence_page
 from metatron.core.interfaces import ConnectorInterface
 from metatron.core.models import Connection, Document
@@ -120,7 +121,14 @@ class ConfluenceConnector(ConnectorInterface):
         space_key: str,
         since: datetime,
     ) -> list[Document]:
-        """Incremental sync using CQL (lastModified filter), then fetch each page."""
+        """Incremental sync using CQL (lastModified filter), then fetch each page.
+
+        CQL only supports minute-precision date filters (``yyyy-MM-dd HH:mm``)
+        so a doc updated in the same minute as the cursor stamp gets re-emitted
+        on every sync until the cursor's minute advances past it. We apply a
+        precise sub-minute post-filter on ``page.version.when`` to drop those
+        boundary docs (MTRNIX-332).
+        """
         documents: list[Document] = []
         cql = f'space="{space_key}" AND type=page' if space_key else "type=page"
         cql += f' AND lastModified > "{since.strftime("%Y-%m-%d %H:%M")}"'
@@ -150,6 +158,12 @@ class ConfluenceConnector(ConnectorInterface):
                         page_id,
                         expand="body.storage,version,history",
                     )
+                    # Precise sub-minute post-filter (MTRNIX-332). CQL is
+                    # minute-resolution; here we drop pages whose actual
+                    # ``version.when`` is <= the cursor.
+                    page_updated = (page.get("version") or {}).get("when")
+                    if not is_strictly_after(page_updated, since):
+                        continue
                     doc = self._page_to_document(page, workspace_id, base_url, space_key)
                     documents.append(doc)
                 except Exception as e:

--- a/src/metatron/connectors/jira.py
+++ b/src/metatron/connectors/jira.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import structlog
 
+from metatron.connectors._filter import is_strictly_after
 from metatron.connectors.jira_processing import (
     jira_issue_to_markdown,
     process_jira_issue,
@@ -94,18 +95,18 @@ class JiraConnector(ConnectorInterface):
                 break
 
             for raw_issue in issues:
+                # Precise post-filter (MTRNIX-332). JQL only narrows to the
+                # minute; here we drop anything whose actual ``updated`` is
+                # <= the cursor at sub-minute resolution. We do this BEFORE
+                # the (expensive) ``_issue_to_document`` parse — ADF extract
+                # + changelog walk + comments parsing is the bulk of the
+                # work, no point doing it just to throw the doc away.
+                if since is not None and not is_strictly_after(
+                    (raw_issue.get("fields") or {}).get("updated"), since
+                ):
+                    continue
                 try:
                     doc = self._issue_to_document(raw_issue, workspace_id)
-                    # Precise post-filter (MTRNIX-332). JQL only narrows to
-                    # the minute; here we drop anything whose actual
-                    # ``updated`` is <= the cursor at sub-minute resolution.
-                    # Without this, an issue updated in the same minute the
-                    # cursor was stamped is re-fetched on every subsequent
-                    # sync until the cursor's minute advances.
-                    if since is not None:
-                        updated_at = self._extract_updated_at(raw_issue)
-                        if updated_at is not None and updated_at <= since:
-                            continue
                     documents.append(doc)
                 except Exception as e:
                     logger.warning("jira.issue.error", error=str(e))
@@ -121,25 +122,9 @@ class JiraConnector(ConnectorInterface):
         logger.info("jira.fetch.done", issues=len(documents))
         return documents
 
-    @staticmethod
-    def _extract_updated_at(raw_issue: dict) -> datetime | None:
-        """Parse the issue's ``updated`` field to a tz-aware datetime.
-
-        Reads the raw Jira REST shape directly (``fields.updated``) — avoids
-        a second ``process_jira_issue`` pass (ADF extract + changelog walk +
-        comments parsing) which already runs inside ``_issue_to_document``.
-
-        Jira returns ISO8601 like ``"2026-05-12T14:02:26.002+0300"``. Returns
-        ``None`` if the field is missing or unparseable — the caller treats
-        that as "do not filter" (safer to over-fetch than to miss data).
-        """
-        try:
-            raw = (raw_issue.get("fields") or {}).get("updated") or ""
-            if not raw:
-                return None
-            return datetime.fromisoformat(raw.replace("Z", "+00:00"))
-        except (ValueError, AttributeError, TypeError):
-            return None
+    # NOTE: sub-minute cursor filtering for the JQL minute-precision trap
+    # lives in ``metatron.connectors._filter.is_strictly_after`` and is
+    # applied directly in ``fetch()`` above — no per-connector parser.
 
     def _issue_to_document(self, raw_issue: dict, workspace_id: str) -> Document:
         structured = process_jira_issue(raw_issue)

--- a/src/metatron/connectors/jira.py
+++ b/src/metatron/connectors/jira.py
@@ -62,6 +62,10 @@ class JiraConnector(ConnectorInterface):
         project_key = self._config.get("project_key", "")
         documents: list[Document] = []
 
+        # JQL's date filter only supports minute precision ("yyyy-MM-dd HH:mm"),
+        # so a cursor at 22:09:40 formatted as "22:09" still matches docs from
+        # 22:09:00-22:09:59. We use the minute filter as a coarse server-side
+        # narrowing and then do a precise post-filter below (MTRNIX-332).
         jql = f'project="{project_key}"' if project_key else "ORDER BY updated DESC"
         if since:
             since_str = since.strftime("%Y-%m-%d %H:%M")
@@ -92,6 +96,16 @@ class JiraConnector(ConnectorInterface):
             for raw_issue in issues:
                 try:
                     doc = self._issue_to_document(raw_issue, workspace_id)
+                    # Precise post-filter (MTRNIX-332). JQL only narrows to
+                    # the minute; here we drop anything whose actual
+                    # ``updated`` is <= the cursor at sub-minute resolution.
+                    # Without this, an issue updated in the same minute the
+                    # cursor was stamped is re-fetched on every subsequent
+                    # sync until the cursor's minute advances.
+                    if since is not None:
+                        updated_at = self._extract_updated_at(raw_issue)
+                        if updated_at is not None and updated_at <= since:
+                            continue
                     documents.append(doc)
                 except Exception as e:
                     logger.warning("jira.issue.error", error=str(e))
@@ -106,6 +120,26 @@ class JiraConnector(ConnectorInterface):
 
         logger.info("jira.fetch.done", issues=len(documents))
         return documents
+
+    @staticmethod
+    def _extract_updated_at(raw_issue: dict) -> datetime | None:
+        """Parse the issue's ``updated`` field to a tz-aware datetime.
+
+        Reads the raw Jira REST shape directly (``fields.updated``) — avoids
+        a second ``process_jira_issue`` pass (ADF extract + changelog walk +
+        comments parsing) which already runs inside ``_issue_to_document``.
+
+        Jira returns ISO8601 like ``"2026-05-12T14:02:26.002+0300"``. Returns
+        ``None`` if the field is missing or unparseable — the caller treats
+        that as "do not filter" (safer to over-fetch than to miss data).
+        """
+        try:
+            raw = (raw_issue.get("fields") or {}).get("updated") or ""
+            if not raw:
+                return None
+            return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except (ValueError, AttributeError, TypeError):
+            return None
 
     def _issue_to_document(self, raw_issue: dict, workspace_id: str) -> Document:
         structured = process_jira_issue(raw_issue)

--- a/src/metatron/storage/postgres.py
+++ b/src/metatron/storage/postgres.py
@@ -462,7 +462,22 @@ class PostgresStore:
         error_message: str | None = None,
         last_synced_at: datetime | None = None,
     ) -> None:
-        """Update connection status, error message, and optional sync timestamp."""
+        """Update connection status, error message, and optional sync timestamp.
+
+        **Asymmetric ``None`` semantics — read carefully:**
+
+        * ``error_message=None`` → SQL writes ``error_message = NULL``. This
+          unconditionally clears any previously-stored error message.
+          (Pre-existing behaviour; not changed by MTRNIX-332.)
+        * ``last_synced_at=None`` → the cursor column is NOT touched (the
+          ``SET last_synced_at = ...`` clause is omitted). This is the
+          mechanism used by ``_run_connection_sync`` to leave the cursor
+          unchanged on failed syncs — advancing it would silently drop
+          documents updated between the last good sync and the failure.
+
+        The divergence is an artefact of the cursor-trap fix in MTRNIX-332;
+        unifying the two patterns is a separate follow-up.
+        """
         logger.info(
             "postgres.connection.update_status",
             connection_id=connection_id,
@@ -1271,9 +1286,7 @@ class PostgresStore:
         )
         async with self._engine.begin() as conn:
             result = await conn.execute(
-                text(
-                    "SELECT count(*) FROM raw_documents WHERE workspace_id = :workspace_id"
-                ),
+                text("SELECT count(*) FROM raw_documents WHERE workspace_id = :workspace_id"),
                 {"workspace_id": workspace_id},
             )
             row = result.first()

--- a/tests/unit/test_admin_reindex.py
+++ b/tests/unit/test_admin_reindex.py
@@ -41,6 +41,17 @@ def seeded_connection_with_cursor() -> tuple[str, str, datetime]:
     return ws, cid, cursor
 
 
+def _make_request_with_app_state() -> MagicMock:
+    """Build a minimal Request-like with app.state.settings (post-S1 refactor)."""
+    from metatron.core.config import Settings
+
+    request = MagicMock()
+    request.app.state.settings = Settings()
+    # No pre-existing pooled store → route lazily creates one.
+    request.app.state.postgres = None
+    return request
+
+
 async def test_reindex_clears_last_synced_at(seeded_connection_with_cursor) -> None:
     """After /reindex, connections.last_synced_at MUST be NULL.
 
@@ -61,8 +72,9 @@ async def test_reindex_clears_last_synced_at(seeded_connection_with_cursor) -> N
     fake_session.__exit__ = MagicMock(return_value=False)
     fake_driver.session.return_value = fake_session
 
+    request = _make_request_with_app_state()
     with patch("metatron.storage.neo4j_graph.get_graph_driver", return_value=fake_driver):
-        resp = await trigger_reindex(x_confirm_reindex="yes")
+        resp = await trigger_reindex(request=request, x_confirm_reindex="yes")
 
     assert resp.sync_state_cleared is True
     with get_session() as s:
@@ -76,6 +88,7 @@ async def test_reindex_requires_confirmation_header() -> None:
     """Without X-Confirm-Reindex: yes, the endpoint must refuse (400)."""
     from fastapi import HTTPException
 
+    request = _make_request_with_app_state()
     with pytest.raises(HTTPException) as exc:
-        await trigger_reindex(x_confirm_reindex=None)
+        await trigger_reindex(request=request, x_confirm_reindex=None)
     assert exc.value.status_code == 400

--- a/tests/unit/test_admin_reindex.py
+++ b/tests/unit/test_admin_reindex.py
@@ -1,0 +1,81 @@
+"""Tests for /admin/reindex — PG cursor reset (MTRNIX-332)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from metatron.api.routes.admin import trigger_reindex
+from metatron.storage.pg_connection import get_session
+from metatron.storage.pg_models import ConnectionRow
+
+
+@pytest.fixture
+def seeded_connection_with_cursor() -> tuple[str, str, datetime]:
+    """Seed a workspace + connection with a non-NULL last_synced_at."""
+    suffix = uuid4().hex[:10]
+    ws = f"ws_reidx_{suffix}"
+    cid = f"conn_reidx_{suffix}"
+    cursor = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    with get_session() as s:
+        s.execute(
+            text("INSERT INTO workspaces (id, name, slug) VALUES (:id, :n, :sl)"),
+            {"id": ws, "n": "t", "sl": ws},
+        )
+        s.add(
+            ConnectionRow(
+                id=cid,
+                workspace_id=ws,
+                connector_type="jira",
+                name="T",
+                config_encrypted=b"x",
+                status="active",
+                enabled=True,
+                last_synced_at=cursor,
+            )
+        )
+    return ws, cid, cursor
+
+
+async def test_reindex_clears_last_synced_at(seeded_connection_with_cursor) -> None:
+    """After /reindex, connections.last_synced_at MUST be NULL.
+
+    Without this, the next sync would still use the old cursor and skip
+    documents that the reindex is meant to re-ingest from scratch.
+    """
+    ws, cid, prior_cursor = seeded_connection_with_cursor
+
+    # Sanity: cursor was set
+    with get_session() as s:
+        assert s.query(ConnectionRow).filter_by(id=cid).first().last_synced_at == prior_cursor
+
+    # Mock Neo4j away — reindex's section 2 (graph clear) requires a live driver
+    # that we don't want to touch from this test.
+    fake_driver = MagicMock()
+    fake_session = MagicMock()
+    fake_session.__enter__ = MagicMock(return_value=fake_session)
+    fake_session.__exit__ = MagicMock(return_value=False)
+    fake_driver.session.return_value = fake_session
+
+    with patch("metatron.storage.neo4j_graph.get_graph_driver", return_value=fake_driver):
+        resp = await trigger_reindex(x_confirm_reindex="yes")
+
+    assert resp.sync_state_cleared is True
+    with get_session() as s:
+        conn = s.query(ConnectionRow).filter_by(id=cid).first()
+        assert conn.last_synced_at is None, (
+            f"reindex must NULL last_synced_at, still {conn.last_synced_at!r}"
+        )
+
+
+async def test_reindex_requires_confirmation_header() -> None:
+    """Without X-Confirm-Reindex: yes, the endpoint must refuse (400)."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await trigger_reindex(x_confirm_reindex=None)
+    assert exc.value.status_code == 400

--- a/tests/unit/test_confluence_connector.py
+++ b/tests/unit/test_confluence_connector.py
@@ -123,3 +123,91 @@ class TestConnectorRegistry:
         register_builtins(registry)
         connector = registry.create("jira")
         assert isinstance(connector, JiraConnector)
+
+
+# ---------------------------------------------------------------------------
+# Sub-minute post-filter (MTRNIX-332) — parity with Jira
+# ---------------------------------------------------------------------------
+
+
+def _page(page_id: str, when: str) -> dict:
+    """Minimal Confluence page payload that survives _page_to_document."""
+    return {
+        "id": page_id,
+        "title": f"Page {page_id}",
+        "body": {"storage": {"value": f"<p>body {page_id}</p>"}},
+        "version": {"when": when, "by": {"displayName": "u"}},
+        "_links": {"webui": f"/spaces/X/pages/{page_id}"},
+    }
+
+
+class TestConfluenceFetchPostFilter:
+    @pytest.mark.asyncio
+    async def test_drops_page_with_version_when_equal_to_since(self) -> None:
+        """CQL minute-precision lets same-minute pages through; post-filter drops them."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock
+
+        connector = ConfluenceConnector()
+        connector._config = {
+            "url": "https://co.atlassian.net",
+            "space_key": "X",
+            "username": "u",
+            "api_token": "t",
+        }
+        since = datetime(2026, 5, 12, 22, 9, 27, tzinfo=UTC)
+
+        connector._client = MagicMock()
+        connector._client.cql = MagicMock(
+            return_value={
+                "results": [{"content": {"id": "100"}}],
+                "totalSize": 1,
+                "size": 1,
+            }
+        )
+        connector._client.get_page_by_id = MagicMock(
+            return_value=_page("100", "2026-05-12T22:09:27.000Z")
+        )
+
+        # _fetch_incremental is sync; call directly.
+        docs = connector._fetch_incremental(
+            workspace_id="ws1",
+            base_url="https://co.atlassian.net",
+            space_key="X",
+            since=since,
+        )
+        assert docs == [], "page with version.when == since must be filtered out"
+
+    @pytest.mark.asyncio
+    async def test_keeps_page_with_version_when_after_since(self) -> None:
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock
+
+        connector = ConfluenceConnector()
+        connector._config = {
+            "url": "https://co.atlassian.net",
+            "space_key": "X",
+            "username": "u",
+            "api_token": "t",
+        }
+        since = datetime(2026, 5, 12, 22, 9, 27, tzinfo=UTC)
+
+        connector._client = MagicMock()
+        connector._client.cql = MagicMock(
+            return_value={
+                "results": [{"content": {"id": "100"}}],
+                "totalSize": 1,
+                "size": 1,
+            }
+        )
+        connector._client.get_page_by_id = MagicMock(
+            return_value=_page("100", "2026-05-12T22:09:28.000Z")
+        )
+
+        docs = connector._fetch_incremental(
+            workspace_id="ws1",
+            base_url="https://co.atlassian.net",
+            space_key="X",
+            since=since,
+        )
+        assert len(docs) == 1

--- a/tests/unit/test_connections_sync.py
+++ b/tests/unit/test_connections_sync.py
@@ -11,7 +11,7 @@ from sqlalchemy import text
 
 from metatron.api.routes.connections import _run_connection_sync
 from metatron.core.config import Settings
-from metatron.core.models import Document
+from metatron.core.models import Document, SyncResult
 from metatron.storage.pg_connection import get_session
 from metatron.storage.pg_models import ConnectionRow, SyncLogRow
 from metatron.storage.postgres import PostgresStore
@@ -152,6 +152,11 @@ async def test_run_connection_sync_failed_does_not_advance_cursor(store, seeded_
     Without the guard, the cursor advances unconditionally in the finally
     block — documents updated between the last good sync and the failure
     are then filtered out on next sync (silent data loss).
+
+    Also tightens the failure path: asserts that the *seeded* exception
+    message reaches the sync_logs row and the connection.error_message —
+    otherwise the test would pass for any internal collaborator failure,
+    not just the one we injected.
     """
     ws, cid = seeded_ids
     sync_id = f"sync_fail_cursor_{uuid4().hex[:10]}"
@@ -184,11 +189,16 @@ async def test_run_connection_sync_failed_does_not_advance_cursor(store, seeded_
         )
 
     with get_session() as s:
+        row = s.query(SyncLogRow).filter_by(id=sync_id).first()
         conn = s.query(ConnectionRow).filter_by(id=cid).first()
-        # status flipped to error, but the cursor must be unchanged.
+        # The exception we seeded must surface end-to-end (tightens the test
+        # so it can't pass for some unrelated unmocked-collaborator failure).
+        assert any("transient network blip" in e for e in row.errors), (
+            f"expected seeded error message in sync_log.errors, got {row.errors!r}"
+        )
+        assert "transient network blip" in (conn.error_message or "")
+        # Cursor must NOT have advanced.
         assert conn.status == "error"
-        # Compare with tolerance: PG may strip TZ depending on column type;
-        # we only care that the value is the prior cursor, not "now()".
         stored = conn.last_synced_at
         if stored.tzinfo is None:
             stored = stored.replace(tzinfo=UTC)
@@ -198,13 +208,113 @@ async def test_run_connection_sync_failed_does_not_advance_cursor(store, seeded_
         )
 
 
+async def test_run_connection_sync_force_full_failed_does_not_advance_cursor(store, seeded_ids):
+    """force_full=True + failure: cursor must still NOT advance (per docstring)."""
+    ws, cid = seeded_ids
+    sync_id = f"sync_force_fail_{uuid4().hex[:10]}"
+
+    prior_cursor = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    with get_session() as s:
+        s.query(ConnectionRow).filter_by(id=cid).update({"last_synced_at": prior_cursor})
+    await store.create_sync_log(sync_id, ws, cid, "jira")
+
+    fake_connector = MagicMock()
+    fake_connector.source_role = "task_tracker"
+    fake_connector.configure = AsyncMock()
+    fake_connector.fetch = AsyncMock(side_effect=RuntimeError("forced full boom"))
+
+    fake_registry = MagicMock()
+    fake_registry.create.return_value = fake_connector
+
+    with patch("metatron.api.routes.connections._get_registry", return_value=fake_registry):
+        await _run_connection_sync(
+            sync_id=sync_id,
+            connection_id=cid,
+            connector_type="jira",
+            config={"url": "http://x"},
+            workspace_id=ws,
+            store=store,
+            event_bus=None,
+            force_full=True,
+            last_synced_at=prior_cursor,
+        )
+
+    with get_session() as s:
+        conn = s.query(ConnectionRow).filter_by(id=cid).first()
+        assert conn.status == "error"
+        stored = conn.last_synced_at
+        if stored.tzinfo is None:
+            stored = stored.replace(tzinfo=UTC)
+        assert stored == prior_cursor
+
+
+async def test_run_connection_sync_success_advances_cursor_past_prior(store, seeded_ids):
+    """Positive path: a successful sync advances the cursor strictly past the prior.
+
+    Pins the success branch behaviour — earlier tests verified `since` was
+    forwarded but not that the cursor actually advanced.
+    """
+    ws, cid = seeded_ids
+    sync_id = f"sync_advance_{uuid4().hex[:10]}"
+
+    prior_cursor = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    with get_session() as s:
+        s.query(ConnectionRow).filter_by(id=cid).update({"last_synced_at": prior_cursor})
+    await store.create_sync_log(sync_id, ws, cid, "jira")
+
+    fake_connector = MagicMock()
+    fake_connector.source_role = "task_tracker"
+    fake_connector.configure = AsyncMock()
+    fake_connector.fetch = AsyncMock(return_value=[])
+
+    fake_registry = MagicMock()
+    fake_registry.create.return_value = fake_connector
+
+    with (
+        patch("metatron.api.routes.connections._get_registry", return_value=fake_registry),
+        patch(
+            "metatron.ingestion.pipeline.ingest_documents",
+            AsyncMock(return_value=_empty_ingest_result()),
+        ),
+        patch(
+            "metatron.ingestion.pipeline.process_all_unsynced_graphs",
+            AsyncMock(return_value={"ok": 0, "errors": 0}),
+        ),
+    ):
+        await _run_connection_sync(
+            sync_id=sync_id,
+            connection_id=cid,
+            connector_type="jira",
+            config={"url": "http://x", "username": "u", "api_token": "t", "project_key": "P"},
+            workspace_id=ws,
+            store=store,
+            event_bus=None,
+            last_synced_at=prior_cursor,
+        )
+
+    with get_session() as s:
+        conn = s.query(ConnectionRow).filter_by(id=cid).first()
+        assert conn.status == "active"
+        stored = conn.last_synced_at
+        if stored.tzinfo is None:
+            stored = stored.replace(tzinfo=UTC)
+        assert stored > prior_cursor, (
+            f"successful sync must advance cursor past prior {prior_cursor!r}, got {stored!r}"
+        )
+        # And the stamp is bounded above by now() — sanity check that we are
+        # using fetch_started_at (captured at function entry), not something
+        # in the far future.
+        assert stored <= datetime.now(UTC), f"cursor stamp must be <= now, got {stored!r}"
+
+
 # ---------------------------------------------------------------------------
 # force_full flag (MTRNIX-332)
 # ---------------------------------------------------------------------------
 
 
-def _empty_ingest_result() -> MagicMock:
-    return MagicMock(
+def _empty_ingest_result() -> SyncResult:
+    """Real SyncResult — fails fast if the dataclass shape drifts."""
+    return SyncResult(
         documents_new=0,
         documents_updated=0,
         documents_skipped=0,

--- a/tests/unit/test_connections_sync.py
+++ b/tests/unit/test_connections_sync.py
@@ -146,22 +146,79 @@ async def test_run_connection_sync_marks_failed_on_exception(store, seeded_ids):
         assert "Jira 500" in (conn.error_message or "")
 
 
+async def test_run_connection_sync_failed_does_not_advance_cursor(store, seeded_ids):
+    """Regression for MTRNIX-332 B1: failed sync must NOT move last_synced_at.
+
+    Without the guard, the cursor advances unconditionally in the finally
+    block — documents updated between the last good sync and the failure
+    are then filtered out on next sync (silent data loss).
+    """
+    ws, cid = seeded_ids
+    sync_id = f"sync_fail_cursor_{uuid4().hex[:10]}"
+
+    # Seed an existing cursor — sync_id_prev "successful" — on the connection.
+    prior_cursor = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    with get_session() as s:
+        s.query(ConnectionRow).filter_by(id=cid).update({"last_synced_at": prior_cursor})
+
+    await store.create_sync_log(sync_id, ws, cid, "jira")
+
+    fake_connector = MagicMock()
+    fake_connector.source_role = "task_tracker"
+    fake_connector.configure = AsyncMock()
+    fake_connector.fetch = AsyncMock(side_effect=RuntimeError("transient network blip"))
+
+    fake_registry = MagicMock()
+    fake_registry.create.return_value = fake_connector
+
+    with patch("metatron.api.routes.connections._get_registry", return_value=fake_registry):
+        await _run_connection_sync(
+            sync_id=sync_id,
+            connection_id=cid,
+            connector_type="jira",
+            config={"url": "http://x"},
+            workspace_id=ws,
+            store=store,
+            event_bus=None,
+            last_synced_at=prior_cursor,
+        )
+
+    with get_session() as s:
+        conn = s.query(ConnectionRow).filter_by(id=cid).first()
+        # status flipped to error, but the cursor must be unchanged.
+        assert conn.status == "error"
+        # Compare with tolerance: PG may strip TZ depending on column type;
+        # we only care that the value is the prior cursor, not "now()".
+        stored = conn.last_synced_at
+        if stored.tzinfo is None:
+            stored = stored.replace(tzinfo=UTC)
+        assert stored == prior_cursor, (
+            f"failed sync MUST NOT advance last_synced_at — was {prior_cursor!r}, "
+            f"now {conn.last_synced_at!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # force_full flag (MTRNIX-332)
 # ---------------------------------------------------------------------------
 
 
-async def test_run_connection_sync_force_full_bypasses_sync_state(store, seeded_ids):
-    """force_full=True must pass since=None to fetch and skip SyncState read."""
+def _empty_ingest_result() -> MagicMock:
+    return MagicMock(
+        documents_new=0,
+        documents_updated=0,
+        documents_skipped=0,
+        errors=[],
+    )
+
+
+async def test_run_connection_sync_force_full_bypasses_cursor(store, seeded_ids):
+    """force_full=True passes since=None even when PG has a stale cursor."""
     ws, cid = seeded_ids
     sync_id = f"sync_force_{uuid4().hex[:10]}"
     await store.create_sync_log(sync_id, ws, cid, "jira")
 
-    # SyncState would normally return a stale cursor — verify we ignore it.
     stale_cursor = datetime(2099, 1, 1, tzinfo=UTC)
-    mock_sync_state = MagicMock()
-    mock_sync_state.get_last_sync = MagicMock(return_value=stale_cursor)
-    mock_sync_state.set_last_sync = MagicMock()
 
     fake_connector = MagicMock()
     fake_connector.source_role = "task_tracker"
@@ -173,17 +230,9 @@ async def test_run_connection_sync_force_full_bypasses_sync_state(store, seeded_
 
     with (
         patch("metatron.api.routes.connections._get_registry", return_value=fake_registry),
-        patch("metatron.connectors.sync_state.SyncState", return_value=mock_sync_state),
         patch(
             "metatron.ingestion.pipeline.ingest_documents",
-            AsyncMock(
-                return_value=MagicMock(
-                    documents_new=0,
-                    documents_updated=0,
-                    documents_skipped=0,
-                    errors=[],
-                )
-            ),
+            AsyncMock(return_value=_empty_ingest_result()),
         ),
     ):
         await _run_connection_sync(
@@ -195,28 +244,23 @@ async def test_run_connection_sync_force_full_bypasses_sync_state(store, seeded_
             store=store,
             event_bus=None,
             force_full=True,
+            last_synced_at=stale_cursor,
         )
 
-    # The whole point: fetch was called with since=None despite the stale cursor.
     fake_connector.fetch.assert_awaited_once()
-    call_kwargs = fake_connector.fetch.await_args.kwargs
-    assert call_kwargs.get("since") is None, (
-        f"force_full=True must pass since=None, got {call_kwargs.get('since')!r}"
+    assert fake_connector.fetch.await_args.kwargs.get("since") is None, (
+        f"force_full=True must pass since=None, got "
+        f"{fake_connector.fetch.await_args.kwargs.get('since')!r}"
     )
-    # SyncState.get_last_sync must NOT have been called — we bypass it entirely.
-    mock_sync_state.get_last_sync.assert_not_called()
 
 
-async def test_run_connection_sync_default_reads_sync_state(store, seeded_ids):
-    """force_full=False (default) keeps the cursor read — regression guard."""
+async def test_run_connection_sync_default_uses_pg_cursor(store, seeded_ids):
+    """force_full=False (default) reads cursor from last_synced_at param (PG)."""
     ws, cid = seeded_ids
     sync_id = f"sync_default_{uuid4().hex[:10]}"
     await store.create_sync_log(sync_id, ws, cid, "jira")
 
     cursor = datetime(2026, 5, 1, tzinfo=UTC)
-    mock_sync_state = MagicMock()
-    mock_sync_state.get_last_sync = MagicMock(return_value=cursor)
-    mock_sync_state.set_last_sync = MagicMock()
 
     fake_connector = MagicMock()
     fake_connector.source_role = "task_tracker"
@@ -228,17 +272,9 @@ async def test_run_connection_sync_default_reads_sync_state(store, seeded_ids):
 
     with (
         patch("metatron.api.routes.connections._get_registry", return_value=fake_registry),
-        patch("metatron.connectors.sync_state.SyncState", return_value=mock_sync_state),
         patch(
             "metatron.ingestion.pipeline.ingest_documents",
-            AsyncMock(
-                return_value=MagicMock(
-                    documents_new=0,
-                    documents_updated=0,
-                    documents_skipped=0,
-                    errors=[],
-                )
-            ),
+            AsyncMock(return_value=_empty_ingest_result()),
         ),
     ):
         await _run_connection_sync(
@@ -249,12 +285,47 @@ async def test_run_connection_sync_default_reads_sync_state(store, seeded_ids):
             workspace_id=ws,
             store=store,
             event_bus=None,
-            # force_full omitted — defaults to False
+            last_synced_at=cursor,
         )
 
     fake_connector.fetch.assert_awaited_once()
     assert fake_connector.fetch.await_args.kwargs.get("since") == cursor
-    mock_sync_state.get_last_sync.assert_called_once_with(ws, "jira")
+
+
+async def test_run_connection_sync_null_cursor_means_full_fetch(store, seeded_ids):
+    """Freshly-created connection has last_synced_at=NULL → since=None → full fetch."""
+    ws, cid = seeded_ids
+    sync_id = f"sync_fresh_{uuid4().hex[:10]}"
+    await store.create_sync_log(sync_id, ws, cid, "jira")
+
+    fake_connector = MagicMock()
+    fake_connector.source_role = "task_tracker"
+    fake_connector.configure = AsyncMock()
+    fake_connector.fetch = AsyncMock(return_value=[])
+
+    fake_registry = MagicMock()
+    fake_registry.create.return_value = fake_connector
+
+    with (
+        patch("metatron.api.routes.connections._get_registry", return_value=fake_registry),
+        patch(
+            "metatron.ingestion.pipeline.ingest_documents",
+            AsyncMock(return_value=_empty_ingest_result()),
+        ),
+    ):
+        await _run_connection_sync(
+            sync_id=sync_id,
+            connection_id=cid,
+            connector_type="jira",
+            config={"url": "http://x", "username": "u", "api_token": "t", "project_key": "P"},
+            workspace_id=ws,
+            store=store,
+            event_bus=None,
+            last_synced_at=None,  # explicit: never synced before
+        )
+
+    fake_connector.fetch.assert_awaited_once()
+    assert fake_connector.fetch.await_args.kwargs.get("since") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_connectors_filter.py
+++ b/tests/unit/test_connectors_filter.py
@@ -1,0 +1,74 @@
+"""Tests for the shared sub-minute cursor post-filter (MTRNIX-332)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from metatron.connectors._filter import is_strictly_after, parse_iso_timestamp
+
+
+class TestParseIsoTimestamp:
+    def test_parses_with_z_suffix(self) -> None:
+        ts = parse_iso_timestamp("2026-05-12T11:02:26.000Z")
+        assert ts == datetime(2026, 5, 12, 11, 2, 26, tzinfo=UTC)
+
+    def test_parses_with_numeric_offset(self) -> None:
+        ts = parse_iso_timestamp("2026-05-12T14:02:26.002+0300")
+        # The parsed value preserves the +0300 offset; the same instant
+        # in UTC is 11:02:26.
+        assert ts is not None
+        assert ts.utcoffset() is not None
+        assert ts.astimezone(UTC) == datetime(2026, 5, 12, 11, 2, 26, 2000, tzinfo=UTC)
+
+    def test_none_returns_none(self) -> None:
+        assert parse_iso_timestamp(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_iso_timestamp("") is None
+
+    def test_non_string_returns_none(self) -> None:
+        assert parse_iso_timestamp(42) is None
+        assert parse_iso_timestamp({"weird": "shape"}) is None
+
+    def test_unparseable_returns_none(self) -> None:
+        assert parse_iso_timestamp("not-a-date") is None
+
+
+class TestIsStrictlyAfter:
+    def test_since_none_always_keeps(self) -> None:
+        """Initial sync (since=None) must not drop anything."""
+        assert is_strictly_after("2026-05-12T11:02:26.000Z", None) is True
+        assert is_strictly_after(None, None) is True
+
+    def test_strictly_after_keeps(self) -> None:
+        since = datetime(2026, 5, 12, 11, 2, 26, tzinfo=UTC)
+        assert is_strictly_after("2026-05-12T11:02:27.000Z", since) is True
+
+    def test_equal_drops(self) -> None:
+        """Boundary equality: same instant as cursor must be filtered out."""
+        since = datetime(2026, 5, 12, 11, 2, 26, tzinfo=UTC)
+        assert is_strictly_after("2026-05-12T11:02:26.000Z", since) is False
+
+    def test_strictly_before_drops(self) -> None:
+        since = datetime(2026, 5, 12, 11, 2, 26, tzinfo=UTC)
+        assert is_strictly_after("2026-05-12T11:02:25.000Z", since) is False
+
+    def test_missing_timestamp_keeps_with_cursor(self) -> None:
+        """When the source doesn't include an `updated`, over-fetch rather
+        than silently drop the doc."""
+        since = datetime(2026, 5, 12, 11, 2, 26, tzinfo=UTC)
+        assert is_strictly_after(None, since) is True
+        assert is_strictly_after("", since) is True
+
+    def test_unparseable_timestamp_keeps(self) -> None:
+        """Same safety bias: parse failure → over-fetch."""
+        since = datetime(2026, 5, 12, 11, 2, 26, tzinfo=UTC)
+        assert is_strictly_after("garbage", since) is True
+
+    def test_tz_aware_comparison_across_offsets(self) -> None:
+        """Comparing UTC cursor against +03:00 timestamp — same instant."""
+        since = datetime(2026, 5, 12, 11, 2, 26, tzinfo=UTC)
+        # 14:02:26 +0300 == 11:02:26 UTC → equal → drop.
+        assert is_strictly_after("2026-05-12T14:02:26.000+0300", since) is False
+        # 14:02:27 +0300 == 11:02:27 UTC → after → keep.
+        assert is_strictly_after("2026-05-12T14:02:27.000+0300", since) is True

--- a/tests/unit/test_jira_connector.py
+++ b/tests/unit/test_jira_connector.py
@@ -61,44 +61,6 @@ class TestJiraDocumentUrl:
 
 
 # ---------------------------------------------------------------------------
-# _extract_updated_at — sub-minute precision for the post-filter (MTRNIX-332)
-# ---------------------------------------------------------------------------
-
-
-class TestExtractUpdatedAt:
-    def test_parses_iso_with_tz_offset(self) -> None:
-        raw = {"fields": {"updated": "2026-05-12T14:02:26.002+0300"}}
-        ts = JiraConnector._extract_updated_at(raw)
-        assert ts == datetime(2026, 5, 12, 11, 2, 26, 2000, tzinfo=UTC)
-
-    def test_parses_iso_with_z_suffix(self) -> None:
-        raw = {"fields": {"updated": "2026-05-12T11:02:26.000Z"}}
-        ts = JiraConnector._extract_updated_at(raw)
-        assert ts is not None
-        assert ts.year == 2026
-        assert ts.tzinfo is not None
-
-    def test_missing_field_returns_none(self) -> None:
-        assert JiraConnector._extract_updated_at({"fields": {}}) is None
-
-    def test_missing_fields_dict_returns_none(self) -> None:
-        assert JiraConnector._extract_updated_at({}) is None
-
-    def test_unparseable_value_returns_none(self) -> None:
-        raw = {"fields": {"updated": "not-a-date"}}
-        assert JiraConnector._extract_updated_at(raw) is None
-
-    def test_does_not_call_process_jira_issue(self) -> None:
-        """W1: helper must read raw dict directly, not re-parse the full issue."""
-        from unittest.mock import patch
-
-        raw = {"fields": {"updated": "2026-05-12T11:02:26.000+0000"}}
-        with patch("metatron.connectors.jira_processing.process_jira_issue") as mock_process:
-            JiraConnector._extract_updated_at(raw)
-        mock_process.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
 # Sub-minute post-filter in fetch (MTRNIX-332)
 # ---------------------------------------------------------------------------
 
@@ -189,3 +151,40 @@ class TestFetchPostFilter:
 
         docs = await connector.fetch(workspace_id="ws1", since=None)
         assert len(docs) == 2
+
+    @pytest.mark.asyncio
+    async def test_filter_runs_before_expensive_issue_parse(self) -> None:
+        """W1: filtered-out issues must skip ``_issue_to_document`` entirely.
+
+        ``_issue_to_document`` runs ADF extract + changelog walk + comments
+        parsing — the bulk of the connector's CPU. Doing that work for an
+        issue we're about to throw away is the regression to prevent.
+        """
+        from unittest.mock import patch
+
+        connector = JiraConnector()
+        connector._config = {"url": "https://co.atlassian.net", "project_key": "P"}
+        since = datetime(2026, 5, 12, 22, 9, 27, tzinfo=UTC)
+        # Two issues: one to drop (==since), one to keep (>since).
+        old = "2026-05-12T22:09:27.000+0000"
+        new = "2026-05-12T22:09:28.000+0000"
+
+        connector._client = MagicMock()
+        connector._client.enhanced_jql = MagicMock(
+            return_value={
+                "issues": [_raw_issue("P-OLD", old), _raw_issue("P-NEW", new)],
+                "isLast": True,
+            }
+        )
+
+        with patch.object(
+            connector, "_issue_to_document", wraps=connector._issue_to_document
+        ) as spy:
+            docs = await connector.fetch(workspace_id="ws1", since=since)
+
+        # Filter ran first → only the new issue was parsed (one call).
+        assert spy.call_count == 1, (
+            f"_issue_to_document called {spy.call_count} times; "
+            "filtered-out issue must be skipped BEFORE the expensive parse"
+        )
+        assert [d.source_id for d in docs] == ["P-NEW"]

--- a/tests/unit/test_jira_connector.py
+++ b/tests/unit/test_jira_connector.py
@@ -1,5 +1,10 @@
 """Tests for Jira connector URL generation."""
 
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
 from metatron.connectors.jira import JiraConnector
 
 
@@ -53,3 +58,134 @@ class TestJiraDocumentUrl:
         }
         doc = connector._issue_to_document(raw_issue, workspace_id="ws1")
         assert doc.url == "https://mycompany.atlassian.net/browse/PROJ-1"
+
+
+# ---------------------------------------------------------------------------
+# _extract_updated_at — sub-minute precision for the post-filter (MTRNIX-332)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractUpdatedAt:
+    def test_parses_iso_with_tz_offset(self) -> None:
+        raw = {"fields": {"updated": "2026-05-12T14:02:26.002+0300"}}
+        ts = JiraConnector._extract_updated_at(raw)
+        assert ts == datetime(2026, 5, 12, 11, 2, 26, 2000, tzinfo=UTC)
+
+    def test_parses_iso_with_z_suffix(self) -> None:
+        raw = {"fields": {"updated": "2026-05-12T11:02:26.000Z"}}
+        ts = JiraConnector._extract_updated_at(raw)
+        assert ts is not None
+        assert ts.year == 2026
+        assert ts.tzinfo is not None
+
+    def test_missing_field_returns_none(self) -> None:
+        assert JiraConnector._extract_updated_at({"fields": {}}) is None
+
+    def test_missing_fields_dict_returns_none(self) -> None:
+        assert JiraConnector._extract_updated_at({}) is None
+
+    def test_unparseable_value_returns_none(self) -> None:
+        raw = {"fields": {"updated": "not-a-date"}}
+        assert JiraConnector._extract_updated_at(raw) is None
+
+    def test_does_not_call_process_jira_issue(self) -> None:
+        """W1: helper must read raw dict directly, not re-parse the full issue."""
+        from unittest.mock import patch
+
+        raw = {"fields": {"updated": "2026-05-12T11:02:26.000+0000"}}
+        with patch("metatron.connectors.jira_processing.process_jira_issue") as mock_process:
+            JiraConnector._extract_updated_at(raw)
+        mock_process.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Sub-minute post-filter in fetch (MTRNIX-332)
+# ---------------------------------------------------------------------------
+
+
+def _raw_issue(key: str, updated: str) -> dict:
+    """Minimal raw Jira REST shape needed by _issue_to_document."""
+    return {
+        "key": key,
+        "fields": {
+            "summary": "x",
+            "description": "y",
+            "issuetype": {"name": "Task"},
+            "status": {"name": "Open"},
+            "priority": {"name": "Medium"},
+            "creator": {"displayName": "A", "emailAddress": "a@co"},
+            "reporter": {"displayName": "A", "emailAddress": "a@co"},
+            "assignee": None,
+            "created": updated,
+            "updated": updated,
+            "resolutiondate": None,
+            "labels": [],
+            "components": [],
+            "comment": {"comments": []},
+        },
+    }
+
+
+class TestFetchPostFilter:
+    @pytest.mark.asyncio
+    async def test_drops_issue_with_updated_equal_to_since(self) -> None:
+        """An issue whose updated == since is sub-minute boundary noise — drop it.
+
+        JQL with minute-precision filter (>= "22:09") matches the same-minute
+        issue (22:09:27); the post-filter must remove it so we don't re-emit
+        the same doc every sync until the cursor's minute advances.
+        """
+        connector = JiraConnector()
+        connector._config = {"url": "https://co.atlassian.net", "project_key": "P"}
+        since = datetime(2026, 5, 12, 22, 9, 27, tzinfo=UTC)
+        same_minute = "2026-05-12T22:09:27.000+0000"
+
+        connector._client = MagicMock()
+        connector._client.enhanced_jql = MagicMock(
+            return_value={
+                "issues": [_raw_issue("P-1", same_minute)],
+                "isLast": True,
+            }
+        )
+
+        docs = await connector.fetch(workspace_id="ws1", since=since)
+        assert docs == [], "issue with updated == since must be filtered out"
+
+    @pytest.mark.asyncio
+    async def test_keeps_issue_with_updated_after_since(self) -> None:
+        connector = JiraConnector()
+        connector._config = {"url": "https://co.atlassian.net", "project_key": "P"}
+        since = datetime(2026, 5, 12, 22, 9, 27, tzinfo=UTC)
+        later = "2026-05-12T22:09:28.000+0000"
+
+        connector._client = MagicMock()
+        connector._client.enhanced_jql = MagicMock(
+            return_value={
+                "issues": [_raw_issue("P-1", later)],
+                "isLast": True,
+            }
+        )
+
+        docs = await connector.fetch(workspace_id="ws1", since=since)
+        assert len(docs) == 1
+        assert docs[0].source_id == "P-1"
+
+    @pytest.mark.asyncio
+    async def test_no_post_filter_when_since_is_none(self) -> None:
+        """Initial sync (since=None) keeps everything regardless of updated."""
+        connector = JiraConnector()
+        connector._config = {"url": "https://co.atlassian.net", "project_key": "P"}
+
+        connector._client = MagicMock()
+        connector._client.enhanced_jql = MagicMock(
+            return_value={
+                "issues": [
+                    _raw_issue("P-1", "2020-01-01T00:00:00.000+0000"),
+                    _raw_issue("P-2", "2026-01-01T00:00:00.000+0000"),
+                ],
+                "isLast": True,
+            }
+        )
+
+        docs = await connector.fetch(workspace_id="ws1", since=None)
+        assert len(docs) == 2


### PR DESCRIPTION
The file-based SyncState was the source of the "every sync returns 1 fetched" trap on prod: the cursor file on disk silently failed to advance (write failure or multi-replica filesystem isolation) while PG's last_synced_at advanced correctly. Each sync then re-fetched the same issue because the JQL filter used a cursor that never moved past the issue's updated timestamp.

Migrate the incremental cursor to PostgreSQL connections.last_synced_at:

- _run_connection_sync receives last_synced_at as a kwarg from trigger_sync (parsed from the connection record's ISO string)
- File-write to .metatron/sync_state.json is removed from the success path (PG already stamps in update_connection_status)
- NULL cursor (freshly-created connection) yields since=None -> full fetch on first sync
- Failed syncs no longer advance the cursor: pass None as last_synced_at on non-success status so the SET clause is skipped. Without this guard, transient failures silently drop documents updated between the last good sync and the failure

Jira-side fix for sub-minute precision: JQL's date filter only supports HH:mm granularity, so a cursor at 22:09:40 formatted as "22:09" still matches issues updated 22:09:00-22:09:59. Add a post-filter using raw_issue.fields.updated (no second process_jira_issue pass) that drops anything whose actual updated <= since.

Admin /reindex now clears connections.last_synced_at = NULL in the same transaction as the raw_documents reset; legacy file-based SyncState is also cleared best-effort for rolling-deploy compatibility.

Tests cover the regression matrix: cursor read from PG, force_full bypass, NULL initial state, failed-sync does-not-advance, Jira post-filter equal/greater/since=None branches, admin reindex clears PG cursor.

Follow-ups (not in this PR):
- Remove SyncState class and test_incremental_sync.py after one release cycle
- Tighten JQL date format with explicit TZ (Atlassian profile-TZ ambiguity in the minute-precision string)