### PR TITLE
feat(api): add total to list endpoint responses (memory, knowledge, traces)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,8 +376,11 @@ Today agent memory is not automatically added to /v1/chat/completions context.
   (default `all`), `limit`, `offset`. Returns `KnowledgeRecordListResponse` with records tagged
   `origin: "agent"|"kb"`, plus `partial: bool` and `failed_sources: list[Literal["agent","kb"]]`.
   `origin=all` fans out via `asyncio.gather`: one leg failing → 200 with `partial=true`; both legs
-  failing → 503. `origin` is endpoint-derived, NOT a DB column. Pagination is approximate under
-  `origin=all` (per-leg fetch + merge + truncate). Backs the Memory Inspector unified view.
+  failing → 503. `origin` is endpoint-derived, NOT a DB column. Pagination is exact, including under
+  `origin=all` (each leg over-fetches `[0, offset+limit)`, global sort, slice — supersedes D-P1-02).
+  Responses carry `total` (grand total under current filters; under `partial=true` only surviving
+  sources are counted) with the invariant `has_more == (offset + count) < total`. Backs the Memory
+  Inspector unified view.
   Query: `lifetime=persistent|session|all` (default `persistent` — preserves Phase 1 behaviour).
   Response shape grows optional `session_id: str | None` and `ttl_expires_at: datetime | None`
   (`None` for KB rows and persistent agent rows). `lifetime=session` returns only unexpired

--- a/src/metatron/api/routes/knowledge.py
+++ b/src/metatron/api/routes/knowledge.py
@@ -131,10 +131,17 @@ class KnowledgeRecordResponse(BaseModel):
 
 
 class KnowledgeRecordListResponse(BaseModel):
-    """Paginated response for ``GET /knowledge/records``."""
+    """Paginated response for ``GET /knowledge/records``.
+
+    ``count`` is the size of the current page; ``total`` is the number of
+    records matching the request filters across all pages (before
+    limit/offset).  Under ``origin=all`` with ``partial=true``, ``total``
+    covers only the sources that responded (the failed leg contributes 0).
+    """
 
     records: list[KnowledgeRecordResponse]
     count: int
+    total: int
     limit: int
     offset: int
     has_more: bool
