### PR TITLE
fix(MTRNIX-337): override ENTRYPOINT for freshness-worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
   freshness-worker:
     build: .
     container_name: metatron-freshness-worker
-    command: python -m metatron.memory.freshness
+    entrypoint: ["python", "-m", "metatron.memory.freshness"]
     env_file: .env
     environment:
       # Override hosts to Docker service names

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -155,7 +155,7 @@ services:
   freshness-worker:
     image: ghcr.io/mtrnix/metatroncore:metatroncore-develop
     container_name: metatron-freshness-worker
-    command: python -m metatron.memory.freshness
+    entrypoint: ["python", "-m", "metatron.memory.freshness"]
     env_file: .env
     environment:
       # Override hosts to Docker service names


### PR DESCRIPTION
The shared Dockerfile sets `ENTRYPOINT ["uvicorn", "metatron.api.app:create_app", ...]` for the API process. In Compose, `command:` only replaces CMD — it is appended to ENTRYPOINT, not substituted. The freshness-worker service therefore launched as `uvicorn ... python -m metatron.memory.freshness`, which made uvicorn choke on `-m` and exit immediately:

    Usage: uvicorn [OPTIONS] APP
    Error: No such option: -m

Replace `command:` with an explicit `entrypoint:` override on the freshness-worker service in both the local and install compose files, so the container runs `python -m metatron.memory.freshness` as intended.