### PR TITLE
feat(MTRNIX-341): add /finops/active-users endpoint

### DIFF
--- a/src/metatron/api/routes/.claude/finops.md
+++ b/src/metatron/api/routes/.claude/finops.md
@@ -59,3 +59,66 @@ Empty days in the period are filled with zeros.
 
 ## Future: Cost Savings (MTRNIX-169, separate task)
 Will add `GET /api/v1/finops/cost-savings` — compares OpenAI API cost vs Metatron infrastructure cost per document. Different formula, different endpoint, same FinOps page.
+
+---
+
+# FinOps — Active Users API (MTRNIX-341)
+
+## Overview
+Backs the "Unique Users" and "Avg Queries/User" dashboard cards. Counts distinct
+authenticated principals who completed a RAG answer in the window, plus total queries
+from the same filtered slice.
+
+## Endpoint
+`GET /api/v1/finops/active-users?workspace_id={id}&days={30}`
+- `days`: 1..365, default 30 (same contract as `/time-savings`).
+
+## Response Schema
+```json
+{
+  "period_days": 30,
+  "active_users": 42,
+  "period_queries": 1337
+}
+```
+- `active_users` — `COUNT(DISTINCT user_id)` over the filtered slice.
+- `period_queries` — `COUNT(*)` over the SAME slice; frontend computes
+  `Avg Queries/User = period_queries / active_users`. Do NOT divide
+  `/time-savings.total_queries` (different slice — includes MCP/other) by `active_users`.
+
+## Data Source
+- Table: `llm_generation_log` (PostgreSQL, migration 022, MTRNIX-336) — NOT `query_traces`.
+- Filter: `source IN ('oai_compat', 'rest')`, `call_site = 'rag_answer'`, `user_id IS NOT NULL`,
+  `created_at >= now() - days`.
+- `user_id` here comes from the authenticated `TelemetryContext` (trustworthy), unlike
+  `query_traces.trace->>'user_id'` which defaults to the literal `"user"` for MCP calls.
+
+## Why these filters
+- `source IN ('oai_compat','rest')` — excludes MCP (no per-user identity), ingestion,
+  freshness, benchmark (system traffic, no user_id).
+- `call_site='rag_answer'` — only the synthesis LLM call counts as "used RAG"; users whose
+  pipeline failed earlier (resolve/translate/expand/classify) are not counted.
+- `user_id IS NOT NULL` — redundant for COUNT(DISTINCT) but REQUIRED for COUNT(*) so anonymous
+  rows don't inflate the avg numerator.
+
+## Known limitations
+- **No workspace-vs-JWT check.** `workspace_id` is a query param; any authenticated caller can
+  read any workspace's counts. Matches the existing `/time-savings` and `/cost-savings` posture.
+  A workspace-scoped JWT check across all FinOps endpoints is tracked separately.
+- **Opt-out is write-time only.** Workspaces with `llm_telemetry_opt_out=true` have no rows and
+  return 0/0 — but only if opted out from the start. Toggling opt-out ON after rows accumulate
+  does not retroactively hide them (no JOIN to `workspaces`).
+- **"Users" = authenticated principals, not humans.** An external agent (Hermes) using one
+  service-account API key over OpenAI-compat counts as one user.
+
+## Implementation Notes
+- `_fetch_active_users()` returns `ActiveUsersCounts` NamedTuple; sync, runs via `asyncio.to_thread()`.
+- `_RAG_ANSWER_CALL_SITE` / `_USER_FACING_SOURCES` module constants — coupled by literal value to
+  `retrieval/search.py` (which passes `call_site="rag_answer"`); search.py is L2 and cannot import
+  upward, so a rename there must be mirrored here manually.
+- Graceful degradation: DB error → `(0, 0)` + structlog warning `finops.active_users.db_error`.
+
+## Related Files
+- Backend: `src/metatron/api/routes/finops.py` (`_fetch_active_users`, `get_active_users`)
+- Backend: `src/metatron/storage/pg_models.py` (`LLMGenerationLogRow`)
+- Tests: `tests/unit/test_finops_active_users.py`

