### PR TITLE
feat(MTRNIX-336): RAG generation telemetry for fine-tuning bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,6 +250,19 @@ METATRON_FRESHNESS_KB_STALE_AFTER_DAYS=90           # higher than memory's 30 (K
 
 
 # =============================================================================
+# LLM generation telemetry — fine-tuning bootstrap (MTRNIX-336)
+# Persists every chat_completion() into the llm_generation_log table so the
+# RAG answer-generation call can later be replaced with a local fine-tuned
+# model. Privacy note: by default every workspace contributes rows; set
+# workspaces.llm_telemetry_opt_out=true per workspace for opt-out, OR flip
+# the master kill-switch below.
+# =============================================================================
+METATRON_LLM_TELEMETRY_ENABLED=true                 # master kill-switch; false → emit_log is a no-op end to end
+METATRON_LLM_TELEMETRY_RETENTION_DAYS=0             # placeholder for future cleanup worker (0 = infinite)
+METATRON_LLM_TELEMETRY_OPT_OUT_CACHE_TTL_SECONDS=60 # TTL for the per-workspace opt-out flag cache
+
+
+# =============================================================================
 # Misc / Ops
 # =============================================================================
 ALLOW_CLEANUP=false                   # gate destructive /api/v1/admin/cleanup* endpoints

--- a/docs/llm_call_sites_audit.md
+++ b/docs/llm_call_sites_audit.md
@@ -5,6 +5,14 @@
 
 Every LLM call site in Metatron Core, with telemetry verdict and wiring status.
 
+## Backward-compatible default for external callers
+
+`chat_completion(..., call_site: str = "unknown")` — keyword-only, **defaults
+to "unknown"**. Plugins / enterprise extensions that import the public
+wrapper without updating their call sites still work; their rows just land
+under the `unknown` bucket and can be filtered or relabelled later. In-tree
+callers always pass a stable label from the table below.
+
 | # | `call_site` label | File | Verdict | Wired | Notes |
 |---|---|---|---|---|---|
 | 1 | `rag_answer` | `retrieval/search.py` | **fine-tuning-grade** | ✓ | Primary target. Two branches: `use_schema=True` (`subtype="team_workflow_schema"`) and regular free-form (`subtype="freeform"`). `update_retrieved_context` called before both LLM invocations. |
@@ -48,9 +56,33 @@ Every LLM call site in Metatron Core, with telemetry verdict and wiring status.
 Formats: `openai-chat-ft` (default), `openai-completion-legacy`, `messages-only`.
 Benchmark/eval rows excluded by default (`--include-eval` to opt in).
 
+## Telemetry safety / hardening behaviours
+
+- **Per-message content cap** — `emit_log` truncates each request message
+  `content` and the response `content` to 8 000 chars (matches the NER
+  upstream cap in `extract_graph_from_text`). Truncation is flagged in
+  `metadata.message_truncated` / `metadata.response_truncated`. Prevents
+  multi-GB JSONB growth on the high-frequency NER path.
+- **Lazy prompt snapshot** — the `messages` argument to `emit_log` can be a
+  zero-arg callable; `emit_log` materialises it only after the opt-out
+  re-check. So when a workspace flips `llm_telemetry_opt_out=true`
+  mid-call, the prompt copy never leaves the upstream `Message` list.
+- **Bounded per-workspace lock cache** — opt-out single-flight uses an
+  `OrderedDict` capped at 1 024 entries (LRU eviction). Locks for evicted
+  workspaces are GC'd when their last holder releases them.
+
 ## Open follow-ups
 
-- `freshness_decision` instrumentation — `LLMBackedDecisionEngine.decide` bypasses the public wrapper.
-- Background writer thread for `emit_log` if PG round-trip overhead is unacceptable on NER path.
-- Retention/cleanup worker for `llm_generation_log` (env var `METATRON_LLM_TELEMETRY_RETENTION_DAYS` is reserved).
+- `freshness_decision` instrumentation — `LLMBackedDecisionEngine.decide`
+  bypasses the public wrapper. **TODO: file Jira issue and link here.**
+  Until then, this audit doc is the canonical placeholder. The fix is
+  either (a) route the engine through `metatron.llm.chat_completion(...,
+  call_site="freshness_decision", provider=<configured>)`, moving the
+  freshness-specific provider override into the wrapper's resolution, or
+  (b) add a parallel provider-level telemetry hook callable from outside
+  the public wrapper.
+- Background writer thread for `emit_log` if PG round-trip overhead is
+  unacceptable on the NER path.
+- Retention/cleanup worker for `llm_generation_log` (env var
+  `METATRON_LLM_TELEMETRY_RETENTION_DAYS` is reserved).
 - Workspace-settings UI/API for `llm_telemetry_opt_out`.

--- a/docs/llm_call_sites_audit.md
+++ b/docs/llm_call_sites_audit.md
@@ -1,0 +1,56 @@
+# LLM Call Sites Audit — MTRNIX-336
+
+**Date:** 2026-05-15
+**Status:** Implemented (11 of 12 call sites wired; `freshness_decision` deferred)
+
+Every LLM call site in Metatron Core, with telemetry verdict and wiring status.
+
+| # | `call_site` label | File | Verdict | Wired | Notes |
+|---|---|---|---|---|---|
+| 1 | `rag_answer` | `retrieval/search.py` | **fine-tuning-grade** | ✓ | Primary target. Two branches: `use_schema=True` (`subtype="team_workflow_schema"`) and regular free-form (`subtype="freeform"`). `update_retrieved_context` called before both LLM invocations. |
+| 2 | `resolve_query` | `retrieval/search.py` | telemetry-only | ✓ | Pre-step inside the same pipeline. Useful for cost analytics; secondary FT signal. |
+| 3 | `translate_query` | `retrieval/search.py` | telemetry-only | ✓ | RU→EN of incoming query. |
+| 4 | `hyde` | `retrieval/query_expansion.py` | telemetry-only | ✓ | Optional path; short inputs. Feature-flagged by `HYDE_ENABLED`. |
+| 5 | `query_expansion` | `retrieval/query_expansion.py` | telemetry-only | ✓ | Costly when on; useful for cost analytics. |
+| 6 | `query_classifier` | `retrieval/query_classifier.py` | **fine-tuning-grade** | ✓ | LLM-fallback path (rule gate handles most queries). Short input → structured JSON; ideal locality target. |
+| 7 | `routing` | `retrieval/routing.py` | telemetry-only | ✓ | Keyword-gated; low volume. |
+| 8 | `translation_to_english` | `ingestion/processors/translation.py` | telemetry-only | ✓ | Ingestion translation (document content). |
+| 9 | `translation_to_russian` | `ingestion/processors/translation.py` | telemetry-only | ✓ | Same as above, reverse direction. |
+| 10 | `ner_extraction` | `storage/neo4j_graph.py` | **fine-tuning-grade** | ✓ | Highest-volume call site (per-document). Strong FT target for a local NER SLM. `extra_metadata` carries `text_truncated`. |
+| 11 | `mcp_action_planner` | `mcp/action_planner.py` | telemetry-only | ✓ | Low volume; structured-output task. |
+| — | `freshness_decision` | `freshness/decision_engine.py` | **deferred (out of scope)** | ✗ | Calls `self._provider.chat_completion` (provider method) directly — NOT the public wrapper. Capturing it requires refactoring `LLMBackedDecisionEngine` to go through `metatron.llm.chat_completion`. Tracked as a follow-up to MTRNIX-336. |
+| (legacy) | `agent_smalltalk` | `agent/router.py` | **skip / deprecated** | ✓ | Legacy Telegram channel path. Wired for consistency; marked deprecated per LEGACY.md. |
+
+## Entry-point context coverage
+
+| Source | Entry-point file | `set_telemetry_context` wired | `source` value |
+|---|---|---|---|
+| REST chat | `api/routes/chat.py` | ✓ | `"rest"` |
+| OpenAI-compat API | `api/routes/openai_compat.py` | ✓ | `"oai_compat"` |
+| MCP server | `mcp/server.py` | ✓ | `"mcp"` |
+| Ingestion pipeline | `ingestion/pipeline.py` | ✓ | `"ingestion"` |
+| Freshness worker | `memory/freshness/worker.py` | ✓ | `"freshness"` |
+| Benchmarker runner | `benchmarker/services/runner.py` | ✓ | `"benchmark"` |
+| Confidence metric | `benchmarker/services/metrics/confidence.py` | ✓ | `"benchmark"` |
+| Offline eval script | `scripts/run_eval.py` | ✓ | `"eval"` |
+
+## Key config vars
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `METATRON_LLM_TELEMETRY_ENABLED` | `true` | Master kill-switch. `false` → all telemetry is a no-op. |
+| `METATRON_LLM_TELEMETRY_RETENTION_DAYS` | `0` | Placeholder. `0` = infinite. No cleanup worker in this ticket. |
+| `METATRON_LLM_TELEMETRY_OPT_OUT_CACHE_TTL_SECONDS` | `60` | TTL for workspace opt-out flag cache. |
+
+## Export
+
+`scripts/export_llm_dataset.py` — streams rows from `llm_generation_log` to JSONL.
+Formats: `openai-chat-ft` (default), `openai-completion-legacy`, `messages-only`.
+Benchmark/eval rows excluded by default (`--include-eval` to opt in).
+
+## Open follow-ups
+
+- `freshness_decision` instrumentation — `LLMBackedDecisionEngine.decide` bypasses the public wrapper.
+- Background writer thread for `emit_log` if PG round-trip overhead is unacceptable on NER path.
+- Retention/cleanup worker for `llm_generation_log` (env var `METATRON_LLM_TELEMETRY_RETENTION_DAYS` is reserved).
+- Workspace-settings UI/API for `llm_telemetry_opt_out`.

--- a/migrations/versions/022_llm_generation_log.py
+++ b/migrations/versions/022_llm_generation_log.py
@@ -6,6 +6,15 @@ dataset assembly. One row per public ``chat_completion()`` invocation.
 Also adds ``llm_telemetry_opt_out`` to ``workspaces`` so per-workspace PII
 opt-out can be toggled by operators without redeployment.
 
+Note on reversibility:
+    ``downgrade()`` drops the ``workspaces.llm_telemetry_opt_out`` column
+    outright — no archive step. Any opt-out flags an operator set will be
+    LOST on downgrade. This is acceptable for a boolean operator-intent
+    flag, but document it in the operator runbook before rolling back.
+    The ``llm_generation_log`` table is dropped as a whole; export the
+    table to JSONL via ``scripts/export_llm_dataset.py`` first if the
+    accumulated data still has value after downgrade.
+
 Revision ID: 022
 Revises: 021
 Create Date: 2026-05-15

--- a/migrations/versions/022_llm_generation_log.py
+++ b/migrations/versions/022_llm_generation_log.py
@@ -1,0 +1,109 @@
+"""Add llm_generation_log table and workspaces.llm_telemetry_opt_out column (MTRNIX-336).
+
+Captures every LLM completion that flows through Metatron for later fine-tuning
+dataset assembly. One row per public ``chat_completion()`` invocation.
+
+Also adds ``llm_telemetry_opt_out`` to ``workspaces`` so per-workspace PII
+opt-out can be toggled by operators without redeployment.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-05-15
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "022"
+down_revision: str | None = "021"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "llm_generation_log",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        # -- what kind of call --
+        sa.Column("call_site", sa.Text(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=True),
+        # -- request context (from ContextVar; may be NULL) --
+        sa.Column("workspace_id", sa.Text(), nullable=True),
+        sa.Column("user_id", sa.Text(), nullable=True),
+        sa.Column("agent_id", sa.Text(), nullable=True),
+        sa.Column("correlation_id", UUID(as_uuid=False), nullable=True),
+        # -- model + provider --
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("model", sa.Text(), nullable=False),
+        # -- the exchange --
+        sa.Column("request_messages", JSONB(), nullable=False),
+        sa.Column("response_content", sa.Text(), nullable=True),
+        sa.Column("prompt_tokens", sa.Integer(), nullable=True),
+        sa.Column("completion_tokens", sa.Integer(), nullable=True),
+        sa.Column("total_tokens", sa.Integer(), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        # -- outcome --
+        sa.Column("success", sa.Boolean(), nullable=False),
+        sa.Column("error_class", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        # -- call-site-specific extras --
+        sa.Column("metadata", JSONB(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        # Outcome coherence check:
+        #   success=True  => response_content must be non-NULL
+        #   success=False => error_class must be set
+        sa.CheckConstraint(
+            "(success AND response_content IS NOT NULL)"
+            " OR (NOT success AND error_class IS NOT NULL)",
+            name="chk_outcome_coherent",
+        ),
+    )
+
+    op.create_index(
+        "ix_llm_log_ws_created",
+        "llm_generation_log",
+        ["workspace_id", sa.text("created_at DESC")],
+    )
+    op.create_index(
+        "ix_llm_log_call_site_created",
+        "llm_generation_log",
+        ["call_site", sa.text("created_at DESC")],
+    )
+    op.create_index(
+        "ix_llm_log_correlation",
+        "llm_generation_log",
+        ["correlation_id"],
+        postgresql_where=sa.text("correlation_id IS NOT NULL"),
+    )
+
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "llm_telemetry_opt_out",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "llm_telemetry_opt_out")
+    op.drop_index("ix_llm_log_correlation", table_name="llm_generation_log")
+    op.drop_index("ix_llm_log_call_site_created", table_name="llm_generation_log")
+    op.drop_index("ix_llm_log_ws_created", table_name="llm_generation_log")
+    op.drop_table("llm_generation_log")

--- a/scripts/export_llm_dataset.py
+++ b/scripts/export_llm_dataset.py
@@ -1,0 +1,384 @@
+"""Export LLM generation log rows to a fine-tuning dataset file.
+
+Usage examples:
+    python scripts/export_llm_dataset.py --call-site rag_answer --out dataset.jsonl
+    python scripts/export_llm_dataset.py \\
+        --call-site rag_answer --call-site query_classifier \\
+        --workspace-id MTRNIX \\
+        --from 2026-01-01 --to 2026-12-31 \\
+        --format openai-chat-ft \\
+        --out out.jsonl
+    python scripts/export_llm_dataset.py --include-eval --out full.jsonl
+    python scripts/export_llm_dataset.py --include-failed --out all.jsonl
+    python scripts/export_llm_dataset.py --no-include-zero-tokens --out quality.jsonl
+
+Formats:
+    openai-chat-ft (default)
+        {"messages": [...request_messages..., {"role": "assistant", "content": "<answer>"}]}
+        Matches the OpenAI fine-tuning Chat Completions format.
+
+    openai-completion-legacy
+        {"prompt": "<concatenated messages>", "completion": "<answer>"}
+        Legacy text-completion-style fine-tunes (OpenAI, Mistral legacy API).
+
+    messages-only
+        Same wire shape as openai-chat-ft but labelled separately for
+        HuggingFace / generic pipelines.
+
+Filters applied by default:
+    - success=true
+    - response_content IS NOT NULL
+    - source NOT IN ('benchmark', 'eval')  (pass --include-eval to disable)
+
+Streams results from PostgreSQL in pages of 1000 rows; never loads the full
+table into memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import UTC, date, datetime
+
+# Ensure src/ is importable when running as a script
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from metatron.core.config import get_settings
+
+# ---------------------------------------------------------------------------
+# SQL helpers
+# ---------------------------------------------------------------------------
+
+_EXCLUDED_SOURCES = ("benchmark", "eval")
+
+_PAGE_SIZE = 1000
+
+
+def _build_query(
+    *,
+    call_sites: list[str],
+    workspace_ids: list[str],
+    from_date: date | None,
+    to_date: date | None,
+    success_only: bool,
+    include_eval: bool,
+    include_zero_tokens: bool,
+    limit: int | None,
+) -> tuple[str, dict]:
+    """Build a raw SQL SELECT with bind params.
+
+    Returns (sql_template, params_dict). Uses cursor-based pagination via
+    ``min_id`` param injected at call time; the function only builds the
+    WHERE body and ORDER/LIMIT suffix.
+    """
+    where_clauses: list[str] = ["id > :min_id"]
+    params: dict = {}
+
+    if success_only:
+        where_clauses.append("success = TRUE")
+        where_clauses.append("response_content IS NOT NULL")
+
+    if not include_eval:
+        where_clauses.append("(source IS NULL OR source NOT IN :excluded_sources)")
+        params["excluded_sources"] = _EXCLUDED_SOURCES
+
+    if not include_zero_tokens:
+        where_clauses.append(
+            "(metadata IS NULL OR (metadata->>'zero_tokens')::boolean IS NOT TRUE)"
+        )
+
+    if call_sites:
+        where_clauses.append("call_site = ANY(:call_sites)")
+        params["call_sites"] = call_sites
+
+    if workspace_ids:
+        where_clauses.append("workspace_id = ANY(:workspace_ids)")
+        params["workspace_ids"] = workspace_ids
+
+    if from_date is not None:
+        where_clauses.append("created_at >= :from_date")
+        params["from_date"] = datetime.combine(from_date, datetime.min.time()).replace(tzinfo=UTC)
+
+    if to_date is not None:
+        where_clauses.append("created_at < :to_date")
+        params["to_date"] = datetime.combine(to_date, datetime.min.time()).replace(tzinfo=UTC)
+
+    where_sql = " AND ".join(where_clauses)
+
+    page_limit = _PAGE_SIZE if limit is None else min(_PAGE_SIZE, limit)
+
+    sql = f"""
+        SELECT
+            id,
+            call_site,
+            source,
+            workspace_id,
+            provider,
+            model,
+            request_messages,
+            response_content,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+            latency_ms,
+            success,
+            error_class,
+            metadata
+        FROM llm_generation_log
+        WHERE {where_sql}
+        ORDER BY id ASC
+        LIMIT :page_limit
+    """
+    params["page_limit"] = page_limit
+    return sql, params
+
+
+# ---------------------------------------------------------------------------
+# Format converters
+# ---------------------------------------------------------------------------
+
+
+def _messages_to_prompt(messages: list[dict]) -> str:
+    """Concatenate message list into a plain text prompt (legacy format)."""
+    parts: list[str] = []
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+        if isinstance(content, list):
+            # Handle content that may be a list of parts (e.g. multimodal shape)
+            content = " ".join(
+                p.get("text", "") if isinstance(p, dict) else str(p) for p in content
+            )
+        parts.append(f"{role}: {content}")
+    return "\n".join(parts)
+
+
+def _row_to_jsonl(row: dict, fmt: str) -> str:
+    """Convert a DB row dict to a JSONL line string."""
+    messages = row["request_messages"]
+    if isinstance(messages, str):
+        messages = json.loads(messages)
+    response = row["response_content"] or ""
+
+    if fmt in ("openai-chat-ft", "messages-only"):
+        record = {
+            "messages": [
+                *messages,
+                {"role": "assistant", "content": response},
+            ]
+        }
+    elif fmt == "openai-completion-legacy":
+        record = {
+            "prompt": _messages_to_prompt(messages),
+            "completion": response,
+        }
+    else:
+        raise ValueError(f"Unknown format: {fmt!r}")
+
+    return json.dumps(record, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Main export loop
+# ---------------------------------------------------------------------------
+
+
+def export(
+    *,
+    call_sites: list[str],
+    workspace_ids: list[str],
+    from_date: date | None,
+    to_date: date | None,
+    fmt: str,
+    out_path: str,
+    success_only: bool,
+    include_eval: bool,
+    include_zero_tokens: bool,
+    limit: int | None,
+) -> int:
+    """Stream rows from PG and write JSONL. Returns count of rows written."""
+    import sqlalchemy as sa
+
+    settings = get_settings()
+    engine = sa.create_engine(settings.postgres_sync_dsn)
+
+    sql_template, base_params = _build_query(
+        call_sites=call_sites,
+        workspace_ids=workspace_ids,
+        from_date=from_date,
+        to_date=to_date,
+        success_only=success_only,
+        include_eval=include_eval,
+        include_zero_tokens=include_zero_tokens,
+        limit=limit,
+    )
+
+    written = 0
+    min_id = 0
+
+    with open(out_path, "w", encoding="utf-8") as fout, engine.connect() as conn:
+        while True:
+            params = {**base_params, "min_id": min_id}
+            result = conn.execute(sa.text(sql_template), params)
+            rows = result.mappings().all()
+            if not rows:
+                break
+
+            for row in rows:
+                line = _row_to_jsonl(dict(row), fmt)
+                fout.write(line + "\n")
+                written += 1
+                if limit is not None and written >= limit:
+                    break
+
+            if limit is not None and written >= limit:
+                break
+
+            last_id = rows[-1]["id"]
+            min_id = last_id
+
+            if len(rows) < _PAGE_SIZE:
+                # Last page
+                break
+
+    engine.dispose()
+    return written
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_date(s: str) -> date:
+    return date.fromisoformat(s)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export llm_generation_log rows to a fine-tuning dataset file.",
+    )
+    parser.add_argument(
+        "--call-site",
+        dest="call_sites",
+        action="append",
+        default=[],
+        metavar="LABEL",
+        help="Filter by call_site label (repeatable). Default: all.",
+    )
+    parser.add_argument(
+        "--workspace-id",
+        dest="workspace_ids",
+        action="append",
+        default=[],
+        metavar="WS_ID",
+        help="Filter by workspace_id (repeatable). Default: all.",
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_date",
+        type=_parse_date,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Include rows with created_at >= this date (UTC).",
+    )
+    parser.add_argument(
+        "--to",
+        dest="to_date",
+        type=_parse_date,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Include rows with created_at < this date (UTC).",
+    )
+    parser.add_argument(
+        "--format",
+        dest="fmt",
+        default="openai-chat-ft",
+        choices=["openai-chat-ft", "openai-completion-legacy", "messages-only"],
+        help="Output format (default: openai-chat-ft).",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        metavar="PATH",
+        help="Output JSONL file path (required).",
+    )
+    parser.add_argument(
+        "--success-only",
+        dest="success_only",
+        action="store_true",
+        default=True,
+        help="Include only rows where success=true (default: on).",
+    )
+    parser.add_argument(
+        "--include-failed",
+        dest="success_only",
+        action="store_false",
+        help="Include failed rows (overrides --success-only).",
+    )
+    parser.add_argument(
+        "--include-eval",
+        dest="include_eval",
+        action="store_true",
+        default=False,
+        help="Include rows from benchmark/eval sources (default: excluded).",
+    )
+    parser.add_argument(
+        "--include-zero-tokens",
+        dest="include_zero_tokens",
+        action="store_true",
+        default=True,
+        help="Include rows where all token counts are 0 (default: on).",
+    )
+    parser.add_argument(
+        "--no-include-zero-tokens",
+        dest="include_zero_tokens",
+        action="store_false",
+        help="Drop rows where metadata.zero_tokens=true.",
+    )
+    parser.add_argument(
+        "--limit",
+        dest="limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Maximum number of rows to export.",
+    )
+
+    args = parser.parse_args()
+
+    print(
+        f"Exporting: call_sites={args.call_sites or 'all'}, "
+        f"workspaces={args.workspace_ids or 'all'}, "
+        f"format={args.fmt}, "
+        f"success_only={args.success_only}, "
+        f"include_eval={args.include_eval}, "
+        f"include_zero_tokens={args.include_zero_tokens}, "
+        f"limit={args.limit or 'none'}"
+    )
+    print(f"Output → {args.out}")
+
+    try:
+        count = export(
+            call_sites=args.call_sites,
+            workspace_ids=args.workspace_ids,
+            from_date=args.from_date,
+            to_date=args.to_date,
+            fmt=args.fmt,
+            out_path=args.out,
+            success_only=args.success_only,
+            include_eval=args.include_eval,
+            include_zero_tokens=args.include_zero_tokens,
+            limit=args.limit,
+        )
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Done. Rows written: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -59,11 +59,14 @@ if "benchmark_qed" not in sys.modules:
     ]:
         sys.modules[_name] = _mock
 
