### PR TITLE
feat: access-checked ?workspace_id override for REST family B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,7 +409,7 @@ Upstream: metatron on port 8000, healthcheck at /health
 ## Conventions
 - Async everywhere: `async def` for handlers, DB calls, LLM calls
 - Config via pydantic-settings, env vars with METATRON_ prefix
-- Workspace isolation: all queries filtered by workspace_id (JWT claim)
+- Workspace isolation: all queries filtered by workspace_id (JWT claim by default). REST family-B endpoints (agents/memory/knowledge) also accept an optional, JWT-access-checked `?workspace_id` query param overriding the auth-derived default (`resolve_workspace_id` in `api/dependencies.py`); a caller may only target a workspace its token grants (`*` or membership), else 403. MCP stays strictly auth-derived.
 - Graceful degradation: `_safe_call()` — Neo4j down → search works without graph
 - Factory pattern: `create_app(settings)` for isolated testing
 - Logging: structlog

--- a/src/metatron/api/.claude/claude.md
+++ b/src/metatron/api/.claude/claude.md
@@ -171,7 +171,7 @@ Memory REST API endpoints (workspace-scoped, RBAC-gated):
 
 **DI helper:** `get_memory_service(request)` — per-workspace cache on `app.state.memory_services`; shared PG engine on `app.state.memory_pg_engine`. Now also wires `freshness_store` (required for the review endpoints) and passes `pg_store` to `MemorySearchService` for graph-leg post-filter parity with the MCP path (MTRNIX-324).
 
-**Workspace resolution:** uses `get_workspace_id(request)` exported from `api.dependencies` (workspace always derived from auth, never from body/query).
+**Workspace resolution:** uses `resolve_workspace_id(request)` from `api.dependencies` — auth-derived by default, with an optional access-checked `?workspace_id` query override on REST family-B endpoints (agents/memory/knowledge); a caller may only target a workspace its JWT grants (`*` or membership), else 403. `get_workspace_id` remains the auth-only base (still used by telemetry / `build_telemetry_context_cm`).
 
 **Schemas:** pydantic v2 request/response models live inline in `routes/memory.py` per codebase convention.
 

--- a/src/metatron/api/dependencies.py
+++ b/src/metatron/api/dependencies.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
-from fastapi import Request  # noqa: TC002 — FastAPI Depends parameters need runtime type
+from fastapi import (  # noqa: TC002 — FastAPI Depends parameters need runtime type
+    HTTPException,
+    Query,
+    Request,
+)
 
 from metatron.core.config import Settings  # noqa: TC001 — runtime annotations in function bodies
 from metatron.llm.telemetry import set_telemetry_context
@@ -81,6 +85,66 @@ def get_workspace_id(request: Request) -> str:
 _resolve_workspace_id = get_workspace_id
 
 