--- a/src/metatron/api/routes/finops.py
+++ b/src/metatron/api/routes/finops.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, date, datetime, timedelta
+from typing import NamedTuple
 
 import structlog
 from fastapi import APIRouter, Query
@@ -217,7 +218,23 @@ async def get_time_savings(
 # ---------------------------------------------------------------------------
 
 
-def _fetch_active_users(workspace_id: str, since: datetime) -> tuple[int, int]:
+# Must match the ``call_site`` string that retrieval/search.py passes when it
+# logs the RAG synthesis LLM call to llm_generation_log. There is no shared
+# constant: search.py lives at L2 and cannot import upward into this L6 module,
+# so this coupling is by literal value. A rename there without updating this
+# constant silently makes the metric return 0 — grep both sites on any change.
+_RAG_ANSWER_CALL_SITE = "rag_answer"
+_USER_FACING_SOURCES = ("oai_compat", "rest")
+
+
+class ActiveUsersCounts(NamedTuple):
+    """Result of :func:`_fetch_active_users` — named to prevent positional swap."""
+
+    active_users: int
+    period_queries: int
+
+
+def _fetch_active_users(workspace_id: str, since: datetime) -> ActiveUsersCounts:
     """Count distinct users and total queries that reached rag_answer in window.
 
     Reads ``llm_generation_log`` (MTRNIX-336), filtering to user-facing RAG
@@ -226,8 +243,17 @@ def _fetch_active_users(workspace_id: str, since: datetime) -> tuple[int, int]:
     ingestion/freshness/benchmark traffic is excluded both by source and by
     ``user_id IS NULL``.
 
-    Returns ``(active_users, period_queries)``. Both are 0 on any DB
-    exception (graceful degradation — dashboard cards never break the page).
+    Opt-out note: workspaces with ``llm_telemetry_opt_out=true`` are NOT
+    filtered here. The exclusion happens upstream at write time
+    (``llm/telemetry.py`` skips the INSERT), so a workspace that has been
+    opted out from the start has no rows and returns ``(0, 0)``. A workspace
+    that toggles opt-out ON *after* accumulating rows will still count those
+    pre-opt-out rows — this query has no JOIN to ``workspaces`` and does not
+    retroactively hide them.
+
+    Returns ``ActiveUsersCounts(active_users, period_queries)``. Both are 0 on
+    any DB exception (graceful degradation — dashboard cards never break the
+    page).
     """
     from sqlalchemy import func, select
 
@@ -246,19 +272,19 @@ def _fetch_active_users(workspace_id: str, since: datetime) -> tuple[int, int]:
                 # anonymous rows would inflate the numerator of Avg = period_queries /
                 # active_users while contributing nothing to the denominator. Do not drop.
                 LLMGenerationLogRow.user_id.isnot(None),
-                LLMGenerationLogRow.source.in_(("oai_compat", "rest")),
-                LLMGenerationLogRow.call_site == "rag_answer",
+                LLMGenerationLogRow.source.in_(_USER_FACING_SOURCES),
+                LLMGenerationLogRow.call_site == _RAG_ANSWER_CALL_SITE,
                 LLMGenerationLogRow.created_at >= since,
             )
             row = session.execute(stmt).one()
-            return int(row.active_users or 0), int(row.period_queries or 0)
+            return ActiveUsersCounts(int(row.active_users or 0), int(row.period_queries or 0))
     except Exception as exc:
         logger.warning(
             "finops.active_users.db_error",
             workspace_id=workspace_id,
             error=str(exc),
         )