+from uuid import uuid4
+
 from metatron.benchmarker.services.eval_loader import (
     DEFAULT_TESTSET_PATH,
     load_eval_testset_from_path,
 )
 from metatron.benchmarker.services.metrics.retrieval import RetrievalMetrics
+from metatron.llm.telemetry import set_telemetry_context
 from metatron.retrieval.search import hybrid_search_and_answer
 from metatron.storage.qdrant import clear_store_cache
 
@@ -116,14 +119,19 @@ async def run_eval(
     if positive_queries:
         print("POSITIVE (should find relevant docs):")
     for q in positive_queries:
-        trace = await hybrid_search_and_answer(
-            query=q.text,
-            user_id=workspace,
-            k=k,
-            workspace_id=None,
-            intent_query=None,
-            return_trace=True,
-        )
+        with set_telemetry_context(
+            workspace_id=workspace,
+            source="eval",
+            correlation_id=uuid4(),
+        ):
+            trace = await hybrid_search_and_answer(
+                query=q.text,
+                user_id=workspace,
+                k=k,
+                workspace_id=None,
+                intent_query=None,
+                return_trace=True,
+            )
         retrieved = trace.get("retrieved_doc_labels", []) if isinstance(trace, dict) else []
         retrieved = list(dict.fromkeys(retrieved))  # deduplicate preserving order
         result = rm.compute(retrieved, q.expected_doc_labels, k=k)
@@ -153,14 +161,19 @@ async def run_eval(
     if negative_queries:
         print("\nNEGATIVE (should NOT find relevant docs):")
     for q in negative_queries:
-        trace = await hybrid_search_and_answer(
-            query=q.text,
-            user_id=workspace,
-            k=k,
-            workspace_id=None,
-            intent_query=None,
-            return_trace=True,
-        )
+        with set_telemetry_context(
+            workspace_id=workspace,
+            source="eval",
+            correlation_id=uuid4(),
+        ):
+            trace = await hybrid_search_and_answer(
+                query=q.text,
+                user_id=workspace,
+                k=k,
+                workspace_id=None,
+                intent_query=None,
+                return_trace=True,
+            )
         retrieved = trace.get("retrieved_doc_labels", []) if isinstance(trace, dict) else []
         retrieved = list(dict.fromkeys(retrieved))  # deduplicate preserving order
         n_retrieved = len(retrieved)

--- a/src/metatron/agent/router.py
+++ b/src/metatron/agent/router.py
@@ -543,6 +543,7 @@ class AgentRouter:
                 temperature=0.7,
                 max_tokens=150,
                 timeout=15,
+                call_site="agent_smalltalk",
             )
             return answer.strip()
         except Exception as e:

--- a/src/metatron/api/dependencies.py
+++ b/src/metatron/api/dependencies.py
@@ -7,14 +7,19 @@ and services. They pull instances from app.state (set during lifespan).
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from fastapi import Request  # noqa: TC002 — FastAPI Depends parameters need runtime type
 
 from metatron.core.config import Settings  # noqa: TC001 — runtime annotations in function bodies
+from metatron.llm.telemetry import set_telemetry_context
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
     from metatron.agents.service import AgentRegistryService
     from metatron.knowledge.service import RawDocumentReadService
+    from metatron.llm.telemetry import TelemetryContext
     from metatron.memory.health import MemoryHealthService
     from metatron.memory.service import MemoryService
     from metatron.memory.snapshot import MemorySnapshotService
@@ -74,6 +79,32 @@ def get_workspace_id(request: Request) -> str:
 
 # Backwards-compatible alias — older callers use the private name.
 _resolve_workspace_id = get_workspace_id
+
+
+def build_telemetry_context_cm(
+    request: Request,
+    *,
+    source: str,
+) -> AbstractContextManager[TelemetryContext]:
+    """Build a TelemetryContext context-manager from the current request.
+
+    Resolves workspace_id via :func:`get_workspace_id` (handles the ``*``
+    admin case), pulls user_id from auth state, generates a fresh
+    correlation_id. Returns the context-manager *unentered* — callers use
+    ``with build_telemetry_context_cm(request, source="rest"): ...``.
+
+    Centralising this here keeps chat / openai-compat / future routes from
+    re-implementing the same five-line dance.
+    """
+    workspace_id = get_workspace_id(request)
+    user = getattr(request.state, "user", {}) or {}
+    user_id: str | None = user.get("id") or user.get("user_id")
+    return set_telemetry_context(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        source=source,
+        correlation_id=uuid4(),
+    )
 
 
 def get_memory_service(request: Request) -> MemoryService:

--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -17,6 +17,8 @@ from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
+from metatron.api.dependencies import build_telemetry_context_cm
+
 logger = structlog.get_logger()
 
 router = APIRouter(tags=["chat"])
@@ -81,24 +83,25 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
 
     plugin_manager = getattr(request.app.state, "plugin_manager", None)
 
-    try:
-        from metatron.retrieval.search import hybrid_search_and_answer
+    with build_telemetry_context_cm(request, source="rest"):
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
 
-        answer = await hybrid_search_and_answer(
-            query=composite_query,
-            user_id=req.user_id,
-            workspace_id=req.workspace_id,
-            k=req.top_k,
-            intent_query=req.question,
-            plugin_manager=plugin_manager,
-            source="rest",
-        )
-    except Exception as exc:
-        logger.error("chat.error", error=str(exc), exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail="Search failed. Please try again.",
-        ) from exc
+            answer = await hybrid_search_and_answer(
+                query=composite_query,
+                user_id=req.user_id,
+                workspace_id=req.workspace_id,
+                k=req.top_k,
+                intent_query=req.question,
+                plugin_manager=plugin_manager,
+                source="rest",
+            )
+        except Exception as exc:
+            logger.error("chat.error", error=str(exc), exc_info=True)
+            raise HTTPException(
+                status_code=500,
+                detail="Search failed. Please try again.",
+            ) from exc
 
     with _history_lock:
         hist = _conversation_history.setdefault(req.user_id, [])
@@ -182,28 +185,29 @@ async def chat_stream(req: ChatRequest, request: Request) -> EventSourceResponse
 
         plugin_manager = getattr(request.app.state, "plugin_manager", None)
 
-        try:
-            from metatron.retrieval.search import hybrid_search_and_answer
+        with build_telemetry_context_cm(request, source="rest"):
+            try:
+                from metatron.retrieval.search import hybrid_search_and_answer
 
-            answer: str = await hybrid_search_and_answer(
-                query=composite_query,
-                user_id=req.user_id,
-                workspace_id=workspace_id,
-                k=req.top_k,
-                intent_query=req.question,
-                plugin_manager=plugin_manager,
-                source="rest",
-            )
-        except Exception as exc:
-            logger.error("chat.stream.error", error=str(exc), exc_info=True)
-            yield {
-                "event": "error",
-                "data": json.dumps(
-                    {"error": "Search failed. Please try again."},
-                ),
-            }
-            yield {"event": "done", "data": "{}"}
-            return
+                answer: str = await hybrid_search_and_answer(
+                    query=composite_query,
+                    user_id=req.user_id,
+                    workspace_id=workspace_id,
+                    k=req.top_k,
+                    intent_query=req.question,
+                    plugin_manager=plugin_manager,
+                    source="rest",
+                )
+            except Exception as exc:
+                logger.error("chat.stream.error", error=str(exc), exc_info=True)
+                yield {
+                    "event": "error",
+                    "data": json.dumps(
+                        {"error": "Search failed. Please try again."},
+                    ),
+                }
+                yield {"event": "done", "data": "{}"}
+                return
 
         # Record history (same as non-streaming endpoint)
         with _history_lock:

--- a/src/metatron/api/routes/openai_compat.py
+++ b/src/metatron/api/routes/openai_compat.py
@@ -19,6 +19,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict
 
+from metatron.llm.telemetry import set_telemetry_context
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
@@ -347,23 +349,29 @@ async def _stream_response(
     yield _chunk({"role": "assistant"})
 
     # Run search pipeline
-    try:
-        from metatron.retrieval.search import hybrid_search_and_answer
+    with set_telemetry_context(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        source="oai_compat",
+        correlation_id=uuid4(),
+    ):
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
 
-        answer = await hybrid_search_and_answer(
-            query=composite_query,
-            user_id=user_id,
-            workspace_id=workspace_id,
-            intent_query=user_message,
-            plugin_manager=plugin_manager,
-            source="oai_compat",
-        )
-    except Exception as exc:
-        logger.error("openai_compat.stream.error", error=str(exc), exc_info=True)
-        yield _chunk({"content": "An error occurred while processing your request."})
-        yield _chunk({}, "stop")
-        yield "data: [DONE]\n\n"
-        return
+            answer = await hybrid_search_and_answer(
+                query=composite_query,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                intent_query=user_message,
+                plugin_manager=plugin_manager,
+                source="oai_compat",
+            )
+        except Exception as exc:
+            logger.error("openai_compat.stream.error", error=str(exc), exc_info=True)
+            yield _chunk({"content": "An error occurred while processing your request."})
+            yield _chunk({}, "stop")
+            yield "data: [DONE]\n\n"
+            return
 
     # Parse sources and convert to markdown
     body, sources = extract_sources_section(answer)
@@ -436,20 +444,26 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
         )
 
     # Non-streaming path
-    try:
-        from metatron.retrieval.search import hybrid_search_and_answer
+    with set_telemetry_context(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        source="oai_compat",
+        correlation_id=uuid4(),
+    ):
+        try:
+            from metatron.retrieval.search import hybrid_search_and_answer
 
-        answer = await hybrid_search_and_answer(
-            query=composite_query,
-            user_id=user_id,
-            workspace_id=workspace_id,
-            intent_query=user_message,
-            plugin_manager=plugin_manager,
-            source="oai_compat",
-        )
-    except Exception as exc:
-        logger.error("openai_compat.search_error", error=str(exc), exc_info=True)
-        return _openai_error(500, "Internal error", "server_error")
+            answer = await hybrid_search_and_answer(
+                query=composite_query,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                intent_query=user_message,
+                plugin_manager=plugin_manager,
+                source="oai_compat",
+            )
+        except Exception as exc:
+            logger.error("openai_compat.search_error", error=str(exc), exc_info=True)
+            return _openai_error(500, "Internal error", "server_error")
 
     # Convert sources to markdown
     from metatron.api.routes.chat import extract_sources_section

--- a/src/metatron/benchmarker/services/metrics/confidence.py
+++ b/src/metatron/benchmarker/services/metrics/confidence.py
@@ -14,12 +14,14 @@ No UQLM / langchain dependencies — uses direct RAG calls instead.
 from __future__ import annotations
 
 import asyncio
+from uuid import uuid4
 
 import httpx
 import numpy as np
 import structlog
 
 from metatron.benchmarker.schemas.test_result import ConfidenceResult
+from metatron.llm.telemetry import set_telemetry_context
 from metatron.retrieval.search import hybrid_search_and_answer_sync
 
 logger = structlog.get_logger()
@@ -147,10 +149,15 @@ class ConfidenceMetric:
     ) -> str:
         """Generate one answer via hybrid_search_and_answer_sync (sync)."""
         try:
-            answer = hybrid_search_and_answer_sync(
-                query=question,
+            with set_telemetry_context(
                 workspace_id=workspace_id,
-            )
+                source="benchmark",
+                correlation_id=uuid4(),
+            ):
+                answer = hybrid_search_and_answer_sync(
+                    query=question,
+                    workspace_id=workspace_id,
+                )
             return str(answer)
         except Exception as exc:
             logger.error("Error generating response: %s", exc)

--- a/src/metatron/benchmarker/services/runner.py
+++ b/src/metatron/benchmarker/services/runner.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 import time
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import structlog
 
 from metatron.benchmarker.schemas.benchmark import BenchmarkQuestion
 from metatron.benchmarker.schemas.test_context import TestContext
 from metatron.benchmarker.schemas.test_result import MetricsResult
+from metatron.llm.telemetry import set_telemetry_context
 from metatron.retrieval.search import hybrid_search_and_answer
 
 if TYPE_CHECKING:
@@ -89,11 +91,16 @@ class TestRunner:
         trace: Any = None
         start = time.time()
         try:
