### PR TITLE
fix(MTRNIX-337): override OLLAMA_HOST for freshness-worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,7 @@ services:
       POSTGRES_HOST: postgres
       QDRANT_HOST: qdrant
       NEO4J_HOST: neo4j
+      OLLAMA_HOST: http://ollama:11434
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 0

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -162,6 +162,7 @@ services:
       POSTGRES_HOST: postgres
       QDRANT_HOST: qdrant
       NEO4J_HOST: neo4j
+      OLLAMA_HOST: http://ollama:11434
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 0


### PR DESCRIPTION
The Linker/Reconciler stages compute embeddings via the Ollama provider, which reads its endpoint from the OLLAMA_HOST env var. The local .env on the dev stand contains `OLLAMA_HOST=http://localhost:11434/`, which works when the API is run on bare metal but resolves to the worker container itself inside Docker — Ollama is in a sibling service.

The `metatron-core` (API) compose entry already overrides `OLLAMA_HOST: http://ollama:11434` in its environment block; the freshness-worker entry was missing the same override, so embedding requests from the worker landed on localhost and hit ECONNREFUSED, failing every memory_record job at the Linker stage.

Add the same override to the freshness-worker environment block in both the local and install compose files.