-        return 0, 0
+        return ActiveUsersCounts(0, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/src/metatron/api/routes/finops.py
+++ b/src/metatron/api/routes/finops.py
@@ -213,6 +213,117 @@ async def get_time_savings(
 
 
 # ---------------------------------------------------------------------------
+# Active users — storage query (sync, runs in thread via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_active_users(workspace_id: str, since: datetime) -> tuple[int, int]:
+    """Count distinct users and total queries that reached rag_answer in window.
+
+    Reads ``llm_generation_log`` (MTRNIX-336), filtering to user-facing RAG
+    completions only (``source IN ('oai_compat', 'rest')`` and
+    ``call_site = 'rag_answer'``). MCP traffic is excluded by source filter;
+    ingestion/freshness/benchmark traffic is excluded both by source and by
+    ``user_id IS NULL``.
+
+    Returns ``(active_users, period_queries)``. Both are 0 on any DB
+    exception (graceful degradation — dashboard cards never break the page).
+    """
+    from sqlalchemy import func, select
+
+    from metatron.storage.pg_connection import get_session
+    from metatron.storage.pg_models import LLMGenerationLogRow
+
+    try:
+        with get_session() as session:
+            stmt = select(
+                func.count(func.distinct(LLMGenerationLogRow.user_id)).label("active_users"),
+                func.count().label("period_queries"),
+            ).where(
+                LLMGenerationLogRow.workspace_id == workspace_id,
+                # NOT NULL is redundant for COUNT(DISTINCT user_id) (PG ignores NULLs in
+                # aggregates) but REQUIRED for COUNT(*) AS period_queries: without it,
+                # anonymous rows would inflate the numerator of Avg = period_queries /
+                # active_users while contributing nothing to the denominator. Do not drop.
+                LLMGenerationLogRow.user_id.isnot(None),
+                LLMGenerationLogRow.source.in_(("oai_compat", "rest")),
+                LLMGenerationLogRow.call_site == "rag_answer",
+                LLMGenerationLogRow.created_at >= since,
+            )
+            row = session.execute(stmt).one()
+            return int(row.active_users or 0), int(row.period_queries or 0)
+    except Exception as exc:
+        logger.warning(
+            "finops.active_users.db_error",
+            workspace_id=workspace_id,
+            error=str(exc),
+        )
+        return 0, 0
+
+
+# ---------------------------------------------------------------------------
+# Active users — response model
+# ---------------------------------------------------------------------------
+
+
+class ActiveUsersResponse(BaseModel):
+    """Active users + total queries from the same filtered slice.
+
+    Both numbers come from the same source (llm_generation_log) and the same
+    filter (source IN ('oai_compat','rest'), call_site='rag_answer',
+    user_id IS NOT NULL), so the frontend can compute
+    Avg Queries/User = period_queries / active_users from a self-consistent
+    slice instead of mixing this endpoint with /finops/time-savings.
+    """
+
+    period_days: int
+    active_users: int
+    period_queries: int
+
+
+# ---------------------------------------------------------------------------
+# Active users — endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get("/active-users", response_model=ActiveUsersResponse)
+async def get_active_users(
+    workspace_id: str = Query(..., description="Workspace ID"),
+    days: int = Query(default=30, ge=1, le=365, description="Lookback period in days"),
+) -> ActiveUsersResponse:
+    """Count distinct users who reached rag_answer in window + total queries.
+
+    Backs the Unique Users and Avg Queries/User dashboard cards. Returns the
+    count of distinct authenticated users who completed a RAG answer
+    (``call_site='rag_answer'``) via OpenAI-compat (``/v1/chat/completions``)
+    or REST (``/api/v1/chat``) in the requested window, plus the total query
+    count from the same filtered slice. MCP traffic and system traffic
+    (ingestion/freshness/benchmark) are excluded by design.
+
+    Returns 0 for both fields on empty results, unknown workspace_id, DB
+    errors, or workspaces with ``llm_telemetry_opt_out=true``.
+
+    Note on "user" semantics: the count is over distinct authenticated
+    principals (whatever populates the ``user_id`` column at the request
+    entry point). An external agent runtime (Hermes, etc.) authenticating
+    via OpenAI-compat with a single service-account API key counts as ONE
+    user even if it serves many humans. The dashboard label "Unique Users"
+    should be read as "unique authenticated principals", not "unique
+    humans".
+    """
+    since = datetime.now(UTC) - timedelta(days=days)
+    active_users, period_queries = await asyncio.to_thread(
+        _fetch_active_users, workspace_id, since
+    )
+
+    return ActiveUsersResponse(
+        period_days=days,
+        active_users=active_users,
+        period_queries=period_queries,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Cost savings — constants (reviewed quarterly, last updated March 2026)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_finops_active_users.py
+++ b/tests/unit/test_finops_active_users.py
@@ -80,14 +80,21 @@ class TestFetchActiveUsers:
 
     @patch("metatron.storage.pg_connection.get_session")
     def test_query_filters_are_correct(self, mock_get_session):
-        """Verify the SQL where-clause has all required filters:
-        workspace_id, user_id IS NOT NULL, source IN (oai_compat, rest),
-        call_site = rag_answer, created_at >= since. Compiled SQL inspection
-        is fragile, so we snapshot the literal SQL string and assert the
-        substrings are present."""
+        """Verify the SQL where-clause has all required filters with the exact
+        values: workspace_id, user_id IS NOT NULL, source IN ('oai_compat',
+        'rest'), call_site = 'rag_answer', created_at >= since.
+
+        Uses literal_binds=True so the actual filter VALUES render inline —
+        otherwise a regression that drops 'rest' from the source tuple or
+        renames the call_site would still pass a loose 'source in' substring
+        check."""
         from sqlalchemy.dialects import postgresql
 
-        from metatron.api.routes.finops import _fetch_active_users
+        from metatron.api.routes.finops import (
+            _RAG_ANSWER_CALL_SITE,
+            _USER_FACING_SOURCES,
+            _fetch_active_users,
+        )
 
         captured_stmt = {}
 
@@ -108,17 +115,21 @@ class TestFetchActiveUsers:
         compiled = str(
             captured_stmt["stmt"].compile(
                 dialect=postgresql.dialect(),
-                compile_kwargs={"literal_binds": False},
+                compile_kwargs={"literal_binds": True},
             )
         ).lower()
 
         assert "llm_generation_log" in compiled
         assert "count(distinct" in compiled  # active_users
         assert "user_id is not null" in compiled
-        assert "source in" in compiled
         assert "call_site" in compiled
         assert "created_at" in compiled
         assert "workspace_id" in compiled
+        # Exact filter VALUES must be present (catches dropped/renamed filters).
+        assert _RAG_ANSWER_CALL_SITE == "rag_answer"
+        assert "'rag_answer'" in compiled
+        for src in _USER_FACING_SOURCES:
+            assert f"'{src}'" in compiled, f"source filter missing {src!r}"
 
 
 class TestActiveUsersEndpoint:

--- a/tests/unit/test_finops_active_users.py
+++ b/tests/unit/test_finops_active_users.py
@@ -1,0 +1,255 @@
+"""Tests for FinOps active-users helper and endpoint."""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+# Lightweight named tuple to mimic SQLAlchemy aggregate row result
+_AggRow = namedtuple("_AggRow", ["active_users", "period_queries"])
+
+
+class TestFetchActiveUsers:
+    """`_fetch_active_users` returns (active_users, period_queries) from llm_generation_log."""
+
+    @staticmethod
+    def _mock_session_returning(row):
+        """Build a MagicMock session whose execute(...).one() returns `row`."""
+        mock_session = MagicMock()
+        mock_session.execute.return_value.one.return_value = row
+        return mock_session
+
+    @patch("metatron.storage.pg_connection.get_session")
+    def test_empty_table_returns_zero_zero(self, mock_get_session):
+        """No rows → (0, 0)."""
+        from metatron.api.routes.finops import _fetch_active_users
+
+        mock_session = self._mock_session_returning(_AggRow(0, 0))
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        since = datetime.now(UTC) - timedelta(days=30)
+        result = _fetch_active_users("ws_test", since)
+
+        assert result == (0, 0)
+        assert mock_session.execute.called
+
+    @patch("metatron.storage.pg_connection.get_session")
+    def test_single_row_returns_one_one(self, mock_get_session):
+        from metatron.api.routes.finops import _fetch_active_users
+
+        mock_session = self._mock_session_returning(_AggRow(1, 1))
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        since = datetime.now(UTC) - timedelta(days=30)
+        assert _fetch_active_users("ws_test", since) == (1, 1)
+
+    @patch("metatron.storage.pg_connection.get_session")
+    def test_distinct_vs_total(self, mock_get_session):
+        """5 rows, 1 user → (1, 5). Confirms helper returns BOTH numbers separately."""
+        from metatron.api.routes.finops import _fetch_active_users
+
+        mock_session = self._mock_session_returning(_AggRow(1, 5))
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        since = datetime.now(UTC) - timedelta(days=30)
+        assert _fetch_active_users("ws_test", since) == (1, 5)
+
+    @patch("metatron.api.routes.finops.logger")
+    @patch("metatron.storage.pg_connection.get_session")
+    def test_db_error_returns_zero_zero_and_logs(self, mock_get_session, mock_logger):
+        """DB exception → (0, 0); structlog warning emitted; never re-raised."""
+        from metatron.api.routes.finops import _fetch_active_users
+
+        mock_session = MagicMock()
+        mock_session.execute.side_effect = Exception("DB down")
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        since = datetime.now(UTC) - timedelta(days=30)
+        result = _fetch_active_users("ws_test", since)
+
+        assert result == (0, 0)
+        mock_logger.warning.assert_called_once()
+        # event name is the first positional arg of structlog's warning(...)
+        event_name = mock_logger.warning.call_args.args[0]
+        assert event_name == "finops.active_users.db_error"
+
+    @patch("metatron.storage.pg_connection.get_session")
+    def test_query_filters_are_correct(self, mock_get_session):
+        """Verify the SQL where-clause has all required filters:
+        workspace_id, user_id IS NOT NULL, source IN (oai_compat, rest),
+        call_site = rag_answer, created_at >= since. Compiled SQL inspection
+        is fragile, so we snapshot the literal SQL string and assert the
+        substrings are present."""
+        from sqlalchemy.dialects import postgresql
+
+        from metatron.api.routes.finops import _fetch_active_users
+
+        captured_stmt = {}
+
+        def capture_execute(stmt, *args, **kwargs):
+            captured_stmt["stmt"] = stmt
+            mock = MagicMock()
+            mock.one.return_value = _AggRow(0, 0)
+            return mock
+
+        mock_session = MagicMock()
+        mock_session.execute.side_effect = capture_execute
+        mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        since = datetime.now(UTC) - timedelta(days=30)
+        _fetch_active_users("ws_test", since)
+
+        compiled = str(
+            captured_stmt["stmt"].compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": False},
+            )
+        ).lower()
+
+        assert "llm_generation_log" in compiled
+        assert "count(distinct" in compiled  # active_users
+        assert "user_id is not null" in compiled
+        assert "source in" in compiled
+        assert "call_site" in compiled
+        assert "created_at" in compiled
+        assert "workspace_id" in compiled
+
+
+class TestActiveUsersEndpoint:
+    """`get_active_users` HTTP endpoint behaviour."""
+
+    @patch("metatron.api.routes.finops._fetch_active_users")
+    async def test_response_shape_and_period_echo(self, mock_fetch):
+        """Response contains period_days (echoed), active_users, period_queries."""
+        from metatron.api.routes.finops import get_active_users
+
+        mock_fetch.return_value = (42, 1337)
+
+        resp = await get_active_users(workspace_id="ws_test", days=30)
+
+        assert resp.period_days == 30
+        assert resp.active_users == 42
+        assert resp.period_queries == 1337
+
+    @patch("metatron.api.routes.finops._fetch_active_users")
+    async def test_days_parameter_passed_to_helper(self, mock_fetch):
+        """`days=7` produces a `since` ~7 days in the past, ±1 minute."""
+        from metatron.api.routes.finops import get_active_users
+
+        mock_fetch.return_value = (0, 0)
+
+        before = datetime.now(UTC)
+        await get_active_users(workspace_id="ws_test", days=7)
+        after = datetime.now(UTC)
+
+        args, _ = mock_fetch.call_args
+        workspace_id_arg, since_arg = args
+        assert workspace_id_arg == "ws_test"
+
+        expected_since_low = before - timedelta(days=7)
+        expected_since_high = after - timedelta(days=7)
+        assert expected_since_low <= since_arg <= expected_since_high
+
+    @patch("metatron.api.routes.finops._fetch_active_users")
+    async def test_zero_values_passthrough(self, mock_fetch):
+        """Helper returning (0, 0) must come through as 0/0, not omitted."""
+        from metatron.api.routes.finops import get_active_users
+
+        mock_fetch.return_value = (0, 0)
+
+        resp = await get_active_users(workspace_id="ws_test", days=30)
+
+        assert resp.period_days == 30
+        assert resp.active_users == 0
+        assert resp.period_queries == 0
+
+
+class TestActiveUsersHttpRoute:
+    """End-to-end route test via FastAPI TestClient — verifies route is mounted
+    and parameter validation (days range 1..365) is enforced by FastAPI."""
+
+    @patch("metatron.api.routes.finops._fetch_active_users")
+    def test_route_returns_200_with_expected_json(self, mock_fetch):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from metatron.api.routes.finops import router
+
+        mock_fetch.return_value = (5, 100)
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+
+        client = TestClient(app)
+        r = client.get("/api/v1/finops/active-users?workspace_id=ws_test&days=14")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {"period_days": 14, "active_users": 5, "period_queries": 100}
+
+    @patch("metatron.api.routes.finops._fetch_active_users")
+    def test_route_default_days_is_30(self, mock_fetch):
+        """Calling without days yields period_days=30 in the response."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from metatron.api.routes.finops import router
+
+        mock_fetch.return_value = (0, 0)
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+
+        client = TestClient(app)
+        r = client.get("/api/v1/finops/active-users?workspace_id=ws_test")
+
+        assert r.status_code == 200
+        assert r.json()["period_days"] == 30
+
+    def test_route_rejects_days_below_one(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from metatron.api.routes.finops import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+
+        client = TestClient(app)
+        r = client.get("/api/v1/finops/active-users?workspace_id=ws_test&days=0")
+
+        assert r.status_code == 422
+
+    def test_route_rejects_days_above_365(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from metatron.api.routes.finops import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+
+        client = TestClient(app)
+        r = client.get("/api/v1/finops/active-users?workspace_id=ws_test&days=999")
+
+        assert r.status_code == 422
+
+    def test_route_requires_workspace_id(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from metatron.api.routes.finops import router
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api/v1")
+
+        client = TestClient(app)
+        r = client.get("/api/v1/finops/active-users")
+
+        assert r.status_code == 422


### PR DESCRIPTION
Returns active_users (distinct authenticated principals who reached call_site='rag_answer' via oai_compat or rest in the window) and period_queries (total queries from the same filtered slice) so the dashboard can compute Avg Queries/User from a self-consistent slice rather than mixing this endpoint with /finops/time-savings (which includes MCP and other channels).

Reads existing llm_generation_log (MTRNIX-336) — no migration, no new env vars. Graceful degradation on DB errors and opt-out workspaces (returns 0/0). Matches existing FinOps auth posture (any authenticated user, no workspace_id JWT cross-check — known limitation tracked separately).