-            trace = await hybrid_search_and_answer(
-                query=question.text,
+            with set_telemetry_context(
                 workspace_id=workspace_id,
-                return_trace=True,
-            )
+                source="benchmark",
+                correlation_id=uuid4(),
+            ):
+                trace = await hybrid_search_and_answer(
+                    query=question.text,
+                    workspace_id=workspace_id,
+                    return_trace=True,
+                )
             latency_ms = (time.time() - start) * 1000
 
             answer = trace["answer"] if isinstance(trace, dict) else str(trace)

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -345,6 +345,23 @@ class Settings(BaseSettings):
         alias="METATRON_ACTIVITY_LOG_ENABLED",
     )
 
+    # --- LLM generation telemetry (MTRNIX-336) ---
+    llm_telemetry_enabled: bool = Field(
+        default=True,
+        alias="METATRON_LLM_TELEMETRY_ENABLED",
+        description="Master kill-switch. false → all telemetry is a no-op.",
+    )
+    llm_telemetry_retention_days: int = Field(
+        default=0,
+        alias="METATRON_LLM_TELEMETRY_RETENTION_DAYS",
+        description="Placeholder. 0 = infinite. No cleanup worker in this ticket.",
+    )
+    llm_telemetry_opt_out_cache_ttl_seconds: int = Field(
+        default=60,
+        alias="METATRON_LLM_TELEMETRY_OPT_OUT_CACHE_TTL_SECONDS",
+        description="TTL for workspace opt-out flag cache.",
+    )
+
     @property
     def cors_origins_list(self) -> list[str]:
         """Parse CORS_ORIGINS comma-separated string into a list."""

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -754,71 +754,62 @@ def _write_graph_strict(
 
     Used by process_unsynced_graphs() where we need to know if the write
     actually succeeded before marking graph_synced=true.
+
+    Wrapped in ``set_telemetry_context(source="ingestion", ...)`` so the
+    NER-extraction LLM call inside ``write_doc_graph`` / ``write_jira_graph``
+    is tagged correctly in ``llm_generation_log``. The other ingestion
+    entry-point (inline ``_write_graph`` inside ``_extract_graphs_parallel``)
+    has its own wrap.
     """
-    # Telemetry: tag this NER-extraction LLM call as source="ingestion" so
-    # rows in llm_generation_log carry the correct provenance. This is the
-    # second of two ingestion entry-points (the other is the inline
-    # _write_graph inside _extract_graphs_parallel); both need the wrap.
     with set_telemetry_context(
         workspace_id=workspace_id,
         source="ingestion",
         correlation_id=uuid4(),
     ):
-        _write_graph_strict_inner(doc, workspace_id, is_jira=is_jira)
+        if is_jira:
+            from metatron.storage.graph_jira import write_jira_graph
 
+            jira_data = {
+                "key": doc.source_id,
+                "summary": doc.title,
+                "status": doc.metadata.get("status", ""),
+                "assignee": doc.metadata.get("assignee"),
+                "reporter": doc.metadata.get("reporter"),
+                "issuetype": doc.metadata.get("issuetype"),
+                "priority": doc.metadata.get("priority"),
+                "description": doc.content[:2000],
+                "created": doc.metadata.get("created_at_str")
+                or (doc.created_at.isoformat() if doc.created_at else None),
+                "updated": doc.metadata.get("updated_at_str")
+                or (doc.updated_at.isoformat() if doc.updated_at else None),
+                "resolved_at": doc.metadata.get("resolved_at_str"),
+            }
+            write_jira_graph(
+                jira_data,
+                doc.content,
+                workspace_id=workspace_id,
+                doc_label=doc.source_id,
+                metadata=doc.metadata,
+            )
+        else:
+            from metatron.storage.neo4j_graph import write_doc_graph
 
-def _write_graph_strict_inner(
-    doc: Document,
-    workspace_id: str,
-    *,
-    is_jira: bool = False,
-) -> None:
-    """Body of _write_graph_strict — kept separate so the telemetry wrap
-    can be applied uniformly without indenting the entire body."""
-    if is_jira:
-        from metatron.storage.graph_jira import write_jira_graph
-
-        jira_data = {
-            "key": doc.source_id,
-            "summary": doc.title,
-            "status": doc.metadata.get("status", ""),
-            "assignee": doc.metadata.get("assignee"),
-            "reporter": doc.metadata.get("reporter"),
-            "issuetype": doc.metadata.get("issuetype"),
-            "priority": doc.metadata.get("priority"),
-            "description": doc.content[:2000],
-            "created": doc.metadata.get("created_at_str")
-            or (doc.created_at.isoformat() if doc.created_at else None),
-            "updated": doc.metadata.get("updated_at_str")
-            or (doc.updated_at.isoformat() if doc.updated_at else None),
-            "resolved_at": doc.metadata.get("resolved_at_str"),
-        }
-        write_jira_graph(
-            jira_data,
-            doc.content,
-            workspace_id=workspace_id,
-            doc_label=doc.source_id,
-            metadata=doc.metadata,
-        )
-    else:
-        from metatron.storage.neo4j_graph import write_doc_graph
-
-        doc_date = (
-            doc.updated_at.isoformat()
-            if doc.updated_at
-            else doc.created_at.isoformat()
-            if doc.created_at
-            else None
-        )
-        write_doc_graph(
-            text=doc.content[:8000],
-            file_name=doc.title or doc.source_id or "untitled",
-            user_id=doc.author or "system",
-            workspace_id=workspace_id,
-            doc_label=doc.source_id,
-            doc_date=doc_date,
-            metadata=doc.metadata,
-        )
+            doc_date = (
+                doc.updated_at.isoformat()
+                if doc.updated_at
+                else doc.created_at.isoformat()
+                if doc.created_at
+                else None
+            )
+            write_doc_graph(
+                text=doc.content[:8000],
+                file_name=doc.title or doc.source_id or "untitled",
+                user_id=doc.author or "system",
+                workspace_id=workspace_id,
+                doc_label=doc.source_id,
+                doc_date=doc_date,
+                metadata=doc.metadata,
+            )
 
 
 def _delete_graph_node(doc_label: str, workspace_id: str) -> None:

--- a/src/metatron/ingestion/pipeline.py
+++ b/src/metatron/ingestion/pipeline.py
@@ -10,6 +10,7 @@ import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from uuid import uuid4
 
 import structlog
 
@@ -22,6 +23,7 @@ from metatron.core.models import Chunk, Document, SyncResult
 from metatron.ingestion.chunking import root_child_chunk, simple_chunk
 from metatron.ingestion.dedup import DeduplicationIndex, simhash
 from metatron.ingestion.processors.dates import extract_date_from_text
+from metatron.llm.telemetry import set_telemetry_context
 
 logger = structlog.get_logger()
 
@@ -672,10 +674,15 @@ def _extract_graphs_parallel(
 
     def _write_graph(doc: Document, ws_id: str) -> str:
         """Write one document to graph, return source_id on success."""
-        if doc.source_type == "jira":
-            _write_jira_to_graph(doc, ws_id)
-        else:
-            _write_doc_to_graph(doc, ws_id)
+        with set_telemetry_context(
+            workspace_id=ws_id,
+            source="ingestion",
+            correlation_id=uuid4(),
+        ):
+            if doc.source_type == "jira":
+                _write_jira_to_graph(doc, ws_id)
+            else:
+                _write_doc_to_graph(doc, ws_id)
         return doc.source_id
 
     failed: list[tuple[Document, str]] = []
@@ -748,6 +755,26 @@ def _write_graph_strict(
     Used by process_unsynced_graphs() where we need to know if the write
     actually succeeded before marking graph_synced=true.
     """
+    # Telemetry: tag this NER-extraction LLM call as source="ingestion" so
+    # rows in llm_generation_log carry the correct provenance. This is the
+    # second of two ingestion entry-points (the other is the inline
+    # _write_graph inside _extract_graphs_parallel); both need the wrap.
+    with set_telemetry_context(
+        workspace_id=workspace_id,
+        source="ingestion",
+        correlation_id=uuid4(),
+    ):
+        _write_graph_strict_inner(doc, workspace_id, is_jira=is_jira)
+
+
+def _write_graph_strict_inner(
+    doc: Document,
+    workspace_id: str,
+    *,
+    is_jira: bool = False,
+) -> None:
+    """Body of _write_graph_strict — kept separate so the telemetry wrap
+    can be applied uniformly without indenting the entire body."""
     if is_jira:
         from metatron.storage.graph_jira import write_jira_graph
 

--- a/src/metatron/ingestion/processors/translation.py
+++ b/src/metatron/ingestion/processors/translation.py
@@ -48,6 +48,7 @@ def translate_to_english(text: str) -> str:  # TODO: async migration
             temperature=0.1,
             max_tokens=4000,
             timeout=60,
+            call_site="translation_to_english",
         )
         return result.strip()
     except Exception:
@@ -77,6 +78,7 @@ def translate_to_russian(text: str) -> str:  # TODO: async migration
             temperature=0.1,
             max_tokens=200,
             timeout=10,
+            call_site="translation_to_russian",
         )
         return result.strip()
     except Exception:

--- a/src/metatron/llm/__init__.py
+++ b/src/metatron/llm/__init__.py
@@ -69,7 +69,7 @@ from metatron.llm.provider import (
     get_llm,
     get_provider_class,
 )
-from metatron.llm.telemetry import emit_log, is_telemetry_writable
+from metatron.llm.telemetry import emit_log
 from metatron.observability.metrics import timed
 
 logger = structlog.get_logger()
@@ -106,7 +106,7 @@ def chat_completion(  # TODO: async migration
     model: str | None = None,
     use_fallback: bool = True,
     *,
-    call_site: str,
+    call_site: str = "unknown",
     **kwargs: Any,
 ) -> str:
     """Send a chat completion request to the configured LLM provider.
@@ -123,8 +123,13 @@ def chat_completion(  # TODO: async migration
         provider: Provider name override (optional).
         model: Model name override (optional).
         use_fallback: Whether to try fallback provider on failure.
-        call_site: Identifier for this LLM call site (required, keyword-only).
-            Used as the ``call_site`` column in ``llm_generation_log``.
+        call_site: Identifier for this LLM call site, used as the
+            ``call_site`` column in ``llm_generation_log``. Keyword-only.
+            Defaults to ``"unknown"`` so external plugins that import
+            ``chat_completion`` without passing ``call_site=...`` keep
+            working — their rows just land under the ``unknown`` bucket.
+            In-tree callers should always pass a stable label from the
+            audit table.
         **kwargs: Additional provider-specific parameters.
 
     Returns:
@@ -147,22 +152,40 @@ def chat_completion(  # TODO: async migration
         else:
             raise ValueError(f"Invalid message type: {type(m)}")
 
-    # Telemetry early-gate — when the workspace has opted out (or the master
-    # kill-switch is off), do NOT build a copy of the prompt content. This
-    # makes the privacy story "we do not process this prompt" rather than the
-    # weaker "we do not store it". emit_log() still re-checks under its own
-    # lock, so a flip mid-call is safe.
-    telemetry_on = is_telemetry_writable()
-    messages_for_log = (
-        [{"role": mo.role, "content": mo.content} for mo in msg_objects] if telemetry_on else []
-    )
+    # Lazy snapshot — emit_log materialises this only AFTER its opt-out
+    # re-check, so when the workspace flips opted-out mid-call the prompt
+    # copy never leaves the Message-object list.
+    def _build_messages_snapshot() -> list[dict[str, Any]]:
+        return [{"role": mo.role, "content": mo.content} for mo in msg_objects]
 
     # Get primary provider
     llm = get_llm(provider_name=provider, model=model)
 
-    fallback_provider_name: str | None = None
-    response: LLMResponse | None = None
     t0 = perf_counter()
+
+    def _emit(
+        *,
+        provider_inst: LLMProvider,
+        response: LLMResponse | None,
+        success: bool,
+        error_class: str | None = None,
+        error_message: str | None = None,
+        fallback_used: bool = False,
+        fallback_provider: str | None = None,
+    ) -> None:
+        emit_log(
+            call_site=call_site,
+            provider=provider_inst.name,
+            model=getattr(provider_inst, "model", "unknown"),
+            messages=_build_messages_snapshot,
+            response=response,
+            latency_ms=int((perf_counter() - t0) * 1000),
+            success=success,
+            error_class=error_class,
+            error_message=error_message,
+            fallback_used=fallback_used,
+            fallback_provider=fallback_provider,
+        )
 
     try:
         response = llm.chat_completion(
@@ -174,60 +197,32 @@ def chat_completion(  # TODO: async migration
             **kwargs,
         )
 
-        latency_ms = int((perf_counter() - t0) * 1000)
-
         # Empty-content guard — convert to synthetic failure so the DB
         # CHECK constraint (success=true → response_content NOT NULL) stays
         # satisfied and export filters are trivial.
         if not response.content.strip():
-            emit_log(
-                call_site=call_site,
-                provider=llm.name,
-                model=getattr(llm, "model", "unknown"),
-                messages=messages_for_log,
+            _emit(
+                provider_inst=llm,
                 response=response,
-                latency_ms=latency_ms,
                 success=False,
                 error_class="EmptyResponse",
                 error_message="provider returned empty content",
-                fallback_used=False,
-                fallback_provider=None,
             )
-            # Return the empty string — callers expect a string, not an exception.
             return response.content
 
-        emit_log(
-            call_site=call_site,
-            provider=llm.name,
-            model=getattr(llm, "model", "unknown"),
-            messages=messages_for_log,
-            response=response,
-            latency_ms=latency_ms,
-            success=True,
-            error_class=None,
-            error_message=None,
-            fallback_used=False,
-            fallback_provider=None,
-        )
+        _emit(provider_inst=llm, response=response, success=True)
         return response.content
 
     except (LLMConnectionError, LLMAuthenticationError, LLMRateLimitError) as e:
         logger.warning("primary_llm_failed", provider=llm.name, error=str(e))
 
         if not use_fallback:
-            latency_ms = int((perf_counter() - t0) * 1000)
-            emit_log(
-                call_site=call_site,
-                provider=llm.name,
-                model=getattr(llm, "model", "unknown"),
-                messages=messages_for_log,
+            _emit(
+                provider_inst=llm,
                 response=None,
-                latency_ms=latency_ms,
                 success=False,
                 error_class=type(e).__name__,
                 error_message=str(e)[:512],
-                fallback_used=False,
-                fallback_provider=None,
             )
             raise
 
@@ -235,7 +230,6 @@ def chat_completion(  # TODO: async migration
         fallback = _get_cached_fallback()
         if fallback and fallback.is_available():
             logger.info("trying_fallback_provider", provider=fallback.name)
-            fallback_provider_name = fallback.name
             try:
                 response = fallback.chat_completion(
                     messages=msg_objects,
@@ -245,58 +239,42 @@ def chat_completion(  # TODO: async migration
                     timeout=timeout,
                     **kwargs,
                 )
-                latency_ms = int((perf_counter() - t0) * 1000)
 
                 if not response.content.strip():
-                    emit_log(
-                        call_site=call_site,
-                        provider=fallback.name,
-                        model=getattr(fallback, "model", "unknown"),
-                        messages=messages_for_log,
+                    _emit(
+                        provider_inst=fallback,
                         response=response,
-                        latency_ms=latency_ms,
                         success=False,
                         error_class="EmptyResponse",
                         error_message="fallback provider returned empty content",
                         fallback_used=True,
-                        fallback_provider=fallback_provider_name,
+                        fallback_provider=fallback.name,
                     )
                     return response.content
 
-                emit_log(
-                    call_site=call_site,
-                    provider=fallback.name,
-                    model=getattr(fallback, "model", "unknown"),
-                    messages=messages_for_log,
+                _emit(
+                    provider_inst=fallback,
                     response=response,
-                    latency_ms=latency_ms,
                     success=True,
-                    error_class=None,
-                    error_message=None,
                     fallback_used=True,
-                    fallback_provider=fallback_provider_name,
+                    fallback_provider=fallback.name,
                 )
                 return response.content
 
             except LLMError as fallback_error:
-                latency_ms = int((perf_counter() - t0) * 1000)
                 logger.error(
                     "fallback_llm_failed",
                     provider=fallback.name,
                     error=str(fallback_error),
                 )
-                emit_log(
-                    call_site=call_site,
-                    provider=fallback.name,
-                    model=getattr(fallback, "model", "unknown"),
-                    messages=messages_for_log,
+                _emit(
+                    provider_inst=fallback,
                     response=None,
-                    latency_ms=latency_ms,
                     success=False,
                     error_class=type(fallback_error).__name__,
                     error_message=str(fallback_error)[:512],
                     fallback_used=True,
-                    fallback_provider=fallback_provider_name,
+                    fallback_provider=fallback.name,
                 )
                 raise LLMError(
                     f"Primary ({llm.name}) and fallback ({fallback.name}) "
@@ -305,19 +283,12 @@ def chat_completion(  # TODO: async migration
                 ) from e
 
         # No fallback available — emit failure row for the primary error.
-        latency_ms = int((perf_counter() - t0) * 1000)
-        emit_log(
-            call_site=call_site,
-            provider=llm.name,
-            model=getattr(llm, "model", "unknown"),
-            messages=messages_for_log,
+        _emit(
+            provider_inst=llm,
             response=None,
-            latency_ms=latency_ms,
             success=False,
             error_class=type(e).__name__,
             error_message=str(e)[:512],
-            fallback_used=False,
-            fallback_provider=None,
         )
         raise
 
@@ -326,7 +297,7 @@ def chat_completion_with_retry(
     messages: list[dict[str, str] | Message],
     max_retries: int = 3,
     *,
-    call_site: str,
+    call_site: str = "unknown",
     **kwargs: Any,
 ) -> str:
     """Chat completion with exponential backoff retry on connection errors.

