### PR TITLE
feat(rag-trace): full RAG debug trace — capture, persistence, read API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## [Unreleased]
 
 ### Added
+- feat(rag-trace): full RAG debug trace for answer debugging. Captures a self-contained per-request
+  trace (user message → resolve/expand/translate/classify → recall-per-channel with full candidate
+  text + scores → merge_and_score with per-signal breakdown → rerank → context_assembly with the
+  assembled prompt → generation with raw + final answer) and persists one `rag_debug_traces` row
+  (migration 024). New L3 module `retrieval/trace.py` (`RagTrace` accumulator + pure phase builders +
+  `maybe_create_trace`/`append_trace_footer` helpers); capture is threaded through
+  `hybrid_search_and_answer` via an optional `rag_trace` param (benchmarker `return_trace` path
+  untouched). New read API `GET /api/v1/traces/{trace_id}` + `GET /api/v1/traces` (viewer+,
+  workspace-scoped; reads NOT gated by the capture flag; 422 on non-UUID). The trace id is appended to
+  chat answers as a `— trace: <uuid>` footer. Rerank is captured after the ACL post-filter so
+  ACL-stripped chunks never enter the trace. New env vars `METATRON_RAG_TRACE_ENABLED` (default true)
+  and `METATRON_RAG_TRACE_FOOTER_ENABLED` (default true). Independent of `llm_generation_log`.
+  Frontend reference: `docs/RAG_TRACE_FRONTEND.md`. (No retention/cleanup yet — table grows unbounded.)
 - feat(memory-scopes): Phase 2 — session memory dual-write to PG + `lifetime` filter in Memory Inspector. `MemoryService.cache_session` now writes through to `memory_records` (Redis remains hot cache; PG write is best-effort, failures log `memory.session.pg_write_failed`). `GET /api/v1/knowledge/records` accepts `lifetime=persistent|session|all` (default `persistent`); response gains optional `session_id` and `ttl_expires_at` fields. Expired session rows are GC'd by a new `SessionGCPass` inside the existing freshness scheduled-scan loop (grace period via `METATRON_MEMORY_SESSION_GC_GRACE_HOURS`, default 24h). `/api/v1/memory/records?session_id=X` stays Redis-only for MCP back-compat.
 - feat(memory-scopes): unified knowledge view in Memory Inspector — new `GET /api/v1/knowledge/records?origin=agent|kb|all` endpoint that fans out across `memory_records` and `raw_documents`. `origin=all` uses `asyncio.gather` with partial-failure semantics (one leg down → 200 + `partial=true`; both down → 503). New L3 module `knowledge/` provides the `RawDocumentReadService` read facade. Zero schema migrations; zero new env vars; no changes to existing memory, MCP, or freshness surfaces. Audit: `docs/superpowers/2026-05-12-memory-scopes-audit.md`.
 - feat(MTRNIX-277): per-agent memory health observability — `GET /api/v1/agents/{id}/memory/health` (viewer+, read-only) returns total ACTIVE / archived counts, 30-day growth timeseries (`growth_timeseries`), unused-record count (`unused_records`), near-duplicate cluster metrics (`duplicate_ratio`, `duplicate_clusters_count`) via SimHash + hamming distance, and source-type distribution. Adds `last_accessed_at` (TIMESTAMPTZ) and `content_simhash` (BIGINT) columns to `memory_records` (migration 021); hybrid search updates `last_accessed_at` fire-and-forget after every result set. Backfill script at `scripts/backfill_memory_simhash.py`. New env vars: `METATRON_MEMORY_STALE_AFTER_DAYS` (30), `METATRON_MEMORY_DUPLICATE_HAMMING_THRESHOLD` (3). Foundation for the W9 memory-health dashboard.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,8 @@ Graph extraction is decoupled from sync (process_all_unsynced_graphs, graph-proc
 - METATRON_FRESHNESS_KB_STALE_AFTER_DAYS (90) — KB stale threshold in days (higher than memory's 30 because KB documents age more slowly)
 - METATRON_SNAPSHOT_DIR (./data/snapshots) — root directory for memory snapshot files (MTRNIX-272)
 - METATRON_SNAPSHOT_MAX_FILE_BYTES (268435456) — per-file size cap (256 MiB) for snapshot exports; exceeded → 413 (MTRNIX-272)
+- METATRON_RAG_TRACE_ENABLED (true) — master flag for RAG debug-trace **capture** (collect per-phase data + persist one `rag_debug_traces` row per traced chat request). false → no capture/persist (and transitively no footer). Does NOT gate the read endpoints — historical traces stay readable. Independent of `llm_generation_log`.
+- METATRON_RAG_TRACE_FOOTER_ENABLED (true) — append the user-visible `— trace: <uuid>` footer to chat answers (OAI + REST chat, stream + non-stream). Decoupled from capture so the footer can be hidden while still tracing. Deliberate dev-phase default; flip to false to suppress the tail without losing capture.
 - See core/config.py for full list
 
 ## External Agent Integration Surfaces
@@ -383,6 +385,12 @@ Today agent memory is not automatically added to /v1/chat/completions context.
   Session memory records are dual-written by `MemoryService.cache_session` to Redis (hot path)
   + PG (visible to Inspector); PG write is best-effort.
 - `/api/v1/documents`, `/api/v1/search` — document CRUD + search
+- `/api/v1/traces` — RAG debug-trace read API (viewer+, workspace-scoped). `GET /traces/{trace_id}`
+  returns the full phased trace JSONB (input → resolve/expand/translate/classify → recall →
+  merge_and_score → rerank → context_assembly → generation; 422 on non-UUID, 404 cross-workspace);
+  `GET /traces` lists recent lightweight rows. Reads are NOT gated by `METATRON_RAG_TRACE_ENABLED`.
+  Backed by `rag_debug_traces` (migration 024) + `retrieval/trace.py` (`RagTrace` accumulator).
+  Frontend reference: `docs/RAG_TRACE_FRONTEND.md`.
 - `/api/v1/workspaces`, `/api/v1/connections`, `/api/v1/sync` — admin surfaces
 
 ### Current chat front-end: OpenWebUI (bundled mode in active use)

--- a/docs/RAG_TRACE_FRONTEND.md
+++ b/docs/RAG_TRACE_FRONTEND.md
@@ -1,0 +1,253 @@
+# RAG Debug Trace — Frontend Reference
+
+## What it is and why
+
+The backend records a **full trace of every RAG request** — everything that happened from the
+user's message to the final answer: query rewriting, classification, what each recall channel found
+with scores, what the reranker kept, the exact prompt sent to the LLM, and the raw vs. final answer.
+
+**Purpose of the page:** debug "strange sources" and "nonsense answers". The user takes a `trace_id`
+(it arrives as a footer in the answer itself — see below), opens the page, and sees step by step why
+a given document ended up in the answer and what actually went into the model.
+
+**Where the `trace_id` comes from:** every assistant answer gets a footer `\n\n— trace: <uuid>`.
+Parse it like this:
+
+```ts
+const m = answer.match(/—\s*trace:\s*([0-9a-f-]{36})/i);
+const traceId = m?.[1] ?? null;
+// to display the answer without the tail:
+const clean = answer.replace(/\n*—\s*trace:\s*[0-9a-f-]{36}\s*$/i, "");
+```
+
+---
+
+## Endpoints
+
+Base: `/api/v1/traces`. **Auth: JWT Bearer** (same as `/memory`, `/knowledge`, `/agents`) — i.e.
+`require_viewer`. The OpenAI-compat key (`mtk_…` / `metatron-test-key`) does **not** work here; a
+normal login token is required. Workspace is taken from the token; you may optionally pass
+`?workspace_id=<id>` (access-checked against the token, else 403).
+
+### 1. Trace detail
+```
+GET /api/v1/traces/{trace_id}
+```
+- **200** → a `RagTrace` object (see interface below).
+- **404** → not found OR belongs to another workspace (isolation).
+- **422** → `trace_id` is not a valid UUID.
+- **401** → missing/invalid Bearer token.
+- Reads are **not** gated by the `METATRON_RAG_TRACE_ENABLED` flag — historical traces are always readable.
+
+### 2. Recent traces list
+```
+GET /api/v1/traces?limit=20&offset=0
+```
+- `limit` 1..100 (default 20), `offset` 0..10000.
+- **200** → `RagTraceListResponse` (lightweight rows, no heavy JSONB — for a table/feed).
+
+---
+
+## Full interface (TypeScript)
+
+> Every field below is actually present in a recorded trace (verified on live records). Numbers are
+> JSON numbers, ids are strings. A candidate's `source` is the **source type** (`"jira"`,
+> `"confluence"`, `"upload"`, `"notion"`, …) — handy for icons.
+
+```ts
+// ───────────────────────── LIST ─────────────────────────
+interface RagTraceListResponse {
+  traces: RagTraceListItem[];
+  count: number;   // number of rows in THIS page (not a grand total — see notes)
+  limit: number;
+  offset: number;
+}
+
+interface RagTraceListItem {
+  trace_id: string;            // uuid
+  created_at: string | null;   // ISO8601
+  query: string;               // = input.raw_user_message
+  source: string | null;       // "oai_compat" | "rest" | ...
+  total_ms: number;
+}
+
+// ─────────────────────── DETAIL (GET /{id}) ───────────────────────
+interface RagTrace {
+  trace_id: string;                 // uuid, matches the answer footer
+  source: string | null;            // surface: "oai_compat" | "rest"
+  workspace_id: string | null;
+  user_id: string | null;
+  agent_id: string | null;          // null for chat/OAI; populated for MCP agents later
+  input: TraceInput;
+  phases: Phase[];                  // always in order (see union below)
+  total_ms: number;                 // full pipeline time, ms
+  created_at: string | null;        // ISO8601 — merged in from the row
+}
+
+interface TraceInput {
+  raw_user_message: string;         // the user's original message
+  history: string[];                // ⚠️ currently always [] (context is folded into composite_query)
+  composite_query: string | null;   // history-aware query — what actually entered the pipeline
+}
+
+// ───────────────────────── PHASES ─────────────────────────
+// Discriminator is the `name` field. Array order:
+// resolve_query → query_expansion → translate_query → classify →
+// recall → merge_and_score → rerank → context_assembly → generation
+type Phase =
+  | LlmStepPhase       // resolve_query | query_expansion | translate_query
+  | ClassifyPhase
+  | RecallPhase
+  | MergePhase
+  | RerankPhase
+  | ContextPhase
+  | GenerationPhase;
+
+// Preprocessing steps (LLM calls); input/output are strings
+interface LlmStepPhase {
+  name: "resolve_query" | "query_expansion" | "translate_query";
+  type: "llm";
+  input: string;
+  output: string;
+}
+
+interface ClassifyPhase {
+  name: "classify";
+  type: "llm";
+  output: {
+    profile: string;       // "execution" | "documentation" | "user_file" | "relationship" | "temporal" | "mixed"
+    method: string;        // "rule" | "llm" | "disabled"
+    confidence: number;    // 0..1
+  };
+}
+
+// Candidate from a recall channel (carries raw_score)
+interface RecallCandidate {
+  chunk_id: string;
+  doc_label: string;
+  title: string;
+  source: string;          // source type for the icon (jira/confluence/...)
+  text: string;            // FULL chunk text (can be large)
+  raw_score: number;       // raw channel score
+}
+
+interface RecallChannel {
+  count: number;
+  candidates: RecallCandidate[];
+}
+
+interface RecallPhase {
+  name: "recall";
+  channels: {
+    dense: RecallChannel;
+    exact: RecallChannel;
+    metadata: RecallChannel;
+    graph: RecallChannel;
+  };
+}
+
+// Candidate after merge + scoring (no raw_score, but with a per-signal breakdown)
+interface MergeCandidate {
+  chunk_id: string;
+  doc_label: string;
+  title: string;
+  source: string;
+  text: string;
+  found_by: string[];                       // which channels found it, e.g. ["dense","graph"]
+  channel_scores: Record<string, number>;   // raw per-channel scores, e.g. {"dense":0.02}
+  recency: number | null;                   // recency signal
+  balance: number | null;                   // source-balance signal
+  signal_score: number;                     // final weighted signal score
+}
+
+interface MergePhase {
+  name: "merge_and_score";
+  weights: Record<string, number>;          // profile weights: dense_weight, graph_weight, metadata_weight, recency_weight, balance_weight (+ freshness_weight if active)
+  candidates: MergeCandidate[];             // the WHOLE pool before the confidence filter
+  dropped_by_min_signal: string[];          // chunk_ids dropped by MIN_SIGNAL_SCORE (default [] — filter off)
+}
+
+// Candidate after the reranker
+interface RerankCandidate {
+  chunk_id: string;
+  doc_label: string;
+  title: string;
+  source: string;
+  text: string;
+  rerank_score: number;     // cross-encoder score (normalized)
+  final_score: number;      // blended signal+rerank — the output ordering
+  kept: boolean;            // in the final set (currently always true: the phase holds only the kept top-k, captured AFTER the ACL post-filter)
+}
+
+interface RerankPhase {
+  name: "rerank";
+  enabled: boolean;         // whether the reranker ran (RERANKER_ENABLED)
+  pool_size: number;        // size of the pool sent to the reranker
+  candidates: RerankCandidate[];
+}
+
+interface Fragment {
+  doc_label: string;
+  title: string;
+  text: string;
+}
+
+interface ContextPhase {
+  name: "context_assembly";
+  primary_fragments: Fragment[];      // PRIMARY evidence
+  supporting_fragments: Fragment[];   // SUPPORTING evidence
+  graph: {
+    entities: GraphItem[];            // graph entities (name/type/aliases, ...)
+    relations: GraphItem[];           // relations (source/target/type)
+    docs: GraphItem[];                // doc labels/nodes from the graph
+  };
+  assembled_prompt: string;           // the FULL context actually sent to the LLM (user part of the prompt)
+}
+
+// Graph items are objects of arbitrary shape (depends on graph data).
+// Typed loosely; common fields are optional.
+interface GraphItem {
+  name?: string;
+  type?: string;
+  source?: string;
+  target?: string;
+  [k: string]: unknown;
+}
+
+// Generation: either success or error
+type GenerationPhase = GenerationOk | GenerationError;
+
+interface GenerationOk {
+  name: "generation";
+  provider: string;        // "deepseek" | "ollama" | "openrouter" | "custom"
+  model: string;           // e.g. "deepseek-chat"
+  raw_answer: string;      // model output BEFORE the sources block is appended
+  final_answer: string;    // final answer WITH sources (without the trace footer)
+}
+
+interface GenerationError {
+  name: "generation";
+  error: string;           // e.g. "llm_answer_failed"
+  raw_answer: null;
+  // provider/model/final_answer are absent in this branch
+}
+```
+
+---
+
+## Notes (important for the UI)
+
+- **`raw_score` exists only on `RecallCandidate`.** In merge it's `channel_scores` + `signal_score`,
+  in rerank it's `rerank_score` / `final_score`. Don't look for the same field across all phases.
+- **`text` is stored in full** in every candidate (recall/merge/rerank) and in fragments — strings can
+  be large (tens of KB combined). Collapse / lazy-expand them on the page.
+- **A candidate's `source` is the source type** (jira/confluence/upload/notion). Icon mapping is the
+  same as the main UI: 📄 confluence, 📋 jira, 📎 upload, 📓 notion.
+- **`agent_id` is currently `null`** for chat/OAI (will be populated once tracing is wired into MCP agents).
+- **`history` is currently always `[]`** — history is folded into `composite_query`.
+- **`count` in the list response is the page size**, not a grand total; paginate via `limit`/`offset`
+  and stop when fewer than `limit` rows come back.
+- **Phase order is fixed**, but a phase can collapse (e.g. `recall.channels.exact.count = 0`). Render by
+  the data actually present, not by index.
+- **The `GenerationError` branch** appears when the LLM call failed — the phase carries `error` and no
+  `final_answer`. The trace is still persisted (partial — up to the point of failure).

--- a/migrations/versions/024_rag_debug_traces.py
+++ b/migrations/versions/024_rag_debug_traces.py
@@ -1,0 +1,57 @@
+"""Add rag_debug_traces table (RAG debug trace).
+
+One row per traced chat request, keyed by the request correlation_id.
+Self-contained full pipeline trace for answer debugging. Independent of
+llm_generation_log.
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-06-02
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "024"
+down_revision: str | None = "023"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rag_debug_traces",
+        sa.Column("trace_id", UUID(as_uuid=False), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("workspace_id", sa.Text(), nullable=True),
+        sa.Column("user_id", sa.Text(), nullable=True),
+        sa.Column("agent_id", sa.Text(), nullable=True),
+        sa.Column("source", sa.Text(), nullable=True),
+        sa.Column("query", sa.Text(), nullable=False),
+        sa.Column("total_ms", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("trace", JSONB(), nullable=False),
+        sa.PrimaryKeyConstraint("trace_id"),
+    )
+    op.create_index(
+        "ix_rag_debug_traces_ws_created",
+        "rag_debug_traces",
+        ["workspace_id", sa.text("created_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_rag_debug_traces_ws_created", table_name="rag_debug_traces")
+    op.drop_table("rag_debug_traces")

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -34,6 +34,7 @@ from metatron.api.routes import (
     skills,
     snapshots,
     sync,
+    traces,
     users,
     workspaces,
 )
@@ -360,6 +361,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(knowledge.router, prefix="/api/v1")
     app.include_router(agents.router, prefix="/api/v1")
     app.include_router(snapshots.router, prefix="/api/v1")
+    app.include_router(traces.router, prefix="/api/v1")
 
     from metatron.api.routes.finops import router as finops_router
 

--- a/src/metatron/api/routes/chat.py
+++ b/src/metatron/api/routes/chat.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
 from metatron.api.dependencies import build_telemetry_context_cm
+from metatron.retrieval.trace import append_trace_footer, maybe_create_trace
 
 logger = structlog.get_logger()
 
@@ -83,7 +84,10 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
 
     plugin_manager = getattr(request.app.state, "plugin_manager", None)
 
-    with build_telemetry_context_cm(request, source="rest"):
+    with build_telemetry_context_cm(request, source="rest") as tctx:
+        rag_trace = maybe_create_trace(
+            tctx, raw_user_message=req.question, composite_query=composite_query
+        )
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
@@ -95,6 +99,7 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
                 intent_query=req.question,
                 plugin_manager=plugin_manager,
                 source="rest",
+                rag_trace=rag_trace,
             )
         except Exception as exc:
             logger.error("chat.error", error=str(exc), exc_info=True)
@@ -112,6 +117,10 @@ async def chat(req: ChatRequest, request: Request) -> ChatResponse:
             oldest = list(_conversation_history.keys())[:50]
             for uid in oldest:
                 del _conversation_history[uid]
+
+    answer = append_trace_footer(
+        answer, rag_trace, enabled=request.app.state.settings.rag_trace_footer_enabled
+    )
 
     return ChatResponse(answer=answer, workspace_id=workspace_id)
 
@@ -185,7 +194,10 @@ async def chat_stream(req: ChatRequest, request: Request) -> EventSourceResponse
 
         plugin_manager = getattr(request.app.state, "plugin_manager", None)
 
-        with build_telemetry_context_cm(request, source="rest"):
+        with build_telemetry_context_cm(request, source="rest") as tctx:
+            rag_trace = maybe_create_trace(
+                tctx, raw_user_message=req.question, composite_query=composite_query
+            )
             try:
                 from metatron.retrieval.search import hybrid_search_and_answer
 
@@ -197,6 +209,7 @@ async def chat_stream(req: ChatRequest, request: Request) -> EventSourceResponse
                     intent_query=req.question,
                     plugin_manager=plugin_manager,
                     source="rest",
+                    rag_trace=rag_trace,
                 )
             except Exception as exc:
                 logger.error("chat.stream.error", error=str(exc), exc_info=True)
@@ -217,6 +230,9 @@ async def chat_stream(req: ChatRequest, request: Request) -> EventSourceResponse
                 del hist[:-20]
 
         body, sources = extract_sources_section(answer)
+        body = append_trace_footer(
+            body, rag_trace, enabled=request.app.state.settings.rag_trace_footer_enabled
+        )
 
         yield {"event": "status", "data": json.dumps({"status": "answering"})}
 

--- a/src/metatron/api/routes/openai_compat.py
+++ b/src/metatron/api/routes/openai_compat.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict
 
 from metatron.llm.telemetry import set_telemetry_context
+from metatron.retrieval.trace import append_trace_footer, maybe_create_trace
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -374,6 +375,7 @@ async def _stream_response(
     completion_id: str,
     created: int,
     plugin_manager: object | None = None,
+    footer_enabled: bool = False,
 ) -> AsyncGenerator[str, None]:
     """Generate OpenAI-format SSE stream from search pipeline."""
     import asyncio
@@ -399,7 +401,10 @@ async def _stream_response(
         user_id=user_id,
         source="oai_compat",
         correlation_id=uuid4(),
-    ):
+    ) as tctx:
+        rag_trace = maybe_create_trace(
+            tctx, raw_user_message=user_message, composite_query=composite_query
+        )
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
@@ -410,6 +415,7 @@ async def _stream_response(
                 intent_query=user_message,
                 plugin_manager=plugin_manager,
                 source="oai_compat",
+                rag_trace=rag_trace,
             )
         except Exception as exc:
             logger.error("openai_compat.stream.error", error=str(exc), exc_info=True)
@@ -422,6 +428,7 @@ async def _stream_response(
     body, sources = extract_sources_section(answer)
     body = _resolve_reference_markers(body, sources)
     final_content = body + _sources_to_markdown(sources)
+    final_content = append_trace_footer(final_content, rag_trace, enabled=footer_enabled)
 
     # Stream answer in sentence chunks
     for sentence in split_into_sentences(final_content):
@@ -475,6 +482,9 @@ async def _legacy_chat_completions_inline(
     composite_query = _build_composite_query(req.messages, user_message)
 
     if req.stream:
+        # append_trace_footer no-ops when no trace was created, so the footer flag
+        # alone is sufficient (capture-off => rag_trace is None => no footer).
+        footer_enabled = request.app.state.settings.rag_trace_footer_enabled
         return StreamingResponse(
             _stream_response(
                 composite_query,
@@ -485,6 +495,7 @@ async def _legacy_chat_completions_inline(
                 completion_id,
                 created,
                 plugin_manager,
+                footer_enabled,
             ),
             media_type="text/event-stream",
         )
@@ -495,7 +506,10 @@ async def _legacy_chat_completions_inline(
         user_id=user_id,
         source="oai_compat",
         correlation_id=uuid4(),
-    ):
+    ) as tctx:
+        rag_trace = maybe_create_trace(
+            tctx, raw_user_message=user_message, composite_query=composite_query
+        )
         try:
             from metatron.retrieval.search import hybrid_search_and_answer
 
@@ -506,6 +520,7 @@ async def _legacy_chat_completions_inline(
                 intent_query=user_message,
                 plugin_manager=plugin_manager,
                 source="oai_compat",
+                rag_trace=rag_trace,
             )
         except Exception as exc:
             logger.error("openai_compat.search_error", error=str(exc), exc_info=True)
@@ -517,6 +532,9 @@ async def _legacy_chat_completions_inline(
     body, sources = extract_sources_section(answer)
     body = _resolve_reference_markers(body, sources)
     final_content = body + _sources_to_markdown(sources)
+    final_content = append_trace_footer(
+        final_content, rag_trace, enabled=request.app.state.settings.rag_trace_footer_enabled
+    )
 
     return {
         "id": completion_id,
@@ -567,9 +585,7 @@ async def chat_completions(req: ChatCompletionRequest, request: Request):
 
     builder = getattr(request.app.state, "proxy_service_builder", None)
     if builder is not None:
-        user_id = (
-            getattr(request.state, "openai_user_id", None) or req.user or "openai-default"
-        )
+        user_id = getattr(request.state, "openai_user_id", None) or req.user or "openai-default"
         plugin_manager = getattr(request.app.state, "plugin_manager", None)
         service = builder(workspace_id)
         return await service.dispatch(

--- a/src/metatron/api/routes/traces.py
+++ b/src/metatron/api/routes/traces.py
@@ -1,0 +1,79 @@
+"""RAG debug trace read API — /api/v1/traces.
+
+Read-only viewer surface for persisted RAG debug traces. NOT gated by
+``METATRON_RAG_TRACE_ENABLED`` — historical traces stay readable even after
+capture is turned off. Workspace-scoped: a trace id from another workspace 404s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated, Any
+from uuid import UUID  # noqa: TC003 — runtime import: FastAPI resolves the path-param annotation
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from metatron.api.dependencies import resolve_workspace_id
+from metatron.auth.dependencies import require_viewer
+from metatron.core.models import User  # noqa: TC001 — FastAPI Annotated DI needs runtime import
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/traces", tags=["traces"])
+
+
+class RagTraceListItem(BaseModel):
+    trace_id: str
+    created_at: str | None
+    query: str
+    source: str | None
+    total_ms: float
+
+
+class RagTraceListResponse(BaseModel):
+    traces: list[RagTraceListItem]
+    count: int
+    limit: int
+    offset: int
+
+
+@router.get("/{trace_id}")
+async def get_trace(
+    trace_id: UUID,
+    request: Request,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+) -> dict[str, Any]:
+    """Fetch one full trace JSONB. 404 if missing or in another workspace.
+
+    ``trace_id`` is typed as ``UUID`` so malformed ids return 422 (not a 500 from
+    a PG ``invalid input syntax for type uuid``).
+    """
+    workspace_id = resolve_workspace_id(request)
+    from metatron.storage.pg_connection import get_rag_trace_sync
+
+    trace = await asyncio.to_thread(get_rag_trace_sync, workspace_id, str(trace_id))
+    if trace is None:
+        raise HTTPException(status_code=404, detail="trace not found")
+    return trace
+
+
+@router.get("", response_model=RagTraceListResponse)
+async def list_traces(
+    request: Request,
+    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
+    limit: int = Query(20, ge=1, le=100),  # noqa: B008
+    offset: int = Query(0, ge=0, le=10000),  # noqa: B008
+) -> RagTraceListResponse:
+    """List recent traces for the workspace (newest-first), lightweight rows."""
+    workspace_id = resolve_workspace_id(request)
+    from metatron.storage.pg_connection import list_rag_traces_sync
+
+    rows = await asyncio.to_thread(list_rag_traces_sync, workspace_id, limit, offset)
+    return RagTraceListResponse(
+        traces=[RagTraceListItem(**r) for r in rows],
+        count=len(rows),
+        limit=limit,
+        offset=offset,
+    )

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -388,9 +388,7 @@ class Settings(BaseSettings):
     proxy_upstream_timeout_ms: int = Field(
         default=120000, alias="METATRON_PROXY_UPSTREAM_TIMEOUT_MS"
     )
-    proxy_knowledge_top_k: int = Field(
-        default=5, alias="METATRON_PROXY_KNOWLEDGE_TOP_K"
-    )
+    proxy_knowledge_top_k: int = Field(default=5, alias="METATRON_PROXY_KNOWLEDGE_TOP_K")
     proxy_entity_trie_ttl_seconds: int = Field(
         default=600, alias="METATRON_PROXY_ENTITY_TRIE_TTL_SECONDS"
     )
@@ -399,6 +397,20 @@ class Settings(BaseSettings):
     )
     proxy_default_upstream_key: str = Field(
         default="", alias="METATRON_PROXY_DEFAULT_UPSTREAM_KEY"
+    )
+
+    # --- RAG debug trace (full pipeline trace for answer debugging) ---
+    rag_trace_enabled: bool = Field(
+        default=True,
+        alias="METATRON_RAG_TRACE_ENABLED",
+        description="Master flag for RAG debug-trace capture (collect phases + persist row). "
+        "Does NOT gate the read endpoints.",
+    )
+    rag_trace_footer_enabled: bool = Field(
+        default=True,
+        alias="METATRON_RAG_TRACE_FOOTER_ENABLED",
+        description="Append the '— trace: <id>' footer to the user-visible answer. "
+        "Independent of capture so the tail can be hidden while still tracing.",
     )
 
     @property

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -13,6 +13,7 @@ import structlog
 
 if TYPE_CHECKING:
     from metatron.core.events import EventBus