+def resolve_workspace_id(request: Request) -> str:
+    """Resolve workspace_id from an optional ``?workspace_id`` query param,
+    access-checked against the caller's JWT.
+
+    - param absent (or literal ``"*"``) -> ``get_workspace_id(request)``
+      (auth-derived, unchanged behaviour).
+    - param present, caller is unscoped (empty ``workspace_ids`` — same
+      "not confined to specific workspaces" meaning ``get_workspace_id`` already
+      gives ``[]``) or holds ``"*"`` or the param is in the caller's
+      ``workspace_ids`` -> the requested workspace is returned.
+    - param present, caller is confined to specific workspaces that do not
+      include it -> ``HTTPException(403)``.
+
+    Reads only ``request.query_params`` and ``request.state.user`` — no
+    WorkspaceManager lookup. A nonexistent workspace yields an empty result set
+    downstream rather than a 404.
+
+    Note: an empty ``workspace_ids`` is treated as unrestricted, matching both
+    ``get_workspace_id`` (which falls back to the default workspace rather than
+    denying) and the ``AUTH_ENABLED=false`` case (where ``request.state.user``
+    is ``{}``). When a real multi-tenant RBAC model lands, revisit whether an
+    empty list should mean "all" or "none".
+    """
+    requested = request.query_params.get("workspace_id")
+    if not requested or requested == "*":
+        return get_workspace_id(request)
+    user = getattr(request.state, "user", {}) or {}
+    allowed = user.get("workspace_ids", []) or []
+    if not allowed or "*" in allowed or requested in allowed:
+        return str(requested)
+    raise HTTPException(status_code=403, detail=f"No access to workspace '{requested}'")
+
+
+def workspace_scope(
+    request: Request,
+    workspace_id: str | None = Query(  # noqa: ARG001 — declared for OpenAPI; value read via request
+        None,
+        description="Target workspace (auth-checked; overrides the JWT-derived default)",
+    ),
+) -> str:
+    """Router-level dependency for REST family B (agents / memory / knowledge /
+    snapshots).
+
+    Two jobs in one place so individual handlers stay clean:
+
+    1. **Declares** ``?workspace_id`` as an optional query parameter — because it
+       is attached to the router, FastAPI surfaces the param in the OpenAPI schema
+       for *every* route under that router, so typed frontend clients can pass it.
+    2. **Enforces** the JWT access check via :func:`resolve_workspace_id` — raises
+       403 for a workspace the caller may not target. This runs even when a
+       handler's service dependency is overridden in tests, so enforcement is
+       uniform.
+
+    The ``workspace_id`` parameter is intentionally unused in the body — the value
+    is read from ``request.query_params`` by :func:`resolve_workspace_id`. Returns
+    the resolved workspace id; service DI helpers re-resolve the same value.
+    """
+    return resolve_workspace_id(request)
+
+
 def build_telemetry_context_cm(
     request: Request,
     *,
@@ -128,7 +192,7 @@ def get_memory_service(request: Request) -> MemoryService:
     from metatron.storage.redis import RedisStore
 
     settings: Settings = request.app.state.settings
-    workspace_id = _resolve_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
 
     services: dict[str, MemoryService] = getattr(
         request.app.state,
@@ -215,7 +279,7 @@ def get_agent_registry_service(request: Request) -> AgentRegistryService:
     from metatron.agents.service import AgentRegistryService
 
     settings: Settings = request.app.state.settings
-    workspace_id = _resolve_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
 
     services: dict[str, AgentRegistryService] = getattr(
         request.app.state,
@@ -260,7 +324,7 @@ def get_memory_health_service(request: Request) -> MemoryHealthService:
     from metatron.storage.memory_postgres import MemoryPostgresStore
 
     settings: Settings = request.app.state.settings
-    workspace_id = _resolve_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
 
     services: dict[str, MemoryHealthService] = getattr(
         request.app.state,
@@ -312,7 +376,7 @@ def get_memory_snapshot_service(request: Request) -> MemorySnapshotService:
     from metatron.storage.memory_qdrant import MemoryQdrantStore
 
     settings: Settings = request.app.state.settings
-    workspace_id = _resolve_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
 
     services: dict[str, MemorySnapshotService] = getattr(
         request.app.state,
@@ -372,7 +436,7 @@ def get_raw_document_service(request: Request) -> RawDocumentReadService:
     from metatron.storage.postgres import PostgresStore
 
     settings: Settings = request.app.state.settings
-    workspace_id = _resolve_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
 
     services: dict[str, RawDocumentReadService] = getattr(
         request.app.state,

--- a/src/metatron/api/dependencies.py
+++ b/src/metatron/api/dependencies.py
@@ -6,6 +6,7 @@ and services. They pull instances from app.state (set during lifespan).
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -81,40 +82,78 @@ def get_workspace_id(request: Request) -> str:
     return settings.default_workspace_id
 
 
-# Backwards-compatible alias — older callers use the private name.
-_resolve_workspace_id = get_workspace_id
+# Workspace ids appear as Qdrant collection-name path components and as
+# filesystem directories under the snapshot root, so the resolver rejects
+# anything outside this charset before returning a value.
+_WORKSPACE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 def resolve_workspace_id(request: Request) -> str:
     """Resolve workspace_id from an optional ``?workspace_id`` query param,
     access-checked against the caller's JWT.
 
-    - param absent (or literal ``"*"``) -> ``get_workspace_id(request)``
-      (auth-derived, unchanged behaviour).
-    - param present, caller is unscoped (empty ``workspace_ids`` — same
-      "not confined to specific workspaces" meaning ``get_workspace_id`` already
-      gives ``[]``) or holds ``"*"`` or the param is in the caller's
+    Semantics:
+    - Param absent or whitespace-only -> :func:`get_workspace_id` (auth-derived).
+    - Param literally ``"*"`` -> ``HTTPException(400)``. ``"*"`` is a wildcard
+      inside the JWT, never a valid request target; reject explicitly instead of
+      silently downgrading to the auth default.
+    - Param outside ``^[A-Za-z0-9_-]{1,64}$`` -> ``HTTPException(400)``. Keeps
+      ``..`` / ``/`` / very long ids out of downstream filesystem and Qdrant
+      paths (a traversal would otherwise be possible via the snapshot service).
+    - Param present, caller token holds ``"*"`` or the param is in the caller's
       ``workspace_ids`` -> the requested workspace is returned.
-    - param present, caller is confined to specific workspaces that do not
-      include it -> ``HTTPException(403)``.
+    - Param present, caller's ``workspace_ids`` does not grant access (incl. the
+      empty-list case) -> ``HTTPException(403)``. ``OptionalAuthMiddleware``
+      normalises admin tokens with empty ``workspace_ids`` into ``["*"]`` so
+      this branch only fires for genuinely-confined callers.
+
+    The resolved value is memoised on ``request.state._workspace_id_cached``
+    so repeat resolutions within a single request (router dep + service DI +
+    in-handler) cannot disagree if a downstream middleware mutates the query
+    string (TOCTOU).
 
     Reads only ``request.query_params`` and ``request.state.user`` — no
-    WorkspaceManager lookup. A nonexistent workspace yields an empty result set
-    downstream rather than a 404.
-
-    Note: an empty ``workspace_ids`` is treated as unrestricted, matching both
-    ``get_workspace_id`` (which falls back to the default workspace rather than
-    denying) and the ``AUTH_ENABLED=false`` case (where ``request.state.user``
-    is ``{}``). When a real multi-tenant RBAC model lands, revisit whether an
-    empty list should mean "all" or "none".
+    WorkspaceManager lookup. A nonexistent (but well-formed and granted)
+    workspace yields an empty result set downstream rather than a 404.
     """
-    requested = request.query_params.get("workspace_id")
-    if not requested or requested == "*":
-        return get_workspace_id(request)
+    cached: str | None = getattr(request.state, "_workspace_id_cached", None)
+    if cached is not None:
+        return cached
+
+    raw = request.query_params.get("workspace_id")
+    requested = (raw or "").strip()
+
+    if not requested:
+        result = get_workspace_id(request)
+        request.state._workspace_id_cached = result
+        return result
+
+    if requested == "*":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "workspace_id='*' is not a valid target — omit the parameter to "
+                "use the auth-derived default"
+            ),
+        )
+
+    if not _WORKSPACE_ID_RE.match(requested):
+        raise HTTPException(
+            status_code=400,
+            detail="workspace_id must match ^[A-Za-z0-9_-]{1,64}$",
+        )
+
     user = getattr(request.state, "user", {}) or {}
-    allowed = user.get("workspace_ids", []) or []
-    if not allowed or "*" in allowed or requested in allowed:
-        return str(requested)
+    allowed_raw = user.get("workspace_ids", [])
+    # Defensive: a plugin auth backend could theoretically return a bare string;
+    # without this guard ``requested in allowed`` becomes a substring match
+    # (e.g. "ws" in "ws-acme" -> True). Coerce non-lists to an empty list.
+    allowed: list[str] = allowed_raw if isinstance(allowed_raw, list) else []
+
+    if "*" in allowed or requested in allowed:
+        request.state._workspace_id_cached = requested
+        return requested
+
     raise HTTPException(status_code=403, detail=f"No access to workspace '{requested}'")
 
 
@@ -159,6 +198,14 @@ def build_telemetry_context_cm(
 
     Centralising this here keeps chat / openai-compat / future routes from
     re-implementing the same five-line dance.
+
+    WARNING — by design this function uses :func:`get_workspace_id`, **not**
+    :func:`resolve_workspace_id`. Audit logs must reflect the JWT-derived
+    workspace, not whatever a ``?workspace_id`` query param requested, otherwise
+    telemetry and authorisation can diverge. If a future caller needs the
+    actually-served workspace in the telemetry context, call
+    ``resolve_workspace_id`` explicitly at the handler instead of changing this
+    helper.
     """
     workspace_id = get_workspace_id(request)
     user = getattr(request.state, "user", {}) or {}

--- a/src/metatron/api/middleware/__init__.py
+++ b/src/metatron/api/middleware/__init__.py
@@ -52,6 +52,16 @@ class OptionalAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         if not settings.auth_enabled:
+            # AUTH off == dev mode == trusted admin. Without this, resolve_workspace_id
+            # would 403 every ?workspace_id call (empty workspace_ids -> no access),
+            # breaking local development. Mirrors the legacy login fallback that issues
+            # `["*"]` for the shared-password admin.
+            request.state.user = {
+                "user_id": "anon",
+                "role": "admin",
+                "workspace_ids": ["*"],
+                "email": "",
+            }
             return await call_next(request)
 
         if path in PUBLIC_PATHS:
@@ -78,10 +88,18 @@ class OptionalAuthMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
+        role = payload.get("role", "viewer")
+        workspace_ids = payload.get("workspace_ids", []) or []
+        # Tolerate older admin tokens issued before login-time normalisation —
+        # an empty workspace_ids on an admin role means "no per-workspace confinement",
+        # which is equivalent to ``["*"]``. Non-admin empty stays empty (-> 403 in resolver).
+        if role == "admin" and not workspace_ids:
+            workspace_ids = ["*"]
+
         request.state.user = {
             "user_id": payload["sub"],
-            "role": payload.get("role", "viewer"),
-            "workspace_ids": payload.get("workspace_ids", []),
+            "role": role,
+            "workspace_ids": workspace_ids,
             "email": payload.get("email", ""),
         }
 

--- a/src/metatron/api/routes/agents.py
+++ b/src/metatron/api/routes/agents.py
@@ -1,8 +1,9 @@
 """Agent Registry REST API — /api/v1/agents.
 
 Exposes CRUD, lifecycle transitions and config-version history for agents
-in a workspace. Workspace is always derived from the authenticated user —
-never accepted from body or query string.
+in a workspace. Workspace is auth-derived by default; an optional
+``?workspace_id`` query param overrides it when the caller's JWT grants access
+("*" or membership), else 403 (``resolve_workspace_id``).
 
 RBAC — aligns with the ``memory/`` module convention:
 
@@ -40,6 +41,8 @@ from metatron.api.dependencies import (
     get_memory_health_service,
     get_memory_service,
     get_memory_snapshot_service,
+    resolve_workspace_id,
+    workspace_scope,
 )
 from metatron.auth.dependencies import require_editor, require_viewer
 from metatron.core.exceptions import (
@@ -65,7 +68,7 @@ from metatron.memory.snapshot import (
 
 logger = structlog.get_logger(__name__)
 
-router = APIRouter(prefix="/agents", tags=["agents"])
+router = APIRouter(prefix="/agents", tags=["agents"], dependencies=[Depends(workspace_scope)])
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +293,9 @@ async def list_agents(
     The two flags are mutually exclusive — passing both ``status=...`` and
     ``include_archived=true`` is rejected with 400.  This keeps the contract
     unambiguous (per MTRNIX-324 R7).
+
+    Workspace scoping (incl. the ``?workspace_id`` access check) is handled by
+    the router-level ``workspace_scope`` dependency.
     """
     if status is not None and include_archived:
         raise HTTPException(
@@ -757,12 +763,10 @@ class ActivitySummaryResponse(BaseModel):
 
 def get_activity_service(request: Request) -> ActivityService:
     """Per-workspace ActivityService, reusing the store wired in create_app()."""
-    from metatron.api.dependencies import _resolve_workspace_id
-
     store = getattr(request.app.state, "activity_store", None)
     if store is None:
         raise HTTPException(status_code=503, detail="activity log disabled")
-    workspace_id = _resolve_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     return ActivityService(store=store, workspace_id=workspace_id)
 
 

--- a/src/metatron/api/routes/auth.py
+++ b/src/metatron/api/routes/auth.py
@@ -49,7 +49,13 @@ async def login(req: LoginRequest, request: Request) -> LoginResponse:
         if not verify_password(req.password, user["password_hash"]):
             raise HTTPException(status_code=401, detail="Invalid email or password")
 
-        workspace_ids = user.get("workspace_ids", [])
+        workspace_ids = user.get("workspace_ids", []) or []
+        # Admin role with no per-workspace confinement means "all workspaces".
+        # Issuing `[]` would later 403 under the strict workspace resolver, so
+        # normalise here at token-issue time (mirrored in OptionalAuthMiddleware
+        # for older tokens already in circulation).
+        if user["role"] == "admin" and not workspace_ids:
+            workspace_ids = ["*"]
         token = create_token(
             user_id=user["id"],
             role=user["role"],

--- a/src/metatron/api/routes/knowledge.py
+++ b/src/metatron/api/routes/knowledge.py
@@ -5,8 +5,9 @@ KB documents (``raw_documents``) under a single endpoint.  The two sources are
 fan-out concurrently under ``origin=all``.
 
 Design decisions (see plan §8 Risks & decisions):
-- ``workspace_id`` is always auth-derived via ``get_workspace_id(request)`` — it
-  is never accepted from the query string or request body (D-P1-01).
+- ``workspace_id`` is auth-derived by default. An optional ``?workspace_id`` query param
+  overrides it, but only when the caller's JWT grants access ("*" or membership); otherwise
+  403. Resolved via ``resolve_workspace_id(request)`` (supersedes D-P1-01 for REST).
 - ``origin=all`` pagination is approximate: each leg fetches up to ``limit`` rows
   ordered by its own ``updated_at DESC``, then the combined page is re-sorted and
   truncated.  ``total = agent_total + kb_total`` is therefore an estimate when the
@@ -39,7 +40,8 @@ from pydantic import BaseModel, Field
 from metatron.api.dependencies import (
     get_memory_service,
     get_raw_document_service,
-    get_workspace_id,
+    resolve_workspace_id,
+    workspace_scope,
 )
 from metatron.auth.dependencies import require_viewer
 from metatron.core.models import (
@@ -56,7 +58,9 @@ from metatron.memory.service import (
 
 logger = structlog.get_logger(__name__)
 
-router = APIRouter(prefix="/knowledge", tags=["knowledge"])
+router = APIRouter(
+    prefix="/knowledge", tags=["knowledge"], dependencies=[Depends(workspace_scope)]
+)
 
 
 # ---------------------------------------------------------------------------
@@ -218,8 +222,9 @@ async def list_knowledge_records(
 ) -> KnowledgeRecordListResponse:
     """Unified, paginated view of agent memory + KB documents.
 
-    ``workspace_id`` is always auth-derived — never accepted from the query
-    string or request body (D-P1-01).
+    ``workspace_id`` is auth-derived by default; an optional ``?workspace_id`` query param
+    overrides it when the caller's JWT grants access ("*" or membership), else 403
+    (supersedes D-P1-01 for REST).
 
     Origin routing:
     - ``origin=agent`` — only ``memory_records``. KB service not called.
@@ -241,7 +246,7 @@ async def list_knowledge_records(
     - ``lifetime=persistent`` (default) returns only non-expiring rows.
     - ``lifetime=all`` returns both.
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
 
     # --- Agent-only path ---
     if origin == KnowledgeOrigin.AGENT:

--- a/src/metatron/api/routes/memory.py
+++ b/src/metatron/api/routes/memory.py
@@ -15,7 +15,11 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from metatron.api.dependencies import get_memory_service, get_workspace_id
+from metatron.api.dependencies import (
+    get_memory_service,
+    resolve_workspace_id,
+    workspace_scope,
+)
 from metatron.auth.dependencies import require_editor, require_viewer
 from metatron.core.exceptions import MemoryNotFoundError
 from metatron.core.models import (
@@ -33,7 +37,7 @@ from metatron.memory.service import (
 
 logger = structlog.get_logger(__name__)
 
-router = APIRouter(prefix="/memory", tags=["memory"])
+router = APIRouter(prefix="/memory", tags=["memory"], dependencies=[Depends(workspace_scope)])
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +189,7 @@ async def create_record(
     SESSION-scoped records are cached in Redis (with TTL); all other scopes
     are persisted in Qdrant (plus best-effort Neo4j).
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     record = MemoryRecord(
         workspace_id=workspace_id,
         agent_id=body.agent_id,
@@ -234,7 +238,7 @@ async def search_records(
     Note: the MCP ``"all"`` sentinel is not accepted here; pass each status
     value explicitly (e.g. ``["active", "archived"]``) to include all.
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     results: list[MemorySearchResult]
 
     # Apply route-layer default — mirrors the MCP layer pattern where the
@@ -307,7 +311,7 @@ async def list_records(
     is explicitly set. This is intentional: the inspector UI needs to see all
     records including ARCHIVED and SUPERSEDED.
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
 
     if session_id is not None:
         session_records = await service.list_session(workspace_id, session_id)
@@ -352,7 +356,7 @@ async def get_record(
     including when a record exists but belongs to a different workspace
     (cross-workspace isolation guaranteed by PG ``WHERE workspace_id = :ws``).
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     record = await service.get(workspace_id, record_id)
     if record is None:
         raise HTTPException(status_code=404, detail="Memory record not found")
@@ -415,7 +419,7 @@ async def get_memory_graph(
 
     Workspace isolation: ``workspace_id`` comes from the JWT only.
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     records, raw_edges = await service.get_graph_neighborhood(
         workspace_id, seed_record_id, depth=depth
     )
@@ -511,7 +515,7 @@ async def list_review_entries(
     Returns 503 when the freshness store is not configured (e.g. the deployment
     does not run the freshness worker).
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     try:
         entries, total = await service.list_review_entries(
             workspace_id,
@@ -560,7 +564,7 @@ async def resolve_review_entry(
     Returns 404 when the review entry or target record does not exist.
     Returns 503 when the freshness store is not configured.
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     if body.action == "merge_into":
         action_str = f"merge_into:{body.target_record_id}"
     else:
@@ -599,7 +603,7 @@ async def delete_record(
     Session records are managed separately via ``invalidate_session`` —
     this endpoint only touches the persistent stores (PG, Qdrant, Neo4j).
     """
-    workspace_id = get_workspace_id(request)
+    workspace_id = resolve_workspace_id(request)
     deleted = await service.delete(workspace_id, record_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Memory record not found")

--- a/src/metatron/api/routes/snapshots.py
+++ b/src/metatron/api/routes/snapshots.py
@@ -5,9 +5,9 @@ live under ``/api/v1/agents/{id}/snapshots`` so the agent context is always
 explicit. The cross-snapshot operations live here because the snapshot id is
 the natural primary key.
 
-Workspace is always derived from the authenticated user — never accepted from
-the request body or query string. A snapshot id from another workspace
-resolves to 404.
+Workspace is auth-derived by default; an optional ``?workspace_id`` query param
+overrides it when the caller's JWT grants access ("*" or membership), else 403.
+A snapshot id outside the resolved workspace resolves to 404.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
-from metatron.api.dependencies import get_memory_snapshot_service
+from metatron.api.dependencies import get_memory_snapshot_service, workspace_scope
 from metatron.api.routes.agents import MemorySnapshotResponse, _snapshot_to_response
 from metatron.api.routes.memory import MemoryRecordResponse, _record_to_response
 from metatron.auth.dependencies import require_editor, require_viewer
@@ -38,7 +38,9 @@ _MAX_RECORD_IDS_PER_REQUEST = 200
 
 logger = structlog.get_logger(__name__)
 
-router = APIRouter(prefix="/snapshots", tags=["snapshots"])
+router = APIRouter(
+    prefix="/snapshots", tags=["snapshots"], dependencies=[Depends(workspace_scope)]
+)
 
 
 class RestoreSnapshotResponse(BaseModel):

--- a/src/metatron/api/routes/snapshots.py
+++ b/src/metatron/api/routes/snapshots.py
@@ -5,9 +5,12 @@ live under ``/api/v1/agents/{id}/snapshots`` so the agent context is always
 explicit. The cross-snapshot operations live here because the snapshot id is
 the natural primary key.
 
-Workspace is auth-derived by default; an optional ``?workspace_id`` query param
-overrides it when the caller's JWT grants access ("*" or membership), else 403.
-A snapshot id outside the resolved workspace resolves to 404.
+Workspace is resolved by the router-level ``workspace_scope`` dependency:
+auth-derived by default, with an optional ``?workspace_id`` query override that
+is honoured only when the caller's JWT grants access (``*`` or membership),
+else 403. Cross-workspace isolation is therefore enforced at resolve time —
+a snapshot id outside the resolved workspace resolves to 404 because the
+``MemorySnapshotService`` is bound to that workspace at construction.
 """
 
 from __future__ import annotations

--- a/tests/unit/api/test_agents_workspace_scoping.py
+++ b/tests/unit/api/test_agents_workspace_scoping.py
@@ -86,3 +86,22 @@ def test_workspace_id_declared_on_resource_keyed_paths(service: AsyncMock) -> No
             checked += 1
     # Sanity: we actually inspected resource-keyed operations, not just the list.
     assert checked >= 5
+
+
+def test_lifecycle_endpoints_enforce_workspace_access(service: AsyncMock) -> None:
+    """Variant B explicitly puts lifecycle (start/stop/pause) under the
+    ?workspace_id contract — make sure a non-member 403s at the router-level
+    workspace_scope dep *before* the handler runs.
+
+    PR-127 review #7: lifecycle has sharper power than reads; explicit coverage
+    here so a regression that drops the router dep can never silently pass.
+    """
+    client = _client(["ws-a"], service)
+    for endpoint in ("start", "stop", "pause"):
+        resp = client.post(f"/api/v1/agents/some-agent/{endpoint}?workspace_id=ws-victim")
+        assert resp.status_code == 403, (
+            f"POST /agents/.../{endpoint} should 403 for non-member, got {resp.status_code}"
+        )
+    service.start_agent.assert_not_awaited()
+    service.stop_agent.assert_not_awaited()
+    service.pause_agent.assert_not_awaited()

--- a/tests/unit/api/test_agents_workspace_scoping.py
+++ b/tests/unit/api/test_agents_workspace_scoping.py
@@ -1,0 +1,88 @@
+"""agents list endpoint honours ?workspace_id with a JWT access check."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from metatron.agents.service import AgentRegistryService
+from metatron.api.dependencies import get_agent_registry_service
+from metatron.api.routes.agents import router as agents_router
+from metatron.auth.dependencies import get_current_user
+from metatron.core.config import Settings
+from metatron.core.models import Role, User
+
+
+def _settings() -> Settings:
+    return Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=False,
+        METATRON_SECRET_KEY="test-secret",
+    )
+
+
+def _user() -> User:
+    return User(
+        id="u1",
+        username="t",
+        email="t@x.com",
+        role=Role.VIEWER,
+        workspace_ids=["*"],
+    )
+
+
+def _client(workspace_ids: list[str], service: AsyncMock) -> TestClient:
+    app = FastAPI()
+    app.state.settings = _settings()
+    app.include_router(agents_router, prefix="/api/v1")
+    app.dependency_overrides[get_agent_registry_service] = lambda: service
+    app.dependency_overrides[get_current_user] = lambda: _user()
+
+    @app.middleware("http")
+    async def _inject(request, call_next):  # type: ignore[no-untyped-def]
+        request.state.user = {"workspace_ids": workspace_ids}
+        return await call_next(request)
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def service() -> AsyncMock:
+    mock = AsyncMock(spec=AgentRegistryService)
+    mock.list_agents.return_value = []
+    return mock
+
+
+def test_list_returns_200_with_workspace_param(service: AsyncMock) -> None:
+    client = _client(["*"], service)
+    resp = client.get("/api/v1/agents/?workspace_id=ws-x")
+    assert resp.status_code == 200
+
+
+def test_list_forbidden_for_non_member(service: AsyncMock) -> None:
+    client = _client(["ws-a"], service)
+    resp = client.get("/api/v1/agents/?workspace_id=ws-x")
+    assert resp.status_code == 403
+
+
+def test_workspace_id_declared_on_resource_keyed_paths(service: AsyncMock) -> None:
+    """Router-level workspace_scope dependency must surface ?workspace_id in the
+    OpenAPI schema for EVERY agents route, incl. resource-keyed ones (variant B)."""
+    client = _client(["*"], service)
+    schema = client.app.openapi()  # type: ignore[attr-defined]
+
+    checked = 0
+    for path, item in schema["paths"].items():
+        if not path.startswith("/api/v1/agents"):
+            continue
+        for method, op in item.items():
+            if method not in {"get", "post", "put", "delete"}:
+                continue
+            names = {p["name"] for p in op.get("parameters", [])}
+            assert "workspace_id" in names, f"{method.upper()} {path} missing workspace_id"
+            checked += 1
+    # Sanity: we actually inspected resource-keyed operations, not just the list.
+    assert checked >= 5

--- a/tests/unit/api/test_get_memory_service.py
+++ b/tests/unit/api/test_get_memory_service.py
@@ -41,6 +41,7 @@ def _make_request(workspace_id: str = "ws-test") -> MagicMock:
     request = MagicMock()
     request.app.state = _State()
     request.state.user = {"workspace_ids": [workspace_id]}
+    request.query_params = {}
     return request
 
 
@@ -149,3 +150,24 @@ class TestGetMemoryServiceWiring:
 
             # FreshnessStore constructor called exactly once
             assert _freshness.call_count == 1
+
+    def test_star_token_query_param_scopes_qdrant_store(self) -> None:
+        """A '*' token with ?workspace_id constructs the Qdrant store for that ws."""
+        request = _make_request(workspace_id="default-ws")
+        request.state.user = {"workspace_ids": ["*"]}
+        request.query_params = {"workspace_id": "ws-x"}
+
+        with (
+            patch(_PATCH_BASES["pg_store"]),
+            patch(_PATCH_BASES["qdrant"]) as _qdrant,
+            patch(_PATCH_BASES["redis_session"]),
+            patch(_PATCH_BASES["redis_store"]),
+            patch(_PATCH_BASES["search"]),
+            patch(_PATCH_BASES["svc"]),
+            patch(_PATCH_BASES["engine"]) as _eng,
+            patch(_PATCH_BASES["freshness"]),
+        ):
+            _eng.return_value = MagicMock()
+            get_memory_service(request)
+
+            assert _qdrant.call_args.kwargs["workspace_id"] == "ws-x"

--- a/tests/unit/api/test_get_memory_service.py
+++ b/tests/unit/api/test_get_memory_service.py
@@ -42,6 +42,11 @@ def _make_request(workspace_id: str = "ws-test") -> MagicMock:
     request.app.state = _State()
     request.state.user = {"workspace_ids": [workspace_id]}
     request.query_params = {}
+    # MagicMock auto-creates truthy attributes on access. The resolver's
+    # request-scoped memoisation uses ``getattr(state, "_workspace_id_cached", None)``,
+    # so without an explicit None it would think there is a cached value and
+    # return that MagicMock instead of resolving.
+    request.state._workspace_id_cached = None
     return request
 
 

--- a/tests/unit/api/test_knowledge_routes.py
+++ b/tests/unit/api/test_knowledge_routes.py
@@ -728,3 +728,62 @@ class TestLifetimeFilter:
 
         _, count_kwargs = mem_service.pg_store.count_records.await_args
         assert count_kwargs["lifetime"] == "persistent"
+
+
+# ---------------------------------------------------------------------------
+# ?workspace_id query scoping + access check (Control Center, family B)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceQueryScoping:
+    def _client(
+        self,
+        *,
+        workspace_ids: list[str],
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> TestClient:
+        app = FastAPI()
+        app.state.settings = settings
+        app.include_router(knowledge_router, prefix="/api/v1")
+        app.dependency_overrides[get_memory_service] = lambda: mem_service
+        app.dependency_overrides[get_raw_document_service] = lambda: raw_doc_service
+        app.dependency_overrides[get_current_user] = lambda: _make_user()
+
+        @app.middleware("http")
+        async def _inject(request, call_next):  # type: ignore[no-untyped-def]
+            request.state.user = {"workspace_ids": workspace_ids}
+            return await call_next(request)
+
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_agent_leg_scopes_to_requested_workspace_for_star_token(
+        self, settings: Settings, mem_service: MagicMock, raw_doc_service: AsyncMock
+    ) -> None:
+        client = self._client(
+            workspace_ids=["*"],
+            settings=settings,
+            mem_service=mem_service,
+            raw_doc_service=raw_doc_service,
+        )
+
+        resp = client.get("/api/v1/knowledge/records?origin=agent&workspace_id=ws-x")
+
+        assert resp.status_code == 200
+        assert mem_service.list_records.await_args.args[0] == "ws-x"
+
+    def test_forbidden_for_non_member(
+        self, settings: Settings, mem_service: MagicMock, raw_doc_service: AsyncMock
+    ) -> None:
+        client = self._client(
+            workspace_ids=["ws-a"],
+            settings=settings,
+            mem_service=mem_service,
+            raw_doc_service=raw_doc_service,
+        )
+
+        resp = client.get("/api/v1/knowledge/records?workspace_id=ws-x")
+
+        assert resp.status_code == 403
+        mem_service.list_records.assert_not_awaited()

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -1017,3 +1017,62 @@ class TestReviewResolve:
             json={"action": "keep"},
         )
         assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# ?workspace_id query scoping + access check (Control Center, family B)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceQueryScoping:
+    def _client(
+        self, *, workspace_ids: list[str], service: AsyncMock, settings: Settings
+    ) -> TestClient:
+        app = FastAPI()
+        app.state.settings = settings
+        app.include_router(memory_router, prefix="/api/v1")
+        app.dependency_overrides[get_memory_service] = lambda: service
+        app.dependency_overrides[get_current_user] = lambda: _make_user()
+
+        @app.middleware("http")
+        async def _inject(request, call_next):  # type: ignore[no-untyped-def]
+            request.state.user = {"workspace_ids": workspace_ids}
+            return await call_next(request)
+
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_search_scopes_to_requested_workspace_for_star_token(
+        self, service: AsyncMock, settings: Settings
+    ) -> None:
+        service.search.return_value = []
+        client = self._client(workspace_ids=["*"], service=service, settings=settings)
+
+        resp = client.post(
+            "/api/v1/memory/search?workspace_id=ws-x",
+            json={"query": "hello"},
+        )
+
+        assert resp.status_code == 200
+        passed_ws = service.search.await_args.args[0]
+        assert passed_ws == "ws-x"
+
+    def test_list_forbidden_for_non_member(
+        self, service: AsyncMock, settings: Settings
+    ) -> None:
+        client = self._client(workspace_ids=["ws-a"], service=service, settings=settings)
+
+        resp = client.get("/api/v1/memory/records?workspace_id=ws-x")
+
+        assert resp.status_code == 403
+        service.list_records.assert_not_awaited()
+
+    def test_list_without_param_uses_auth_derived(
+        self, service: AsyncMock, settings: Settings
+    ) -> None:
+        service.list_records.return_value = []
+        client = self._client(workspace_ids=["ws-a"], service=service, settings=settings)
+
+        resp = client.get("/api/v1/memory/records")
+
+        assert resp.status_code == 200
+        assert service.list_records.await_args.args[0] == "ws-a"

--- a/tests/unit/api/test_resolve_workspace_id.py
+++ b/tests/unit/api/test_resolve_workspace_id.py
@@ -1,5 +1,12 @@
 """Unit tests for resolve_workspace_id — query-aware workspace resolution
-with a JWT access check (family-B Control Center scoping)."""
+with a JWT access check (family-B Control Center scoping).
+
+After the PR-127 review the resolver is strict: empty/whitespace -> auth-derived
+fallback, explicit ``"*"`` -> 400, charset/length-violating input -> 400, and
+absence of access -> 403. There is no fail-open branch for empty ``workspace_ids``;
+admin tokens are normalised to ``["*"]`` by ``OptionalAuthMiddleware`` and by the
+email-login flow before they ever reach this resolver.
+"""
 
 from __future__ import annotations
 
@@ -20,9 +27,16 @@ def _request(*, workspace_ids: list[str], query: dict[str, str] | None = None) -
         AUTH_ENABLED=False,
         METATRON_SECRET_KEY="test-secret",
     )
+    # SimpleNamespace allows arbitrary attribute writes — the resolver memoises
+    # on ``request.state._workspace_id_cached``, so state must be writable.
     state = SimpleNamespace(user={"workspace_ids": workspace_ids})
     app = SimpleNamespace(state=SimpleNamespace(settings=settings))
     return SimpleNamespace(state=state, app=app, query_params=query or {})
+
+
+# ---------------------------------------------------------------------------
+# Absent / whitespace param -> auth-derived fallback
+# ---------------------------------------------------------------------------
 
 
 def test_absent_param_falls_back_to_auth_derived() -> None:
@@ -33,8 +47,18 @@ def test_absent_param_falls_back_to_auth_derived() -> None:
 
 def test_absent_param_star_token_uses_default() -> None:
     req = _request(workspace_ids=["*"], query={})
-    # default_workspace_id from Settings
     assert resolve_workspace_id(req) == req.app.state.settings.default_workspace_id
+
+
+def test_whitespace_only_param_treated_as_absent() -> None:
+    # ``%20%20`` survives URL decoding as "  "; strip -> empty -> auth-derived.
+    req = _request(workspace_ids=["ws-a"], query={"workspace_id": "   "})
+    assert resolve_workspace_id(req) == "ws-a"
+
+
+# ---------------------------------------------------------------------------
+# Access check
+# ---------------------------------------------------------------------------
 
 
 def test_star_token_grants_any_requested_workspace() -> None:
@@ -54,17 +78,20 @@ def test_non_member_request_is_forbidden() -> None:
     assert exc.value.status_code == 403
 
 
-def test_empty_workspace_ids_is_unrestricted() -> None:
-    # Empty list == unscoped (mirrors get_workspace_id's fallback semantics and
-    # the AUTH_ENABLED=false {} case). The default admin token has [].
+def test_empty_workspace_ids_is_forbidden() -> None:
+    # Strict: empty list = "confined to nothing", not "unrestricted".
+    # Admin tokens are normalised to ``["*"]`` upstream — see middleware and
+    # the email-login flow. If this test ever needs to flip, both upstream
+    # normalisation sites have to change too.
     req = _request(workspace_ids=[], query={"workspace_id": "ws-x"})
-    assert resolve_workspace_id(req) == "ws-x"
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 403
 
 
-def test_no_user_state_is_unrestricted() -> None:
-    # AUTH_ENABLED=false -> request.state.user == {} -> allowed == [] -> permit.
-    from types import SimpleNamespace
-
+def test_missing_user_state_is_forbidden() -> None:
+    # AUTH_ENABLED=true + missing user dict (shouldn't happen with the current
+    # middleware, but defence in depth): no workspace_ids -> 403, never silent.
     settings = Settings(
         METATRON_ENV="development",
         AUTH_ENABLED=False,
@@ -75,10 +102,69 @@ def test_no_user_state_is_unrestricted() -> None:
         app=SimpleNamespace(state=SimpleNamespace(settings=settings)),
         query_params={"workspace_id": "ws-x"},
     )
-    assert resolve_workspace_id(req) == "ws-x"
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 403
 
 
-def test_explicit_star_value_is_ignored() -> None:
-    # "*" is not a real workspace; treat as absent -> auth-derived
+def test_workspace_ids_as_string_does_not_substring_match() -> None:
+    # If a plugin auth backend ever returns ``workspace_ids`` as a bare string
+    # (schema drift for a single-workspace tenant), ``"ws" in "ws-acme"`` would
+    # otherwise be True. The resolver coerces non-list types to an empty list.
+    req = _request(workspace_ids=[], query={"workspace_id": "ws"})
+    req.state.user = {"workspace_ids": "ws-acme"}  # type: ignore[assignment]
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Input validation — 400s before any access check
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_star_value_is_rejected() -> None:
+    # ``"*"`` is a JWT wildcard, not a request target. Pre-fix it silently
+    # downgraded to the auth-derived default; now 400 explicitly.
     req = _request(workspace_ids=["*"], query={"workspace_id": "*"})
-    assert resolve_workspace_id(req) == req.app.state.settings.default_workspace_id
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 400
+
+
+def test_path_traversal_workspace_id_is_rejected() -> None:
+    # Closes the snapshot-service path traversal: ``../../tmp`` would otherwise
+    # have been concatenated into a filesystem path under the snapshot root.
+    req = _request(workspace_ids=["*"], query={"workspace_id": "../../tmp"})
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 400
+
+
+def test_overlong_workspace_id_is_rejected() -> None:
+    req = _request(workspace_ids=["*"], query={"workspace_id": "a" * 65})
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 400
+
+
+def test_invalid_charset_workspace_id_is_rejected() -> None:
+    req = _request(workspace_ids=["*"], query={"workspace_id": "ws with space"})
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Memoisation
+# ---------------------------------------------------------------------------
+
+
+def test_result_is_memoised_on_request_state() -> None:
+    # Single-source-of-truth: once resolved, subsequent calls within the same
+    # request return the cached value even if query_params mutates afterwards
+    # (defence against TOCTOU between router dep, DI helper, and handler).
+    req = _request(workspace_ids=["*"], query={"workspace_id": "ws-x"})
+    assert resolve_workspace_id(req) == "ws-x"
+    req.query_params = {"workspace_id": "ws-y"}  # type: ignore[assignment]
+    assert resolve_workspace_id(req) == "ws-x"

--- a/tests/unit/api/test_resolve_workspace_id.py
+++ b/tests/unit/api/test_resolve_workspace_id.py
@@ -1,0 +1,84 @@
+"""Unit tests for resolve_workspace_id — query-aware workspace resolution
+with a JWT access check (family-B Control Center scoping)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from metatron.api.dependencies import resolve_workspace_id
+from metatron.core.config import Settings
+
+
+def _request(*, workspace_ids: list[str], query: dict[str, str] | None = None) -> Any:
+    """Minimal stand-in for a FastAPI Request consumed by resolve_workspace_id."""
+    settings = Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=False,
+        METATRON_SECRET_KEY="test-secret",
+    )
+    state = SimpleNamespace(user={"workspace_ids": workspace_ids})
+    app = SimpleNamespace(state=SimpleNamespace(settings=settings))
+    return SimpleNamespace(state=state, app=app, query_params=query or {})
+
+
+def test_absent_param_falls_back_to_auth_derived() -> None:
+    # workspace_ids[0] (not "*") -> returned, query ignored
+    req = _request(workspace_ids=["ws-a", "ws-b"], query={})
+    assert resolve_workspace_id(req) == "ws-a"
+
+
+def test_absent_param_star_token_uses_default() -> None:
+    req = _request(workspace_ids=["*"], query={})
+    # default_workspace_id from Settings
+    assert resolve_workspace_id(req) == req.app.state.settings.default_workspace_id
+
+
+def test_star_token_grants_any_requested_workspace() -> None:
+    req = _request(workspace_ids=["*"], query={"workspace_id": "ws-x"})
+    assert resolve_workspace_id(req) == "ws-x"
+
+
+def test_member_token_grants_listed_workspace() -> None:
+    req = _request(workspace_ids=["ws-a", "ws-b"], query={"workspace_id": "ws-b"})
+    assert resolve_workspace_id(req) == "ws-b"
+
+
+def test_non_member_request_is_forbidden() -> None:
+    req = _request(workspace_ids=["ws-a"], query={"workspace_id": "ws-x"})
+    with pytest.raises(HTTPException) as exc:
+        resolve_workspace_id(req)
+    assert exc.value.status_code == 403
+
+
+def test_empty_workspace_ids_is_unrestricted() -> None:
+    # Empty list == unscoped (mirrors get_workspace_id's fallback semantics and
+    # the AUTH_ENABLED=false {} case). The default admin token has [].
+    req = _request(workspace_ids=[], query={"workspace_id": "ws-x"})
+    assert resolve_workspace_id(req) == "ws-x"
+
+
+def test_no_user_state_is_unrestricted() -> None:
+    # AUTH_ENABLED=false -> request.state.user == {} -> allowed == [] -> permit.
+    from types import SimpleNamespace
+
+    settings = Settings(
+        METATRON_ENV="development",
+        AUTH_ENABLED=False,
+        METATRON_SECRET_KEY="test-secret",
+    )
+    req = SimpleNamespace(
+        state=SimpleNamespace(user={}),
+        app=SimpleNamespace(state=SimpleNamespace(settings=settings)),
+        query_params={"workspace_id": "ws-x"},
+    )
+    assert resolve_workspace_id(req) == "ws-x"
+
+
+def test_explicit_star_value_is_ignored() -> None:
+    # "*" is not a real workspace; treat as absent -> auth-derived
+    req = _request(workspace_ids=["*"], query={"workspace_id": "*"})
+    assert resolve_workspace_id(req) == req.app.state.settings.default_workspace_id

--- a/tests/unit/test_dependencies_agent_registry.py
+++ b/tests/unit/test_dependencies_agent_registry.py
@@ -16,6 +16,7 @@ def test_event_bus_passed_into_agent_registry_service() -> None:
     req.app = app
     req.state = MagicMock()
     req.state.user = {"workspace_ids": ["ws_test"]}
+    req.query_params = {}
 
     svc = get_agent_registry_service(req)
     # Service must have the bus wired — same instance as the plugin manager's bus
@@ -29,6 +30,7 @@ def test_event_bus_reused_across_calls_same_workspace() -> None:
     req.app = app
     req.state = MagicMock()
     req.state.user = {"workspace_ids": ["ws_test"]}
+    req.query_params = {}
 
     svc1 = get_agent_registry_service(req)
     svc2 = get_agent_registry_service(req)

--- a/tests/unit/test_dependencies_agent_registry.py
+++ b/tests/unit/test_dependencies_agent_registry.py
@@ -17,6 +17,7 @@ def test_event_bus_passed_into_agent_registry_service() -> None:
     req.state = MagicMock()
     req.state.user = {"workspace_ids": ["ws_test"]}
     req.query_params = {}
+    req.state._workspace_id_cached = None
 
     svc = get_agent_registry_service(req)
     # Service must have the bus wired — same instance as the plugin manager's bus
@@ -31,6 +32,7 @@ def test_event_bus_reused_across_calls_same_workspace() -> None:
     req.state = MagicMock()
     req.state.user = {"workspace_ids": ["ws_test"]}
     req.query_params = {}
+    req.state._workspace_id_cached = None
 
     svc1 = get_agent_registry_service(req)
     svc2 = get_agent_registry_service(req)

--- a/tests/unit/test_dependencies_memory_event_bus.py
+++ b/tests/unit/test_dependencies_memory_event_bus.py
@@ -21,6 +21,7 @@ def test_event_bus_passed_into_memory_service() -> None:
     req.state = MagicMock()
     req.state.user = {"workspace_ids": ["ws_test"]}
     req.query_params = {}
+    req.state._workspace_id_cached = None
 
     svc = get_memory_service(req)
     assert svc._event_bus is app.state.plugin_manager.get_event_bus()

--- a/tests/unit/test_dependencies_memory_event_bus.py
+++ b/tests/unit/test_dependencies_memory_event_bus.py
@@ -20,6 +20,7 @@ def test_event_bus_passed_into_memory_service() -> None:
     req.app = app
     req.state = MagicMock()
     req.state.user = {"workspace_ids": ["ws_test"]}
+    req.query_params = {}
 
     svc = get_memory_service(req)
     assert svc._event_bus is app.state.plugin_manager.get_event_bus()


### PR DESCRIPTION
Control Center pages (Agent Registry, Memory Inspector, Knowledge) did not react to workspace switching because agents/memory/knowledge endpoints resolved workspace strictly from the JWT (and fell back to the default workspace for admin tokens). Introduces resolve_workspace_id, a query-aware resolver with a JWT access check, and attaches it via a router-level workspace_scope dependency on the agents/memory/knowledge/snapshots routers so ?workspace_id is declared in OpenAPI for every route (incl. resource-keyed ones — variant B) and 403 is enforced uniformly. Empty workspace_ids is treated as unrestricted to match get_workspace_id and the AUTH_ENABLED=false case (default admin token has []). MCP path and build_telemetry_context_cm are intentionally unchanged.