### PR TITLE
chore(MTRNIX-337): enable freshness-worker by default on dev stand

### DIFF
--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -180,7 +180,6 @@ services:
         condition: service_healthy
     networks:
       - metatron_full
-    profiles: ["freshness"]
     restart: unless-stopped
 
   metatron-ui:


### PR DESCRIPTION
Removes the `freshness` profile gate from the `freshness-worker` service so the worker is brought up alongside the rest of the stack on `docker compose up`, without needing an explicit `--profile freshness` flag at deploy time.

The container already hardcodes `METATRON_FRESHNESS_ENABLED=true` in its own `environment:` block, so it is safe to start unconditionally — the producer side stays a no-op until the API also sees the flag via `.env`.