### PR TITLE
fix(api): optional benchmarker import must not crash startup; cap benchmark-qed <0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,11 @@ channels = [
     "discord.py>=2.4,<3",
 ]
 benchmarker = [
-    "benchmark-qed>=0.1.0",
+    # <0.4: benchmark-qed 0.4.0 added graphrag-llm, whose import-time
+    # nest_asyncio2.apply() raises ValueError under uvloop and would crash
+    # API startup (see the guarded import in api/app.py). Re-evaluate the cap
+    # when graphrag-llm stops patching the loop at import.
+    "benchmark-qed>=0.1.0,<0.4",
     "nest-asyncio>=1.5.0",
     "numpy>=1.24.0",
     "beautifulsoup4>=4.12,<5",

--- a/src/metatron/api/app.py
+++ b/src/metatron/api/app.py
@@ -411,8 +411,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 cap = settings.proxy_entity_trie_max_entities_per_ws
                 with driver.session() as session:
                     result = session.run(
-                        "MATCH (e:Entity {workspace_id: $ws}) "
-                        "RETURN e.name AS name LIMIT $cap",
+                        "MATCH (e:Entity {workspace_id: $ws}) RETURN e.name AS name LIMIT $cap",
                         {"ws": workspace_id, "cap": cap},
                     )
                     return [row["name"] for row in result if row["name"]]
@@ -483,22 +482,32 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 port=settings.qdrant_http_port,
             )
             mem_search = MemorySearchService(
-                qdrant=qdrant_store, redis=redis_cache, pg_store=pg_store,
+                qdrant=qdrant_store,
+                redis=redis_cache,
+                pg_store=pg_store,
             )
             mem_service = MemoryService(
-                redis_cache=redis_cache, qdrant_store=qdrant_store,
-                pg_store=pg_store, workspace_id=workspace_id,
-                search=mem_search, event_bus=bus,
+                redis_cache=redis_cache,
+                qdrant_store=qdrant_store,
+                pg_store=pg_store,
+                workspace_id=workspace_id,
+                search=mem_search,
+                event_bus=bus,
             )
             assembler = AgentContextAssembler(
-                memory_service=mem_service, memory_search=mem_search, settings=settings,
+                memory_service=mem_service,
+                memory_search=mem_search,
+                settings=settings,
             )
             agent_service = AgentRegistryService(
-                AgentPersistence(engine), workspace_id=workspace_id, event_bus=bus,
+                AgentPersistence(engine),
+                workspace_id=workspace_id,
+                event_bus=bus,
             )
             creds_store = LlmUpstreamCredentialsStore(engine, fernet_key=settings.fernet_key)
             credentials = UpstreamCredentialsResolver(
-                creds_store, default_key=settings.proxy_default_upstream_key,
+                creds_store,
+                default_key=settings.proxy_default_upstream_key,
             )
             activity_store = getattr(app.state, "activity_store", None)
 
@@ -518,7 +527,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 event_bus=bus,
                 settings=settings,
                 activity_logger_factory=lambda ws: ProxyActivityLogger(
-                    store=activity_store, workspace_id=ws,
+                    store=activity_store,
+                    workspace_id=ws,
                 ),
                 tool_result_enricher_factory=_enricher_for,
                 rag_stream_factory=build_rag_stream,
@@ -528,15 +538,20 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
         app.include_router(proxy_router)
 
-    # Lazy import benchmarker module router (optional dependency)
+    # Lazy import benchmarker module router (optional dependency).
+    # Broad except is deliberate: the optional dev-eval module must never take the
+    # API down. Its third-party deps can raise more than ImportError at import time —
+    # e.g. graphrag_llm (via benchmark-qed) calls nest_asyncio2.apply() on import,
+    # which raises ValueError under uvloop ("Can't patch loop of type uvloop.Loop").
     try:
         from metatron.benchmarker.api import router as benchmarker_module_router
 
         app.include_router(benchmarker_module_router, prefix="/api/v1/benchmarker")
         logger.info("Benchmarker module loaded successfully")