@@ -275,6 +282,7 @@ async def list_knowledge_records(
         return KnowledgeRecordListResponse(
             records=responses,
             count=len(responses),
+            total=mem_total,
             limit=limit,
             offset=offset,
             has_more=(offset + limit) < mem_total,
@@ -298,6 +306,7 @@ async def list_knowledge_records(
         return KnowledgeRecordListResponse(
             records=responses,
             count=len(responses),
+            total=kb_only_total,
             limit=limit,
             offset=offset,
             has_more=(offset + limit) < kb_only_total,
@@ -366,6 +375,7 @@ async def list_knowledge_records(
     return KnowledgeRecordListResponse(
         records=page,
         count=len(page),
+        total=total,
         limit=limit,
         offset=offset,
         has_more=(offset + limit) < total,

--- a/src/metatron/api/routes/knowledge.py
+++ b/src/metatron/api/routes/knowledge.py
@@ -8,10 +8,13 @@ Design decisions (see plan §8 Risks & decisions):
 - ``workspace_id`` is auth-derived by default. An optional ``?workspace_id`` query param
   overrides it, but only when the caller's JWT grants access ("*" or membership); otherwise
   403. Resolved via ``resolve_workspace_id(request)`` (supersedes D-P1-01 for REST).
-- ``origin=all`` pagination is approximate: each leg fetches up to ``limit`` rows
-  ordered by its own ``updated_at DESC``, then the combined page is re-sorted and
-  truncated.  ``total = agent_total + kb_total`` is therefore an estimate when the
-  two counts are used together with a merged page (D-P1-02).
+- ``origin=all`` pagination is exact via over-fetch (supersedes the D-P1-02
+  approximation): each leg fetches ``offset + limit`` rows from position 0, the
+  combined set is globally re-sorted by ``updated_at DESC`` (tie-break: ``id``)
+  and sliced ``[offset : offset + limit]``.  ``total = agent_total + kb_total``
+  is exact.  Cost grows with offset (worst case ~10.2k rows per leg at the
+  offset cap); switch to a keys-then-hydrate two-phase fetch if workspaces
+  outgrow this.
 - KB rows have no ``tags`` column → always ``[]``.  Do not synthesise from metadata
   (D-P1-03).
 - KB ``connector_type`` is surfaced as ``source_type`` (D-P1-04).
@@ -137,6 +140,7 @@ class KnowledgeRecordListResponse(BaseModel):
     records matching the request filters across all pages (before
     limit/offset).  Under ``origin=all`` with ``partial=true``, ``total``
     covers only the sources that responded (the failed leg contributes 0).
+    Invariant: ``has_more == (offset + count) < total``.
     """
 
     records: list[KnowledgeRecordResponse]
@@ -240,9 +244,9 @@ async def list_knowledge_records(
       returns ``200`` with ``partial=true`` and the other source's rows.  On
       total failure, returns ``503``.
 
-    Pagination under ``origin=all`` is approximate (D-P1-02): each leg returns
-    up to ``limit`` rows ordered by its own ``updated_at DESC``; the combined page
-    is re-sorted and truncated to ``limit``.  ``total = agent_total + kb_total``.
+    Pagination under ``origin=all`` is exact via over-fetch (see module
+    docstring): each leg fetches ``offset + limit`` rows from 0, the combined
+    set is globally sorted and sliced.  ``total = agent_total + kb_total``.
 
     Lifetime filtering (agent leg only; KB rows are unaffected):
     - ``lifetime=session`` returns only unexpired session records
@@ -265,7 +269,7 @@ async def list_knowledge_records(
                     offset=offset,
                     lifetime=lifetime.value,
                 ),
-                memory_service.pg_store.count_records(
+                memory_service.count_records(
                     workspace_id,
                     lifetime=lifetime.value,
                 ),
@@ -285,7 +289,7 @@ async def list_knowledge_records(
             total=mem_total,
             limit=limit,
             offset=offset,
-            has_more=(offset + limit) < mem_total,
+            has_more=(offset + len(responses)) < mem_total,
         )
 
     # --- KB-only path ---
@@ -309,15 +313,18 @@ async def list_knowledge_records(
             total=kb_only_total,
             limit=limit,
             offset=offset,
-            has_more=(offset + limit) < kb_only_total,
+            has_more=(offset + len(responses)) < kb_only_total,
         )
 
     # --- All (fan-out) path ---
+    # Exact merged pagination: each leg over-fetches the full window
+    # [0, offset + limit) so the global sort below can slice the true page.
+    fetch_depth = offset + limit
     results = await asyncio.gather(
         _fetch_agent_leg(
-            memory_service, workspace_id, limit=limit, offset=offset, lifetime=lifetime
+            memory_service, workspace_id, limit=fetch_depth, offset=0, lifetime=lifetime
         ),
-        _fetch_kb_leg(raw_doc_service, limit=limit, offset=offset),
+        _fetch_kb_leg(raw_doc_service, limit=fetch_depth, offset=0),
         return_exceptions=True,
     )
 
@@ -363,13 +370,14 @@ async def list_knowledge_records(
     if partial and len(failed_sources) == 2:
         raise HTTPException(status_code=503, detail="knowledge sources unavailable")
 
-    # Merge, re-sort by updated_at DESC (approximate — see D-P1-02), truncate.
+    # Merge, global sort by updated_at DESC (tie-break: id, for stable pages
+    # across requests), then slice the exact page window.
     combined = agent_records + kb_records_resp
     combined.sort(
-        key=lambda r: r.updated_at,
+        key=lambda r: (r.updated_at, r.id),
         reverse=True,
     )
-    page = combined[:limit]
+    page = combined[offset : offset + limit]
     total = agent_total + kb_total
 
     return KnowledgeRecordListResponse(
@@ -378,7 +386,7 @@ async def list_knowledge_records(
         total=total,
         limit=limit,
         offset=offset,
-        has_more=(offset + limit) < total,
+        has_more=(offset + len(page)) < total,
         partial=partial,
         failed_sources=failed_sources,
     )
@@ -400,7 +408,7 @@ async def _fetch_agent_leg(
     """Fetch agent memory records and total count concurrently."""
     records, total = await asyncio.gather(
         service.list_records(workspace_id, limit=limit, offset=offset, lifetime=lifetime.value),
-        service.pg_store.count_records(workspace_id, lifetime=lifetime.value),
+        service.count_records(workspace_id, lifetime=lifetime.value),
     )
     return [_memory_record_to_response(r) for r in records], total
 

--- a/src/metatron/api/routes/memory.py
+++ b/src/metatron/api/routes/memory.py
@@ -341,7 +341,7 @@ async def list_records(
             limit=limit,
             offset=offset,
         ),
-        service.pg_store.count_records(
+        service.count_records(
             workspace_id,
             agent_id=agent_id,
             scope=scope,

--- a/src/metatron/api/routes/memory.py
+++ b/src/metatron/api/routes/memory.py
@@ -7,6 +7,7 @@ accepted from the request body or query string.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime  # noqa: TC003 — pydantic field validation needs runtime resolution
 from typing import Annotated, Any, Literal
@@ -133,10 +134,16 @@ class MemorySearchResponse(BaseModel):
 
 
 class MemoryRecordListResponse(BaseModel):
-    """Response body for listing memory records."""
+    """Response body for listing memory records.
+
+    ``count`` is the size of the current page; ``total`` is the number of
+    records matching the request filters across all pages (before
+    limit/offset).
+    """
 
     records: list[MemoryRecordResponse]
     count: int
+    total: int
     limit: int
     offset: int
     has_more: bool
@@ -318,28 +325,37 @@ async def list_records(
         return MemoryRecordListResponse(
             records=[_record_to_response(r) for r in session_records],
             count=len(session_records),
+            total=len(session_records),
             limit=limit,
             offset=offset,
             has_more=False,
         )
 
-    records = await service.list_records(
-        workspace_id,
-        agent_id=agent_id,
-        scope=scope,
-        kind_filter=kind_filter,
-        status=status_filter,
-        limit=limit + 1,
-        offset=offset,
+    records, total = await asyncio.gather(
+        service.list_records(
+            workspace_id,
+            agent_id=agent_id,
+            scope=scope,
+            kind_filter=kind_filter,
+            status=status_filter,
+            limit=limit,
+            offset=offset,
+        ),
+        service.pg_store.count_records(
+            workspace_id,
+            agent_id=agent_id,
+            scope=scope,
+            kind_filter=kind_filter,
+            status=status_filter,
+        ),
     )
-    has_more = len(records) > limit
-    trimmed = records[:limit]
     return MemoryRecordListResponse(
-        records=[_record_to_response(r) for r in trimmed],
-        count=len(trimmed),
+        records=[_record_to_response(r) for r in records],
+        count=len(records),
+        total=total,
         limit=limit,
         offset=offset,
-        has_more=has_more,
+        has_more=(offset + len(records)) < total,
     )
 
 

--- a/src/metatron/api/routes/traces.py
+++ b/src/metatron/api/routes/traces.py
@@ -33,8 +33,11 @@ class RagTraceListItem(BaseModel):
 
 
 class RagTraceListResponse(BaseModel):
+    """``count`` is the current page size; ``total`` is the workspace-wide trace count."""
+
     traces: list[RagTraceListItem]
     count: int
+    total: int
     limit: int
     offset: int
 
@@ -72,12 +75,16 @@ async def list_traces(
 ) -> RagTraceListResponse:
     """List recent traces for the workspace (newest-first), lightweight rows."""
     workspace_id = resolve_workspace_id(request)
-    from metatron.storage.pg_connection import list_rag_traces_sync
+    from metatron.storage.pg_connection import count_rag_traces_sync, list_rag_traces_sync
 
-    rows = await asyncio.to_thread(list_rag_traces_sync, workspace_id, limit, offset)
+    rows, total = await asyncio.gather(
+        asyncio.to_thread(list_rag_traces_sync, workspace_id, limit, offset),
+        asyncio.to_thread(count_rag_traces_sync, workspace_id),
+    )
     return RagTraceListResponse(
         traces=[RagTraceListItem(**r) for r in rows],
         count=len(rows),
+        total=total,
         limit=limit,
         offset=offset,
     )

--- a/src/metatron/memory/service.py
+++ b/src/metatron/memory/service.py
@@ -422,6 +422,33 @@ class MemoryService:
             offset=offset,
         )
 
+    async def count_records(
+        self,
+        workspace_id: str,
+        *,
+        agent_id: str | None = None,
+        scope: MemoryScope | None = None,
+        kind_filter: list[MemoryKind] | None = None,
+        status: list[LifecycleStatus] | None = None,
+        lifetime: str = "all",
+    ) -> int:
+        """Count records matching the same filter surface as :meth:`list_records`.
+
+        Pagination companion: routes pair this with ``list_records`` (same
+        filters, no limit/offset) to expose an exact ``total``. Goes through
+        the service (not ``pg_store`` directly) so ``_check_workspace`` gates
+        the call like every other public method.
+        """
+        self._check_workspace(workspace_id)
+        return await self._pg.count_records(
+            workspace_id,
+            agent_id=agent_id,
+            scope=scope,
+            kind_filter=kind_filter,
+            status=status,
+            lifetime=lifetime,
+        )
+
     async def list_preferences(
         self,
         workspace_id: str,

--- a/src/metatron/storage/pg_connection.py
+++ b/src/metatron/storage/pg_connection.py
@@ -249,6 +249,18 @@ def list_rag_traces_sync(workspace_id: str, limit: int, offset: int) -> list[dic
         ]
 
 
+def count_rag_traces_sync(workspace_id: str) -> int:
+    """Count traces for a workspace (pagination total for the list endpoint)."""
+    from metatron.storage.pg_models import RagDebugTraceRow
+
+    with get_session() as session:
+        return (
+            session.query(RagDebugTraceRow)
+            .filter(RagDebugTraceRow.workspace_id == workspace_id)
+            .count()
+        )
+
+
 def upsert_document_fetch_stats_sync(
     workspace_id: str,
     doc_stats: dict[str, dict],

--- a/tests/unit/api/test_knowledge_routes.py
+++ b/tests/unit/api/test_knowledge_routes.py
@@ -156,6 +156,7 @@ class TestEmptyWorkspace:
         body = resp.json()
         assert body["records"] == []
         assert body["count"] == 0
+        assert body["total"] == 0
         assert body["has_more"] is False
         assert body["partial"] is False
         assert body["failed_sources"] == []
@@ -272,6 +273,7 @@ class TestBothSources:
         body = resp.json()
         assert len(body["records"]) == 5  # 3 + 2
         # total from both legs
+        assert body["total"] == 5
         # has_more = (0 + 10) < (3 + 2) = 10 < 5 = False
         assert body["has_more"] is False
 
@@ -291,6 +293,7 @@ class TestBothSources:
 
         resp = client.get("/api/v1/knowledge/records?limit=5")
         body = resp.json()
+        assert body["total"] == 300
         assert body["has_more"] is True
 
 
@@ -315,6 +318,7 @@ class TestOriginAgentFilter:
         body = resp.json()
         assert len(body["records"]) == 1
         assert body["records"][0]["origin"] == "agent"
+        assert body["total"] == 1
         # KB service was NOT called
         raw_doc_service.list_records.assert_not_awaited()
 
@@ -339,6 +343,7 @@ class TestOriginKbFilter:
         body = resp.json()
         assert len(body["records"]) == 1
         assert body["records"][0]["origin"] == "kb"
+        assert body["total"] == 1
         # Memory service list_records was NOT called
         mem_service.list_records.assert_not_awaited()
 
@@ -395,6 +400,8 @@ class TestPartialFailureAgentLeg:
         assert "agent" in body["failed_sources"]
         assert len(body["records"]) == 1
         assert body["records"][0]["origin"] == "kb"
+        # total covers only the surviving source (failed leg contributes 0)
+        assert body["total"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_knowledge_routes.py
+++ b/tests/unit/api/test_knowledge_routes.py
@@ -98,11 +98,10 @@ def settings() -> Settings:
 
 @pytest.fixture
 def mem_service() -> MagicMock:
-    """MemoryService mock with a pg_store sub-mock."""
+    """MemoryService mock (list_records + count_records pair)."""
     mock = MagicMock(spec=MemoryService)
     mock.list_records = AsyncMock(return_value=[])
-    mock.pg_store = MagicMock()
-    mock.pg_store.count_records = AsyncMock(return_value=0)
+    mock.count_records = AsyncMock(return_value=0)
     return mock
 
 
@@ -176,7 +175,7 @@ class TestAgentOnlyData:
     ) -> None:
         record = _sample_mem_record()
         mem_service.list_records = AsyncMock(return_value=[record])
-        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        mem_service.count_records = AsyncMock(return_value=1)
         raw_doc_service.list_records = AsyncMock(return_value=([], 0))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -195,7 +194,7 @@ class TestAgentOnlyData:
         older = _sample_mem_record(id="old", updated_at=datetime(2025, 1, 1, tzinfo=UTC))
         newer = _sample_mem_record(id="new", updated_at=datetime(2026, 6, 1, tzinfo=UTC))
         mem_service.list_records = AsyncMock(return_value=[older, newer])
-        mem_service.pg_store.count_records = AsyncMock(return_value=2)
+        mem_service.count_records = AsyncMock(return_value=2)
         raw_doc_service.list_records = AsyncMock(return_value=([], 0))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -220,7 +219,7 @@ class TestKbOnlyData:
     ) -> None:
         doc = _sample_raw_doc()
         mem_service.list_records = AsyncMock(return_value=[])
-        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        mem_service.count_records = AsyncMock(return_value=0)
         raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -241,7 +240,7 @@ class TestKbOnlyData:
         """T17 — RawDocument.connector_type appears as source_type."""
         doc = _sample_raw_doc(connector_type="confluence")
         mem_service.list_records = AsyncMock(return_value=[])
-        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        mem_service.count_records = AsyncMock(return_value=0)
         raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -265,7 +264,7 @@ class TestBothSources:
         mem_records = [_sample_mem_record(id=f"m{i}") for i in range(3)]
         kb_docs = [_sample_raw_doc(id=f"d{i}") for i in range(2)]
         mem_service.list_records = AsyncMock(return_value=mem_records)
-        mem_service.pg_store.count_records = AsyncMock(return_value=3)
+        mem_service.count_records = AsyncMock(return_value=3)
         raw_doc_service.list_records = AsyncMock(return_value=(kb_docs, 2))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -287,7 +286,7 @@ class TestBothSources:
         kb_docs = [_sample_raw_doc(id=f"d{i}") for i in range(3)]
         # total = 100 + 200 = 300; offset=0; limit=5 → has_more=True
         mem_service.list_records = AsyncMock(return_value=mem_records)
-        mem_service.pg_store.count_records = AsyncMock(return_value=100)
+        mem_service.count_records = AsyncMock(return_value=100)
         raw_doc_service.list_records = AsyncMock(return_value=(kb_docs, 200))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -310,7 +309,7 @@ class TestOriginAgentFilter:
         raw_doc_service: AsyncMock,
     ) -> None:
         mem_service.list_records = AsyncMock(return_value=[_sample_mem_record()])
-        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        mem_service.count_records = AsyncMock(return_value=1)
         client = _make_client(settings, mem_service, raw_doc_service)
 
         resp = client.get("/api/v1/knowledge/records?origin=agent")
@@ -354,14 +353,15 @@ class TestOriginKbFilter:
 
 
 class TestPagination:
-    def test_pagination_params_forwarded(
+    def test_origin_all_legs_overfetch_full_window(
         self,
         settings: Settings,
         mem_service: MagicMock,
         raw_doc_service: AsyncMock,
     ) -> None:
+        """origin=all: each leg fetches [0, offset+limit) so the merged page is exact."""
         mem_service.list_records = AsyncMock(return_value=[])
-        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        mem_service.count_records = AsyncMock(return_value=0)
         raw_doc_service.list_records = AsyncMock(return_value=([], 0))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -369,10 +369,76 @@ class TestPagination:
         assert resp.status_code == 200
         mem_service.list_records.assert_awaited_once()
         call_kwargs = mem_service.list_records.await_args
+        assert call_kwargs[1]["limit"] == 30  # offset + limit
+        assert call_kwargs[1]["offset"] == 0
+
+        raw_doc_service.list_records.assert_awaited_once_with(limit=30, offset=0)
+
+    def test_single_origin_forwards_limit_offset_unchanged(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        """origin=agent: pagination pushes down to the source — no over-fetch."""
+        mem_service.list_records = AsyncMock(return_value=[])
+        mem_service.count_records = AsyncMock(return_value=0)
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=agent&limit=10&offset=20")
+        assert resp.status_code == 200
+        call_kwargs = mem_service.list_records.await_args
         assert call_kwargs[1]["limit"] == 10
         assert call_kwargs[1]["offset"] == 20
 
-        raw_doc_service.list_records.assert_awaited_once_with(limit=10, offset=20)
+    def test_origin_all_offset_slices_exact_global_page(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        """Page 2 of the merged view contains the true global tail, not per-leg offsets."""
+        mem_records = [
+            _sample_mem_record(id="m-new", updated_at=datetime(2026, 4, 1, tzinfo=UTC)),
+            _sample_mem_record(id="m-old", updated_at=datetime(2026, 1, 1, tzinfo=UTC)),
+        ]
+        kb_docs = [
+            _sample_raw_doc(id="d-new", updated_at=datetime(2026, 3, 1, tzinfo=UTC)),
+            _sample_raw_doc(id="d-old", updated_at=datetime(2026, 2, 1, tzinfo=UTC)),
+        ]
+        mem_service.list_records = AsyncMock(return_value=mem_records)
+        mem_service.count_records = AsyncMock(return_value=2)
+        raw_doc_service.list_records = AsyncMock(return_value=(kb_docs, 2))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all&limit=2&offset=2")
+        assert resp.status_code == 200
+        body = resp.json()
+        # Global order: m-new(04) > d-new(03) > d-old(02) > m-old(01); page 2 = tail.
+        assert [r["id"] for r in body["records"]] == ["d-old", "m-old"]
+        assert body["count"] == 2
+        assert body["total"] == 4
+        assert body["has_more"] is False
+
+    def test_origin_all_offset_past_total_is_empty_not_infinite(
+        self,
+        settings: Settings,
+        mem_service: MagicMock,
+        raw_doc_service: AsyncMock,
+    ) -> None:
+        """offset >= total: empty page, has_more=False (no infinite-next loop)."""
+        mem_service.list_records = AsyncMock(return_value=[_sample_mem_record(id="m1")])
+        mem_service.count_records = AsyncMock(return_value=1)
+        raw_doc_service.list_records = AsyncMock(return_value=([], 0))
+        client = _make_client(settings, mem_service, raw_doc_service)
+
+        resp = client.get("/api/v1/knowledge/records?origin=all&limit=50&offset=50")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["records"] == []
+        assert body["count"] == 0
+        assert body["total"] == 1
+        assert body["has_more"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -388,7 +454,7 @@ class TestPartialFailureAgentLeg:
         raw_doc_service: AsyncMock,
     ) -> None:
         mem_service.list_records = AsyncMock(side_effect=RuntimeError("PG down"))
-        mem_service.pg_store.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        mem_service.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
         doc = _sample_raw_doc()
         raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
         client = _make_client(settings, mem_service, raw_doc_service)
@@ -418,7 +484,7 @@ class TestPartialFailureKbLeg:
     ) -> None:
         record = _sample_mem_record()
         mem_service.list_records = AsyncMock(return_value=[record])
-        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        mem_service.count_records = AsyncMock(return_value=1)
         raw_doc_service.list_records = AsyncMock(side_effect=RuntimeError("Qdrant timeout"))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -444,7 +510,7 @@ class TestBothLegsFailure:
         raw_doc_service: AsyncMock,
     ) -> None:
         mem_service.list_records = AsyncMock(side_effect=RuntimeError("PG down"))
-        mem_service.pg_store.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        mem_service.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
         raw_doc_service.list_records = AsyncMock(side_effect=RuntimeError("KB down"))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -466,7 +532,7 @@ class TestSingleLegFailure:
         raw_doc_service: AsyncMock,
     ) -> None:
         mem_service.list_records = AsyncMock(side_effect=RuntimeError("PG down"))
-        mem_service.pg_store.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
+        mem_service.count_records = AsyncMock(side_effect=RuntimeError("PG down"))
         client = _make_client(settings, mem_service, raw_doc_service)
 
         resp = client.get("/api/v1/knowledge/records?origin=agent")
@@ -499,7 +565,7 @@ class TestWorkspaceIsolation:
     ) -> None:
         """The workspace_id passed to the service must match the auth-derived value."""
         mem_service.list_records = AsyncMock(return_value=[])
-        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        mem_service.count_records = AsyncMock(return_value=0)
         raw_doc_service.list_records = AsyncMock(return_value=([], 0))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -669,7 +735,7 @@ class TestLifetimeFilter:
             ttl_expires_at=future_ttl,
         )
         mem_service.list_records = AsyncMock(return_value=[record])
-        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        mem_service.count_records = AsyncMock(return_value=1)
         raw_doc_service.list_records = AsyncMock(return_value=([], 0))
         client = _make_client(settings, mem_service, raw_doc_service)
 
@@ -689,7 +755,7 @@ class TestLifetimeFilter:
         """Persistent agent rows have session_id=None and ttl_expires_at=None."""
         record = _sample_mem_record()  # no session_id or ttl_expires_at
         mem_service.list_records = AsyncMock(return_value=[record])
-        mem_service.pg_store.count_records = AsyncMock(return_value=1)
+        mem_service.count_records = AsyncMock(return_value=1)
         client = _make_client(settings, mem_service, raw_doc_service)
 
         resp = client.get("/api/v1/knowledge/records?origin=agent")
@@ -713,7 +779,7 @@ class TestLifetimeFilter:
         doc = _sample_raw_doc()
         raw_doc_service.list_records = AsyncMock(return_value=([doc], 1))
         mem_service.list_records = AsyncMock(return_value=[])
-        mem_service.pg_store.count_records = AsyncMock(return_value=0)
+        mem_service.count_records = AsyncMock(return_value=0)
         client = _make_client(settings, mem_service, raw_doc_service)
 
         resp = client.get("/api/v1/knowledge/records?origin=kb&lifetime=session")
@@ -733,7 +799,7 @@ class TestLifetimeFilter:
         client = _make_client(settings, mem_service, raw_doc_service)
         client.get("/api/v1/knowledge/records?origin=agent")
 
-        _, count_kwargs = mem_service.pg_store.count_records.await_args
+        _, count_kwargs = mem_service.count_records.await_args
         assert count_kwargs["lifetime"] == "persistent"
 
 

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -74,6 +74,8 @@ def _sample_record(**overrides: Any) -> MemoryRecord:
 def service() -> AsyncMock:
     """An AsyncMock MemoryService for dependency override."""
     mock = AsyncMock(spec=MemoryService)
+    mock.pg_store = MagicMock()
+    mock.pg_store.count_records = AsyncMock(return_value=0)
     return mock
 
 
@@ -274,6 +276,7 @@ class TestListRecords:
         service: AsyncMock,
     ) -> None:
         service.list_records.return_value = [_sample_record(id="m1")]
+        service.pg_store.count_records = AsyncMock(return_value=1)
 
         response = client.get(
             "/api/v1/memory/records",
@@ -288,6 +291,7 @@ class TestListRecords:
         assert response.status_code == 200
         body = response.json()
         assert body["count"] == 1
+        assert body["total"] == 1
         assert body["limit"] == 10
         assert body["offset"] == 0
         assert body["has_more"] is False
@@ -296,8 +300,13 @@ class TestListRecords:
         kwargs = service.list_records.await_args.kwargs
         assert kwargs["agent_id"] == "agent-1"
         assert kwargs["scope"] == MemoryScope.PER_AGENT
-        assert kwargs["limit"] == 11  # limit + 1 for has_more detection
+        assert kwargs["limit"] == 10
         assert kwargs["offset"] == 0
+
+        # count_records must receive the same filter surface as list_records.
+        count_kwargs = service.pg_store.count_records.await_args.kwargs
+        assert count_kwargs["agent_id"] == "agent-1"
+        assert count_kwargs["scope"] == MemoryScope.PER_AGENT
 
     def test_list_records_session_branch(
         self,
@@ -319,6 +328,7 @@ class TestListRecords:
         assert response.status_code == 200
         body = response.json()
         assert body["count"] == 1
+        assert body["total"] == 1
         service.list_session.assert_awaited_once_with("ws-test", "sess-1")
         service.list_records.assert_not_awaited()
 
@@ -327,7 +337,8 @@ class TestListRecords:
         client: TestClient,
         service: AsyncMock,
     ) -> None:
-        service.list_records.return_value = [_sample_record(id=f"m{i}") for i in range(3)]
+        service.list_records.return_value = [_sample_record(id=f"m{i}") for i in range(2)]
+        service.pg_store.count_records = AsyncMock(return_value=3)
 
         response = client.get(
             "/api/v1/memory/records",
@@ -337,8 +348,29 @@ class TestListRecords:
         assert response.status_code == 200
         body = response.json()
         assert body["count"] == 2
+        assert body["total"] == 3
         assert body["has_more"] is True
         assert len(body["records"]) == 2
+
+    def test_list_total_respects_filters_last_page(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """Last page: offset + count == total → has_more=False, total unchanged."""
+        service.list_records.return_value = [_sample_record(id="m-last")]
+        service.pg_store.count_records = AsyncMock(return_value=3)
+
+        response = client.get(
+            "/api/v1/memory/records",
+            params={"limit": 2, "offset": 2},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert body["total"] == 3
+        assert body["has_more"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -1056,9 +1088,7 @@ class TestWorkspaceQueryScoping:
         passed_ws = service.search.await_args.args[0]
         assert passed_ws == "ws-x"
 
-    def test_list_forbidden_for_non_member(
-        self, service: AsyncMock, settings: Settings
-    ) -> None:
+    def test_list_forbidden_for_non_member(self, service: AsyncMock, settings: Settings) -> None:
         client = self._client(workspace_ids=["ws-a"], service=service, settings=settings)
 
         resp = client.get("/api/v1/memory/records?workspace_id=ws-x")

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
@@ -74,8 +74,7 @@ def _sample_record(**overrides: Any) -> MemoryRecord:
 def service() -> AsyncMock:
     """An AsyncMock MemoryService for dependency override."""
     mock = AsyncMock(spec=MemoryService)
-    mock.pg_store = MagicMock()
-    mock.pg_store.count_records = AsyncMock(return_value=0)
+    mock.count_records = AsyncMock(return_value=0)
     return mock
 
 
@@ -276,7 +275,7 @@ class TestListRecords:
         service: AsyncMock,
     ) -> None:
         service.list_records.return_value = [_sample_record(id="m1")]
-        service.pg_store.count_records = AsyncMock(return_value=1)
+        service.count_records = AsyncMock(return_value=1)
 
         response = client.get(
             "/api/v1/memory/records",
@@ -304,7 +303,7 @@ class TestListRecords:
         assert kwargs["offset"] == 0
 
         # count_records must receive the same filter surface as list_records.
-        count_kwargs = service.pg_store.count_records.await_args.kwargs
+        count_kwargs = service.count_records.await_args.kwargs
         assert count_kwargs["agent_id"] == "agent-1"
         assert count_kwargs["scope"] == MemoryScope.PER_AGENT
 
@@ -338,7 +337,7 @@ class TestListRecords:
         service: AsyncMock,
     ) -> None:
         service.list_records.return_value = [_sample_record(id=f"m{i}") for i in range(2)]
-        service.pg_store.count_records = AsyncMock(return_value=3)
+        service.count_records = AsyncMock(return_value=3)
 
         response = client.get(
             "/api/v1/memory/records",
@@ -359,7 +358,7 @@ class TestListRecords:
     ) -> None:
         """Last page: offset + count == total → has_more=False, total unchanged."""
         service.list_records.return_value = [_sample_record(id="m-last")]
-        service.pg_store.count_records = AsyncMock(return_value=3)
+        service.count_records = AsyncMock(return_value=3)
 
         response = client.get(
             "/api/v1/memory/records",

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -594,6 +594,33 @@ class TestWorkspaceIsolation:
         with pytest.raises(ValueError, match="workspace_id mismatch"):
             await service.get("ws_other", "mem001")
 
+    async def test_rejects_mismatch_on_count_records(self) -> None:
+        service, _, _, _ = _make_service(workspace_id="ws1")
+
+        with pytest.raises(ValueError, match="workspace_id mismatch"):
+            await service.count_records("ws_other")
+
+    async def test_count_records_delegates_filters_to_pg(self) -> None:
+        service, _, _, pg_store = _make_service(workspace_id="ws1")
+        pg_store.count_records.return_value = 7
+
+        total = await service.count_records(
+            "ws1",
+            agent_id="agent1",
+            scope=MemoryScope.PER_AGENT,
+            lifetime="persistent",
+        )
+
+        assert total == 7
+        pg_store.count_records.assert_awaited_once_with(
+            "ws1",
+            agent_id="agent1",
+            scope=MemoryScope.PER_AGENT,
+            kind_filter=None,
+            status=None,
+            lifetime="persistent",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Content hash exact-match semantics

--- a/tests/unit/test_traces_endpoint.py
+++ b/tests/unit/test_traces_endpoint.py
@@ -89,10 +89,14 @@ def test_list_traces_shape(client):
     ]
     # Trailing slash is the registered path (redirect_slashes=False; the ui-cc
     # nginx rewrites bare /api/v1/traces to /api/v1/traces/ — repo convention).
-    with patch("metatron.storage.pg_connection.list_rag_traces_sync", return_value=rows):
+    with (
+        patch("metatron.storage.pg_connection.list_rag_traces_sync", return_value=rows),
+        patch("metatron.storage.pg_connection.count_rag_traces_sync", return_value=7),
+    ):
         resp = client.get("/api/v1/traces/?limit=5&offset=0")
     assert resp.status_code == 200
     body = resp.json()
     assert body["count"] == 1
+    assert body["total"] == 7
     assert body["traces"][0]["trace_id"] == "t-1"
     assert body["limit"] == 5


### PR DESCRIPTION
## Why

Frontend request: Memory Inspector pagination has no grand total — `count` is the current page size and the only continuation signal is `has_more`, so the UI can't render a windowed paginator (jump-to-page, "of N"). Confirmed live on workspace MTRNIX: `limit=200 → count:200, has_more:true`, real total 534 unobtainable in one response.

## What

Additive `total` field (records matching the request filters, before limit/offset) on three list endpoints. `count` keeps its existing page-size semantics — no breaking change.

- **`GET /api/v1/knowledge/records`** — exposes the total the route already computed internally for `has_more` (`agent_total + kb_total` under `origin=all`). Under `partial=true` the failed leg contributes 0 → `total` covers surviving sources only (frontend already renders the partial state).
- **`GET /api/v1/memory/records`** — replaces the `limit+1` has_more trick with `asyncio.gather(list_records, count_records)`; `count_records` receives the identical filter surface (`agent_id`, `scope`, `kind_filter`, `status`). Session branch (Redis, unpaginated) returns `total == count`.
- **`GET /api/v1/traces/`** — new `count_rag_traces_sync` in `pg_connection.py` + `total` in the list response.

Invariant: `has_more == (offset + count < total)` on all paths.

## Follow-up commit (review items 1+2 + exact pagination)

- `origin=all` pagination is now **exact** (supersedes the D-P1-02 approximation): each leg over-fetches `[0, offset+limit)`, global sort by `updated_at DESC` (tie-break `id`), slice `[offset : offset+limit]`. Page jumps no longer skip/duplicate rows at leg boundaries. Cost bounded by the 10k offset cap; keys-then-hydrate two-phase fetch is the escape hatch at scale.
- New `MemoryService.count_records` (same filter surface as `list_records`, runs `_check_workspace`) — memory and knowledge routes no longer reach into `service.pg_store`.
- `has_more` unified to `(offset + count) < total` everywhere — safe now that merged pages are exact.

## Tests

- `tests/unit/api/test_knowledge_routes.py` — `total` asserted on empty / merged / partial / single-origin paths
- `tests/unit/api/test_memory_routes.py` — filter-parity between `list_records` and `count_records`, has_more via total, last-page case, session branch
- `tests/unit/test_traces_endpoint.py` — list shape with `total`

89/89 targeted tests pass. Full unit suite: identical pass/fail picture to develop baseline (20 pre-existing failures from local env, none related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