+    from metatron.retrieval.trace import RagTrace
 
 from metatron.core.config import Settings
 from metatron.core.events import DOCUMENT_ACCESSED, QUERY_EXECUTED
@@ -59,6 +60,13 @@ from metatron.retrieval.token_budget import (
     select_fragments_within_budget,
     truncate_graph_context,
 )
+from metatron.retrieval.trace import (
+    build_context_phase,
+    build_merge_phase,
+    build_recall_phase,
+    build_rerank_phase,
+    is_trace_enabled,
+)
 from metatron.storage.graph_ops import (  # TODO: async migration
     get_doc_labels_by_entities,
     get_entities_by_doc_labels,
@@ -69,6 +77,23 @@ from metatron.storage.graph_ops import (  # TODO: async migration
 
 logger = structlog.get_logger()
 _s = Settings()
+
+# Maps the active LLM provider to the Settings attribute holding its model name,
+# so the rag_trace generation phase records the real model (Settings has no
+# single ``llm_model`` field — the name is provider-specific).
+_PROVIDER_MODEL_ATTR = {
+    "ollama": "ollama_llm_model",
+    "deepseek": "deepseek_model",
+    "openrouter": "openrouter_model",
+    "custom": "custom_llm_model",
+}
+
+
+def _active_llm_model(settings: Settings) -> str:
+    """Resolve the configured model name for the active provider (best-effort)."""
+    return getattr(settings, _PROVIDER_MODEL_ATTR.get(settings.llm_provider, ""), "") or ""
+
+
 _MAX_TOTAL, _MAX_FRAG = _s.search_max_total_chars, _s.search_max_fragment_chars
 _GRAPH_DEPTH = int(getattr(_s, "search_graph_depth", 2))
 
@@ -881,6 +906,7 @@ async def hybrid_search_and_answer(  # noqa: C901
     *,
     source: str = "rest",
     session_id: str | None = None,
+    rag_trace: RagTrace | None = None,
 ) -> str | dict:
     """End-to-end hybrid search and answer generation (async)."""
     import time
@@ -889,6 +915,24 @@ async def hybrid_search_and_answer(  # noqa: C901
 
     start_time = time.time()
     agent_id = current_agent_id.get()
+
+    if rag_trace is not None:
+        rag_trace.source = source
+        rag_trace.workspace_id = workspace_id
+        rag_trace.user_id = user_id
+        rag_trace.agent_id = agent_id
+
+    async def _persist_rag_trace() -> None:
+        """Persist the debug trace (gated by flag). Never raises into the answer path."""
+        if rag_trace is None or not is_trace_enabled():
+            return
+        try:
+            rag_trace.total_ms = (time.time() - start_time) * 1000
+            from metatron.storage.pg_connection import store_rag_trace_sync
+
+            await asyncio.to_thread(store_rag_trace_sync, rag_trace.to_dict())
+        except Exception:
+            logger.warning("rag_trace.persist_failed", exc_info=True)
 
     raw_query = (intent_query or query or "").strip()
     # Resolve contextual references (relative dates, pronouns) using the full
@@ -902,10 +946,17 @@ async def hybrid_search_and_answer(  # noqa: C901
     use_schema = should_use_team_workflow_schema(rq)
     lang = detect_response_language(rq)
 
+    if rag_trace is not None:
+        rag_trace.phase("resolve_query", type="llm", input=rq_original, output=rq)
+
     # Expand query for better BM25 recall (adds status keywords, synonyms)
     eq = await asyncio.to_thread(expand_query, rq)
+    if rag_trace is not None:
+        rag_trace.phase("query_expansion", type="llm", input=rq, output=eq)
     # Translate expanded query for vector/BM25 search if it has Cyrillic
     sq = await asyncio.to_thread(translate_query_to_english, eq) if _has_cyrillic(eq) else eq
+    if rag_trace is not None:
+        rag_trace.phase("translate_query", type="llm", input=eq, output=sq)
 
     # -- Classify query intent --
     if _s.query_classifier_enabled:
@@ -923,6 +974,17 @@ async def hybrid_search_and_answer(  # noqa: C901
         )
     else:
         classification = {"profile": "mixed", "confidence": 1.0, "method": "disabled"}
+
+    if rag_trace is not None:
+        rag_trace.phase(
+            "classify",
+            type="llm",
+            output={
+                "profile": classification["profile"],
+                "method": classification["method"],
+                "confidence": classification["confidence"],
+            },
+        )
 
     _profile_weights = get_profile_weights(classification["profile"])
 
@@ -983,6 +1045,11 @@ async def hybrid_search_and_answer(  # noqa: C901
     # -- Merge and deduplicate across channels --
     merged = merge_channels([dense_results, exact_results, metadata_results, graph_results])
 
+    if rag_trace is not None:
+        rag_trace.phase(
+            **build_recall_phase(dense_results, exact_results, metadata_results, graph_results)
+        )
+
     # -- Build per-channel doc provenance for activity logging (DOCUMENT_ACCESSED) --
     # MergedResult.channels is list[str]; chunk_id is the stable identifier.
     docs_by_channel: dict[str, list[str]] = {}
@@ -1000,6 +1067,7 @@ async def hybrid_search_and_answer(  # noqa: C901
 
     _scoring_weights = {k: v for k, v in _profile_weights.items() if k != "blend_weight"}
 
+    signal_components: dict[str, dict[str, float]] = {}
     for mr in merged:
         mem = mr["memory"]
         date_str = mem.get("date") or (mem.get("payload") or {}).get("date")
@@ -1017,11 +1085,29 @@ async def hybrid_search_and_answer(  # noqa: C901
             balance=bal,
             **_scoring_weights,
         )
+        if rag_trace is not None:
+            signal_components[mr["chunk_id"]] = {"recency": rec, "balance": bal}
 
     # Build score_map keyed by chunk_id (no mutation of memory dicts)
     score_map: dict[str, float] = {mr["chunk_id"]: mr.get("signal_score", 0) for mr in merged}
 
     merged.sort(key=lambda x: x.get("signal_score", 0), reverse=True)
+
+    # -- Capture merge_and_score (full scored set, before the confidence filter) --
+    if rag_trace is not None:
+        _dropped_ids = (
+            [mr["chunk_id"] for mr in merged if score_map[mr["chunk_id"]] < _s.min_signal_score]
+            if _s.min_signal_score > 0
+            else []
+        )
+        rag_trace.phase(
+            **build_merge_phase(
+                merged,
+                weights=_scoring_weights,
+                signal_components=signal_components,
+                dropped_ids=_dropped_ids,
+            )
+        )
 
     # -- Confidence filter: drop candidates below threshold --
     if _s.min_signal_score > 0:
@@ -1030,6 +1116,7 @@ async def hybrid_search_and_answer(  # noqa: C901
             no_info = "I don't have enough information to answer this question."
             if lang.lower() == "russian":
                 no_info = "У меня недостаточно информации для ответа на этот вопрос."
+            await _persist_rag_trace()
             if return_trace:
                 return {
                     "answer": no_info,
@@ -1102,6 +1189,14 @@ async def hybrid_search_and_answer(  # noqa: C901
         for hook in plugin_manager.get_pipeline_hooks("search_post_rerank"):
             post_ctx = await hook(post_ctx)
         base = post_ctx.get("chunks", base)
+
+    # Capture rerank AFTER the ACL post-filter so chunks an ACL hook stripped never
+    # land in the trace (the read endpoint is workspace-scoped but not ACL-group-scoped,
+    # so a captured-but-filtered chunk would be a cross-group leak channel).
+    if rag_trace is not None:
+        rag_trace.phase(
+            **build_rerank_phase(base, score_map, pool_size=pool_size, enabled=_s.reranker_enabled)
+        )
 
     frags, seen_h, total_c, doc_stats = _collect_frags(base, set(), 0)
     _mark_evidence_role(frags, classification["profile"])
@@ -1178,6 +1273,9 @@ async def hybrid_search_and_answer(  # noqa: C901
     # regular mode: use full composite query to leverage conversation context for follow-ups
     ctx = _build_ctx(rq if use_schema else query, lang, frags, g_ents, g_rels, g_docs)
 
+    if rag_trace is not None:
+        rag_trace.phase(**build_context_phase(frags, g_ents, g_rels, g_docs, assembled_prompt=ctx))
+
     # Stash the assembled context on the telemetry ContextVar so emit_log can
     # include it in the rag_answer row's metadata.retrieved_context field.
     update_retrieved_context(ctx)
@@ -1231,13 +1329,27 @@ async def hybrid_search_and_answer(  # noqa: C901
     except Exception:
         logger.error("search.llm_answer_failed", exc_info=True)
         n = len(base)
+        if rag_trace is not None:
+            rag_trace.phase("generation", error="llm_answer_failed", raw_answer=None)
+        await _persist_rag_trace()
         return f"Found {n} relevant documents but couldn't generate an answer. Please try again."
+
+    answer_with_sources = _append_sources(answer, base)
+
+    if rag_trace is not None:
+        rag_trace.phase(
+            "generation",
+            provider=_s.llm_provider,
+            model=_active_llm_model(_s),
+            raw_answer=answer,
+            final_answer=answer_with_sources,
+        )
 
     # Return full trace for benchmarker integration when requested
     if return_trace:
         _token_budget_used = sum(len(f["text"]) for f in frags) // 4 if frags else 0
         result = {
-            "answer": _append_sources(answer, base),
+            "answer": answer_with_sources,
             "source_results": base,
             "fragments": frags,
             "graph_entities": g_ents,
@@ -1273,7 +1385,7 @@ async def hybrid_search_and_answer(  # noqa: C901
             "retrieved_doc_labels": [r.get("doc_label", "") for r in base if r.get("doc_label")],
         }
     else:
-        result = _append_sources(answer, base)
+        result = answer_with_sources
 
     # Log query trace to PostgreSQL (async, non-blocking)
     if workspace_id:
@@ -1340,6 +1452,8 @@ async def hybrid_search_and_answer(  # noqa: C901
         )
     except Exception:  # noqa: BLE001 — observability must never break search
         logger.exception("activity_log.search_emit_failed")
+
+    await _persist_rag_trace()
 
     return result
 

--- a/src/metatron/retrieval/trace.py
+++ b/src/metatron/retrieval/trace.py
@@ -1,0 +1,256 @@
+"""RAG debug trace — accumulator + pure phase builders (MTRNIX).
+
+A ``RagTrace`` is seeded by chat entry-points with the request ``correlation_id``
+and passed into ``hybrid_search_and_answer``, which fills context fields and
+appends one dict per pipeline phase. The full structure is persisted to
+``rag_debug_traces`` and read back by ``/api/v1/traces``. Self-contained:
+deliberately duplicates prompt/answer rather than joining to llm_generation_log.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from metatron.core.config import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from uuid import UUID
+
+    from metatron.llm.telemetry import TelemetryContext
+
+
+def is_trace_enabled() -> bool:
+    """True when RAG debug-trace capture is on (master flag)."""
+    return get_settings().rag_trace_enabled
+
+
+def footer_for(trace_id: UUID) -> str:
+    """The user-visible answer footer carrying the trace id."""
+    return f"\n\n— trace: {trace_id}"
+
+
+def maybe_create_trace(
+    tctx: TelemetryContext,
+    *,
+    raw_user_message: str,
+    composite_query: str | None = None,
+    history: list[str] | None = None,
+) -> RagTrace | None:
+    """Seed a RagTrace from the request's telemetry context, or None if capture is off.
+
+    Single entry-point helper so chat / OAI (stream + non-stream) don't each
+    repeat the enabled-check + ``RagTrace(...)`` + ``set_input`` dance.
+    """
+    if not is_trace_enabled() or tctx.correlation_id is None:
+        return None
+    trace = RagTrace(trace_id=tctx.correlation_id)
+    trace.set_input(
+        raw_user_message=raw_user_message,
+        history=history,
+        composite_query=composite_query,
+    )
+    return trace
+
+
+def append_trace_footer(text: str, trace: RagTrace | None, *, enabled: bool) -> str:
+    """Append the ``— trace: <id>`` footer when a trace exists and the footer is enabled."""
+    if trace is None or not enabled:
+        return text
+    return text + footer_for(trace.trace_id)
+
+
+@dataclass
+class RagTrace:
+    """Mutable per-request trace accumulator.
+
+    Entry-points set only ``trace_id`` and ``set_input(...)``; ``source`` /
+    ``workspace_id`` / ``user_id`` / ``agent_id`` are filled inside the pipeline
+    (single source of truth — they cannot diverge from what the pipeline used).
+    """
+
+    trace_id: UUID
+    source: str | None = None
+    workspace_id: str | None = None
+    user_id: str | None = None
+    agent_id: str | None = None
+    input: dict[str, Any] = field(default_factory=dict)
+    phases: list[dict[str, Any]] = field(default_factory=list)
+    total_ms: float = 0.0
+
+    def set_input(
+        self,
+        *,
+        raw_user_message: str,
+        history: list[str] | None = None,
+        composite_query: str | None = None,
+    ) -> None:
+        self.input = {
+            "raw_user_message": raw_user_message,
+            "history": history or [],
+            "composite_query": composite_query,
+        }
+
+    def phase(self, name: str, **data: Any) -> None:
+        """Append a phase. Cheap, never raises."""
+        self.phases.append({"name": name, **data})
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "trace_id": str(self.trace_id),
+            "source": self.source,
+            "workspace_id": self.workspace_id,
+            "user_id": self.user_id,
+            "agent_id": self.agent_id,
+            "input": self.input,
+            "phases": self.phases,
+            "total_ms": self.total_ms,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pure phase builders — take pipeline-local data, return JSONB-serialisable dicts.
+# Defensive .get() everywhere: candidate dicts are flat Qdrant hits whose exact
+# keys vary by source; missing keys degrade to "" / 0.0, never KeyError.
+# ---------------------------------------------------------------------------
+
+
+def _candidate_summary(mem: Mapping[str, Any], *, score: float | None = None) -> dict[str, Any]:
+    """Summarise one recall candidate (full text retained per design)."""
+    raw_payload = mem.get("payload")
+    payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
+    raw_metadata = mem.get("metadata")
+    metadata: dict[str, Any] = raw_metadata if isinstance(raw_metadata, dict) else {}
+    summary: dict[str, Any] = {
+        "chunk_id": str(mem.get("id", "")),
+        "doc_label": mem.get("doc_label", "") or payload.get("doc_label", ""),
+        "title": mem.get("title", "") or payload.get("title", ""),
+        # Source type lives under "type" in these hit dicts (cf. search._result_type),
+        # with source_type/source as secondary fallbacks.
+        "source": (
+            mem.get("type")
+            or mem.get("source_type")
+            or mem.get("source")
+            or payload.get("type")
+            or payload.get("source_type")
+            or metadata.get("type")
+            or ""
+        ),
+        "text": mem.get("text", "") or mem.get("memory", "") or payload.get("text", ""),
+    }
+    if score is not None:
+        summary["raw_score"] = score
+    return summary
+
+
+def build_recall_phase(
+    dense: Sequence[Mapping[str, Any]],
+    exact: Sequence[Mapping[str, Any]],
+    metadata: Sequence[Mapping[str, Any]],
+    graph: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """One phase aggregating the four recall channels with per-candidate detail."""
+
+    def _chan(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+        return {
+            "count": len(results),
+            "candidates": [
+                _candidate_summary(r.get("memory", {}), score=r.get("score")) for r in results
+            ],
+        }
+
+    return {
+        "name": "recall",
+        "channels": {
+            "dense": _chan(dense),
+            "exact": _chan(exact),
+            "metadata": _chan(metadata),
+            "graph": _chan(graph),
+        },
+    }
+
+
+def build_merge_phase(
+    merged: Sequence[Mapping[str, Any]],
+    *,
+    weights: dict[str, float],
+    signal_components: dict[str, dict[str, float]],
+    dropped_ids: list[str],
+) -> dict[str, Any]:
+    """Merged-and-scored candidates with per-signal breakdown + confidence drops."""
+    candidates: list[dict[str, Any]] = []
+    for mr in merged:
+        cid = mr["chunk_id"]
+        comp = signal_components.get(cid, {})
+        candidates.append(
+            {
+                **_candidate_summary(mr.get("memory", {})),
+                "found_by": list(mr.get("channels", [])),
+                "channel_scores": dict(mr.get("channel_scores", {})),
+                "recency": comp.get("recency"),
+                "balance": comp.get("balance"),
+                "signal_score": mr.get("signal_score", 0.0),
+            }
+        )
+    return {
+        "name": "merge_and_score",
+        "weights": weights,
+        "candidates": candidates,
+        "dropped_by_min_signal": list(dropped_ids),
+    }
+
+
+def build_rerank_phase(
+    base: Sequence[Mapping[str, Any]],
+    score_map: dict[str, float],
+    *,
+    pool_size: int,
+    enabled: bool,
+) -> dict[str, Any]:
+    """Rerank candidates with signal/rerank/final scores and kept flags."""
+    candidates: list[dict[str, Any]] = []
+    for r in base:
+        cid = str(r.get("id", ""))
+        candidates.append(
+            {
+                **_candidate_summary(r),
+                "rerank_score": r.get("rerank_score", 0.0),
+                "final_score": score_map.get(cid, 0.0),
+                "kept": True,
+            }
+        )
+    return {
+        "name": "rerank",
+        "enabled": enabled,
+        "pool_size": pool_size,
+        "candidates": candidates,
+    }
+
+
+def build_context_phase(
+    frags: Sequence[Mapping[str, Any]],
+    g_ents: Sequence[Any],
+    g_rels: Sequence[Any],
+    g_docs: Sequence[Any],
+    *,
+    assembled_prompt: str,
+) -> dict[str, Any]:
+    """Final fragments (split by evidence role) + graph context + the LLM prompt."""
+
+    def _frag(f: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "doc_label": f.get("doc_label", ""),
+            "title": f.get("title", ""),
+            "text": f.get("text", ""),
+        }
+
+    primary = [_frag(f) for f in frags if f.get("evidence_marker") == "PRIMARY"]
+    supporting = [_frag(f) for f in frags if f.get("evidence_marker") != "PRIMARY"]
+    return {
+        "name": "context_assembly",
+        "primary_fragments": primary,
+        "supporting_fragments": supporting,
+        "graph": {"entities": list(g_ents), "relations": list(g_rels), "docs": list(g_docs)},
+        "assembled_prompt": assembled_prompt,
+    }

--- a/src/metatron/storage/pg_connection.py
+++ b/src/metatron/storage/pg_connection.py
@@ -168,6 +168,87 @@ def store_query_trace_sync(
     return trace_id
 
 
+def store_rag_trace_sync(trace: dict) -> None:
+    """Persist one RAG debug trace synchronously (called via asyncio.to_thread).
+
+    ``trace`` is the full ``RagTrace.to_dict()`` payload. Never raises — a write
+    failure must not break the answer path; it is logged at WARNING and dropped.
+    """
+    from datetime import UTC, datetime
+
+    from metatron.storage.pg_models import RagDebugTraceRow
+
+    trace_id = trace.get("trace_id")
+    if not trace_id:
+        logger.warning("postgres.rag_trace.store_skipped_no_id")
+        return
+
+    try:
+        with get_session() as session:
+            row = RagDebugTraceRow(
+                trace_id=trace_id,
+                workspace_id=trace.get("workspace_id"),
+                user_id=trace.get("user_id"),
+                agent_id=trace.get("agent_id"),
+                source=trace.get("source"),
+                query=(trace.get("input") or {}).get("raw_user_message") or "",
+                total_ms=float(trace.get("total_ms") or 0.0),
+                trace=trace,
+                created_at=datetime.now(UTC),
+            )
+            session.add(row)
+            session.commit()
+        logger.info("postgres.rag_trace.stored", trace_id=trace_id)
+    except Exception as e:
+        logger.warning("postgres.rag_trace.store_failed", trace_id=trace_id, error=str(e))
+
+
+def get_rag_trace_sync(workspace_id: str, trace_id: str) -> dict | None:
+    """Fetch one trace's JSONB payload, workspace-scoped. None if absent/cross-workspace."""
+    from metatron.storage.pg_models import RagDebugTraceRow
+
+    with get_session() as session:
+        row = (
+            session.query(RagDebugTraceRow)
+            .filter(
+                RagDebugTraceRow.trace_id == trace_id,
+                RagDebugTraceRow.workspace_id == workspace_id,
+            )
+            .first()
+        )
+        if row is None:
+            return None
+        # Merge the row's created_at into the JSONB payload (column, not stored in trace).
+        payload = dict(row.trace)
+        payload["created_at"] = row.created_at.isoformat() if row.created_at else None
+        return payload
+
+
+def list_rag_traces_sync(workspace_id: str, limit: int, offset: int) -> list[dict]:
+    """List recent traces for a workspace (newest-first), lightweight rows (no JSONB)."""
+    from metatron.storage.pg_models import RagDebugTraceRow
+
+    with get_session() as session:
+        rows = (
+            session.query(RagDebugTraceRow)
+            .filter(RagDebugTraceRow.workspace_id == workspace_id)
+            .order_by(RagDebugTraceRow.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+            .all()
+        )
+        return [
+            {
+                "trace_id": r.trace_id,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "query": r.query,
+                "source": r.source,
+                "total_ms": r.total_ms,
+            }
+            for r in rows
+        ]
+
+
 def upsert_document_fetch_stats_sync(
     workspace_id: str,
     doc_stats: dict[str, dict],

--- a/src/metatron/storage/pg_models.py
+++ b/src/metatron/storage/pg_models.py
@@ -309,6 +309,32 @@ class QueryTraceRow(Base):  # type: ignore[misc]
         }
 
 
+class RagDebugTraceRow(Base):  # type: ignore[misc]
+    """Full RAG pipeline debug trace (one row per traced chat request).
+
+    ``trace_id`` is the request ``correlation_id``. Self-contained: ``trace``
+    JSONB holds the whole phased structure (input → preprocessing → recall →
+    scoring → rerank → context → generation). Independent of ``llm_generation_log``.
+    Not a FK to workspaces so rows survive workspace deletion.
+    """
+
+    __tablename__ = "rag_debug_traces"
+
+    trace_id = Column(UUID(as_uuid=False), primary_key=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=text("NOW()"))
+    workspace_id = Column(Text, nullable=True)
+    user_id = Column(Text, nullable=True)
+    agent_id = Column(Text, nullable=True)
+    source = Column(Text, nullable=True)
+    query = Column(Text, nullable=False)
+    total_ms = Column(Float, nullable=False, server_default="0")
+    trace = Column(JSONB, nullable=False)
+
+    __table_args__ = (
+        Index("ix_rag_debug_traces_ws_created", "workspace_id", text("created_at DESC")),
+    )
+
+
 class DocumentFetchStatsRow(Base):  # type: ignore[misc]
     """Per-day document fetch statistics for FinOps cost savings."""
 

--- a/tests/unit/test_rag_trace.py
+++ b/tests/unit/test_rag_trace.py
@@ -1,0 +1,189 @@
+"""Unit tests for retrieval/trace.py — RagTrace accumulator + pure builders."""
+
+from __future__ import annotations
+
+import json
+from uuid import UUID
+
+from metatron.retrieval.trace import (
+    RagTrace,
+    append_trace_footer,
+    build_context_phase,
+    build_merge_phase,
+    build_recall_phase,
+    build_rerank_phase,
+    footer_for,
+    is_trace_enabled,
+)
+
+_TID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def test_phase_appends_in_order():
+    t = RagTrace(trace_id=_TID)
+    t.phase("a", x=1)
+    t.phase("b", y=2)
+    assert [p["name"] for p in t.phases] == ["a", "b"]
+    assert t.phases[0] == {"name": "a", "x": 1}
+
+
+def test_set_input_and_to_dict_shape():
+    t = RagTrace(trace_id=_TID, source="oai_compat", workspace_id="ws", user_id="u")
+    t.set_input(raw_user_message="hi", history=["prev"], composite_query="hi")
+    t.phase("classify", output={"profile": "mixed"})
+    t.total_ms = 12.5
+    d = t.to_dict()
+    assert d["trace_id"] == str(_TID)
+    assert d["source"] == "oai_compat"
+    assert d["workspace_id"] == "ws"
+    assert d["input"]["raw_user_message"] == "hi"
+    assert d["total_ms"] == 12.5
+    assert d["phases"][0]["name"] == "classify"
+
+
+def test_footer_contains_id():
+    f = footer_for(_TID)
+    assert str(_TID) in f
+    assert f.startswith("\n\n")
+
+
+def test_append_trace_footer_branches():
+    t = RagTrace(trace_id=_TID)
+    # appends when a trace exists and footer is enabled
+    out = append_trace_footer("ans", t, enabled=True)
+    assert out == "ans" + footer_for(_TID)
+    assert str(_TID) in out
+    # no-op when footer disabled (capture still on)
+    assert append_trace_footer("ans", t, enabled=False) == "ans"
+    # no-op when there is no trace (capture off)
+    assert append_trace_footer("ans", None, enabled=True) == "ans"
+
+
+def test_is_trace_enabled_reflects_setting(monkeypatch):
+    from metatron.core import config
+
+    monkeypatch.setattr(config.get_settings(), "rag_trace_enabled", False, raising=False)
+    assert is_trace_enabled() is False
+
+
+def test_build_recall_phase_summarises_candidates():
+    dense = [
+        {
+            "chunk_id": "c1",
+            "doc_label": "DOC-1",
+            "score": 0.9,
+            "channel": "dense",
+            "memory": {
+                "id": "c1",
+                "doc_label": "DOC-1",
+                "title": "T1",
+                "text": "full text",
+                "type": "jira",
+            },
+        }
+    ]
+    phase = build_recall_phase(dense, [], [], [])
+    assert phase["name"] == "recall"
+    assert phase["channels"]["dense"]["count"] == 1
+    cand = phase["channels"]["dense"]["candidates"][0]
+    assert cand["chunk_id"] == "c1"
+    assert cand["text"] == "full text"
+    assert cand["raw_score"] == 0.9
+    # source is derived from the hit's "type" key (cf. search._result_type)
+    assert cand["source"] == "jira"
+    assert phase["channels"]["exact"]["count"] == 0
+
+
+def test_build_merge_phase_includes_signals_and_dropped():
+    merged = [
+        {
+            "chunk_id": "c1",
+            "doc_label": "DOC-1",
+            "channels": ["dense", "graph"],
+            "channel_scores": {"dense": 0.8, "graph": 0.3},
+            "signal_score": 0.55,
+            "memory": {"id": "c1", "doc_label": "DOC-1", "text": "txt"},
+        }
+    ]
+    components = {"c1": {"recency": 1.0, "balance": 0.5}}
+    phase = build_merge_phase(
+        merged,
+        weights={"dense_weight": 0.35},
+        signal_components=components,
+        dropped_ids=["c1"],
+    )
+    assert phase["name"] == "merge_and_score"
+    c = phase["candidates"][0]
+    assert c["found_by"] == ["dense", "graph"]
+    assert c["channel_scores"] == {"dense": 0.8, "graph": 0.3}
+    assert c["recency"] == 1.0
+    assert c["balance"] == 0.5
+    assert c["signal_score"] == 0.55
+    assert phase["dropped_by_min_signal"] == ["c1"]
+
+
+def test_build_rerank_phase_marks_kept():
+    base = [
+        {"id": "c1", "doc_label": "DOC-1", "rerank_score": 0.9, "text": "t"},
+        {"id": "c2", "doc_label": "DOC-2", "rerank_score": 0.1, "text": "t"},
+    ]
+    score_map = {"c1": 0.7, "c2": 0.2}
+    phase = build_rerank_phase(base, score_map, pool_size=2, enabled=True)
+    assert phase["name"] == "rerank"
+    assert phase["enabled"] is True
+    assert phase["pool_size"] == 2
+    ids = {c["chunk_id"]: c for c in phase["candidates"]}
+    assert ids["c1"]["rerank_score"] == 0.9
+    assert ids["c1"]["final_score"] == 0.7
+    assert ids["c1"]["kept"] is True
+
+
+def test_to_dict_is_json_serialisable():
+    """The persisted payload must round-trip through JSON (it lands in JSONB)."""
+    t = RagTrace(trace_id=_TID, source="oai_compat", workspace_id="ws")
+    t.set_input(raw_user_message="q", history=[], composite_query="q")
+    t.phase(
+        **build_recall_phase(
+            [
+                {
+                    "chunk_id": "c1",
+                    "score": 0.9,
+                    "memory": {"id": "c1", "doc_label": "D", "text": "t"},
+                }
+            ],
+            [],
+            [],
+            [],
+        )
+    )
+    t.phase(
+        **build_merge_phase(
+            [
+                {
+                    "chunk_id": "c1",
+                    "channels": ["dense"],
+                    "channel_scores": {"dense": 0.9},
+                    "signal_score": 0.5,
+                    "memory": {"id": "c1", "text": "t"},
+                }
+            ],
+            weights={"dense_weight": 0.35},
+            signal_components={"c1": {"recency": 1.0, "balance": 0.5}},
+            dropped_ids=[],
+        )
+    )
+    # Must not raise — proves no datetime/UUID/object leaked into the payload.
+    dumped = json.dumps(t.to_dict())
+    assert '"trace_id"' in dumped
+
+
+def test_build_context_phase_splits_roles():
+    frags = [
+        {"text": "p", "doc_label": "DOC-1", "evidence_marker": "PRIMARY"},
+        {"text": "s", "doc_label": "DOC-2", "evidence_marker": "SUPPORTING"},
+    ]
+    phase = build_context_phase(frags, [], [], [], assembled_prompt="PROMPT")
+    assert phase["name"] == "context_assembly"
+    assert len(phase["primary_fragments"]) == 1
+    assert len(phase["supporting_fragments"]) == 1
+    assert phase["assembled_prompt"] == "PROMPT"

--- a/tests/unit/test_search_rag_trace.py
+++ b/tests/unit/test_search_rag_trace.py
@@ -1,0 +1,193 @@
+"""Wiring test: hybrid_search_and_answer populates and persists a RagTrace."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import UUID
+
+from metatron.retrieval.trace import RagTrace
+
+_SEARCH_MODULE = "metatron.retrieval.search"
+_TID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _patch_search_internals():
+    return {
+        "merge_channels": patch(
+            f"{_SEARCH_MODULE}.merge_channels",
+            return_value=[
+                {
+                    "chunk_id": "c1",
+                    "doc_label": "DOC-1",
+                    "memory": {"id": "c1", "doc_label": "DOC-1", "text": "text one"},
+                    "channels": ["dense"],
+                    "channel_scores": {"dense": 0.9},
+                }
+            ],
+        ),
+        "chat_completion_with_retry": patch(
+            f"{_SEARCH_MODULE}.chat_completion_with_retry",
+            return_value="Test answer",
+        ),
+        "get_graph_entities": patch(f"{_SEARCH_MODULE}.get_graph_entities", return_value=[]),
+        "get_entities_by_doc_labels": patch(
+            f"{_SEARCH_MODULE}.get_entities_by_doc_labels", return_value=[]
+        ),
+        "get_graph_relationships": patch(
+            f"{_SEARCH_MODULE}.get_graph_relationships", return_value=[]
+        ),
+        "get_doc_labels_by_entities": patch(
+            f"{_SEARCH_MODULE}.get_doc_labels_by_entities", return_value=[]
+        ),
+        "expand_query": patch(
+            f"{_SEARCH_MODULE}.expand_query", side_effect=lambda q: f"expanded {q}"
+        ),
+        "translate_query_to_english": patch(
+            f"{_SEARCH_MODULE}.translate_query_to_english", side_effect=lambda q: q
+        ),
+        "select_fragments_within_budget": patch(
+            f"{_SEARCH_MODULE}.select_fragments_within_budget",
+            return_value=[
+                {
+                    "text": "fragment one",
+                    "evidence_marker": "PRIMARY",
+                    "title": "Doc One",
+                    "doc_label": "DOC-1",
+                    "date": "",
+                }
+            ],
+        ),
+        "estimate_graph_tokens": patch(f"{_SEARCH_MODULE}.estimate_graph_tokens", return_value=0),
+        "truncate_graph_context": patch(
+            f"{_SEARCH_MODULE}.truncate_graph_context", return_value=([], [], [])
+        ),
+        "detect_response_language": patch(
+            f"{_SEARCH_MODULE}.detect_response_language", return_value="en"
+        ),
+        "should_use_team_workflow_schema": patch(
+            f"{_SEARCH_MODULE}.should_use_team_workflow_schema", return_value=False
+        ),
+        "classify_query": patch(
+            f"{_SEARCH_MODULE}.classify_query",
+            return_value={"profile": "mixed", "confidence": 1.0, "method": "rule"},
+        ),
+        "recall_dense_async": patch(f"{_SEARCH_MODULE}.recall_dense_async", return_value=[]),
+        "recall_exact_async": patch(f"{_SEARCH_MODULE}.recall_exact_async", return_value=[]),
+        "recall_metadata_async": patch(f"{_SEARCH_MODULE}.recall_metadata_async", return_value=[]),
+        "recall_graph_async": patch(f"{_SEARCH_MODULE}.recall_graph_async", return_value=[]),
+    }
+
+
+async def test_rag_trace_is_populated_and_persisted(monkeypatch):
+    captured: dict = {}
+
+    def _fake_store(trace: dict) -> None:
+        captured.update(trace)
+
+    monkeypatch.setattr(
+        "metatron.storage.pg_connection.store_rag_trace_sync", _fake_store, raising=True
+    )
+
+    patches = _patch_search_internals()
+    for p in patches.values():
+        p.start()
+    try:
+        from metatron.retrieval.search import hybrid_search_and_answer
+
+        trace = RagTrace(trace_id=_TID)
+        trace.set_input(
+            raw_user_message="What is Metatron?",
+            history=[],
+            composite_query="What is Metatron?",
+        )
+        answer = await hybrid_search_and_answer(
+            query="What is Metatron?",
+            workspace_id="ws_test",
+            rag_trace=trace,
+        )
+    finally:
+        for p in patches.values():
+            p.stop()
+
+    assert isinstance(answer, str)
+    # Context fields filled by the pipeline (single source of truth)
+    assert trace.source == "rest"
+    assert trace.workspace_id == "ws_test"
+    # All expected phase names present
+    names = [p["name"] for p in trace.phases]
+    for expected in (
+        "resolve_query",
+        "query_expansion",
+        "translate_query",
+        "classify",
+        "recall",
+        "merge_and_score",
+        "rerank",
+        "context_assembly",
+        "generation",
+    ):
+        assert expected in names, f"missing phase {expected}"
+    # Persisted dict reached the store with the right id
+    assert captured.get("trace_id") == str(_TID)
+    assert captured.get("total_ms", 0) >= 0
+
+
+async def test_trace_persisted_on_llm_failure(monkeypatch):
+    """If answer generation raises, the partial trace is still persisted with an
+    error-marked generation phase (the failed-answer case is worth debugging too)."""
+    captured: dict = {}
+    monkeypatch.setattr(
+        "metatron.storage.pg_connection.store_rag_trace_sync",
+        lambda trace: captured.update(trace),
+        raising=True,
+    )
+
+    patches = _patch_search_internals()
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("llm down")
+
+    patches["chat_completion_with_retry"] = patch(
+        f"{_SEARCH_MODULE}.chat_completion_with_retry", side_effect=_boom
+    )
+    for p in patches.values():
+        p.start()
+    try:
+        from metatron.retrieval.search import hybrid_search_and_answer
+
+        trace = RagTrace(trace_id=_TID)
+        trace.set_input(raw_user_message="q", history=[], composite_query="q")
+        answer = await hybrid_search_and_answer(query="q", workspace_id="ws_test", rag_trace=trace)
+    finally:
+        for p in patches.values():
+            p.stop()
+
+    assert "couldn't generate an answer" in answer
+    # Persisted despite the failure, with an error-marked generation phase.
+    assert captured.get("trace_id") == str(_TID)
+    gen = [p for p in trace.phases if p["name"] == "generation"]
+    assert gen and gen[-1].get("error") == "llm_answer_failed"
+
+
+async def test_no_rag_trace_does_not_persist(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "metatron.storage.pg_connection.store_rag_trace_sync",
+        lambda trace: calls.append(trace),
+        raising=True,
+    )
+    patches = _patch_search_internals()
+    for p in patches.values():
+        p.start()
+    try:
+        from metatron.retrieval.search import hybrid_search_and_answer
+
+        result = await hybrid_search_and_answer(
+            query="Test", workspace_id="ws_test", return_trace=True
+        )
+    finally:
+        for p in patches.values():
+            p.stop()
+    # Benchmarker path (rag_trace=None) must not persist a debug trace
+    assert calls == []
+    assert isinstance(result, dict)

--- a/tests/unit/test_traces_endpoint.py
+++ b/tests/unit/test_traces_endpoint.py
@@ -1,0 +1,96 @@
+"""Endpoint tests for the RAG debug trace read API."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from metatron.api.routes.traces import router as traces_router
+from metatron.auth.dependencies import get_current_user
+from metatron.core.config import Settings
+from metatron.core.models import Role, User
+
+
+def _make_user() -> User:
+    return User(
+        id="u1",
+        username="tester",
+        email="t@example.com",
+        role=Role.VIEWER,
+        workspace_ids=["ws-test"],
+    )
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.state.settings = Settings(AUTH_ENABLED=False)
+    app.include_router(traces_router, prefix="/api/v1")
+    app.dependency_overrides[get_current_user] = _make_user
+    return TestClient(app, raise_server_exceptions=False)
+
+
+_UUID = "11111111-1111-1111-1111-111111111111"
+
+
+def test_get_trace_returns_payload(client):
+    payload = {"trace_id": _UUID, "phases": [], "input": {"raw_user_message": "hi"}}
+    with patch("metatron.storage.pg_connection.get_rag_trace_sync", return_value=payload):
+        resp = client.get(f"/api/v1/traces/{_UUID}")
+    assert resp.status_code == 200
+    assert resp.json()["trace_id"] == _UUID
+
+
+def test_get_trace_unknown_is_404(client):
+    # A well-formed but unknown UUID resolves to None in the store -> 404.
+    with patch("metatron.storage.pg_connection.get_rag_trace_sync", return_value=None):
+        resp = client.get("/api/v1/traces/00000000-0000-0000-0000-000000000000")
+    assert resp.status_code == 404
+
+
+def test_get_trace_malformed_uuid_is_422(client):
+    # Non-UUID path param is rejected by FastAPI validation, not a 500 from PG.
+    resp = client.get("/api/v1/traces/not-a-uuid")
+    assert resp.status_code == 422
+
+
+def test_get_trace_works_when_capture_disabled(client):
+    # Reads are NOT gated by the capture flag.
+    payload = {"trace_id": _UUID, "phases": []}
+    with patch("metatron.storage.pg_connection.get_rag_trace_sync", return_value=payload):
+        resp = client.get(f"/api/v1/traces/{_UUID}")
+    assert resp.status_code == 200
+
+
+def test_get_trace_queries_auth_resolved_workspace(client):
+    """Isolation contract: the route passes the auth-resolved workspace to the store,
+    not a client-supplied one — so a trace id is only ever read within the caller's
+    workspace (cross-workspace ids resolve to None → 404 in the store)."""
+    expected_ws = client.app.state.settings.default_workspace_id
+    mock = MagicMock(return_value={"trace_id": _UUID, "phases": []})
+    with patch("metatron.storage.pg_connection.get_rag_trace_sync", mock):
+        client.get(f"/api/v1/traces/{_UUID}")
+    assert mock.call_args.args[0] == expected_ws
+    assert mock.call_args.args[1] == _UUID
+
+
+def test_list_traces_shape(client):
+    rows = [
+        {
+            "trace_id": "t-1",
+            "created_at": "2026-06-02T00:00:00+00:00",
+            "query": "q",
+            "source": "oai_compat",
+            "total_ms": 12.0,
+        }
+    ]
+    with patch("metatron.storage.pg_connection.list_rag_traces_sync", return_value=rows):
+        resp = client.get("/api/v1/traces?limit=5&offset=0")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["traces"][0]["trace_id"] == "t-1"
+    assert body["limit"] == 5


### PR DESCRIPTION
Capture a self-contained debug trace of every RAG request (OAI /v1/chat/completions and legacy /api/v1/chat, stream + non-stream) from user message to answer, persist it to PostgreSQL, embed its id in the answer, and expose read endpoints for a frontend viewer. Independent of llm_generation_log.

- retrieval/trace.py: RagTrace accumulator + pure phase builders + maybe_create_trace / append_trace_footer helpers; is_trace_enabled / footer_for.
- retrieval/search.py: rag_trace param + ~9 capture points (resolve/expand/translate/ classify/recall/merge_and_score/rerank/context_assembly/generation) + awaited persist; benchmarker return_trace path untouched.
- storage: RagDebugTraceRow ORM + migration 023 (rag_debug_traces, DESC index) + store/get/list_rag_traces_sync.
- api/routes/traces.py: GET /api/v1/traces/{id} + GET /api/v1/traces (viewer+, ws-scoped, reads NOT gated by the capture flag).
- config: METATRON_RAG_TRACE_ENABLED + METATRON_RAG_TRACE_FOOTER_ENABLED (both default true).
- candidate source derived from hit "type" (jira/confluence/...); generation phase records provider + resolved model name.
- tests: trace builders, search wiring, persist-on-llm-failure, endpoint, footer flag.
- docs/RAG_TRACE_FRONTEND.md: frontend interface + endpoint reference.