### PR TITLE
fix(api): register traces list route with trailing slash (CC proxy 404)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ Thumbs.db
 
 # Claude/AI artifacts
 .claude/skills/
+.claude/scheduled_tasks.lock
 .scratch/
 .gh_alerts.json
 .gh_alerts_summary.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,7 +388,8 @@ Today agent memory is not automatically added to /v1/chat/completions context.
 - `/api/v1/traces` — RAG debug-trace read API (viewer+, workspace-scoped). `GET /traces/{trace_id}`
   returns the full phased trace JSONB (input → resolve/expand/translate/classify → recall →
   merge_and_score → rerank → context_assembly → generation; 422 on non-UUID, 404 cross-workspace);
-  `GET /traces` lists recent lightweight rows. Reads are NOT gated by `METATRON_RAG_TRACE_ENABLED`.
+  `GET /traces/` (trailing slash — collection-endpoint convention, redirect_slashes=False) lists
+  recent lightweight rows. Reads are NOT gated by `METATRON_RAG_TRACE_ENABLED`.
   Backed by `rag_debug_traces` (migration 024) + `retrieval/trace.py` (`RagTrace` accumulator).
   Frontend reference: `docs/RAG_TRACE_FRONTEND.md`.
 - `/api/v1/workspaces`, `/api/v1/connections`, `/api/v1/sync` — admin surfaces

--- a/docs/RAG_TRACE_FRONTEND.md
+++ b/docs/RAG_TRACE_FRONTEND.md
@@ -41,8 +41,11 @@ GET /api/v1/traces/{trace_id}
 
 ### 2. Recent traces list
 ```
-GET /api/v1/traces?limit=20&offset=0
+GET /api/v1/traces/?limit=20&offset=0
 ```
+- **Note the trailing slash** — the API runs with `redirect_slashes=False`, so when calling it
+  directly the slash is required (same as `/api/v1/agents/`). Through the CC UI proxy both
+  `/api/v1/traces` and `/api/v1/traces/` work (nginx normalises the bare path).
 - `limit` 1..100 (default 20), `offset` 0..10000.
 - **200** → `RagTraceListResponse` (lightweight rows, no heavy JSONB — for a table/feed).
 

--- a/src/metatron/api/routes/traces.py
+++ b/src/metatron/api/routes/traces.py
@@ -59,7 +59,11 @@ async def get_trace(
     return trace
 
 
-@router.get("", response_model=RagTraceListResponse)
+# NB: "/" (not ""), matching the repo convention for collection endpoints
+# (cf. agents.py / workspaces.py): the app runs with redirect_slashes=False and
+# the ui-cc nginx rewrites bare /api/v1/<collection> to a trailing-slash path,
+# so a slash-less registration is unreachable through the CC proxy.
+@router.get("/", response_model=RagTraceListResponse)
 async def list_traces(
     request: Request,
     user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001

--- a/tests/unit/test_traces_endpoint.py
+++ b/tests/unit/test_traces_endpoint.py
@@ -87,8 +87,10 @@ def test_list_traces_shape(client):
             "total_ms": 12.0,
         }
     ]
+    # Trailing slash is the registered path (redirect_slashes=False; the ui-cc
+    # nginx rewrites bare /api/v1/traces to /api/v1/traces/ — repo convention).
     with patch("metatron.storage.pg_connection.list_rag_traces_sync", return_value=rows):
-        resp = client.get("/api/v1/traces?limit=5&offset=0")
+        resp = client.get("/api/v1/traces/?limit=5&offset=0")
     assert resp.status_code == 200
     body = resp.json()
     assert body["count"] == 1


### PR DESCRIPTION
## Problem

`GET https://ui-cc.../api/v1/traces?workspace_id=...` → **404**, while `GET /api/v1/traces/{id}` works.

## Root cause

The list route was registered as `""` → path `/api/v1/traces` (no slash). The repo convention for collection endpoints is `"/"` (cf. `agents.py:277`, `workspaces.py:60`): the app runs with `redirect_slashes=False` (`app.py:271`) and the **ui-cc nginx** rewrites bare collection paths to trailing-slash form:

```nginx
# metatronui-cc/nginx-cc.conf
rewrite ^(/api/v1/(?!upload)[a-z0-9_-]+)$ $1/ last;
```

So through the proxy the request arrives as `/api/v1/traces/`, which matches nothing → 404. The by-id route has a path segment, is untouched by the rewrite, and works.

Bisect evidence (dev stand): direct API `/api/v1/traces` → 401 (route exists, wants auth); via ui-cc → 404; control `/api/v1/agents` via ui-cc → 401.

## Fix

- `@router.get("")` → `@router.get("/")` (one line) + convention note.
- Test updated to the registered path; docs note the trailing slash (direct calls need it, via CC proxy both forms work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)