--- a/src/metatron/llm/__init__.py
+++ b/src/metatron/llm/__init__.py
@@ -47,7 +47,8 @@ Configuration via environment variables::
 """
 
 import time
-from typing import Any, Dict, List, Optional, Union
+from time import perf_counter
+from typing import Any
 
 import structlog
 
@@ -68,6 +69,7 @@ from metatron.llm.provider import (
     get_llm,
     get_provider_class,
 )
+from metatron.llm.telemetry import emit_log, is_telemetry_writable
 from metatron.observability.metrics import timed
 
 logger = structlog.get_logger()
@@ -103,6 +105,8 @@ def chat_completion(  # TODO: async migration
     provider: str | None = None,
     model: str | None = None,
     use_fallback: bool = True,
+    *,
+    call_site: str,
     **kwargs: Any,
 ) -> str:
     """Send a chat completion request to the configured LLM provider.
@@ -111,7 +115,7 @@ def chat_completion(  # TODO: async migration
     selection, fallback on failure, and returns just the response content.
 
     Args:
-        messages: List of messages, either as dicts or Message objects.
+        messages: Sequence of messages, each as a dict or Message instance.
         temperature: Sampling temperature (0-2, default 0.7).
         max_tokens: Maximum tokens in response (optional).
         json_mode: Request JSON output format (default False).
@@ -119,6 +123,8 @@ def chat_completion(  # TODO: async migration
         provider: Provider name override (optional).
         model: Model name override (optional).
         use_fallback: Whether to try fallback provider on failure.
+        call_site: Identifier for this LLM call site (required, keyword-only).
+            Used as the ``call_site`` column in ``llm_generation_log``.
         **kwargs: Additional provider-specific parameters.
 
     Returns:
@@ -141,8 +147,22 @@ def chat_completion(  # TODO: async migration
         else:
             raise ValueError(f"Invalid message type: {type(m)}")
 
+    # Telemetry early-gate — when the workspace has opted out (or the master
+    # kill-switch is off), do NOT build a copy of the prompt content. This
+    # makes the privacy story "we do not process this prompt" rather than the
+    # weaker "we do not store it". emit_log() still re-checks under its own
+    # lock, so a flip mid-call is safe.
+    telemetry_on = is_telemetry_writable()
+    messages_for_log = (
+        [{"role": mo.role, "content": mo.content} for mo in msg_objects] if telemetry_on else []
+    )
+
     # Get primary provider
     llm = get_llm(provider_name=provider, model=model)
+
+    fallback_provider_name: str | None = None
+    response: LLMResponse | None = None
+    t0 = perf_counter()
 
     try:
         response = llm.chat_completion(
@@ -153,18 +173,69 @@ def chat_completion(  # TODO: async migration
             timeout=timeout,
             **kwargs,
         )
+
+        latency_ms = int((perf_counter() - t0) * 1000)
+
+        # Empty-content guard — convert to synthetic failure so the DB
+        # CHECK constraint (success=true → response_content NOT NULL) stays
+        # satisfied and export filters are trivial.
+        if not response.content.strip():
+            emit_log(
+                call_site=call_site,
+                provider=llm.name,
+                model=getattr(llm, "model", "unknown"),
+                messages=messages_for_log,
+                response=response,
+                latency_ms=latency_ms,
+                success=False,
+                error_class="EmptyResponse",
+                error_message="provider returned empty content",
+                fallback_used=False,
+                fallback_provider=None,
+            )
+            # Return the empty string — callers expect a string, not an exception.
+            return response.content
+
+        emit_log(
+            call_site=call_site,
+            provider=llm.name,
+            model=getattr(llm, "model", "unknown"),
+            messages=messages_for_log,
+            response=response,
+            latency_ms=latency_ms,
+            success=True,
+            error_class=None,
+            error_message=None,
+            fallback_used=False,
+            fallback_provider=None,
+        )
         return response.content
 
     except (LLMConnectionError, LLMAuthenticationError, LLMRateLimitError) as e:
         logger.warning("primary_llm_failed", provider=llm.name, error=str(e))
 
         if not use_fallback:
+            latency_ms = int((perf_counter() - t0) * 1000)
+            emit_log(
+                call_site=call_site,
+                provider=llm.name,
+                model=getattr(llm, "model", "unknown"),
+                messages=messages_for_log,
+                response=None,
+                latency_ms=latency_ms,
+                success=False,
+                error_class=type(e).__name__,
+                error_message=str(e)[:512],
+                fallback_used=False,
+                fallback_provider=None,
+            )
             raise
 
         # Try fallback provider
         fallback = _get_cached_fallback()
         if fallback and fallback.is_available():
             logger.info("trying_fallback_provider", provider=fallback.name)
+            fallback_provider_name = fallback.name
             try:
                 response = fallback.chat_completion(
                     messages=msg_objects,
@@ -174,12 +245,58 @@ def chat_completion(  # TODO: async migration
                     timeout=timeout,
                     **kwargs,
                 )
+                latency_ms = int((perf_counter() - t0) * 1000)
+
+                if not response.content.strip():
+                    emit_log(
+                        call_site=call_site,
+                        provider=fallback.name,
+                        model=getattr(fallback, "model", "unknown"),
+                        messages=messages_for_log,
+                        response=response,
+                        latency_ms=latency_ms,
+                        success=False,
+                        error_class="EmptyResponse",
+                        error_message="fallback provider returned empty content",
+                        fallback_used=True,
+                        fallback_provider=fallback_provider_name,
+                    )
+                    return response.content
+
+                emit_log(
+                    call_site=call_site,
+                    provider=fallback.name,
+                    model=getattr(fallback, "model", "unknown"),
+                    messages=messages_for_log,
+                    response=response,
+                    latency_ms=latency_ms,
+                    success=True,
+                    error_class=None,
+                    error_message=None,
+                    fallback_used=True,
+                    fallback_provider=fallback_provider_name,
+                )
                 return response.content
+
             except LLMError as fallback_error:
+                latency_ms = int((perf_counter() - t0) * 1000)
                 logger.error(
                     "fallback_llm_failed",
                     provider=fallback.name,
                     error=str(fallback_error),
+                )
+                emit_log(
+                    call_site=call_site,
+                    provider=fallback.name,
+                    model=getattr(fallback, "model", "unknown"),
+                    messages=messages_for_log,
+                    response=None,
+                    latency_ms=latency_ms,
+                    success=False,
+                    error_class=type(fallback_error).__name__,
+                    error_message=str(fallback_error)[:512],
+                    fallback_used=True,
+                    fallback_provider=fallback_provider_name,
                 )
                 raise LLMError(
                     f"Primary ({llm.name}) and fallback ({fallback.name}) "
@@ -187,13 +304,29 @@ def chat_completion(  # TODO: async migration
                     f"Fallback error: {fallback_error}"
                 ) from e
 
-        # No fallback available
+        # No fallback available — emit failure row for the primary error.
+        latency_ms = int((perf_counter() - t0) * 1000)
+        emit_log(
+            call_site=call_site,
+            provider=llm.name,
+            model=getattr(llm, "model", "unknown"),
+            messages=messages_for_log,
+            response=None,
+            latency_ms=latency_ms,
+            success=False,
+            error_class=type(e).__name__,
+            error_message=str(e)[:512],
+            fallback_used=False,
+            fallback_provider=None,
+        )
         raise
 
 
 def chat_completion_with_retry(
     messages: list[dict[str, str] | Message],
     max_retries: int = 3,
+    *,
+    call_site: str,
     **kwargs: Any,
 ) -> str:
     """Chat completion with exponential backoff retry on connection errors.
@@ -201,9 +334,15 @@ def chat_completion_with_retry(
     Retries only on LLMConnectionError (timeout, network). Auth and rate
     limit errors are raised immediately since retrying won't help.
 
+    Each retry attempt is a fresh call into ``chat_completion``, so a
+    retried call produces N rows (failed) followed by one (success) in
+    ``llm_generation_log``, each sharing the same ``correlation_id``
+    inherited from the ambient ContextVar.
+
     Args:
-        messages: List of messages, either as dicts or Message objects.
+        messages: Sequence of messages, each as a dict or Message instance.
         max_retries: Maximum number of attempts (default 3).
+        call_site: Identifier for this LLM call site (required, keyword-only).
         **kwargs: Passed through to chat_completion().
 
     Returns:
@@ -218,7 +357,7 @@ def chat_completion_with_retry(
     last_error: LLMConnectionError | None = None
     for attempt in range(1, max_retries + 1):
         try:
-            return chat_completion(messages=messages, **kwargs)
+            return chat_completion(messages=messages, call_site=call_site, **kwargs)
         except LLMConnectionError as e:
             last_error = e
             if attempt < max_retries:

--- a/src/metatron/llm/telemetry.py
+++ b/src/metatron/llm/telemetry.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import OrderedDict
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
@@ -31,7 +32,7 @@ import structlog
 from metatron.core.config import get_settings
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
     from uuid import UUID
 
 logger = structlog.get_logger()
@@ -133,21 +134,36 @@ def add_extra_metadata(**kv: Any) -> None:
 # ---------------------------------------------------------------------------
 
 # {workspace_id: (opt_out: bool, fetched_at: float)}
-_opt_out_cache: dict[str, tuple[bool, float]] = {}
+_opt_out_cache: OrderedDict[str, tuple[bool, float]] = OrderedDict()
 # Coarse lock guarding the cache dict and the per-workspace lock dict below.
 _opt_out_cache_lock = threading.Lock()
 # Per-workspace locks ensure N concurrent misses on the same workspace_id
 # issue ONE PG SELECT, not N — without blocking misses on other workspaces.
-_opt_out_per_ws_locks: dict[str, threading.Lock] = {}
+# Bounded LRU prevents unbounded growth on deployments with many short-lived
+# workspaces (ephemeral test fixtures, future per-agent tenants, etc).
+_opt_out_per_ws_locks: OrderedDict[str, threading.Lock] = OrderedDict()
+_OPT_OUT_LOCK_CAP = 1024
 
 
 def _get_per_ws_lock(workspace_id: str) -> threading.Lock:
-    """Return the lock for ``workspace_id``, creating it if needed."""
+    """Return the lock for ``workspace_id``, creating it if needed.
+
+    Uses a bounded LRU: when the dict exceeds ``_OPT_OUT_LOCK_CAP`` entries,
+    the least-recently-used lock is dropped. An evicted lock that is still
+    being held by a concurrent caller stays alive via the holder's local
+    reference; the next caller for that workspace creates a fresh lock and
+    the old one is GC'd when the holder releases it. Worst case is two
+    callers briefly racing on a cold workspace — no correctness issue.
+    """
     with _opt_out_cache_lock:
         lock = _opt_out_per_ws_locks.get(workspace_id)
         if lock is None:
             lock = threading.Lock()
             _opt_out_per_ws_locks[workspace_id] = lock
+            if len(_opt_out_per_ws_locks) > _OPT_OUT_LOCK_CAP:
+                _opt_out_per_ws_locks.popitem(last=False)
+        else:
+            _opt_out_per_ws_locks.move_to_end(workspace_id)
         return lock
 
 
@@ -208,11 +224,11 @@ def _is_opted_out(workspace_id: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Public predicate — lets callers skip building the request-message snapshot
-# entirely when telemetry will not write anything for this call. Used by
-# llm.chat_completion to honour GDPR opt-out semantics ("we don't process",
-# not just "we don't store"): when the workspace has opted out, the prompt
-# never leaves the message-object list as a separate copy.
+# Public predicate — callers can use this as a fast-path check before doing
+# expensive prompt-snapshot work. Note: ``emit_log`` itself takes a callable
+# for ``messages``, so most call sites do NOT need to gate manually — the
+# snapshot is built only after the opt-out re-check inside emit_log. This
+# helper is kept for diagnostic / introspection use.
 # ---------------------------------------------------------------------------
 
 
@@ -223,11 +239,6 @@ def is_telemetry_writable() -> bool:
     read from the ambient :data:`current_telemetry_ctx`; when missing the
     function returns True (writes proceed with ``workspace_id IS NULL`` so
     the data is not lost).
-
-    Race window: if the workspace flips opt-out between this check and the
-    eventual :func:`emit_log` call, ``emit_log`` re-checks under the lock
-    and drops the row — so this predicate is a fast-path optimisation,
-    not a correctness gate.
     """
     settings = get_settings()
     if not settings.llm_telemetry_enabled:
@@ -243,12 +254,54 @@ def is_telemetry_writable() -> bool:
 # ---------------------------------------------------------------------------
 
 
+# Maximum per-message-content / response-content size in characters. Anything
+# larger is truncated and flagged in metadata. 8 000 matches the NER text
+# truncation in storage/neo4j_graph.py:extract_graph_from_text so an
+# ner_extraction prompt that hit the upstream cap is always small enough to
+# fit; chosen as a single cap for simplicity (oversized rag_answer prompts get
+# the same treatment — fine for the FT dataset; full context is reconstructible
+# from retrieved_context + the upstream document store anyway).
+_MAX_CONTENT_CHARS = 8_000
+
+
+def _cap_messages(
+    messages: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], bool]:
+    """Cap each message's content to ``_MAX_CONTENT_CHARS``.
+
+    Returns ``(capped_messages, truncated)`` — ``truncated`` is True iff at
+    least one message was shortened. The capped copy is a fresh list so the
+    caller's original list is untouched.
+    """
+    capped: list[dict[str, Any]] = []
+    truncated = False
+    for m in messages:
+        content = m.get("content", "")
+        if isinstance(content, str) and len(content) > _MAX_CONTENT_CHARS:
+            new = dict(m)
+            new["content"] = content[:_MAX_CONTENT_CHARS]
+            capped.append(new)
+            truncated = True
+        else:
+            capped.append(m)
+    return capped, truncated
+
+
+def _cap_response(text: str | None) -> tuple[str | None, bool]:
+    """Cap response content to ``_MAX_CONTENT_CHARS``. Returns ``(text, truncated)``."""
+    if text is None:
+        return None, False
+    if len(text) > _MAX_CONTENT_CHARS:
+        return text[:_MAX_CONTENT_CHARS], True
+    return text, False
+
+
 def emit_log(
     *,
     call_site: str,
     provider: str,
     model: str,
-    messages: list[dict[str, Any]],
+    messages: list[dict[str, Any]] | Callable[[], list[dict[str, Any]]],
     response: Any | None,  # LLMResponse | None — typed as Any to avoid circular import
     latency_ms: int,
     success: bool,
@@ -265,7 +318,12 @@ def emit_log(
         call_site: Identifier string from the audit table (e.g. "rag_answer").
         provider: Provider name (e.g. "ollama", "deepseek").
         model: Model name as returned by the provider.
-        messages: The request messages list (serialisable dicts).
+        messages: The request messages — either an already-built list of
+            serialisable dicts, OR a zero-argument callable that builds it.
+            Passing a callable lets the caller defer materialisation until
+            AFTER the kill-switch / opt-out re-check, so a prompt copy never
+            lives in process memory when the workspace has opted out
+            mid-call (closes the race window on the entry-time gate).
         response: LLMResponse on success, None on failure.
         latency_ms: Wall-clock ms for the LLM call.
         success: True if the provider returned non-empty content.
@@ -288,20 +346,30 @@ def emit_log(
     retrieved_context = ctx.retrieved_context if ctx is not None else None
     extra_metadata = dict(ctx.extra_metadata) if ctx is not None and ctx.extra_metadata else {}
 
-    # Per-workspace opt-out.
+    # Per-workspace opt-out — checked BEFORE we materialise the prompt
+    # snapshot, so when the workspace has opted out the prompt copy never
+    # leaves the upstream Message-object list. Callers passing a callable
+    # for ``messages`` rely on this gate for the "we don't process" privacy
+    # posture; callers passing a pre-built list also benefit (we still drop
+    # the row, just at the cost of one extra in-memory copy upstream).
     if workspace_id is not None and _is_opted_out(workspace_id):
         return
+
+    # Materialise the request messages list (deferred construction — see docstring).
+    raw_messages = messages() if callable(messages) else messages
+    capped_messages, message_truncated = _cap_messages(raw_messages)
 
     # Token counts via property accessors (always return int, default 0).
     if response is not None:
         prompt_tokens: int = response.prompt_tokens
         completion_tokens: int = response.completion_tokens
         total_tokens: int = response.total_tokens
-        response_content: str | None = response.content if success else None
+        raw_response_content: str | None = response.content if success else None
     else:
         prompt_tokens = completion_tokens = total_tokens = 0
-        response_content = None
+        raw_response_content = None
 
+    response_content, response_truncated = _cap_response(raw_response_content)
     zero_tokens = total_tokens == 0 and prompt_tokens == 0 and completion_tokens == 0
 
     # Build metadata JSONB.
@@ -311,8 +379,16 @@ def emit_log(
         "zero_tokens": zero_tokens,
         **extra_metadata,
     }
+    if message_truncated:
+        metadata["message_truncated"] = True
+    if response_truncated:
+        metadata["response_truncated"] = True
     if retrieved_context is not None and call_site == "rag_answer":
-        metadata["retrieved_context"] = retrieved_context
+        # retrieved_context is also capped — same rationale as request/response content.
+        ctx_capped, ctx_truncated = _cap_response(retrieved_context)
+        metadata["retrieved_context"] = ctx_capped
+        if ctx_truncated:
+            metadata["retrieved_context_truncated"] = True
 
     try:
         from metatron.storage.llm_generation_log import LLMLogRowData, insert_log_row_sync
@@ -326,7 +402,7 @@ def emit_log(
             correlation_id=str(correlation_id) if correlation_id is not None else None,
             provider=provider,
             model=model,
-            request_messages=messages,
+            request_messages=capped_messages,
             response_content=response_content,
             prompt_tokens=prompt_tokens if prompt_tokens else None,
             completion_tokens=completion_tokens if completion_tokens else None,

--- a/src/metatron/llm/telemetry.py
+++ b/src/metatron/llm/telemetry.py
@@ -1,0 +1,347 @@
+"""LLM generation telemetry context and emission (MTRNIX-336).
+
+This module owns the per-request TelemetryContext ContextVar, the
+``set_telemetry_context`` context-manager helper used by entry-points
+(REST, MCP, ingestion, freshness), the ``update_retrieved_context`` mutator
+called just before the RAG-answer LLM call, and the synchronous ``emit_log``
+that writes one row to ``llm_generation_log``.
+
+Design constraints
+------------------
+* ``emit_log`` is **fully synchronous** — ``chat_completion`` runs inside
+  ``asyncio.to_thread`` (no event loop in the calling thread), so
+  ``asyncio.create_task`` would raise RuntimeError. The insert goes via
+  ``storage.pg_connection.get_session()`` (psycopg2) in the same thread.
+* The module never raises from ``emit_log`` — any write failure is logged at
+  WARNING and silently discarded.
+* The opt-out cache is protected by ``threading.Lock`` (sync code path).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from metatron.core.config import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from uuid import UUID
+
+logger = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# TelemetryContext dataclass — mutable so update_retrieved_context can patch
+# the current instance in-place without resetting the ContextVar token.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TelemetryContext:
+    """Mutable per-request telemetry context propagated via ContextVar."""
+
+    workspace_id: str | None = None
+    user_id: str | None = None
+    agent_id: str | None = None
+    source: str | None = None
+    correlation_id: UUID | None = None
+    retrieved_context: str | None = None
+    extra_metadata: dict[str, Any] | None = None
+
+
+# Module-level ContextVar — isolated per asyncio Task and per thread.
+current_telemetry_ctx: ContextVar[TelemetryContext | None] = ContextVar(
+    "current_telemetry_ctx", default=None
+)
+
+
+# ---------------------------------------------------------------------------
+# Context manager for entry-points
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def set_telemetry_context(
+    *,
+    workspace_id: str | None = None,
+    user_id: str | None = None,
+    agent_id: str | None = None,
+    source: str | None = None,
+    correlation_id: UUID | None = None,
+) -> Generator[TelemetryContext, None, None]:
+    """Push a fresh TelemetryContext onto the ContextVar for the duration of the block.
+
+    Nested usage: the child scope replaces the parent for its duration; on exit
+    the parent's token is restored.  The child does NOT inherit the parent's
+    ``retrieved_context`` — each scope starts clean.
+    """
+    ctx = TelemetryContext(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        source=source,
+        correlation_id=correlation_id,
+    )
+    token: Token[TelemetryContext | None] = current_telemetry_ctx.set(ctx)
+    try:
+        yield ctx
+    finally:
+        current_telemetry_ctx.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Mutator — called just before the RAG-answer LLM call
+# ---------------------------------------------------------------------------
+
+
+def update_retrieved_context(text: str) -> None:
+    """Set retrieved_context on the current TelemetryContext instance.
+
+    No-op when no context is active.
+    """
+    ctx = current_telemetry_ctx.get()
+    if ctx is not None:
+        ctx.retrieved_context = text
+
+
+def add_extra_metadata(**kv: Any) -> None:
+    """Merge keys into ``extra_metadata`` on the current TelemetryContext.
+
+    Safer than ``current_telemetry_ctx.get().extra_metadata = {...}``: assign
+    obliterates whatever a previous call site wrote. This helper merges, so
+    multiple call sites in the same scope (search.py setting subtype/lang,
+    neo4j_graph.py setting doc_label) can coexist.
+
+    No-op when no context is active.
+    """
+    ctx = current_telemetry_ctx.get()
+    if ctx is None:
+        return
+    if ctx.extra_metadata is None:
+        ctx.extra_metadata = {}
+    ctx.extra_metadata.update(kv)
+
+
+# ---------------------------------------------------------------------------
+# Opt-out cache (workspace-level, TTL-based, threading.Lock guarded)
+# ---------------------------------------------------------------------------
+
+# {workspace_id: (opt_out: bool, fetched_at: float)}
+_opt_out_cache: dict[str, tuple[bool, float]] = {}
+# Coarse lock guarding the cache dict and the per-workspace lock dict below.
+_opt_out_cache_lock = threading.Lock()
+# Per-workspace locks ensure N concurrent misses on the same workspace_id
+# issue ONE PG SELECT, not N — without blocking misses on other workspaces.
+_opt_out_per_ws_locks: dict[str, threading.Lock] = {}
+
+
+def _get_per_ws_lock(workspace_id: str) -> threading.Lock:
+    """Return the lock for ``workspace_id``, creating it if needed."""
+    with _opt_out_cache_lock:
+        lock = _opt_out_per_ws_locks.get(workspace_id)
+        if lock is None:
+            lock = threading.Lock()
+            _opt_out_per_ws_locks[workspace_id] = lock
+        return lock
+
+
+def _is_opted_out(workspace_id: str) -> bool:
+    """Return True if the workspace has llm_telemetry_opt_out=true.
+
+    Uses a TTL cache to avoid a PG round-trip on every LLM call. Concurrent
+    misses on the same ``workspace_id`` are serialised by a per-workspace
+    lock that is held across the SELECT — so a thundering herd of N callers
+    issues exactly one query; the (N-1) followers read the freshly-populated
+    cache entry on entry into the critical section.
+    """
+    settings = get_settings()
+    ttl = settings.llm_telemetry_opt_out_cache_ttl_seconds
+    now = time.monotonic()
+
+    # Fast path — read cache without holding the per-ws lock.
+    with _opt_out_cache_lock:
+        entry = _opt_out_cache.get(workspace_id)
+    if entry is not None:
+        opt_out, fetched_at = entry
+        if now - fetched_at < ttl:
+            return opt_out
+
+    # Slow path — acquire the per-workspace lock so only one caller queries PG.
+    ws_lock = _get_per_ws_lock(workspace_id)
+    with ws_lock:
+        # Re-check under the lock — another waiter may have populated the entry.
+        now = time.monotonic()
+        with _opt_out_cache_lock:
+            entry = _opt_out_cache.get(workspace_id)
+        if entry is not None:
+            opt_out, fetched_at = entry
+            if now - fetched_at < ttl:
+                return opt_out
+
+        # Still missing — issue the SELECT.
+        try:
+            from metatron.storage.pg_connection import get_session
+            from metatron.storage.pg_models import WorkspaceRow
+
+            with get_session() as session:
+                row = session.query(WorkspaceRow).filter_by(id=workspace_id).first()
+                opt_out = bool(row.llm_telemetry_opt_out) if row is not None else False
+        except Exception as exc:
+            logger.warning(
+                "llm_telemetry.opt_out_check_failed",
+                workspace_id=workspace_id,
+                error=str(exc),
+            )
+            # Fail open — write the row so we don't lose data on transient DB errors.
+            return False
+
+        with _opt_out_cache_lock:
+            _opt_out_cache[workspace_id] = (opt_out, time.monotonic())
+
+        return opt_out
+
+
+# ---------------------------------------------------------------------------
+# Public predicate — lets callers skip building the request-message snapshot
+# entirely when telemetry will not write anything for this call. Used by
+# llm.chat_completion to honour GDPR opt-out semantics ("we don't process",
+# not just "we don't store"): when the workspace has opted out, the prompt
+# never leaves the message-object list as a separate copy.
+# ---------------------------------------------------------------------------
+
+
+def is_telemetry_writable() -> bool:
+    """Return True iff a row produced now would actually be written.
+
+    Cheap path: kill-switch check + opt-out cache lookup. Workspace_id is
+    read from the ambient :data:`current_telemetry_ctx`; when missing the
+    function returns True (writes proceed with ``workspace_id IS NULL`` so
+    the data is not lost).
+
+    Race window: if the workspace flips opt-out between this check and the
+    eventual :func:`emit_log` call, ``emit_log`` re-checks under the lock
+    and drops the row — so this predicate is a fast-path optimisation,
+    not a correctness gate.
+    """
+    settings = get_settings()
+    if not settings.llm_telemetry_enabled:
+        return False
+    ctx = current_telemetry_ctx.get()
+    if ctx is None or not ctx.workspace_id:
+        return True
+    return not _is_opted_out(ctx.workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# emit_log — the main entry point called by chat_completion()
+# ---------------------------------------------------------------------------
+
+
+def emit_log(
+    *,
+    call_site: str,
+    provider: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    response: Any | None,  # LLMResponse | None — typed as Any to avoid circular import
+    latency_ms: int,
+    success: bool,
+    error_class: str | None,
+    error_message: str | None,
+    fallback_used: bool,
+    fallback_provider: str | None,
+) -> None:
+    """Write one telemetry row to llm_generation_log.
+
+    Fully synchronous.  Never raises — all exceptions are caught and logged.
+
+    Args:
+        call_site: Identifier string from the audit table (e.g. "rag_answer").
+        provider: Provider name (e.g. "ollama", "deepseek").
+        model: Model name as returned by the provider.
+        messages: The request messages list (serialisable dicts).
+        response: LLMResponse on success, None on failure.
+        latency_ms: Wall-clock ms for the LLM call.
+        success: True if the provider returned non-empty content.
+        error_class: Exception class name on failure (or "EmptyResponse").
+        error_message: Short error text, already truncated to ≤512 chars.
+        fallback_used: True when the primary provider failed and fallback ran.
+        fallback_provider: Fallback provider name when fallback_used=True.
+    """
+    settings = get_settings()
+    if not settings.llm_telemetry_enabled:
+        return
+
+    # Read the ambient ContextVar.
+    ctx = current_telemetry_ctx.get()
+    workspace_id = ctx.workspace_id if ctx is not None else None
+    user_id = ctx.user_id if ctx is not None else None
+    agent_id = ctx.agent_id if ctx is not None else None
+    source = ctx.source if ctx is not None else None
+    correlation_id = ctx.correlation_id if ctx is not None else None
+    retrieved_context = ctx.retrieved_context if ctx is not None else None
+    extra_metadata = dict(ctx.extra_metadata) if ctx is not None and ctx.extra_metadata else {}
+
+    # Per-workspace opt-out.
+    if workspace_id is not None and _is_opted_out(workspace_id):
+        return
+
+    # Token counts via property accessors (always return int, default 0).
+    if response is not None:
+        prompt_tokens: int = response.prompt_tokens
+        completion_tokens: int = response.completion_tokens
+        total_tokens: int = response.total_tokens
+        response_content: str | None = response.content if success else None
+    else:
+        prompt_tokens = completion_tokens = total_tokens = 0
+        response_content = None
+
+    zero_tokens = total_tokens == 0 and prompt_tokens == 0 and completion_tokens == 0
+
+    # Build metadata JSONB.
+    metadata: dict[str, Any] = {
+        "fallback_used": fallback_used,
+        "fallback_provider": fallback_provider,
+        "zero_tokens": zero_tokens,
+        **extra_metadata,
+    }
+    if retrieved_context is not None and call_site == "rag_answer":
+        metadata["retrieved_context"] = retrieved_context
+
+    try:
+        from metatron.storage.llm_generation_log import LLMLogRowData, insert_log_row_sync
+
+        row = LLMLogRowData(
+            call_site=call_site,
+            source=source,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            agent_id=agent_id,
+            correlation_id=str(correlation_id) if correlation_id is not None else None,
+            provider=provider,
+            model=model,
+            request_messages=messages,
+            response_content=response_content,
+            prompt_tokens=prompt_tokens if prompt_tokens else None,
+            completion_tokens=completion_tokens if completion_tokens else None,
+            total_tokens=total_tokens if total_tokens else None,
+            latency_ms=latency_ms,
+            success=success,
+            error_class=error_class,
+            error_message=error_message,
+            metadata=metadata,
+        )
+        insert_log_row_sync(row)
+    except Exception as exc:
+        logger.warning(
+            "llm_telemetry.write_failed",
+            call_site=call_site,
+            provider=provider,
+            error=str(exc),
+        )

--- a/src/metatron/mcp/action_planner.py
+++ b/src/metatron/mcp/action_planner.py
@@ -212,6 +212,7 @@ class ActionPlanner:
                 ],
                 temperature=0.1,
                 timeout=30,
+                call_site="mcp_action_planner",
             )
         except Exception as e:
             logger.error("action.planner.llm_error", error=str(e))

--- a/src/metatron/mcp/server.py
+++ b/src/metatron/mcp/server.py
@@ -173,24 +173,22 @@ def _wrap_tool_with_activity(
         # changes, propagate `agent_id` explicitly into the spawned task.
         token = bind_agent_id(agent_id) if agent_id is not None else None
 
-        # Push telemetry context so all LLM calls inside this MCP tool are
-        # tagged with workspace_id, agent_id, and a fresh correlation_id.
-        telemetry_cm = set_telemetry_context(
-            workspace_id=workspace_id or None,
-            agent_id=agent_id,
-            source="mcp",
-            correlation_id=uuid4(),
-        )
-        telemetry_cm.__enter__()
-
         error: BaseException | None = None
         try:
-            return await handler(*args, **kwargs)
+            # Telemetry context wraps the handler — `with` ensures correct
+            # __exit__ semantics even if anyone later adds exception-aware
+            # cleanup inside set_telemetry_context.
+            with set_telemetry_context(
+                workspace_id=workspace_id or None,
+                agent_id=agent_id,
+                source="mcp",
+                correlation_id=uuid4(),
+            ):
+                return await handler(*args, **kwargs)
         except BaseException as exc:  # noqa: BLE001 — emit then re-raise
             error = exc
             raise
         finally:
-            telemetry_cm.__exit__(None, None, None)
             if token is not None:
                 current_agent_id.reset(token)
             duration_ms = int((time.monotonic() - start) * 1000)

--- a/src/metatron/mcp/server.py
+++ b/src/metatron/mcp/server.py
@@ -17,6 +17,7 @@ import os
 import time
 from functools import wraps
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import structlog
 from mcp.server import FastMCP
@@ -24,6 +25,7 @@ from mcp.server.streamable_http import TransportSecuritySettings
 
 from metatron.activity.context import bind_agent_id, current_agent_id
 from metatron.core.events import ERROR_OCCURRED, TOOL_CALLED
+from metatron.llm.telemetry import set_telemetry_context
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -171,6 +173,16 @@ def _wrap_tool_with_activity(
         # changes, propagate `agent_id` explicitly into the spawned task.
         token = bind_agent_id(agent_id) if agent_id is not None else None
 
+        # Push telemetry context so all LLM calls inside this MCP tool are
+        # tagged with workspace_id, agent_id, and a fresh correlation_id.
+        telemetry_cm = set_telemetry_context(
+            workspace_id=workspace_id or None,
+            agent_id=agent_id,
+            source="mcp",
+            correlation_id=uuid4(),
+        )
+        telemetry_cm.__enter__()
+
         error: BaseException | None = None
         try:
             return await handler(*args, **kwargs)
@@ -178,6 +190,7 @@ def _wrap_tool_with_activity(
             error = exc
             raise
         finally:
+            telemetry_cm.__exit__(None, None, None)
             if token is not None:
                 current_agent_id.reset(token)
             duration_ms = int((time.monotonic() - start) * 1000)
@@ -229,9 +242,7 @@ def _tool_with_activity(*decorator_args: Any, **decorator_kwargs: Any) -> Any:
         # ``_ACTIVITY_BUS_GETTER`` directly would freeze the no-op default into
         # every wrapper closure. Re-reading via globals each invocation lets
         # ``set_activity_bus_getter`` from create_app() take effect.
-        wrapped = _wrap_tool_with_activity(
-            name, func, bus_getter=lambda: _ACTIVITY_BUS_GETTER()
-        )
+        wrapped = _wrap_tool_with_activity(name, func, bus_getter=lambda: _ACTIVITY_BUS_GETTER())
         wrapped.__name__ = func.__name__
         wrapped.__qualname__ = getattr(func, "__qualname__", func.__name__)
         return registrar(wrapped)

--- a/src/metatron/memory/freshness/worker.py
+++ b/src/metatron/memory/freshness/worker.py
@@ -44,6 +44,7 @@ import os
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import structlog
 
@@ -51,6 +52,7 @@ from metatron.core.config import get_settings
 from metatron.core.models import FreshnessJob, LifecycleStatus, MachineEvent
 from metatron.freshness import metrics
 from metatron.freshness.worker_id import build_worker_id
+from metatron.llm.telemetry import set_telemetry_context
 
 if TYPE_CHECKING:
     from metatron.freshness.coordination import CoordinationStore
@@ -339,70 +341,75 @@ class FreshnessWorker:
             return
 
         decision_action = "skipped_missing"
-        try:
-            await pipeline.linker.run(ws, target_id)
-            await pipeline.reconciler.run(ws, target_id)
-            await pipeline.monitor.run(ws, target_id)
-            await pipeline.curator.run(ws, target_id)
+        with set_telemetry_context(
+            workspace_id=ws,
+            source="freshness",
+            correlation_id=uuid4(),
+        ):
+            try:
+                await pipeline.linker.run(ws, target_id)
+                await pipeline.reconciler.run(ws, target_id)
+                await pipeline.monitor.run(ws, target_id)
+                await pipeline.curator.run(ws, target_id)
 
-            record = await pipeline.target.get(ws, target_id)
-            eligible_statuses = {
-                LifecycleStatus.ACTIVE,
-                LifecycleStatus.REVIEW_NEEDED,
-            }
-            if pipeline.target.supports_candidate_promotion:
-                eligible_statuses.add(LifecycleStatus.CANDIDATE)
-            if record is not None and record.status in eligible_statuses:
-                from metatron.freshness.apply_decision import apply_decision
+                record = await pipeline.target.get(ws, target_id)
+                eligible_statuses = {
+                    LifecycleStatus.ACTIVE,
+                    LifecycleStatus.REVIEW_NEEDED,
+                }
+                if pipeline.target.supports_candidate_promotion:
+                    eligible_statuses.add(LifecycleStatus.CANDIDATE)
+                if record is not None and record.status in eligible_statuses:
+                    from metatron.freshness.apply_decision import apply_decision
 
-                decision = await self._decision_engine.decide(
-                    content=record.content,
-                    workspace_id=ws,
-                    record_id=target_id,
-                )
-                metrics.decision_confidence.observe(decision.confidence)
-                settings = get_settings()
-                result = await apply_decision(
-                    workspace_id=ws,
-                    record=record,
-                    decision=decision,
-                    threshold=settings.freshness_decision_confidence_threshold,
-                    target=pipeline.target,
-                    freshness_store=self._freshness_pg,
-                )
-                decision_action = str(result.get("action") or decision.action)
+                    decision = await self._decision_engine.decide(
+                        content=record.content,
+                        workspace_id=ws,
+                        record_id=target_id,
+                    )
+                    metrics.decision_confidence.observe(decision.confidence)
+                    settings = get_settings()
+                    result = await apply_decision(
+                        workspace_id=ws,
+                        record=record,
+                        decision=decision,
+                        threshold=settings.freshness_decision_confidence_threshold,
+                        target=pipeline.target,
+                        freshness_store=self._freshness_pg,
+                    )
+                    decision_action = str(result.get("action") or decision.action)
 
-            metrics.jobs_total.labels(status="ok", workspace_id=ws).inc()
-        except Exception:
-            metrics.jobs_total.labels(status="error", workspace_id=ws).inc()
-            metrics.worker_errors.labels(stage="process").inc()
-            logger.error(
-                "freshness.worker.job_failed",
-                workspace_id=ws,
-                target_kind=target_kind,
-                target_id=target_id,
-                exc_info=True,
-            )
-            raise
-        finally:
-            duration_ms = int((time.monotonic() - started) * 1000)
-            await self._freshness_pg.save_machine_event(
-                MachineEvent(
+                metrics.jobs_total.labels(status="ok", workspace_id=ws).inc()
+            except Exception:
+                metrics.jobs_total.labels(status="error", workspace_id=ws).inc()
+                metrics.worker_errors.labels(stage="process").inc()
+                logger.error(
+                    "freshness.worker.job_failed",
                     workspace_id=ws,
-                    event_type="freshness_job_processed",
                     target_kind=target_kind,
                     target_id=target_id,
-                    payload={
-                        "event_type": job.event_type,
-                        "decision_action": decision_action,
-                        "duration_ms": duration_ms,
-                    },
+                    exc_info=True,
                 )
-            )
-            # LREM the job from the processing list (MTRNIX-316). Must
-            # happen whether we succeeded or raised so the orphan-reclaim
-            # pass does not re-process a job we already completed.
-            await self._coord.complete_job(self._worker_id, job)
+                raise
+            finally:
+                duration_ms = int((time.monotonic() - started) * 1000)
+                await self._freshness_pg.save_machine_event(
+                    MachineEvent(
+                        workspace_id=ws,
+                        event_type="freshness_job_processed",
+                        target_kind=target_kind,
+                        target_id=target_id,
+                        payload={
+                            "event_type": job.event_type,
+                            "decision_action": decision_action,
+                            "duration_ms": duration_ms,
+                        },
+                    )
+                )
+                # LREM the job from the processing list (MTRNIX-316). Must
+                # happen whether we succeeded or raised so the orphan-reclaim
+                # pass does not re-process a job we already completed.
+                await self._coord.complete_job(self._worker_id, job)
 
 
 def _inc_reclaim_error(env_label: str, stage: str) -> None:

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -188,6 +188,7 @@ def _llm_classify(query: str) -> QueryClassification:
             temperature=0.0,
             max_tokens=60,
             timeout=int(os.getenv("METATRON_AUX_LLM_TIMEOUT", "10")),
+            call_site="query_classifier",
         )
         parsed = json.loads(raw.strip())
         profile = parsed.get("profile", "mixed")

--- a/src/metatron/retrieval/query_expansion.py
+++ b/src/metatron/retrieval/query_expansion.py
@@ -95,6 +95,7 @@ def expand_query(query: str, timeout: int | None = None) -> str:
             temperature=0.1,
             max_tokens=300,
             timeout=timeout,
+            call_site="query_expansion",
         )
         expanded = expanded.strip().strip('"').strip("'")
 
@@ -158,6 +159,7 @@ def generate_hypothetical_document(query: str, timeout: int = 8) -> str | None:
             temperature=0.3,
             max_tokens=200,
             timeout=timeout,
+            call_site="hyde",
         )
         text = text.strip()
         return text if text else None

--- a/src/metatron/retrieval/routing.py
+++ b/src/metatron/retrieval/routing.py
@@ -130,6 +130,7 @@ def should_use_team_workflow_schema(question: str) -> bool:  # TODO: async migra
         max_tokens=200,
         json_mode=True,
         timeout=20,
+        call_site="routing",
     )
     decision = TeamWorkflowRoutingDecision.model_validate_json(_extract_json_object(content))
     return decision.route == "schema_guided_team_workflow"

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -21,6 +21,7 @@ from metatron.ingestion.processors.dates import (
     extract_date_range,
 )
 from metatron.llm import chat_completion, chat_completion_with_retry  # TODO: async migration
+from metatron.llm.telemetry import add_extra_metadata, update_retrieved_context
 from metatron.observability.metrics import timed
 from metatron.retrieval.alias_registry import get_alias_registry
 from metatron.retrieval.aliases import resolve_person_name
@@ -97,6 +98,7 @@ def resolve_query(query: str) -> str:
             temperature=0,
             max_tokens=200,
             timeout=10,
+            call_site="resolve_query",
         )
         resolved = resolved.strip()
 
@@ -324,6 +326,7 @@ def translate_query_to_english(query: str) -> str:  # TODO: async migration
             temperature=0.1,
             max_tokens=200,
             timeout=10,
+            call_site="translate_query",
         )
         return t.strip()
     except Exception:
@@ -1174,6 +1177,28 @@ async def hybrid_search_and_answer(  # noqa: C901
     # use_schema mode: use only current question (rq) to avoid history noise in structured output
     # regular mode: use full composite query to leverage conversation context for follow-ups
     ctx = _build_ctx(rq if use_schema else query, lang, frags, g_ents, g_rels, g_docs)
+
+    # Stash the assembled context on the telemetry ContextVar so emit_log can
+    # include it in the rag_answer row's metadata.retrieved_context field.
+    update_retrieved_context(ctx)
+
+    # Stash call-site metadata for the rag_answer row.
+    doc_ids = [r.get("doc_label", "") for r in base[:20] if isinstance(r, dict)]
+    if use_schema:
+        add_extra_metadata(
+            subtype="team_workflow_schema",
+            lang=lang,
+            query=rq[:200],
+            doc_ids=doc_ids,
+        )
+    else:
+        add_extra_metadata(
+            subtype="freeform",
+            lang=lang,
+            query=(rq if isinstance(rq, str) else query)[:200],
+            doc_ids=doc_ids,
+        )
+
     try:
         if use_schema:
             sys_prompt = TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT.format(response_language=lang)
@@ -1186,6 +1211,7 @@ async def hybrid_search_and_answer(  # noqa: C901
                 temperature=0.2,
                 json_mode=True,
                 timeout=60,
+                call_site="rag_answer",
             )
             answer = (json.loads(_extract_json_object(c)).get("answer") or "").strip()
         else:
@@ -1199,6 +1225,7 @@ async def hybrid_search_and_answer(  # noqa: C901
                     ],
                     temperature=0.2,
                     timeout=60,
+                    call_site="rag_answer",
                 )
             ).strip()
     except Exception:

--- a/src/metatron/storage/llm_generation_log.py
+++ b/src/metatron/storage/llm_generation_log.py
@@ -1,0 +1,88 @@
+"""Thin synchronous store for llm_generation_log rows (MTRNIX-336).
+
+This module is intentionally minimal — one INSERT, no reads, no batching.
+The export utility (scripts/export_llm_dataset.py) reads via raw SQL.
+
+Called from metatron.llm.telemetry.emit_log() which runs inside a thread-pool
+worker (asyncio.to_thread), so the insert must be synchronous. The single extra
+PG round-trip per LLM call is paid in the worker thread; the event loop is
+never blocked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from metatron.storage.pg_connection import get_session
+from metatron.storage.pg_models import LLMGenerationLogRow
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class LLMLogRowData:
+    """All fields required for a single llm_generation_log insert."""
+
+    call_site: str
+    provider: str
+    model: str
+    request_messages: list[dict[str, Any]]
+    success: bool
+    # Optional / nullable fields
+    source: str | None = None
+    workspace_id: str | None = None
+    user_id: str | None = None
+    agent_id: str | None = None
+    correlation_id: str | None = None  # UUID as str
+    response_content: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    latency_ms: int | None = None
+    error_class: str | None = None
+    error_message: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+def insert_log_row_sync(row: LLMLogRowData) -> None:
+    """Insert one row into llm_generation_log synchronously via psycopg2.
+
+    Must be called from a sync context (the telemetry wrapper runs inside
+    asyncio.to_thread so no event loop is running in the calling thread).
+
+    Never raises — any exception is logged at DEBUG level and swallowed.
+    Callers should additionally catch at the emit_log() level.
+    """
+    try:
+        with get_session() as session:
+            log_row = LLMGenerationLogRow(
+                call_site=row.call_site,
+                source=row.source,
+                workspace_id=row.workspace_id,
+                user_id=row.user_id,
+                agent_id=row.agent_id,
+                correlation_id=row.correlation_id,
+                provider=row.provider,
+                model=row.model,
+                request_messages=row.request_messages,
+                response_content=row.response_content,
+                prompt_tokens=row.prompt_tokens,
+                completion_tokens=row.completion_tokens,
+                total_tokens=row.total_tokens,
+                latency_ms=row.latency_ms,
+                success=row.success,
+                error_class=row.error_class,
+                error_message=row.error_message,
+                extra_metadata=row.metadata,
+            )
+            session.add(log_row)
+    except Exception as exc:
+        logger.debug(
+            "llm_telemetry.store.insert_failed",
+            call_site=row.call_site,
+            error=str(exc),
+        )
+        raise

--- a/src/metatron/storage/neo4j_graph.py
+++ b/src/metatron/storage/neo4j_graph.py
@@ -144,7 +144,8 @@ def graph_retry(max_attempts: int = 3):
 
 def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
     """Extract entities and relationships from text via LLM."""
-    if len(text) > max_text_length:
+    text_truncated = len(text) > max_text_length
+    if text_truncated:
         text = text[:max_text_length] + "..."
         logger.warning("graph.extract.truncated", max_len=max_text_length)
 
@@ -166,6 +167,18 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
         "- Keep names under 50 characters\n\n"
         f'Text:\n\n"""{text}"""'
     )
+
+    # Push NER-specific metadata onto the telemetry context so emit_log can
+    # include it in the ner_extraction row's metadata field. add_extra_metadata
+    # merges instead of overwriting, so adjacent callers in the same scope keep
+    # their keys (e.g. ingestion-level doc_label).
+    try:
+        from metatron.llm.telemetry import add_extra_metadata
+
+        add_extra_metadata(text_truncated=text_truncated)
+    except Exception:
+        pass  # telemetry is best-effort; never block the NER path
+
     content = ""
     for attempt in range(3):
         try:
@@ -183,6 +196,7 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
                 temperature=0.1,
                 json_mode=True,
                 timeout=120,
+                call_site="ner_extraction",
             )
             break
         except Exception as e:

--- a/src/metatron/storage/pg_models.py
+++ b/src/metatron/storage/pg_models.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     Column,
     Date,
@@ -24,7 +25,7 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -46,6 +47,7 @@ class WorkspaceRow(Base):  # type: ignore[misc]
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
     created_by = Column(String(64), nullable=True)
+    llm_telemetry_opt_out = Column(Boolean, nullable=False, server_default=text("false"))
 
     members = relationship(
         "WorkspaceMemberRow", back_populates="workspace", cascade="all, delete-orphan"
@@ -327,4 +329,60 @@ class DocumentFetchStatsRow(Base):  # type: ignore[misc]
         UniqueConstraint("workspace_id", "doc_label", "fetch_date", name="uq_doc_fetch_stats"),
         Index("ix_doc_fetch_stats_workspace", "workspace_id"),
         Index("ix_doc_fetch_stats_date", "workspace_id", "fetch_date"),
+    )
+
+
+class LLMGenerationLogRow(Base):  # type: ignore[misc]
+    """ORM model for llm_generation_log (MTRNIX-336).
+
+    Used for inserts only — the export script queries via raw SQL.
+    Note: workspace_id is NOT a FK to workspaces so rows are still written
+    when workspace_id is NULL or when the workspace was deleted.
+    """
+
+    __tablename__ = "llm_generation_log"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=text("NOW()"))
+
+    # -- what kind of call --
+    call_site = Column(Text, nullable=False)
+    source = Column(Text, nullable=True)
+
+    # -- request context (from ContextVar; may be NULL) --
+    workspace_id = Column(Text, nullable=True)
+    user_id = Column(Text, nullable=True)
+    agent_id = Column(Text, nullable=True)
+    correlation_id = Column(UUID(as_uuid=False), nullable=True)
+
+    # -- model + provider --
+    provider = Column(Text, nullable=False)
+    model = Column(Text, nullable=False)
+
+    # -- the exchange --
+    request_messages = Column(JSONB, nullable=False)
+    response_content = Column(Text, nullable=True)
+    prompt_tokens = Column(Integer, nullable=True)
+    completion_tokens = Column(Integer, nullable=True)
+    total_tokens = Column(Integer, nullable=True)
+    latency_ms = Column(Integer, nullable=True)
+
+    # -- outcome --
+    success = Column(Boolean, nullable=False)
+    error_class = Column(Text, nullable=True)
+    error_message = Column(Text, nullable=True)
+
+    # -- call-site-specific extras --
+    # NOTE: 'metadata' is reserved by SQLAlchemy Declarative API, so the
+    # Python attribute is named 'extra_metadata' while the DB column stays 'metadata'.
+    extra_metadata = Column("metadata", JSONB, nullable=True)
+
+    __table_args__ = (
+        Index("ix_llm_log_ws_created", "workspace_id", text("created_at DESC")),
+        Index("ix_llm_log_call_site_created", "call_site", text("created_at DESC")),
+        Index(
+            "ix_llm_log_correlation",
+            "correlation_id",
+            postgresql_where=text("correlation_id IS NOT NULL"),
+        ),
     )

--- a/tests/unit/test_chat_completion_telemetry.py
+++ b/tests/unit/test_chat_completion_telemetry.py
@@ -1,0 +1,297 @@
+"""Unit tests for LLM telemetry integration in chat_completion (MTRNIX-336).
+
+Coverage:
+- Provider success → emit_log called with correct fields (call_site, model,
+  provider, tokens, latency >= 0, success=True, fallback_used=False).
+- Provider returns empty content → row has success=False, error_class="EmptyResponse";
+  caller still receives "" (no behaviour change).
+- Primary raises LLMConnectionError, fallback succeeds → one row with
+  success=True, fallback_used=True.
+- Primary raises LLMConnectionError, no fallback → success=False, error re-raised.
+- chat_completion_with_retry with N transient failures then success → N+1 rows.
+- Empty usage dict → prompt_tokens=0, completion_tokens=0, zero_tokens=True in metadata.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metatron.llm.base import LLMConnectionError, LLMResponse
+
+# emit_log is imported into metatron.llm at module load time, so the patch
+# target is the LOCAL binding inside metatron.llm — not metatron.llm.telemetry.
+_EMIT_LOG_PATH = "metatron.llm.emit_log"
+# Real storage insert path — patching here works regardless of import order.
+_INSERT_PATH = "metatron.storage.llm_generation_log.insert_log_row_sync"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(
+    name: str = "mock_provider",
+    model: str = "mock-model",
+    content: str = "hello",
+    usage: dict | None = None,
+    side_effect: Exception | None = None,
+) -> MagicMock:
+    provider = MagicMock()
+    provider.name = name
+    provider.model = model
+    provider.is_available.return_value = True
+    if side_effect is not None:
+        provider.chat_completion.side_effect = side_effect
+    else:
+        default_usage = {
+            "prompt_tokens": 5,
+            "completion_tokens": 3,
+            "total_tokens": 8,
+        }
+        provider.chat_completion.return_value = LLMResponse(
+            content=content,
+            model=model,
+            provider=name,
+            usage=usage if usage is not None else default_usage,
+        )
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+def test_emit_log_called_on_success() -> None:
+    provider = _make_provider(name="ollama", model="llama3")
+
+    captured: list[dict] = []
+
+    def fake_emit(**kwargs: object) -> None:
+        captured.append(dict(kwargs))
+
+    with (
+        patch("metatron.llm.get_llm", return_value=provider),
+        patch("metatron.llm._get_cached_fallback", return_value=None),
+        patch(_EMIT_LOG_PATH, side_effect=fake_emit),
+    ):
+        from metatron.llm import chat_completion
+
+        result = chat_completion(
+            messages=[{"role": "user", "content": "hi"}],
+            call_site="rag_answer",
+        )
+
+    assert result == "hello"
+    assert len(captured) == 1
+    row = captured[0]
+    assert row["call_site"] == "rag_answer"
+    assert row["provider"] == "ollama"
+    assert row["model"] == "llama3"
+    assert row["success"] is True
+    assert row["fallback_used"] is False
+    assert row["fallback_provider"] is None
+    assert row["error_class"] is None
+    assert row["latency_ms"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# Empty content → EmptyResponse
+# ---------------------------------------------------------------------------
+
+
+def test_empty_response_emits_failure_row_but_caller_gets_empty_string() -> None:
+    provider = _make_provider(name="ollama", model="llama3", content="")
+
+    captured: list[dict] = []
+
+    def fake_emit(**kwargs: object) -> None:
+        captured.append(dict(kwargs))
+
+    with (
+        patch("metatron.llm.get_llm", return_value=provider),
+        patch("metatron.llm._get_cached_fallback", return_value=None),
+        patch(_EMIT_LOG_PATH, side_effect=fake_emit),
+    ):
+        from metatron.llm import chat_completion
+
+        result = chat_completion(
+            messages=[{"role": "user", "content": "hi"}],
+            call_site="rag_answer",
+        )
+
+    # Caller receives empty string — behaviour is unchanged.
+    assert result == ""
+    assert len(captured) == 1
+    row = captured[0]
+    assert row["success"] is False
+    assert row["error_class"] == "EmptyResponse"
+
+
+# ---------------------------------------------------------------------------
+# Fallback success
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_success_emits_one_row_with_fallback_used() -> None:
+    primary = _make_provider(
+        name="deepseek",
+        model="deepseek-chat",
+        side_effect=LLMConnectionError("timeout"),
+    )
+    fallback = _make_provider(name="ollama", model="llama3", content="fallback result")
+
+    captured: list[dict] = []
+
+    def fake_emit(**kwargs: object) -> None:
+        captured.append(dict(kwargs))
+
+    with (
+        patch("metatron.llm.get_llm", return_value=primary),
+        patch("metatron.llm._get_cached_fallback", return_value=fallback),
+        patch(_EMIT_LOG_PATH, side_effect=fake_emit),
+    ):
+        from metatron.llm import chat_completion
+
+        result = chat_completion(
+            messages=[{"role": "user", "content": "hi"}],
+            call_site="rag_answer",
+            use_fallback=True,
+        )
+
+    assert result == "fallback result"
+    assert len(captured) == 1
+    row = captured[0]
+    assert row["success"] is True
+    assert row["fallback_used"] is True
+    assert row["fallback_provider"] == "ollama"
+
+
+# ---------------------------------------------------------------------------
+# No fallback → failure row + exception re-raised
+# ---------------------------------------------------------------------------
+
+
+def test_no_fallback_emits_failure_row_and_raises() -> None:
+    primary = _make_provider(
+        name="ollama",
+        model="llama3",
+        side_effect=LLMConnectionError("network error"),
+    )
+
+    captured: list[dict] = []
+
+    def fake_emit(**kwargs: object) -> None:
+        captured.append(dict(kwargs))
+
+    with (
+        patch("metatron.llm.get_llm", return_value=primary),
+        patch("metatron.llm._get_cached_fallback", return_value=None),
+        patch(_EMIT_LOG_PATH, side_effect=fake_emit),
+    ):
+        from metatron.llm import chat_completion
+
+        with pytest.raises(LLMConnectionError):
+            chat_completion(
+                messages=[{"role": "user", "content": "hi"}],
+                call_site="rag_answer",
+                use_fallback=True,  # fallback=None, so effectively no fallback
+            )
+
+    assert len(captured) == 1
+    row = captured[0]
+    assert row["success"] is False
+    assert row["error_class"] == "LLMConnectionError"
+
+
+# ---------------------------------------------------------------------------
+# chat_completion_with_retry — N failures then success → N+1 rows
+# ---------------------------------------------------------------------------
+
+
+def test_retry_produces_failure_then_success_rows() -> None:
+    ok_response = LLMResponse(
+        content="ok",
+        model="llama3",
+        provider="ollama",
+        usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+    )
+    err = LLMConnectionError("transient")
+
+    # 2 failures then success
+    provider = MagicMock()
+    provider.name = "ollama"
+    provider.model = "llama3"
+    provider.is_available.return_value = True
+    provider.chat_completion.side_effect = [err, err, ok_response]
+
+    captured: list[dict] = []
+
+    def fake_emit(**kwargs: object) -> None:
+        captured.append(dict(kwargs))
+
+    with (
+        patch("metatron.llm.get_llm", return_value=provider),
+        patch("metatron.llm._get_cached_fallback", return_value=None),
+        patch(_EMIT_LOG_PATH, side_effect=fake_emit),
+        patch("metatron.llm.time.sleep"),  # don't actually sleep
+    ):
+        from metatron.llm import chat_completion_with_retry
+
+        result = chat_completion_with_retry(
+            messages=[{"role": "user", "content": "hi"}],
+            call_site="rag_answer",
+            max_retries=3,
+            use_fallback=False,
+        )
+
+    assert result == "ok"
+    # 2 failures + 1 success = 3 emit_log calls
+    assert len(captured) == 3
+    assert captured[0]["success"] is False
+    assert captured[1]["success"] is False
+    assert captured[2]["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Empty usage dict → zero_tokens=True in metadata
+# ---------------------------------------------------------------------------
+
+
+def test_empty_usage_dict_yields_zero_tokens_metadata() -> None:
+    provider = _make_provider(name="custom", model="local", usage={})
+
+    # We patch insert_log_row_sync to capture the metadata built inside emit_log.
+    rows_captured: list = []
+
+    def fake_insert(row: object) -> None:
+        rows_captured.append(row)
+
+    import metatron.llm.telemetry as tel_mod
+
+    with (
+        patch("metatron.llm.get_llm", return_value=provider),
+        patch("metatron.llm._get_cached_fallback", return_value=None),
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        patch(_INSERT_PATH, side_effect=fake_insert),
+    ):
+        from metatron.llm import chat_completion
+
+        chat_completion(
+            messages=[{"role": "user", "content": "hi"}],
+            call_site="rag_answer",
+            use_fallback=False,
+        )
+
+    assert len(rows_captured) == 1
+    metadata = rows_captured[0].metadata
+    assert metadata["zero_tokens"] is True

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -114,6 +114,7 @@ class TestLLMRetry:
         result = chat_completion_with_retry(
             messages=[{"role": "user", "content": "hi"}],
             max_retries=3,
+            call_site="test",
         )
         assert result == "success"
         assert mock_cc.call_count == 2
@@ -131,6 +132,7 @@ class TestLLMRetry:
             chat_completion_with_retry(
                 messages=[{"role": "user", "content": "hi"}],
                 max_retries=3,
+                call_site="test",
             )
         assert mock_cc.call_count == 3
         assert mock_sleep.call_count == 2  # sleeps between attempts, not after last
@@ -142,6 +144,7 @@ class TestLLMRetry:
             chat_completion_with_retry(
                 messages=[{"role": "user", "content": "hi"}],
                 max_retries=3,
+                call_site="test",
             )
         assert mock_cc.call_count == 1
 
@@ -151,6 +154,7 @@ class TestLLMRetry:
         result = chat_completion_with_retry(
             messages=[{"role": "user", "content": "hi"}],
             max_retries=3,
+            call_site="test",
         )
         assert result == "instant"
         assert mock_cc.call_count == 1

--- a/tests/unit/test_export_dataset.py
+++ b/tests/unit/test_export_dataset.py
@@ -1,0 +1,283 @@
+"""Unit tests for scripts/export_llm_dataset.py (MTRNIX-336).
+
+Coverage:
+- openai-chat-ft format produces expected JSON shape.
+- openai-completion-legacy format produces prompt/completion shape.
+- messages-only format produces same shape as openai-chat-ft.
+- --success-only filter excludes failed rows.
+- source IN ('benchmark','eval') rows excluded by default; --include-eval includes them.
+- --no-include-zero-tokens drops rows where metadata.zero_tokens=true.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the export script without executing its __main__ block
+# ---------------------------------------------------------------------------
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "export_llm_dataset.py"
+
+
+def _load_export_module():
+    """Dynamically import export_llm_dataset without running main()."""
+    spec = importlib.util.spec_from_file_location("export_llm_dataset", _SCRIPT_PATH)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_export = _load_export_module()
+_row_to_jsonl = _export._row_to_jsonl
+_messages_to_prompt = _export._messages_to_prompt
+export_fn = _export.export
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What is the capital of France?"},
+]
+
+_RESPONSE = "Paris."
+
+_BASE_ROW = {
+    "id": 1,
+    "call_site": "rag_answer",
+    "source": "rest",
+    "workspace_id": "ws_test",
+    "provider": "ollama",
+    "model": "llama3",
+    "request_messages": _MESSAGES,
+    "response_content": _RESPONSE,
+    "prompt_tokens": 10,
+    "completion_tokens": 3,
+    "total_tokens": 13,
+    "latency_ms": 450,
+    "success": True,
+    "error_class": None,
+    "metadata": {"fallback_used": False, "fallback_provider": None, "zero_tokens": False},
+}
+
+
+# ---------------------------------------------------------------------------
+# Format tests (unit — no DB needed)
+# ---------------------------------------------------------------------------
+
+
+def test_row_to_jsonl_openai_chat_ft() -> None:
+    line = _row_to_jsonl(dict(_BASE_ROW), "openai-chat-ft")
+    obj = json.loads(line)
+    assert "messages" in obj
+    msgs = obj["messages"]
+    # request_messages + assistant turn
+    assert len(msgs) == len(_MESSAGES) + 1
+    last = msgs[-1]
+    assert last["role"] == "assistant"
+    assert last["content"] == _RESPONSE
+
+
+def test_row_to_jsonl_messages_only_same_shape_as_oai() -> None:
+    oai = json.loads(_row_to_jsonl(dict(_BASE_ROW), "openai-chat-ft"))
+    mo = json.loads(_row_to_jsonl(dict(_BASE_ROW), "messages-only"))
+    assert oai == mo
+
+
+def test_row_to_jsonl_openai_completion_legacy() -> None:
+    line = _row_to_jsonl(dict(_BASE_ROW), "openai-completion-legacy")
+    obj = json.loads(line)
+    assert "prompt" in obj
+    assert "completion" in obj
+    assert obj["completion"] == _RESPONSE
+    # Prompt should contain the user message text
+    assert "What is the capital of France?" in obj["prompt"]
+
+
+def test_row_to_jsonl_unknown_format_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown format"):
+        _row_to_jsonl(dict(_BASE_ROW), "bad-format")
+
+
+def test_messages_to_prompt_concatenates_roles() -> None:
+    prompt = _messages_to_prompt(_MESSAGES)
+    assert "system:" in prompt
+    assert "user:" in prompt
+    assert "France" in prompt
+
+
+def test_messages_to_prompt_handles_list_content() -> None:
+    msgs = [{"role": "user", "content": [{"text": "hello"}, {"text": " world"}]}]
+    prompt = _messages_to_prompt(msgs)
+    assert "hello" in prompt
+    assert "world" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Integration-style export tests (mock DB)
+# ---------------------------------------------------------------------------
+
+
+def _make_db_rows(*rows: dict[str, Any]) -> list[MagicMock]:
+    """Convert plain dicts into MagicMock mapping objects (simulate SQLAlchemy result)."""
+    result = []
+    for r in rows:
+        m = MagicMock()
+        m.__getitem__ = lambda self, key, _r=r: _r[key]
+        m.keys = lambda _r=r: _r.keys()
+        result.append(m)
+    return result
+
+
+def _run_export(rows_pages: list[list[dict]], **export_kwargs: Any) -> list[dict]:
+    """Run export() against mocked SQLAlchemy result and parse written JSONL lines."""
+
+    def _make_conn_mock(pages: list[list[dict]]):
+        page_iter = iter(pages)
+
+        def execute(stmt, params):
+            try:
+                page = next(page_iter)
+            except StopIteration:
+                page = []
+            result_mock = MagicMock()
+            # mappings().all() returns the page
+            result_mock.mappings.return_value.all.return_value = page
+            return result_mock
+
+        conn_mock = MagicMock()
+        conn_mock.execute = execute
+        conn_mock.__enter__ = lambda self: self
+        conn_mock.__exit__ = MagicMock(return_value=False)
+        return conn_mock
+
+    with tempfile.NamedTemporaryFile(mode="r", suffix=".jsonl", delete=False) as f:
+        out_path = f.name
+
+    try:
+        engine_mock = MagicMock()
+        engine_mock.connect.return_value = _make_conn_mock(rows_pages)
+        engine_mock.dispose = MagicMock()
+
+        settings_mock = MagicMock()
+        settings_mock.postgres_sync_dsn = "postgresql://fake"
+
+        with (
+            patch("scripts.export_llm_dataset.get_settings", return_value=settings_mock),
+            patch("sqlalchemy.create_engine", return_value=engine_mock),
+        ):
+            export_fn(
+                call_sites=[],
+                workspace_ids=[],
+                from_date=None,
+                to_date=None,
+                fmt=export_kwargs.get("fmt", "openai-chat-ft"),
+                out_path=out_path,
+                success_only=export_kwargs.get("success_only", True),
+                include_eval=export_kwargs.get("include_eval", False),
+                include_zero_tokens=export_kwargs.get("include_zero_tokens", True),
+                limit=export_kwargs.get("limit"),
+            )
+
+        with open(out_path) as fh:
+            lines = [line.strip() for line in fh if line.strip()]
+        return [json.loads(line) for line in lines]
+    finally:
+        os.unlink(out_path)
+
+
+def test_export_writes_correct_number_of_rows() -> None:
+    row1 = dict(_BASE_ROW, id=1)
+    row2 = dict(_BASE_ROW, id=2, response_content="Berlin.")
+    # Two pages: first returns 2 rows, second returns empty (signals last page).
+    result = _run_export([[row1, row2], []])
+    assert len(result) == 2
+
+
+def test_export_openai_chat_ft_shape() -> None:
+    row = dict(_BASE_ROW, id=1)
+    result = _run_export([[row], []], fmt="openai-chat-ft")
+    assert len(result) == 1
+    assert "messages" in result[0]
+    msgs = result[0]["messages"]
+    assert msgs[-1]["role"] == "assistant"
+    assert msgs[-1]["content"] == _RESPONSE
+
+
+def test_export_benchmark_rows_excluded_by_default() -> None:
+    # Whitebox check: ensure the WHERE clause contains the excluded_sources param.
+    # In production the SQL filters benchmark/eval rows; here we verify the
+    # query is built with the right exclusion clause.
+    sql_templates: list[str] = []
+    original_build = _export._build_query
+
+    def capturing_build(**kwargs):
+        sql, params = original_build(**kwargs)
+        sql_templates.append(sql)
+        return sql, params
+
+    with patch.object(_export, "_build_query", side_effect=capturing_build):
+        _run_export([[]], include_eval=False)
+
+    assert sql_templates
+    # The WHERE must reference 'excluded_sources' when include_eval=False
+    assert "excluded_sources" in sql_templates[0]
+
+
+def test_export_include_eval_flag_removes_source_filter() -> None:
+    sql_templates: list[str] = []
+    original_build = _export._build_query
+
+    def capturing_build(**kwargs):
+        sql, params = original_build(**kwargs)
+        sql_templates.append(sql)
+        return sql, params
+
+    with patch.object(_export, "_build_query", side_effect=capturing_build):
+        _run_export([[]], include_eval=True)
+
+    assert sql_templates
+    assert "excluded_sources" not in sql_templates[0]
+
+
+def test_export_no_include_zero_tokens_adds_filter() -> None:
+    sql_templates: list[str] = []
+    original_build = _export._build_query
+
+    def capturing_build(**kwargs):
+        sql, params = original_build(**kwargs)
+        sql_templates.append(sql)
+        return sql, params
+
+    with patch.object(_export, "_build_query", side_effect=capturing_build):
+        _run_export([[]], include_zero_tokens=False)
+
+    assert sql_templates
+    assert "zero_tokens" in sql_templates[0]
+
+
+def test_export_success_only_adds_filter() -> None:
+    sql_templates: list[str] = []
+    original_build = _export._build_query
+
+    def capturing_build(**kwargs):
+        sql, params = original_build(**kwargs)
+        sql_templates.append(sql)
+        return sql, params
+
+    with patch.object(_export, "_build_query", side_effect=capturing_build):
+        _run_export([[]], success_only=True)
+
+    assert sql_templates
+    assert "success = TRUE" in sql_templates[0]

--- a/tests/unit/test_llm_telemetry.py
+++ b/tests/unit/test_llm_telemetry.py
@@ -407,3 +407,183 @@ def test_emit_log_zero_tokens_flag_false_when_tokens_present() -> None:
 
     assert len(captured) == 1
     assert captured[0]["zero_tokens"] is False
+
+
+# ---------------------------------------------------------------------------
+# Content-size cap (MTRNIX-336 follow-up — prevents JSONB bloat on NER path)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_log_caps_long_request_message_content() -> None:
+    """request_messages content longer than _MAX_CONTENT_CHARS is truncated."""
+    from metatron.llm import telemetry as tel_mod
+    from metatron.llm.base import LLMResponse
+
+    huge = "x" * 20_000  # well above the 8 000 cap
+    response = LLMResponse(content="ok", model="m", provider="p", usage={})
+    captured: list[object] = []
+
+    def fake_insert(row: object) -> None:
+        captured.append(row)
+
+    with (
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        patch(_INSERT_PATH, side_effect=fake_insert),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="ner_extraction",
+            provider="p",
+            model="m",
+            messages=[{"role": "user", "content": huge}],
+            response=response,
+            latency_ms=10,
+            success=True,
+            error_class=None,
+            error_message=None,
+            fallback_used=False,
+            fallback_provider=None,
+        )
+
+    assert len(captured) == 1
+    row = captured[0]
+    assert len(row.request_messages[0]["content"]) == tel_mod._MAX_CONTENT_CHARS  # type: ignore[attr-defined]
+    assert row.metadata.get("message_truncated") is True  # type: ignore[attr-defined]
+
+
+def test_emit_log_caps_long_response_content() -> None:
+    """response_content longer than _MAX_CONTENT_CHARS is truncated with flag."""
+    from metatron.llm import telemetry as tel_mod
+    from metatron.llm.base import LLMResponse
+
+    huge = "y" * 20_000
+    response = LLMResponse(content=huge, model="m", provider="p", usage={"prompt_tokens": 1})
+    captured: list[object] = []
+
+    def fake_insert(row: object) -> None:
+        captured.append(row)
+
+    with (
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        patch(_INSERT_PATH, side_effect=fake_insert),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="rag_answer",
+            provider="p",
+            model="m",
+            messages=[{"role": "user", "content": "small"}],
+            response=response,
+            latency_ms=10,
+            success=True,
+            error_class=None,
+            error_message=None,
+            fallback_used=False,
+            fallback_provider=None,
+        )
+
+    assert len(captured) == 1
+    row = captured[0]
+    assert len(row.response_content) == tel_mod._MAX_CONTENT_CHARS  # type: ignore[attr-defined]
+    assert row.metadata.get("response_truncated") is True  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Lazy messages callable — never invoked when row is dropped
+# ---------------------------------------------------------------------------
+
+
+def test_emit_log_does_not_invoke_callable_when_opted_out() -> None:
+    """When workspace is opted out, the messages callable is NEVER called.
+
+    This is the load-bearing assertion for the privacy posture: "we don't
+    process this prompt" (vs the weaker "we don't store it").
+    """
+    from metatron.llm import telemetry as tel_mod
+
+    call_count = {"n": 0}
+
+    def lazy_messages() -> list[dict]:
+        call_count["n"] += 1
+        return [{"role": "user", "content": "secret prompt"}]
+
+    with (
+        patch.object(tel_mod, "_is_opted_out", return_value=True),
+        patch(_INSERT_PATH) as mock_insert,
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        set_telemetry_context(workspace_id="ws_opted_out", source="rest"),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="rag_answer",
+            provider="p",
+            model="m",
+            messages=lazy_messages,
+            response=None,
+            latency_ms=5,
+            success=False,
+            error_class="LLMConnectionError",
+            error_message="x",
+            fallback_used=False,
+            fallback_provider=None,
+        )
+
+    assert call_count["n"] == 0, "messages callable must not be invoked on opt-out"
+    mock_insert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Per-workspace lock LRU eviction (MTRNIX-336 follow-up — prevents lock dict
+# growth without bound on deployments with many short-lived workspaces)
+# ---------------------------------------------------------------------------
+
+
+def test_per_workspace_lock_dict_evicts_lru() -> None:
+    """When the per-workspace lock dict exceeds the cap, oldest entries drop."""
+    from metatron.llm import telemetry as tel_mod
+
+    # Snapshot and reset state so test order doesn't matter.
+    original_locks = dict(tel_mod._opt_out_per_ws_locks)
+    original_cap = tel_mod._OPT_OUT_LOCK_CAP
+    tel_mod._opt_out_per_ws_locks.clear()
+    tel_mod._OPT_OUT_LOCK_CAP = 3  # type: ignore[misc]
+    try:
+        tel_mod._get_per_ws_lock("ws_a")
+        tel_mod._get_per_ws_lock("ws_b")
+        tel_mod._get_per_ws_lock("ws_c")
+        assert list(tel_mod._opt_out_per_ws_locks.keys()) == ["ws_a", "ws_b", "ws_c"]
+        # Adding a 4th evicts the LRU (ws_a).
+        tel_mod._get_per_ws_lock("ws_d")
+        assert list(tel_mod._opt_out_per_ws_locks.keys()) == ["ws_b", "ws_c", "ws_d"]
+        # Touching ws_b moves it to most-recent; next insertion evicts ws_c.
+        tel_mod._get_per_ws_lock("ws_b")
+        tel_mod._get_per_ws_lock("ws_e")
+        assert list(tel_mod._opt_out_per_ws_locks.keys()) == ["ws_d", "ws_b", "ws_e"]
+    finally:
+        tel_mod._opt_out_per_ws_locks.clear()
+        tel_mod._opt_out_per_ws_locks.update(original_locks)
+        tel_mod._OPT_OUT_LOCK_CAP = original_cap  # type: ignore[misc]

--- a/tests/unit/test_llm_telemetry.py
+++ b/tests/unit/test_llm_telemetry.py
@@ -1,0 +1,409 @@
+"""Unit tests for llm/telemetry.py (MTRNIX-336).
+
+Coverage:
+- set_telemetry_context — set/reset, nested scopes, child does not inherit
+  parent's retrieved_context.
+- update_retrieved_context — mutates current ctx; no-op when no ctx active.
+- emit_log — no-op when kill-switch disabled.
+- emit_log — no-op when workspace opt-out is true (mocked store).
+- emit_log — writes when workspace_id is NULL.
+- emit_log — on store failure, warning logged, never raises.
+- emit_log — from asyncio.to_thread succeeds (regression guard for sync path).
+- zero_tokens flag is true when response.total_tokens == 0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    import pytest
+
+from metatron.llm.telemetry import (
+    current_telemetry_ctx,
+    set_telemetry_context,
+    update_retrieved_context,
+)
+
+# Path to the real module's insert function — patching it directly works no
+# matter what other tests have already imported.
+_INSERT_PATH = "metatron.storage.llm_generation_log.insert_log_row_sync"
+
+# ---------------------------------------------------------------------------
+# set_telemetry_context
+# ---------------------------------------------------------------------------
+
+
+def test_set_telemetry_context_sets_and_resets() -> None:
+    assert current_telemetry_ctx.get() is None
+    with set_telemetry_context(workspace_id="ws_a", source="rest"):
+        ctx = current_telemetry_ctx.get()
+        assert ctx is not None
+        assert ctx.workspace_id == "ws_a"
+        assert ctx.source == "rest"
+    assert current_telemetry_ctx.get() is None
+
+
+def test_set_telemetry_context_nested_child_does_not_inherit_retrieved() -> None:
+    """Child scope starts with retrieved_context=None even if parent set it."""
+    with set_telemetry_context(workspace_id="ws_parent", source="rest") as parent_ctx:
+        parent_ctx.retrieved_context = "parent docs"
+        with set_telemetry_context(workspace_id="ws_child", source="mcp") as child_ctx:
+            assert child_ctx.retrieved_context is None
+        # Parent restored after child scope exits.
+        restored = current_telemetry_ctx.get()
+        assert restored is not None
+        assert restored.workspace_id == "ws_parent"
+        assert restored.retrieved_context == "parent docs"
+
+
+def test_set_telemetry_context_resets_on_exception() -> None:
+    try:
+        with set_telemetry_context(workspace_id="ws_x"):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert current_telemetry_ctx.get() is None
+
+
+def test_set_telemetry_context_isolation_across_tasks() -> None:
+    """Each asyncio Task gets its own ContextVar copy."""
+
+    async def task(ws: str) -> str | None:
+        with set_telemetry_context(workspace_id=ws):
+            await asyncio.sleep(0)
+            ctx = current_telemetry_ctx.get()
+            return ctx.workspace_id if ctx else None
+
+    async def run() -> tuple[str | None, str | None]:
+        return await asyncio.gather(task("ws_a"), task("ws_b"))
+
+    a, b = asyncio.run(run())
+    assert a == "ws_a"
+    assert b == "ws_b"
+    assert current_telemetry_ctx.get() is None
+
+
+# ---------------------------------------------------------------------------
+# update_retrieved_context
+# ---------------------------------------------------------------------------
+
+
+def test_update_retrieved_context_mutates_current_ctx() -> None:
+    with set_telemetry_context(workspace_id="ws"):
+        update_retrieved_context("some retrieved docs")
+        ctx = current_telemetry_ctx.get()
+        assert ctx is not None
+        assert ctx.retrieved_context == "some retrieved docs"
+
+
+def test_update_retrieved_context_noop_when_no_ctx() -> None:
+    assert current_telemetry_ctx.get() is None
+    # Should not raise.
+    update_retrieved_context("docs")
+    assert current_telemetry_ctx.get() is None
+
+
+# ---------------------------------------------------------------------------
+# emit_log — kill-switch
+# ---------------------------------------------------------------------------
+
+
+def test_emit_log_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """emit_log returns immediately when METATRON_LLM_TELEMETRY_ENABLED=false."""
+    from metatron.llm import telemetry as tel_mod
+
+    monkeypatch.setattr(
+        tel_mod,
+        "get_settings",
+        lambda: MagicMock(
+            llm_telemetry_enabled=False,
+            llm_telemetry_opt_out_cache_ttl_seconds=60,
+        ),
+    )
+
+    with patch(_INSERT_PATH) as mock_insert:
+        # Need to import after monkeypatching to pick up the new settings mock
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="rag_answer",
+            provider="ollama",
+            model="llama3",
+            messages=[{"role": "user", "content": "hi"}],
+            response=None,
+            latency_ms=100,
+            success=False,
+            error_class="LLMConnectionError",
+            error_message="timeout",
+            fallback_used=False,
+            fallback_provider=None,
+        )
+        mock_insert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# emit_log — opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_emit_log_noop_when_workspace_opted_out() -> None:
+    """emit_log skips write when the workspace has opt_out=true."""
+    from metatron.llm import telemetry as tel_mod
+
+    with (
+        patch.object(tel_mod, "_is_opted_out", return_value=True),
+        patch(_INSERT_PATH) as mock_insert,
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        set_telemetry_context(workspace_id="ws_opted_out", source="rest"),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="rag_answer",
+            provider="ollama",
+            model="llama3",
+            messages=[{"role": "user", "content": "hi"}],
+            response=None,
+            latency_ms=50,
+            success=False,
+            error_class="LLMConnectionError",
+            error_message="x",
+            fallback_used=False,
+            fallback_provider=None,
+        )
+        mock_insert.assert_not_called()
+
+
+def test_emit_log_writes_when_workspace_id_is_null() -> None:
+    """When workspace_id is None, opt-out cannot be evaluated — row is written."""
+    from metatron.llm import telemetry as tel_mod
+    from metatron.llm.base import LLMResponse
+
+    response = LLMResponse(
+        content="ok",
+        model="llama3",
+        provider="ollama",
+        usage={"prompt_tokens": 5, "completion_tokens": 3},
+    )
+
+    with (
+        patch.object(tel_mod, "get_settings") as mock_settings,
+        patch(_INSERT_PATH) as mock_insert,
+    ):
+        mock_settings.return_value = MagicMock(
+            llm_telemetry_enabled=True,
+            llm_telemetry_opt_out_cache_ttl_seconds=60,
+        )
+        # No telemetry context → workspace_id is None.
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="rag_answer",
+            provider="ollama",
+            model="llama3",
+            messages=[{"role": "user", "content": "hi"}],
+            response=response,
+            latency_ms=50,
+            success=True,
+            error_class=None,
+            error_message=None,
+            fallback_used=False,
+            fallback_provider=None,
+        )
+        mock_insert.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# emit_log — store failure is swallowed
+# ---------------------------------------------------------------------------
+
+
+def test_emit_log_swallows_store_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """emit_log catches store exceptions, logs warning, and does not re-raise."""
+    from metatron.llm import telemetry as tel_mod
+    from metatron.llm.base import LLMResponse
+
+    response = LLMResponse(
+        content="ok",
+        model="llama3",
+        provider="ollama",
+        usage={"prompt_tokens": 1},
+    )
+
+    with (
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        patch(
+            _INSERT_PATH,
+            side_effect=RuntimeError("DB offline"),
+        ),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        # Must not raise.
+        emit_log(
+            call_site="rag_answer",
+            provider="ollama",
+            model="llama3",
+            messages=[{"role": "user", "content": "hi"}],
+            response=response,
+            latency_ms=10,
+            success=True,
+            error_class=None,
+            error_message=None,
+            fallback_used=False,
+            fallback_provider=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# emit_log — sync path works inside asyncio.to_thread (no event loop in thread)
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_log_from_to_thread_does_not_raise() -> None:
+    """Smoke test: emit_log can be called from a thread-pool worker (no event loop)."""
+    from metatron.llm import telemetry as tel_mod
+
+    with (
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        patch(_INSERT_PATH),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        def sync_call() -> None:
+            emit_log(
+                call_site="rag_answer",
+                provider="ollama",
+                model="llama3",
+                messages=[{"role": "user", "content": "hi"}],
+                response=None,
+                latency_ms=5,
+                success=False,
+                error_class="LLMConnectionError",
+                error_message="x",
+                fallback_used=False,
+                fallback_provider=None,
+            )
+
+        # asyncio.to_thread runs in a thread where there is NO running event loop.
+        await asyncio.to_thread(sync_call)
+
+
+# ---------------------------------------------------------------------------
+# zero_tokens metadata flag
+# ---------------------------------------------------------------------------
+
+
+def test_emit_log_zero_tokens_flag_true_when_all_zero() -> None:
+    """zero_tokens=true when provider omits usage counts (all 0)."""
+    from metatron.llm import telemetry as tel_mod
+    from metatron.llm.base import LLMResponse
+
+    # Provider that returns empty usage dict (e.g. Ollama without eval_count)
+    response = LLMResponse(content="ok", model="llama3", provider="ollama", usage={})
+    captured: list[dict] = []
+
+    def fake_insert(row: object) -> None:
+        # row is LLMLogRowData; grab metadata
+        captured.append(row.metadata)  # type: ignore[union-attr]
+
+    with (
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        patch(_INSERT_PATH, side_effect=fake_insert),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="rag_answer",
+            provider="ollama",
+            model="llama3",
+            messages=[{"role": "user", "content": "hi"}],
+            response=response,
+            latency_ms=50,
+            success=True,
+            error_class=None,
+            error_message=None,
+            fallback_used=False,
+            fallback_provider=None,
+        )
+
+    assert len(captured) == 1
+    assert captured[0]["zero_tokens"] is True
+
+
+def test_emit_log_zero_tokens_flag_false_when_tokens_present() -> None:
+    """zero_tokens=false when provider returns real token counts."""
+    from metatron.llm import telemetry as tel_mod
+    from metatron.llm.base import LLMResponse
+
+    response = LLMResponse(
+        content="ok",
+        model="llama3",
+        provider="ollama",
+        usage={"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+    )
+    captured: list[dict] = []
+
+    def fake_insert(row: object) -> None:
+        captured.append(row.metadata)  # type: ignore[union-attr]
+
+    with (
+        patch.object(
+            tel_mod,
+            "get_settings",
+            return_value=MagicMock(
+                llm_telemetry_enabled=True,
+                llm_telemetry_opt_out_cache_ttl_seconds=60,
+            ),
+        ),
+        patch(_INSERT_PATH, side_effect=fake_insert),
+    ):
+        from metatron.llm.telemetry import emit_log
+
+        emit_log(
+            call_site="rag_answer",
+            provider="ollama",
+            model="llama3",
+            messages=[{"role": "user", "content": "hi"}],
+            response=response,
+            latency_ms=50,
+            success=True,
+            error_class=None,
+            error_message=None,
+            fallback_used=False,
+            fallback_provider=None,
+        )
+
+    assert len(captured) == 1
+    assert captured[0]["zero_tokens"] is False


### PR DESCRIPTION
Persist every LLM completion that flows through Metatron into a new PostgreSQL table (llm_generation_log) so a fine-tuning dataset can be assembled later for replacing the RAG answer-generation call with a local model. Bootstrap-only — no on-prem migration, no streaming capture, no retention worker.

Coverage:
- 11 of 12 LLM call sites instrumented via a single keyword-only call_site kwarg on chat_completion()/chat_completion_with_retry(): rag_answer, resolve_query, translate_query, hyde, query_expansion, query_classifier, routing, translation_to_english, translation_to_russian, ner_extraction, mcp_action_planner. agent_smalltalk wired for consistency (legacy/deprecated). freshness_decision deferred — bypasses the public wrapper, tracked in audit doc as follow-up.
- Entry-points push a TelemetryContext via ContextVar: REST (rest), OpenAI-compat (oai_compat), MCP tool wrapper (mcp), ingestion pipeline (ingestion) — both _write_graph and _write_graph_strict for decoupled graph extraction, benchmarker (benchmark), offline eval script (eval). Source tag lets the export utility exclude eval/benchmark traffic from the FT dataset.

Design notes:
- Writes are synchronous via psycopg2 inside the worker thread — asyncio.create_task() is unsafe from asyncio.to_thread workers (no running event loop). Single round-trip per LLM call; event loop is never blocked.
- One row per public chat_completion() invocation. Fallback recorded as metadata.fallback_used; retries naturally produce N failure rows
  + one success row from chat_completion_with_retry.
- Per-workspace opt-out via workspaces.llm_telemetry_opt_out (default FALSE) with 60s TTL cache and single-flight per-workspace lock. Early-gate inside chat_completion skips prompt-snapshot construction when opt-out or kill-switch is active — privacy posture is "we don't process this prompt", not "we don't store it". emit_log re-checks under its own lock, so flips mid-call are safe.
- Master kill-switch METATRON_LLM_TELEMETRY_ENABLED=true by default; emit_log never raises, write failures are logged at WARNING.
- Empty provider responses become synthetic failures with error_class='EmptyResponse' so the chk_outcome_coherent CHECK constraint stays satisfied and downstream filters are trivial.
- metadata JSONB carries fallback_used/zero_tokens common keys plus per-site extras (rag_answer subtype freeform|team_workflow_schema + lang + doc_ids; ner_extraction text_truncated + doc_label). add_extra_metadata() helper merges instead of overwriting so multiple call sites in the same scope coexist.

Schema (migration 022):
- llm_generation_log: id, created_at, call_site, source, workspace_id, user_id, agent_id, correlation_id, provider, model, request_messages, response_content, prompt/completion/total_tokens, latency_ms, success, error_class, error_message, metadata. Indexes on (workspace_id, created_at DESC), (call_site, created_at DESC), partial on correlation_id WHERE NOT NULL. CHECK constraint: (success AND response_content IS NOT NULL) OR (NOT success AND error_class IS NOT NULL).
- workspaces.llm_telemetry_opt_out BOOL NOT NULL DEFAULT FALSE.

Export utility: scripts/export_llm_dataset.py emits openai-chat-ft (OpenAI fine-tune Chat format), openai-completion-legacy, or messages-only JSONL. Streams over created_at cursor. Filters out benchmark/eval sources by default; --include-eval opts in. --no-include-zero-tokens drops rows where every token count is 0.

Audit deliverable: docs/llm_call_sites_audit.md tabulates all sites with verdicts (fine-tuning-grade vs telemetry-only) and notes the freshness_decision deferral path.

New env vars (core/config.py):
- METATRON_LLM_TELEMETRY_ENABLED=true (master kill-switch)
- METATRON_LLM_TELEMETRY_RETENTION_DAYS=0 (placeholder, no worker yet)
- METATRON_LLM_TELEMETRY_OPT_OUT_CACHE_TTL_SECONDS=60

Tests (31 new, 4 retry tests adjusted):
- test_llm_telemetry: set/reset/nested scopes, update_retrieved_context mutation, kill-switch and opt-out skip, store-failure swallow, sync emit from asyncio.to_thread (B1 regression guard), zero_tokens flag.
- test_chat_completion_telemetry: success/empty-content/fallback/retry/ no-fallback/empty-usage paths, fallback_used metadata.
- test_export_dataset: each format shape, success-only and benchmark/eval/zero-tokens filter defaults.

Verified end-to-end on dev stand: REST /api/v1/chat, /v1/chat/completions, MCP metatron_search via streamable-http, Jira+Confluence ingestion all produce correctly-tagged rows with shared correlation_id per request.