### PR TITLE
fix(MTRNIX-395): freshness lifecycle fixes — reachable STALE + dedup …

### DIFF
--- a/scripts/cleanup_mirror_review_entries.py
+++ b/scripts/cleanup_mirror_review_entries.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Remove mirror duplicate-review entries (MTRNIX-395).
+
+A possible-duplicate finding is undirected, but the freshness Reconciler used
+to create a directed ``ReviewEntry`` per record. When both members of a pair
+were processed, the queue ended up holding two rows for the same pair:
+``(target=A, related=B)`` and the mirror ``(target=B, related=A)``. The
+Reconciler now dedups undirectedly going forward and ``resolve_review``
+cascade-deletes the mirror — this script cleans up the rows that accumulated
+before the fix.
+
+For each undirected pair flagged in both directions it keeps one entry
+(deterministically the one whose ``target_id`` sorts first) and deletes the
+mirror. Single-direction findings and non-paired reasons
+(``low_confidence_decision``) are left untouched.
+
+Idempotent — re-running after cleanup finds no remaining mirrors.
+
+Usage:
+    python scripts/cleanup_mirror_review_entries.py \\
+        --workspace-id MTRNIX [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+sys.path.insert(0, "src")
+
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metatron.core.config import get_settings
+from metatron.storage.freshness_pg import FreshnessStore
+
+_PAIRED_REASON = "possible_duplicate"
+
+
+async def _run(workspace_id: str, dry_run: bool) -> None:
+    settings = get_settings()
+    engine = create_async_engine(settings.postgres_dsn)
+    store = FreshnessStore(engine)
+
+    deleted = 0
+    pairs_collapsed = 0
+    try:
+        entries = await store.list_review_entries(
+            workspace_id,
+            target_kind="memory_record",
+            reason=_PAIRED_REASON,
+            limit=100000,
+        )
+        # Index directed entries by their (target, related) edge.
+        by_edge: dict[tuple[str, str], str] = {}
+        for e in entries:
+            if not e.related_record_id:
+                continue
+            by_edge[(e.target_id, e.related_record_id)] = e.id
+
+        handled: set[frozenset[str]] = set()
+        for e in entries:
+            if not e.related_record_id:
+                continue
+            pair = frozenset({e.target_id, e.related_record_id})
+            if pair in handled or len(pair) < 2:
+                continue
+            forward = (e.target_id, e.related_record_id)
+            mirror = (e.related_record_id, e.target_id)
+            if mirror not in by_edge:
+                continue  # only one direction — nothing to collapse
+            handled.add(pair)
+            pairs_collapsed += 1
+            # Keep the entry whose target_id sorts first; delete the other.
+            keep_edge, drop_edge = (
+                (forward, mirror) if forward[0] <= mirror[0] else (mirror, forward)
+            )
+            drop_id = by_edge[drop_edge]
+            print(
+                f"pair {keep_edge[0]}<->{keep_edge[1]}: keep {by_edge[keep_edge]} drop {drop_id}"
+            )
+            if not dry_run:
+                await store.delete_review_entry(workspace_id, drop_id)
+                deleted += 1
+    finally:
+        await engine.dispose()
+
+    mode = "dry-run" if dry_run else "applied"
+    print(
+        f"cleanup ({mode}): workspace={workspace_id} "
+        f"mirror_pairs={pairs_collapsed} deleted={deleted}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Remove mirror duplicate-review entries (MTRNIX-395)."
+    )
+    parser.add_argument("--workspace-id", required=True, help="Target workspace id.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report mirror pairs without deleting.",
+    )
+    args = parser.parse_args()
+    asyncio.run(_run(args.workspace_id, args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/metatron/freshness/stages/reconciler.py
+++ b/src/metatron/freshness/stages/reconciler.py
@@ -158,6 +158,21 @@ class Reconciler:
             )
             if existing is not None:
                 return existing
+            # MTRNIX-395: a duplicate pair is undirected — when the partner
+            # record was processed first it created the mirror entry
+            # (target=related_id, related=target_id). Treat that as the same
+            # finding so the queue holds one row per pair, not two. (Single
+            # worker processes jobs sequentially; a TOCTOU window exists only
+            # under multi-worker deployments, accepted for now.)
+            mirror = await self._freshness_store.find_review_entry(
+                workspace_id,
+                target_id=related_id,
+                target_kind=target_kind,
+                reason=self.REASON,
+                related_record_id=target_id,
+            )
+            if mirror is not None:
+                return mirror
 
             entry = ReviewEntry(
                 workspace_id=workspace_id,

--- a/src/metatron/memory/service.py
+++ b/src/metatron/memory/service.py
@@ -794,6 +794,7 @@ class MemoryService:
         # same transaction. Only meaningful for paired reasons (those carry a
         # ``related_record_id``); low-confidence entries have none.
         mirror_id: str | None = None
+        mirror_target_id: str = ""  # partner record (B) — set iff mirror found
         if entry.related_record_id:
             mirror = await self._freshness_store.find_review_entry(
                 workspace_id,
@@ -804,6 +805,7 @@ class MemoryService:
             )
             if mirror is not None and mirror.id != review_id:
                 mirror_id = mirror.id
+                mirror_target_id = mirror.target_id
 
         # 3. Resolve the new status / verification_state / superseded_by.
         new_status: LifecycleStatus
@@ -876,8 +878,33 @@ class MemoryService:
             await self._freshness_store.delete_review_entry(workspace_id, review_id, conn=conn)
             if mirror_id is not None:
                 # Cascade-delete the mirror entry (MTRNIX-395) so the pair
-                # leaves the queue as a unit.
+                # leaves the queue as a unit. This is intentional for ALL
+                # actions, including ``merge_into`` a third record: the pair
+                # A<->B is considered settled once either side is resolved, so
+                # the B->A mirror is moot even when A merges into some C. If B
+                # is genuinely similar to the survivor, the Reconciler re-flags
+                # it on B's next pipeline pass.
                 await self._freshness_store.delete_review_entry(workspace_id, mirror_id, conn=conn)
+                # Give the partner record (B) its own audit row so a per-record
+                # review-history view explains why its queue entry vanished —
+                # otherwise the only trace is the ``mirror_review_entry_id`` on
+                # this (A) event. Same event_type so it surfaces in the shared
+                # audit stream; ``action="cascade_mirror"`` distinguishes it.
+                mirror_evt = MachineEvent(
+                    workspace_id=workspace_id,
+                    event_type="freshness_review_resolved",
+                    actor=actor,
+                    target_kind="memory_record",
+                    target_id=mirror_target_id,
+                    payload={
+                        "review_entry_id": mirror_id,
+                        "action": "cascade_mirror",
+                        "resolved_via_review_entry_id": review_id,
+                        "resolved_via_target_id": entry.target_id,
+                        "reason": entry.reason,
+                    },
+                )
+                await self._freshness_store.save_machine_event(mirror_evt, conn=conn)
             saved_evt = await self._freshness_store.save_machine_event(evt, conn=conn)
 
         # 7. Best-effort Qdrant payload sync.

--- a/src/metatron/memory/service.py
+++ b/src/metatron/memory/service.py
@@ -787,6 +787,24 @@ class MemoryService:
             raise MemoryNotFoundError(msg)
         old_status = record.status.value
 
+        # 2b. MTRNIX-395: a duplicate pair may have a mirror review entry
+        # (target=related, related=target) created when the partner record
+        # was processed in the opposite direction. Resolving this entry
+        # settles the pair, so the mirror is moot — cascade-delete it in the
+        # same transaction. Only meaningful for paired reasons (those carry a
+        # ``related_record_id``); low-confidence entries have none.
+        mirror_id: str | None = None
+        if entry.related_record_id:
+            mirror = await self._freshness_store.find_review_entry(
+                workspace_id,
+                target_id=entry.related_record_id,
+                target_kind="memory_record",
+                reason=entry.reason,
+                related_record_id=entry.target_id,
+            )
+            if mirror is not None and mirror.id != review_id:
+                mirror_id = mirror.id
+
         # 3. Resolve the new status / verification_state / superseded_by.
         new_status: LifecycleStatus
         if action_kind == "merge_into":
@@ -831,6 +849,7 @@ class MemoryService:
             target_id=entry.target_id,
             payload={
                 "review_entry_id": review_id,
+                "mirror_review_entry_id": mirror_id,
                 "action": action_kind,
                 "merge_into_target_id": merge_target,
                 "old_status": old_status,
@@ -842,15 +861,23 @@ class MemoryService:
         async with self._pg.begin() as conn:
             # ``superseded_by=None`` means "leave unchanged" per
             # ``update_lifecycle`` semantics; we only pass it for merge_into.
+            # ``bump_updated_at=True`` (MTRNIX-395): a human resolution is a
+            # freshness signal — refresh the clock so a kept record does not
+            # immediately re-STALE on the next scheduled scan.
             await self._pg.update_lifecycle(
                 workspace_id,
                 entry.target_id,
                 status=new_status,
                 verification_state=verification_state,
                 superseded_by=superseded_by,
+                bump_updated_at=True,
                 conn=conn,
             )
             await self._freshness_store.delete_review_entry(workspace_id, review_id, conn=conn)
+            if mirror_id is not None:
+                # Cascade-delete the mirror entry (MTRNIX-395) so the pair
+                # leaves the queue as a unit.
+                await self._freshness_store.delete_review_entry(workspace_id, mirror_id, conn=conn)
             saved_evt = await self._freshness_store.save_machine_event(evt, conn=conn)
 
         # 7. Best-effort Qdrant payload sync.

--- a/src/metatron/storage/memory_postgres.py
+++ b/src/metatron/storage/memory_postgres.py
@@ -554,12 +554,26 @@ class MemoryPostgresStore:
         valid_until: datetime | None = None,
         append_tag: str | None = None,
         append_tags: list[str] | None = None,
+        bump_updated_at: bool = False,
         conn: AsyncConnection | None = None,
     ) -> MemoryRecord | None:
-        """Freshness-pipeline partial update for lifecycle columns.
+        """Partial update for lifecycle columns.
 
-        Only supplied fields are written. Always bumps ``updated_at``. The
-        ``append_tag`` helper lets Curator add a tag idempotently without
+        Only supplied fields are written. **By default does NOT touch
+        ``updated_at``** (MTRNIX-395): ``updated_at`` is the content-freshness
+        clock that ``FreshnessMonitor`` reads to decide STALE, and the
+        automated freshness pipeline (Linker/Monitor/Curator/DecisionEngine)
+        must not reset it — bumping it on the Linker's ``evidence_count``
+        write reset the clock on every pipeline pass, so STALE was unreachable.
+
+        ``bump_updated_at=True`` opts back into the bump for **human-initiated**
+        curation that genuinely refreshes the record — notably
+        ``MemoryService.resolve_review`` keeping/curating a record, where an
+        operator's decision IS a freshness signal and the record should not
+        immediately re-STALE on the next scan. Genuine content edits go through
+        ``save()``, which sets ``updated_at`` itself.
+
+        The ``append_tag`` helper lets Curator add a tag idempotently without
         having to round-trip the full record. ``append_tags`` is the batch
         variant used by the freshness DecisionEngine to merge N tags in a
         single UPDATE (no N+1); dedup happens in SQL so concurrent writers
@@ -625,11 +639,16 @@ class MemoryPostgresStore:
                     unique_tags.append(t)
             params["new_tags"] = json.dumps(unique_tags)
 
+        # MTRNIX-395: only bump ``updated_at`` when the caller asks (human
+        # curation). The automated freshness pipeline passes the default
+        # (False) so its writes do not reset the STALE clock — see docstring.
+        if bump_updated_at:
+            set_parts.append("updated_at = :updated_at")
+            params["updated_at"] = datetime.now(UTC)
+
         if not set_parts:
             return await self.get(workspace_id, record_id)
 
-        set_parts.append("updated_at = :updated_at")
-        params["updated_at"] = datetime.now(UTC)
         set_clause = ", ".join(set_parts)
 
         sql = text(

--- a/tests/unit/memory/freshness/test_reconciler.py
+++ b/tests/unit/memory/freshness/test_reconciler.py
@@ -117,6 +117,40 @@ class TestReconciler:
         assert out is existing
         fs.save_review_entry.assert_not_awaited()
 
+    async def test_mirror_pair_is_not_duplicated(self) -> None:
+        """MTRNIX-395: if the reverse-direction entry exists, reuse it.
+
+        When the partner record (rec2) was processed first it created
+        (target=rec2, related=rec1). Processing rec1 must NOT create the
+        mirror (target=rec1, related=rec2) — the pair is one finding.
+        """
+        rec, pg, qdrant, coord, fs = _build_reconciler()
+        coord.acquire_lock.return_value = "tok"
+        pg.get.return_value = _record()
+        qdrant.search.return_value = [
+            {"record_id": "rec1", "score": 1.0},
+            {"record_id": "rec2", "score": 0.95},
+        ]
+        mirror = ReviewEntry(
+            id="mirror",
+            workspace_id="ws1",
+            target_id="rec2",
+            target_kind="memory_record",
+            reason="possible_duplicate",
+            related_record_id="rec1",
+            content="",
+            confidence=0.95,
+        )
+        # Forward lookup (target=rec1, related=rec2) → None; mirror lookup
+        # (target=rec2, related=rec1) → the existing mirror entry.
+        fs.find_review_entry.side_effect = [None, mirror]
+
+        with patch(_ALIAS_PATH, return_value=None):
+            out = await rec.run("ws1", "rec1")
+
+        assert out is mirror
+        fs.save_review_entry.assert_not_awaited()
+
     async def test_lock_contention_returns_none(self) -> None:
         rec, pg, qdrant, coord, _fs = _build_reconciler()
         coord.acquire_lock.return_value = None

--- a/tests/unit/memory/test_service_review.py
+++ b/tests/unit/memory/test_service_review.py
@@ -176,6 +176,9 @@ class TestResolveReviewKeep:
         assert kw["status"] == LifecycleStatus.ACTIVE
         assert kw["verification_state"] == "keep_resolved"
         assert kw.get("superseded_by") is None
+        # MTRNIX-395: a human keep refreshes the freshness clock so the record
+        # does not re-STALE on the next scheduled scan.
+        assert kw["bump_updated_at"] is True
 
         fs.delete_review_entry.assert_awaited_once()
         assert fs.delete_review_entry.await_args.args == ("ws1", "r1")
@@ -411,6 +414,57 @@ class TestResolveReviewAtomicity:
         assert _RollbackTxn.exited_with_exception
         # Best-effort Qdrant sync must not run when the transaction fails.
         deps["qdrant"].update_payload.assert_not_awaited()
+
+
+class TestResolveReviewMirrorCascade:
+    """MTRNIX-395: resolving one side of a duplicate pair cascade-deletes the
+    mirror review entry so the pair leaves the queue as a unit."""
+
+    async def test_mirror_entry_is_cascade_deleted(self) -> None:
+        fs = MagicMock()
+        # Primary entry is paired (carries a related_record_id).
+        primary = _review(review_id="r1", target_id="mem001")
+        primary.related_record_id = "mem002"
+        fs.list_review_entries = AsyncMock(return_value=[primary])
+        # Mirror lookup (target=mem002, related=mem001) returns the mirror.
+        mirror = _review(review_id="r_mirror", target_id="mem002")
+        mirror.related_record_id = "mem001"
+        fs.find_review_entry = AsyncMock(return_value=mirror)
+        fs.delete_review_entry = AsyncMock(return_value=True)
+        fs.save_machine_event = AsyncMock(side_effect=lambda evt, **_kw: evt)
+        pg = MagicMock()
+        pg.get = AsyncMock(return_value=_record())
+        pg.update_lifecycle = AsyncMock(return_value=_record(status=LifecycleStatus.ARCHIVED))
+        service, _ = _make_service(freshness_store=fs, pg_store=pg)
+
+        await service.resolve_review("ws1", review_id="r1", action="archive")
+
+        # Both the primary and the mirror were deleted.
+        deleted_ids = {c.args[1] for c in fs.delete_review_entry.await_args_list}
+        assert deleted_ids == {"r1", "r_mirror"}
+        # Mirror id recorded in the audit payload.
+        saved_evt = fs.save_machine_event.await_args.args[0]
+        assert saved_evt.payload["mirror_review_entry_id"] == "r_mirror"
+
+    async def test_no_mirror_lookup_for_unpaired_reason(self) -> None:
+        """low_confidence_decision entries carry no related_record_id — the
+        mirror lookup must be skipped entirely."""
+        fs = MagicMock()
+        fs.list_review_entries = AsyncMock(
+            return_value=[_review(reason="low_confidence_decision")]
+        )
+        fs.find_review_entry = AsyncMock()
+        fs.delete_review_entry = AsyncMock(return_value=True)
+        fs.save_machine_event = AsyncMock(side_effect=lambda evt, **_kw: evt)
+        pg = MagicMock()
+        pg.get = AsyncMock(return_value=_record())
+        pg.update_lifecycle = AsyncMock(return_value=_record(status=LifecycleStatus.ACTIVE))
+        service, _ = _make_service(freshness_store=fs, pg_store=pg)
+
+        await service.resolve_review("ws1", review_id="r1", action="keep")
+
+        fs.find_review_entry.assert_not_awaited()
+        fs.delete_review_entry.assert_awaited_once()
 
 
 class TestSearchStatusFilterPlumbing:

--- a/tests/unit/memory/test_service_review.py
+++ b/tests/unit/memory/test_service_review.py
@@ -442,9 +442,18 @@ class TestResolveReviewMirrorCascade:
         # Both the primary and the mirror were deleted.
         deleted_ids = {c.args[1] for c in fs.delete_review_entry.await_args_list}
         assert deleted_ids == {"r1", "r_mirror"}
-        # Mirror id recorded in the audit payload.
-        saved_evt = fs.save_machine_event.await_args.args[0]
-        assert saved_evt.payload["mirror_review_entry_id"] == "r_mirror"
+
+        # Two audit events: the primary (target=A) carrying the mirror link,
+        # and a dedicated cascade event on the partner record (target=B).
+        events = [c.args[0] for c in fs.save_machine_event.await_args_list]
+        primary = next(e for e in events if e.target_id == "mem001")
+        assert primary.payload["mirror_review_entry_id"] == "r_mirror"
+        partner = next(e for e in events if e.target_id == "mem002")
+        assert partner.event_type == "freshness_review_resolved"
+        assert partner.payload["action"] == "cascade_mirror"
+        assert partner.payload["review_entry_id"] == "r_mirror"
+        assert partner.payload["resolved_via_review_entry_id"] == "r1"
+        assert partner.payload["resolved_via_target_id"] == "mem001"
 
     async def test_no_mirror_lookup_for_unpaired_reason(self) -> None:
         """low_confidence_decision entries carry no related_record_id — the

--- a/tests/unit/storage/test_memory_postgres_lifecycle.py
+++ b/tests/unit/storage/test_memory_postgres_lifecycle.py
@@ -108,6 +108,57 @@ class TestUpdateLifecycle:
         assert out.evidence_count == 3
         assert out.verification_state == "verified"
 
+    async def test_lifecycle_update_does_not_bump_updated_at(self) -> None:
+        """MTRNIX-395: update_lifecycle must not touch ``updated_at``.
+
+        It is the freshness clock FreshnessMonitor reads for STALE; bumping it
+        on the Linker's evidence_count write made STALE unreachable. Only
+        ``save()`` (a real content edit) may move ``updated_at``.
+        """
+        store, engine = _make_store()
+        conn = AsyncMock()
+        updated = dict(_BASE_ROW, evidence_count=5)
+        result = MagicMock()
+        result.first.return_value = _mock_row(updated)
+        conn.execute.return_value = result
+        engine.begin.return_value = _FakeCtx(conn)
+
+        await store.update_lifecycle("ws1", "mem001", evidence_count=5)
+
+        sql = str(conn.execute.call_args.args[0])
+        # ``updated_at`` may still appear in the RETURNING column list — what
+        # must NOT happen is a SET write of it.
+        assert "updated_at = :updated_at" not in sql
+        assert "SET evidence_count = :evidence_count WHERE" in sql
+        params = conn.execute.call_args.args[1]
+        assert "updated_at" not in params
+
+    async def test_bump_updated_at_flag_writes_updated_at(self) -> None:
+        """MTRNIX-395: human curation opts back into the updated_at bump.
+
+        ``resolve_review`` passes ``bump_updated_at=True`` so a kept record's
+        freshness clock is refreshed and it does not immediately re-STALE.
+        """
+        store, engine = _make_store()
+        conn = AsyncMock()
+        updated = dict(_BASE_ROW, status="active")
+        result = MagicMock()
+        result.first.return_value = _mock_row(updated)
+        conn.execute.return_value = result
+        engine.begin.return_value = _FakeCtx(conn)
+
+        await store.update_lifecycle(
+            "ws1",
+            "mem001",
+            status=MemoryStatus.ACTIVE,
+            bump_updated_at=True,
+        )
+
+        sql = str(conn.execute.call_args.args[0])
+        assert "updated_at = :updated_at" in sql
+        params = conn.execute.call_args.args[1]
+        assert "updated_at" in params
+
     async def test_empty_update_falls_back_to_get(self) -> None:
         store, engine = _make_store()
         conn = AsyncMock()


### PR DESCRIPTION
…review queue

memory_records STALE was unreachable: update_lifecycle always bumped updated_at, so the Linker's evidence_count write reset the freshness clock on every pipeline pass before FreshnessMonitor could evaluate it. Stop bumping updated_at by default (it is the content-freshness clock; only save() should move it) and add an explicit bump_updated_at flag for human-initiated curation — resolve_review passes it so a kept record does not immediately re-STALE on the next scheduled scan.

Duplicate pairs produced mirror review entries (A->B and B->A) because the Reconciler idempotency key was directional. Add an undirected check so the queue holds one row per pair, cascade-delete the mirror on resolve_review, and ship scripts/cleanup_mirror_review_entries.py to clear pre-existing mirrors.