-    except ImportError as e:
+    except Exception as e:  # noqa: BLE001 — optional module must not break startup
         logger.warning(
-            "Benchmarker module not available (missing optional dependencies): %s",
+            "Benchmarker module not available (optional dependency failed to load): %s: %s",
+            type(e).__name__,
             e,
         )
 

--- a/tests/unit/test_app_optional_benchmarker.py
+++ b/tests/unit/test_app_optional_benchmarker.py
@@ -1,0 +1,53 @@
+"""create_app must survive optional benchmarker deps failing with non-ImportError.
+
+Regression guard for the uvloop/nest_asyncio2 startup crash: graphrag_llm (a
+benchmark-qed transitive dependency) calls ``nest_asyncio2.apply()`` at import
+time, which raises ``ValueError`` under uvloop ("Can't patch loop of type
+uvloop.Loop"). The optional-module guard in ``create_app`` must swallow ANY
+exception from that import, not just ImportError — an optional dev-eval tool
+must never take the API down.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import sys
+
+import pytest
+
+from metatron.core.config import Settings
+
+
+class _ExplodingFinder(importlib.abc.MetaPathFinder):
+    """Raises ValueError when the benchmarker api module is imported."""
+
+    target = "metatron.benchmarker.api"
+
+    def find_spec(self, fullname, path=None, target=None):  # noqa: ARG002
+        if fullname == self.target:
+            raise ValueError("Can't patch loop of type <class 'uvloop.Loop'>")
+        return None
+
+
+@pytest.fixture
+def exploding_benchmarker(monkeypatch):
+    # Purge cached benchmarker modules so the import really goes through the finder.
+    # monkeypatch restores the original sys.modules entries on teardown.
+    for name in list(sys.modules):
+        if name == "metatron.benchmarker.api" or name.startswith("metatron.benchmarker.api."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    finder = _ExplodingFinder()
+    sys.meta_path.insert(0, finder)
+    yield
+    sys.meta_path.remove(finder)
+
+
+def test_create_app_survives_benchmarker_valueerror(exploding_benchmarker):
+    from metatron.api.app import create_app
+
+    app = create_app(Settings(AUTH_ENABLED=False))
+
+    paths = {getattr(r, "path", "") for r in app.routes}
+    # App built; benchmarker module routes absent; the rest of the app intact.
+    assert not any(p.startswith("/api/v1/benchmarker/") for p in paths)
+    assert "/health" in paths


### PR DESCRIPTION
## Problem

Deploy fails: API container crashes on boot with
`ValueError: Can't patch loop of type <class 'uvloop.Loop'>`.

Root cause: the image rebuild resolved **benchmark-qed 0.4.0** (range was open: `>=0.1.0`), which newly depends on **graphrag-llm** — whose `__init__` calls `nest_asyncio2.apply()` at import time. Under uvloop (always present via `uvicorn[standard]`; the entrypoint loads the app inside the running uvloop loop) that raises `ValueError`. The optional-module guard in `create_app` only caught `ImportError`, so the `ValueError` killed the container. Last known-good resolve is 0.3.0 (no graphrag-llm). Neither of the two recently merged PRs touched dependencies — this is unpinned-dependency drift triggered by the rebuild.

## Fix (two parts)

- **`create_app`**: broaden the optional-benchmarker guard to `except Exception` — the dev-eval module must never take the API down (graceful degradation). On failure the API boots with benchmarker skipped + a warning naming the exception class.
- **`pyproject`**: cap `benchmark-qed>=0.1.0,<0.4` so the resolve deterministically returns to the known-good 0.3.0 and the benchmarker module keeps actually working in the image. Re-evaluate the cap when graphrag-llm stops patching the event loop at import.

Net effect after merge + rebuild: API boots, benchmarker works exactly as before May 31.

## Tests

- New regression test simulates a **non-ImportError** during the benchmarker import via a meta-path finder and asserts `create_app` survives. Verified **red on the old guard, green on the fix**.

## Notes

- Also includes a ruff-format normalization of `api/app.py` (the file was left format-dirty on develop; hunks are cosmetic only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)