### PR TITLE
feat(MTRNIX-397): fix RAG core retrieval — query-level scoring + channel triggers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,8 +93,13 @@ OLLAMA_NUM_CTX=32768                  # context window for Ollama chat
 OLLAMA_REQUEST_TIMEOUT=               # seconds; empty = library default
 
 # --- DeepSeek ---
+# Active models: deepseek-v4-pro (capable) / deepseek-v4-flash (fast, cheap).
+# deepseek-chat / deepseek-reasoner are DEPRECATED (retire 2026-07-24) — avoid for new setups.
 DEEPSEEK_API_KEY=
-DEEPSEEK_MODEL=deepseek-chat
+DEEPSEEK_MODEL=deepseek-v4-pro         # HEAVY tier (final RAG answer)
+# MTRNIX-397: FAST tier for service LLM calls (resolve/expand/classify/NER/slots).
+# Empty = inherit DEEPSEEK_MODEL at runtime. Only used by the deepseek provider.
+DEEPSEEK_MODEL_FAST=deepseek-v4-flash
 
 # --- OpenRouter ---
 OPENROUTER_API_KEY=
@@ -145,6 +150,19 @@ HYDE_ENABLED=false                    # HyDE for short/vague queries
 ADAPTIVE_RRF_ENABLED=false            # adaptive RRF fusion (regresses metrics, off)
 ENABLE_SEMANTIC_MATCHING=true         # semantic entity matching in resolver
 METATRON_HIERARCHICAL_CHUNKING_ENABLED=true
+
+# --- MTRNIX-397 retrieval core fixes (defaults = today's behaviour) ---
+# S1: normalize the signal score by the channels that actually returned results (query-level).
+# Inert when every weighted channel returns >=1 result; safe on by default.
+METATRON_RETRIEVAL_SCORING_NORMALIZE_ACTIVE_ONLY=true
+# B0: FAST-LLM slot extraction (dates/people/jira keys/entities/activity) feeds channel
+# triggers on top of regex. Off = regex-only (unchanged). Hardened: timeout + JSON + fallback.
+METATRON_RETRIEVAL_SLOT_EXTRACTION_ENABLED=false
+METATRON_RETRIEVAL_SLOT_EXTRACTION_TIMEOUT=6   # slot-extraction LLM timeout (seconds)
+# G1: seed the graph channel from extracted entities instead of the dead exact-text NER path.
+METATRON_RETRIEVAL_GRAPH_NER_ENABLED=false
+# M6: when a resolved date is beyond the corpus, fall back to recent in-progress items.
+METATRON_RETRIEVAL_FUTURE_DATE_FALLBACK_ENABLED=false
 
 # --- HyDE tuning ---
 HYDE_MAX_WORDS=4                      # max query word count to trigger HyDE

--- a/scripts/rag_eval_397.py
+++ b/scripts/rag_eval_397.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""MTRNIX-397 reproducible RAG eval — before/after harness.
+
+Runs a fixed set of queries (three buckets: regression / positive / adversarial) through
+the live REST chat endpoint, pulls each RAG debug trace, and prints a structured per-query
+summary so a reviewer can diff "before" vs "after" without eyeballing raw traces.
+
+This is the M-4 merge gate for the regression bucket. It needs a live stand (Postgres /
+Qdrant / Neo4j) and trace capture enabled (METATRON_RAG_TRACE_ENABLED=true). It is NOT a
+unit test — run it manually:
+
+    python scripts/rag_eval_397.py \
+        --base-url http://localhost:8000 \
+        --email "$METATRON_ADMIN_EMAIL" --password "$METATRON_ADMIN_PASSWORD" \
+        --workspace MTRNIX --out before.json
+
+Re-run after each phase with --out after.json, then diff the two JSON files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.request
+from collections import Counter
+from typing import Any
+
+# Query buckets -------------------------------------------------------------
+
+REGRESSION = [
+    "what are next weeks tasks",
+    "Check jira sprint for week 22",
+    "Use jira mtrnix and GitHub to show next week activity",
+    "what type of model do you use? how many parameters?",  # must NOT regress
+]
+POSITIVE = [
+    "what is MTRNIX-281 about",
+    "summarize the 2026-05-08 daily summary",
+    "who works on the freshness pipeline",
+    "what was done for memory health",
+]
+ADVERSARIAL = [
+    "what are the tasks for the week of 2027-01-04",  # future, no data → must not fabricate
+    "extract the link from https://example.com/auth?code=abc",  # non-RAG
+    "что в спринте на следующей неделе и кто над чем работает",  # cross-language, multi-intent
+    "tell me about the Atlantis migration project",  # likely absent → must say "not found"
+]
+
+_TRACE_RE = re.compile(r"trace:\s*([0-9a-f-]{36})", re.IGNORECASE)
+_TICKET_RE = re.compile(r"\b[A-Z]{2,}-\d+\b")
+
+
+def _post(url: str, body: dict, token: str | None = None, timeout: int = 180) -> dict:
+    data = json.dumps(body).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read().decode())
+
+
+def _get(url: str, token: str, timeout: int = 60) -> dict:
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read().decode())
+
+
+def _login(base: str, email: str, password: str) -> str:
+    out = _post(f"{base}/api/v1/auth/login", {"email": email, "password": password})
+    return out["token"]
+
+
+def _phase(trace: dict, name: str) -> dict | None:
+    for p in trace.get("phases", []):
+        if p.get("name") == name:
+            return p
+    return None
+
+
+def _summarize_trace(trace: dict, answer: str) -> dict[str, Any]:
+    recall = _phase(trace, "recall") or {}
+    channels = recall.get("channels", {})
+    chan_counts = {
+        c: (ch.get("count") if isinstance(ch, dict) else len(ch)) for c, ch in channels.items()
+    }
+    merge = _phase(trace, "merge_and_score") or {}
+    cands = merge.get("candidates", [])
+    titles = Counter((c.get("title") or "")[:40] for c in cands)
+    dups = sum(n - 1 for n in titles.values() if n > 1)
+    rerank = _phase(trace, "rerank") or {}
+    rc = sorted(rerank.get("candidates", []), key=lambda x: x.get("final_score", 0), reverse=True)
+    top5 = [(c.get("source"), (c.get("title") or "")[:40]) for c in rc[:5]]
+    gen = _phase(trace, "generation") or {}
+    classify = _phase(trace, "classify") or {}
+    # Tickets cited in the answer (for the negative bucket's no-hallucination check).
+    cited = sorted(set(_TICKET_RE.findall(answer)))
+    return {
+        "profile": (classify.get("output") or {}).get("profile"),
+        "channels": chan_counts,
+        "dup_candidates": dups,
+        "src_dist": dict(Counter(c.get("source") for c in cands)),
+        "rerank_top5": top5,
+        "ungrounded_tickets": gen.get("ungrounded_tickets"),
+        "cited_tickets": cited,
+        "answer_head": answer[:200],
+    }
+
+
+def run_bucket(base: str, token: str, workspace: str, name: str, queries: list[str]) -> list:
+    rows = []
+    for q in queries:
+        try:
+            body = {"message": q, "workspace_id": workspace}
+            resp = _post(f"{base}/api/v1/chat", body, token=token)
+            answer = resp.get("answer") or resp.get("response") or json.dumps(resp)[:200]
+            m = _TRACE_RE.search(answer)
+            summary: dict[str, Any] = {"query": q}
+            if m:
+                trace = _get(f"{base}/api/v1/traces/{m.group(1)}", token)
+                summary.update(_summarize_trace(trace, answer))
+                summary["trace_id"] = m.group(1)
+            else:
+                summary["error"] = "no trace footer in answer"
+                summary["answer_head"] = answer[:200]
+            rows.append(summary)
+            print(f"[{name}] {q[:50]:50}  profile={summary.get('profile')}  "
+                  f"channels={summary.get('channels')}")
+        except Exception as e:  # noqa: BLE001 — eval harness, report and continue
+            rows.append({"query": q, "error": str(e)})
+            print(f"[{name}] {q[:50]:50}  ERROR {e}")
+        time.sleep(1)
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="MTRNIX-397 RAG eval harness")
+    ap.add_argument("--base-url", required=True)
+    ap.add_argument("--email", required=True)
+    ap.add_argument("--password", required=True)
+    ap.add_argument("--workspace", default="MTRNIX")
+    ap.add_argument("--out", default="rag_eval_397.json")
+    args = ap.parse_args()
+
+    base = args.base_url.rstrip("/")
+    token = _login(base, args.email, args.password)
+    result = {
+        "regression": run_bucket(base, token, args.workspace, "regression", REGRESSION),
+        "positive": run_bucket(base, token, args.workspace, "positive", POSITIVE),
+        "adversarial": run_bucket(base, token, args.workspace, "adversarial", ADVERSARIAL),
+    }
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+    print(f"\nWrote {args.out}. Diff before/after JSON to evaluate the change.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/metatron/connectors/jira.py
+++ b/src/metatron/connectors/jira.py
@@ -167,6 +167,8 @@ class JiraConnector(ConnectorInterface):
                 "created_at_str": structured.get("created") or "",
                 "updated_at_str": structured.get("updated") or "",
                 "resolved_at_str": structured.get("resolutiondate") or "",
+                # MTRNIX-397 (M5a): searchable due date for task/sprint date queries.
+                "due_date": structured.get("duedate") or "",
             },
             **({"created_at": created_at} if created_at else {}),
             **({"updated_at": updated_at} if updated_at else {}),

--- a/src/metatron/connectors/jira_processing.py
+++ b/src/metatron/connectors/jira_processing.py
@@ -115,6 +115,9 @@ def process_jira_issue(data: dict | bytes | str) -> dict:
         "created": fields.get("created"),
         "updated": fields.get("updated"),
         "resolutiondate": fields.get("resolutiondate"),
+        # MTRNIX-397 (M5a): standard Jira due date (ISO YYYY-MM-DD or null) — indexed as a
+        # searchable `due_date` payload so "tasks due next week" can be answered by date.
+        "duedate": fields.get("duedate"),
         "priority": fields.get("priority", {}).get("name") if fields.get("priority") else None,
         "issuetype": fields.get("issuetype", {}).get("name") if fields.get("issuetype") else None,
         "description": description_text,

--- a/src/metatron/core/config.py
+++ b/src/metatron/core/config.py
@@ -127,6 +127,11 @@ class Settings(BaseSettings):
     # --- DeepSeek ---
     deepseek_api_key: str = Field("", alias="DEEPSEEK_API_KEY")
     deepseek_model: str = Field("deepseek-chat", alias="DEEPSEEK_MODEL")
+    # MTRNIX-397 (A): FAST tier for service LLM calls (resolve/expand/classify/NER/slots).
+    # Empty string => inherit the heavy `deepseek_model` at runtime, so an unset FAST var is
+    # byte-identical to today even with a custom DEEPSEEK_MODEL. Only used by the deepseek
+    # provider; tiering is a no-op for other providers (see metatron.llm.tiers).
+    deepseek_model_fast: str = Field("", alias="DEEPSEEK_MODEL_FAST")
 
     # --- Benchmarker ---
     benchmarker_embedding_proxy_url: str = Field(
@@ -211,6 +216,32 @@ class Settings(BaseSettings):
     blend_weight: float = 0.3
     rerank_pool_size: int = 35
     min_signal_score: float = 0.0  # 0.0 = disabled. Set > 0 to filter low-confidence results.
+    # MTRNIX-397 (S1): normalize the signal score by the weights of channels that actually
+    # returned results for the query (query-level), instead of by the sum of ALL weights.
+    # Prevents the score collapsing to source-balance noise when metadata/graph channels are
+    # empty. Mathematically inert when every weighted channel returns >=1 result.
+    retrieval_scoring_normalize_active_only: bool = Field(
+        True, alias="METATRON_RETRIEVAL_SCORING_NORMALIZE_ACTIVE_ONLY"
+    )
+    # MTRNIX-397 (B0): FAST-LLM slot extraction feeds channel triggers (dates/people/jira
+    # keys/entities/activity) on top of regex. Default off — when off the regex path is used
+    # unchanged. Hardened: timeout + strict JSON parse + fallback to regex on any failure.
+    retrieval_slot_extraction_enabled: bool = Field(
+        False, alias="METATRON_RETRIEVAL_SLOT_EXTRACTION_ENABLED"
+    )
+    retrieval_slot_extraction_timeout: int = Field(
+        6, alias="METATRON_RETRIEVAL_SLOT_EXTRACTION_TIMEOUT"
+    )
+    # MTRNIX-397 (G1): seed the graph recall channel from extracted entities instead of the
+    # broken get_graph_entities(query) exact-text-match NER path. Default off.
+    retrieval_graph_ner_enabled: bool = Field(
+        False, alias="METATRON_RETRIEVAL_GRAPH_NER_ENABLED"
+    )
+    # MTRNIX-397 (M6): when a resolved date is beyond the corpus, fall back to recent
+    # in-progress items instead of returning nothing. Default off.
+    retrieval_future_date_fallback_enabled: bool = Field(
+        False, alias="METATRON_RETRIEVAL_FUTURE_DATE_FALLBACK_ENABLED"
+    )
 
     # --- HyDE (Hypothetical Document Embedding) ---
     hyde_enabled: bool = Field(False, alias="HYDE_ENABLED")

--- a/src/metatron/core/logging.py
+++ b/src/metatron/core/logging.py
@@ -6,6 +6,7 @@ Call configure_logging() once at startup.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import sys
 
@@ -35,6 +36,15 @@ def configure_logging(log_level: str = "INFO", json_output: bool = True) -> None
         log_level: Minimum log level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
         json_output: If True, emit JSON lines. If False, use colored console output.
     """
+    # Windows consoles default to a legacy code page (e.g. cp1251). Indexed document
+    # content (Jira/Confluence) contains Unicode (→, em-dashes) that such a stream cannot
+    # encode, raising UnicodeEncodeError inside the logging handler. Force UTF-8 on stdout
+    # (and stderr, used by handleError) so logging never chokes on Unicode payloads. Done
+    # before the renderer/colorama wrap stdout so the wrapped stream is already UTF-8.
+    for _stream in (sys.stdout, sys.stderr):
+        with contextlib.suppress(Exception):
+            _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_log_level,

--- a/src/metatron/llm/__init__.py
+++ b/src/metatron/llm/__init__.py
@@ -158,6 +158,14 @@ def chat_completion(  # TODO: async migration
     def _build_messages_snapshot() -> list[dict[str, Any]]:
         return [{"role": mo.role, "content": mo.content} for mo in msg_objects]
 
+    # MTRNIX-397 (A): route service call_sites to the FAST model tier when no explicit
+    # model override was passed. No-op for non-deepseek providers and for HEAVY call_sites.
+    if model is None:
+        from metatron.core.config import get_settings
+        from metatron.llm.tiers import resolve_model_for_call_site
+
+        model = resolve_model_for_call_site(call_site, model, get_settings())
+
     # Get primary provider
     llm = get_llm(provider_name=provider, model=model)
 

--- a/src/metatron/llm/tiers.py
+++ b/src/metatron/llm/tiers.py
@@ -1,0 +1,56 @@
+"""Map an LLM ``call_site`` to a model tier (MTRNIX-397, A).
+
+Service calls (query resolution, expansion, classification, translation, NER, slot
+extraction) run on a cheaper/faster FAST model; the final answer (``rag_answer``) runs
+on the HEAVY model. Tiering is provider-agnostic at the routing level — only the model
+*name* is DeepSeek-specific, so for any non-DeepSeek provider this is a no-op and the
+provider's configured model is used.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from metatron.core.config import Settings
+
+# Service call_sites that should use the FAST model. Everything else (notably
+# ``rag_answer``) stays on the HEAVY model.
+FAST_CALL_SITES: frozenset[str] = frozenset(
+    {
+        "resolve_query",
+        "translate_query",
+        "query_classifier",
+        "query_expansion",
+        "routing",
+        "hyde",
+        "ner_extraction",
+        "slot_extraction",
+        "translation_to_english",
+        "translation_to_russian",
+    }
+)
+
+
+def resolve_model_for_call_site(
+    call_site: str, explicit_model: str | None, settings: Settings
+) -> str | None:
+    """Return the model-name override for ``call_site``, or ``None`` for the provider default.
+
+    Rules:
+    - an explicit ``model=`` override always wins;
+    - tiering only applies to the ``deepseek`` provider (model names are deepseek-specific);
+      any other provider returns ``None`` (use its configured model);
+    - FAST call_sites resolve to ``deepseek_model_fast``, inheriting the heavy
+      ``deepseek_model`` at runtime when the FAST var is empty (so an unset FAST var is
+      byte-identical to today);
+    - HEAVY call_sites return ``None`` so ``get_llm`` uses the provider default
+      (``deepseek_model``).
+    """
+    if explicit_model:
+        return explicit_model
+    if getattr(settings, "llm_provider", "") != "deepseek":
+        return None
+    if call_site in FAST_CALL_SITES:
+        return settings.deepseek_model_fast or settings.deepseek_model
+    return None

--- a/src/metatron/retrieval/channels.py
+++ b/src/metatron/retrieval/channels.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from functools import lru_cache
 from typing import TYPE_CHECKING, TypedDict
 
@@ -479,11 +480,36 @@ def recall_metadata(ctx: RecallContext) -> list[ScoredResult]:
         hits: list[dict] = []
 
         if ctx.extracted_dates:
+            date_list = list(ctx.extracted_dates)
             date_hits = _post_filter_acl(
-                store.search_by_date(ctx.extracted_dates, limit=limit),
+                store.search_by_date(date_list, limit=limit),
                 ctx.access_filter,
             )
             hits.extend(date_hits)
+            # MTRNIX-397 (M5a): for task/sprint queries also match Jira due dates.
+            if ctx.is_activity_query:
+                hits.extend(
+                    _post_filter_acl(
+                        store.search_by_date(date_list, limit=limit, key="due_date"),
+                        ctx.access_filter,
+                    )
+                )
+            # MTRNIX-397 (M6): a FUTURE-dated non-activity query with no hits (e.g. next week,
+            # nothing indexed yet) → recent in-progress. Guarded by date > today so historical
+            # "what happened on 2024-01-01" with an empty week does NOT trigger the fallback.
+            elif (
+                getattr(ctx.settings, "retrieval_future_date_fallback_enabled", False) is True
+                and not date_hits
+                and date_list
+                and max(date_list) > datetime.now(UTC).strftime("%Y-%m-%d")
+            ):
+                for status in _ACTIVITY_STATUSES:
+                    hits.extend(
+                        _post_filter_acl(
+                            store.search_by_status(status, limit=limit),
+                            ctx.access_filter,
+                        )
+                    )
 
         # Person-specific: search by assignee for each resolved name (skips general status)
         if ctx.detected_person:
@@ -528,11 +554,36 @@ async def recall_metadata_async(ctx: RecallContext) -> list[ScoredResult]:
         hits: list[dict] = []
 
         if ctx.extracted_dates:
+            date_list = list(ctx.extracted_dates)
             date_hits = _post_filter_acl(
-                await store.search_by_date(list(ctx.extracted_dates), limit=limit),
+                await store.search_by_date(date_list, limit=limit),
                 ctx.access_filter,
             )
             hits.extend(date_hits)
+            # MTRNIX-397 (M5a): for task/sprint queries also match Jira due dates.
+            if ctx.is_activity_query:
+                hits.extend(
+                    _post_filter_acl(
+                        await store.search_by_date(date_list, limit=limit, key="due_date"),
+                        ctx.access_filter,
+                    )
+                )
+            # MTRNIX-397 (M6): a FUTURE-dated non-activity query with no hits (e.g. next week,
+            # nothing indexed yet) → recent in-progress. Guarded by date > today so historical
+            # "what happened on 2024-01-01" with an empty week does NOT trigger the fallback.
+            elif (
+                getattr(ctx.settings, "retrieval_future_date_fallback_enabled", False) is True
+                and not date_hits
+                and date_list
+                and max(date_list) > datetime.now(UTC).strftime("%Y-%m-%d")
+            ):
+                for status in _ACTIVITY_STATUSES:
+                    hits.extend(
+                        _post_filter_acl(
+                            await store.search_by_status(status, limit=limit),
+                            ctx.access_filter,
+                        )
+                    )
 
         # Person-specific: search by assignee for each resolved name
         if ctx.detected_person:
@@ -612,15 +663,19 @@ def recall_graph(ctx: RecallContext) -> list[ScoredResult]:
         seeds.update(ctx.extracted_title_entities)
         seeds.update(ctx.detected_person)
 
-        # 2. Graph entity match on query (existing behavior)
+        # 2. Graph entity match on query. MTRNIX-397 (G1): the legacy get_graph_entities()
+        # path matches a Document whose full raw_text EQUALS the query string, so for a real
+        # query it returns nothing. When retrieval_graph_ner_enabled is on, skip that dead
+        # Neo4j round-trip — seeds come from the (slot-augmented) ctx fields above instead.
         query_for_ner = ctx.translated_query or ctx.original_query
-        graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
-        seeds.update(e["name"] for e in graph_ents if "name" in e)
-        # Also add 1-hop aliases returned by get_graph_entities
-        for e in graph_ents:
-            for alias in e.get("aliases", []):
-                if alias:
-                    seeds.add(alias)
+        if getattr(ctx.settings, "retrieval_graph_ner_enabled", False) is not True:
+            graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
+            seeds.update(e["name"] for e in graph_ents if "name" in e)
+            # Also add 1-hop aliases returned by get_graph_entities
+            for e in graph_ents:
+                for alias in e.get("aliases", []):
+                    if alias:
+                        seeds.add(alias)
 
         if not seeds:
             return []
@@ -697,15 +752,19 @@ async def recall_graph_async(ctx: RecallContext) -> list[ScoredResult]:
         seeds.update(ctx.extracted_title_entities)
         seeds.update(ctx.detected_person)
 
-        # 2. Graph entity match on query (existing behavior)
+        # 2. Graph entity match on query. MTRNIX-397 (G1): the legacy get_graph_entities()
+        # path matches a Document whose full raw_text EQUALS the query string, so for a real
+        # query it returns nothing. When retrieval_graph_ner_enabled is on, skip that dead
+        # Neo4j round-trip — seeds come from the (slot-augmented) ctx fields above instead.
         query_for_ner = ctx.translated_query or ctx.original_query
-        graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
-        seeds.update(e["name"] for e in graph_ents if "name" in e)
-        # Also add 1-hop aliases returned by get_graph_entities
-        for e in graph_ents:
-            for alias in e.get("aliases", []):
-                if alias:
-                    seeds.add(alias)
+        if getattr(ctx.settings, "retrieval_graph_ner_enabled", False) is not True:
+            graph_ents = list(_cached_get_graph_entities((query_for_ner,), ctx.workspace_id))
+            seeds.update(e["name"] for e in graph_ents if "name" in e)
+            # Also add 1-hop aliases returned by get_graph_entities
+            for e in graph_ents:
+                for alias in e.get("aliases", []):
+                    if alias:
+                        seeds.add(alias)
 
         if not seeds:
             return []

--- a/src/metatron/retrieval/prompts.py
+++ b/src/metatron/retrieval/prompts.py
@@ -32,6 +32,9 @@ or "per [CONFLUENCE] Architecture Overview..."
 - If sources contradict each other, state both versions with their sources.
 - If the context is insufficient to answer, say so directly. Do not guess.
 - Never mix facts from context with hypotheses or general knowledge.
+- NEVER cite a ticket key (e.g. MTRNIX-123), document title, or fact that is not present \
+in the provided context. If the relevant data was not retrieved, say it was not found in \
+the knowledge base rather than inventing identifiers.
 
 ## Source references
 When you mention a specific document, ticket, or page title in your answer, wrap its name in \
@@ -85,6 +88,10 @@ Resolve:
 - Relative dates ("the day before that", "за день до этого", "next day", \
 "на следующий день", "a week before", "за неделю до") → concrete dates based \
 on context and current date
+- Week / sprint expressions ("next week", "this week", "week 22", "следующая неделя", \
+"текущий спринт") → a concrete ISO date range "YYYY-MM-DD..YYYY-MM-DD" (the Mon–Sun \
+span of that week) based on the current date, e.g. "tasks for the week \
+2026-06-08..2026-06-14"
 - Pronouns and demonstratives referring to prior context ("about it", "про это", \
 "what happened there", "что там было") → the actual subject from context
 - Any other references that require conversation history to understand
@@ -97,4 +104,29 @@ Rules:
 - Keep the rewritten query concise — a search query, not a sentence
 - When the query has "context: ... | question: ..." format, output only the \
 resolved question, not the context prefix\
+"""
+
+
+# MTRNIX-397 (B0): structured signal extraction for recall-channel gating. Runs on the
+# FAST model. Output MUST be a single JSON object and nothing else.
+SLOT_EXTRACTION_SYSTEM_PROMPT = """\
+You extract structured search signals from a knowledge-base query. The query may mention
+dates, people, Jira ticket keys, named entities, and task/sprint activity.
+
+Return ONLY a single JSON object (no prose, no markdown fences) with EXACTLY these keys:
+{
+  "date_range": ["YYYY-MM-DD", "YYYY-MM-DD"] or null,
+  "people": [list of person full names mentioned, may be empty],
+  "jira_keys": [list of Jira issue keys like "MTRNIX-123", may be empty],
+  "entities": [list of named entities / projects / products, may be empty],
+  "is_activity": true if the query is about current/planned work, sprints, tasks, status,
+  "needs_retrieval": false ONLY for meta/non-knowledge requests (e.g. "extract the link
+    from this URL", "translate this", title/tag generation), true otherwise
+}
+
+Rules:
+- Use the current date to resolve relative ranges ("next week", "this sprint", "week 22")
+  into a concrete "date_range". A single day → both ends equal. No date → null.
+- Do NOT invent values. Empty lists / null when nothing applies.
+- Output must be valid JSON parseable by a strict parser.\
 """

--- a/src/metatron/retrieval/query_classifier.py
+++ b/src/metatron/retrieval/query_classifier.py
@@ -34,12 +34,17 @@ class QueryClassification(TypedDict):
 # individual weights has no effect while the classifier is active.
 # Disable the classifier (QUERY_CLASSIFIER_ENABLED=False) to use Settings weights.
 QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
-    # Optimized via two-phase grid search (2026-03-30, MTRNIX workspace)
+    # Optimized via two-phase grid search (2026-03-30, MTRNIX workspace).
+    # MTRNIX-397 (S2/S3): dense_weight floors (>=0.2) and the temporal recency_weight are
+    # INTERIM values — they keep dense/recency alive for natural-language temporal/execution
+    # queries that the original grid-search eval set lacked. Weight is redistributed FROM the
+    # often-empty metadata/graph channels, so each profile's signal weights still sum to 0.85.
+    # To be replaced by a re-run of `make grid-search` on the extended eval set (Phase 6, S-grid).
     "execution": {
-        "dense_weight": 0.0,
+        "dense_weight": 0.2,
         "graph_weight": 0.0,
-        "metadata_weight": 0.5,
-        "recency_weight": 0.3,
+        "metadata_weight": 0.35,
+        "recency_weight": 0.25,
         "balance_weight": 0.05,
         "blend_weight": 0.7,
     },
@@ -68,10 +73,10 @@ QUERY_PROFILE_WEIGHTS: dict[str, dict[str, float]] = {
         "blend_weight": 0.9,
     },
     "temporal": {
-        "dense_weight": 0.0,
-        "graph_weight": 0.3,
-        "metadata_weight": 0.5,
-        "recency_weight": 0.0,
+        "dense_weight": 0.2,
+        "graph_weight": 0.1,
+        "metadata_weight": 0.25,
+        "recency_weight": 0.25,
         "balance_weight": 0.05,
         "blend_weight": 0.5,
     },

--- a/src/metatron/retrieval/scoring.py
+++ b/src/metatron/retrieval/scoring.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import math
 from datetime import UTC, datetime
+from typing import Any
 
 
 def recency_score(
@@ -71,6 +72,7 @@ def compute_signal_score(
     balance_weight: float = 0.05,
     freshness: float = 1.0,
     freshness_weight: float = 0.0,
+    active_channels: set[str] | None = None,
 ) -> float:
     """Compute normalized multi-signal score for a retrieval candidate.
 
@@ -83,6 +85,18 @@ def compute_signal_score(
     ``freshness_weight`` defaults to 0.0 — when unchanged, the formula is
     numerically identical to Phase A (the term contributes 0 to the
     numerator and 0 to the denominator sum).
+
+    MTRNIX-397 (S1): ``active_channels`` is the set of recall channels that
+    returned >=1 result *for the whole query* (``"dense"``/``"graph"``/
+    ``"exact"``/``"metadata"``). When provided, the denominator only counts
+    the weights of channels that actually fired, so the score does not
+    collapse to source-balance noise when ``metadata``/``graph`` are empty.
+    ``recency``/``balance``/``freshness`` are NOT channels and are always
+    counted. ``metadata_weight`` is kept when ``exact`` OR ``metadata``
+    fired (the metadata term is ``max(exact, metadata)``). This MUST be
+    computed once per query and passed identically to every candidate so
+    all candidates share the same denominator. ``None`` reproduces the
+    legacy all-weights denominator exactly.
     """
     vector = channel_scores.get("dense", 0.0)
     graph = channel_scores.get("graph", 0.0)
@@ -91,27 +105,27 @@ def compute_signal_score(
         channel_scores.get("metadata", 0.0),
     )
 
-    raw = (
-        dense_weight * vector
-        + graph_weight * graph
-        + metadata_weight * metadata
-        + recency_weight * recency
-        + balance_weight * balance
-        + freshness_weight * freshness
-    )
+    # recency / balance / freshness are not channels — always counted.
+    raw = recency_weight * recency + balance_weight * balance + freshness_weight * freshness
+    weight_sum = recency_weight + balance_weight + freshness_weight
 
-    weight_sum = (
-        dense_weight
-        + graph_weight
-        + metadata_weight
-        + recency_weight
-        + balance_weight
-        + freshness_weight
-    )
+    # Channel terms: included in BOTH numerator and denominator together, so the
+    # output stays in [0, 1]. When active_channels is given, only channels that
+    # fired for the query contribute; otherwise (legacy) all channels contribute.
+    if active_channels is None or "dense" in active_channels:
+        raw += dense_weight * vector
+        weight_sum += dense_weight
+    if active_channels is None or "graph" in active_channels:
+        raw += graph_weight * graph
+        weight_sum += graph_weight
+    if active_channels is None or active_channels & {"exact", "metadata"}:
+        raw += metadata_weight * metadata
+        weight_sum += metadata_weight
+
     return raw / weight_sum if weight_sum > 0 else 0.0
 
 
-def normalize_rerank_scores(results: list[dict]) -> None:
+def normalize_rerank_scores(results: list[dict[str, Any]]) -> None:
     """Normalize rerank_score values in-place to [0, 1] via min-max.
 
     If all scores are equal or list has <= 1 element, all scores become 1.0.

--- a/src/metatron/retrieval/search.py
+++ b/src/metatron/retrieval/search.py
@@ -6,8 +6,8 @@ import asyncio
 import json
 import re
 from collections import Counter
-from datetime import datetime
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -38,6 +38,7 @@ from metatron.retrieval.channels import (
 from metatron.retrieval.prompts import (
     HYBRID_SYSTEM_PROMPT,
     QUERY_RESOLVER_SYSTEM_PROMPT,
+    SLOT_EXTRACTION_SYSTEM_PROMPT,
     TEAM_WORKFLOW_SCHEMA_SPEC,
     TEAM_WORKFLOW_SCHEMA_SYSTEM_PROMPT,
 )
@@ -148,6 +149,82 @@ def resolve_query(query: str) -> str:
         return query
 
 
+def _parse_slots(raw: str) -> dict[str, Any] | None:
+    """Strictly parse slot-extraction LLM output into a normalized dict, or None.
+
+    Defensive against markdown fences and partial/invalid output. Returns None on any
+    problem so the caller falls back to the regex extraction path (MTRNIX-397 B0).
+    """
+    if not raw:
+        return None
+    text = raw.strip()
+    if text.startswith("```"):  # strip ```json ... ``` fences
+        text = text.strip("`")
+        if text[:4].lower() == "json":
+            text = text[4:]
+        text = text.strip()
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    def _str_list(v: object) -> list[str]:
+        if not isinstance(v, list):
+            return []
+        return [s.strip() for s in v if isinstance(s, str) and s.strip()]
+
+    dr = data.get("date_range")
+    date_range: tuple[str, str] | None = None
+    if isinstance(dr, list) and len(dr) == 2 and all(isinstance(x, str) for x in dr):
+        date_range = (dr[0], dr[1])
+
+    return {
+        "date_range": date_range,
+        "people": _str_list(data.get("people")),
+        "jira_keys": [k.upper() for k in _str_list(data.get("jira_keys"))],
+        "entities": _str_list(data.get("entities")),
+        "is_activity": bool(data.get("is_activity", False)),
+        # Reserved for the non-RAG bypass (MTRNIX-397 R1/2.3, deferred pending product
+        # sign-off) — extracted now but not yet consumed by any caller.
+        "needs_retrieval": bool(data.get("needs_retrieval", True)),
+    }
+
+
+@timed("slot_extraction")
+def extract_slots(query: str, settings: Settings | None = None) -> dict[str, Any] | None:
+    """FAST-LLM structured signal extraction for recall-channel gating (MTRNIX-397 B0).
+
+    Flag-gated (``retrieval_slot_extraction_enabled``). Hardened: bounded timeout, strict
+    JSON parsing, fallback to ``None`` (→ regex path) on any failure. Never raises.
+    """
+    s = settings if settings is not None else _s
+    # `is not True` (not just falsy) so a MagicMock settings in tests — whose attributes are
+    # auto-truthy — does not accidentally fire the LLM call. Strict opt-in via the real flag.
+    if getattr(s, "retrieval_slot_extraction_enabled", False) is not True:
+        return None
+    try:
+        today = datetime.now(UTC).strftime("%Y-%m-%d")  # UTC: align week boundary with recency
+        raw = chat_completion(
+            messages=[
+                {"role": "system", "content": SLOT_EXTRACTION_SYSTEM_PROMPT},
+                {"role": "user", "content": f"Current date: {today}\n\nQuery: {query}"},
+            ],
+            temperature=0,
+            max_tokens=250,
+            timeout=getattr(s, "retrieval_slot_extraction_timeout", 6),
+            call_site="slot_extraction",
+        )
+        slots = _parse_slots(raw)
+        if slots is None:
+            logger.warning("slot_extraction.parse_failed", query=query[:100])
+        return slots
+    except Exception as e:
+        logger.warning("slot_extraction.failed", error=str(e))
+        return None
+
+
 def _run_hooks_sync(plugin_manager, hook_name: str, context: dict) -> dict:
     """Run async pipeline hooks from synchronous code safely.
 
@@ -179,13 +256,28 @@ _ACTIVITY_KW = [
     "working",
     "active",
     "progress",
+    # MTRNIX-397 (M3): task-tracker vocabulary so "what's in the sprint / next week's
+    # tasks / backlog" queries trigger the metadata (activity-status) channel. Substring
+    # match — avoid tokens that collide with common words (e.g. bare "due" -> "during").
+    "sprint",
+    "backlog",
+    "todo",
+    "to do",
+    "planned",
+    "task",
     "делает",
     "работает",
     "занимается",
     "текущ",
+    "спринт",
+    "задач",
+    "бэклог",
 ]
 
 _JIRA_KEY_RE = re.compile(r"\b([A-Z]{2,}-\d+)\b", re.IGNORECASE)
+# MTRNIX-397 (M7): "YYYY-MM-DD..YYYY-MM-DD" range, emitted by the LLM query resolver for
+# week/sprint expressions so the metadata channel searches the whole span, not one day.
+_ISO_RANGE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})\s*\.\.\s*(\d{4}-\d{2}-\d{2})")
 
 _PERSON_RU = re.compile(
     r"(?:делает|занимается|работает|насчёт|насчет|про)\s+(\w+)",
@@ -500,6 +592,28 @@ def _append_sources(answer: str, results: list) -> str:
     return answer
 
 
+def find_ungrounded_tickets(answer: str, results: list[dict[str, Any]]) -> list[str]:
+    """Return ticket-like tokens (e.g. ``MTRNIX-123``) cited in ``answer`` but absent from
+    the retrieved ``results`` — i.e. likely hallucinated (MTRNIX-397 H1).
+
+    Pure / side-effect free. The caller logs (and can surface in the trace); the answer is
+    NOT mutated, so a false positive can never corrupt a correct answer.
+    """
+    cited = {k.upper() for k in _JIRA_KEY_RE.findall(answer)}
+    if not cited:
+        return []
+    parts: list[str] = []
+    for mem in results:
+        payload = mem.get("payload") or {}
+        parts.append(str(mem.get("title") or payload.get("title") or ""))
+        parts.append(str(mem.get("text") or payload.get("data") or payload.get("memory") or ""))
+        parts.append(str(mem.get("doc_label") or payload.get("doc_label") or ""))
+    # Exact ticket-key set membership (not substring) — otherwise a cited "MTRNIX-2" would
+    # count as grounded when sources only contain "MTRNIX-281".
+    grounded = {k.upper() for k in _JIRA_KEY_RE.findall(" ".join(parts))}
+    return sorted(t for t in cited if t not in grounded)
+
+
 # Fixed display order for source_role groups (when no PRIMARY group takes priority)
 _SOURCE_ROLE_ORDER = ["knowledge_base", "task_tracker", "user_upload", "communication"]
 _SOURCE_ROLE_LABELS = {
@@ -587,15 +701,23 @@ def _extract_fast_signals(query: str) -> tuple[list[str], tuple[str, ...] | None
     jira_keys = _JIRA_KEY_RE.findall(query)
     jira_keys = list(dict.fromkeys(k.upper() for k in jira_keys))
 
-    # Date extraction
-    date_range = extract_date_range(query)
-    extracted_dates: tuple[str, ...] | None = None
-    if date_range:
-        from metatron.ingestion.processors.dates import get_dates_in_range
+    from metatron.ingestion.processors.dates import get_dates_in_range
 
-        dates_list = get_dates_in_range(date_range[0], date_range[1])
+    # Date extraction
+    extracted_dates: tuple[str, ...] | None = None
+    # MTRNIX-397 (M7): explicit ISO range "YYYY-MM-DD..YYYY-MM-DD" (emitted by the LLM
+    # resolver for week/sprint expressions) → expand to the full day span, not a single day.
+    iso_range = _ISO_RANGE_RE.search(query)
+    if iso_range:
+        dates_list = get_dates_in_range(iso_range.group(1), iso_range.group(2))
         if dates_list:
             extracted_dates = tuple(dates_list)
+    if not extracted_dates:
+        date_range = extract_date_range(query)
+        if date_range:
+            dates_list = get_dates_in_range(date_range[0], date_range[1])
+            if dates_list:
+                extracted_dates = tuple(dates_list)
     if not extracted_dates:
         single_date = extract_date_from_text(query)
         if single_date:
@@ -638,6 +760,7 @@ def _build_recall_context(
     workspace_id: str | None,
     access_filter=None,
     settings: Settings | None = None,
+    slots: dict[str, Any] | None = None,
 ) -> RecallContext:
     """Consolidate all extraction logic into a single RecallContext.
 
@@ -645,6 +768,10 @@ def _build_recall_context(
     and activity signals from the query text. This replaces the scattered
     inline extraction that was previously spread across lines 616-668
     of hybrid_search_and_answer.
+
+    MTRNIX-397 (B0): when ``slots`` (FAST-LLM slot extraction output) is provided, its
+    signals are UNIONed on top of the regex extraction — never replacing it — so the regex
+    path remains the floor and channels gain coverage on natural-language phrasings.
     """
     jira_keys, extracted_dates = _extract_fast_signals(original_query)
 
@@ -666,6 +793,22 @@ def _build_recall_context(
             if not full_names:
                 full_names = resolve_person_name(person_token)
             detected_person = list(full_names) if full_names else []
+
+    # MTRNIX-397 (B0 union): merge LLM-extracted slots on top of the regex signals.
+    if slots:
+        jira_keys = list(dict.fromkeys(jira_keys + list(slots.get("jira_keys") or [])))
+        if slots.get("people"):
+            detected_person = list(dict.fromkeys(detected_person + list(slots["people"])))
+        if slots.get("entities"):  # E1: extend title entities, never replace
+            title_entities = list(dict.fromkeys(title_entities + list(slots["entities"])))
+        is_activity = is_activity or bool(slots.get("is_activity"))
+        dr = slots.get("date_range")
+        if dr and len(dr) == 2:
+            from metatron.ingestion.processors.dates import get_dates_in_range
+
+            slot_dates = tuple(get_dates_in_range(dr[0], dr[1]))
+            if slot_dates:
+                extracted_dates = tuple(dict.fromkeys((extracted_dates or ()) + slot_dates))
 
     return RecallContext(
         original_query=original_query,
@@ -949,6 +1092,11 @@ async def hybrid_search_and_answer(  # noqa: C901
     if rag_trace is not None:
         rag_trace.phase("resolve_query", type="llm", input=rq_original, output=rq)
 
+    # MTRNIX-397 (B0): FAST-LLM slot extraction (flag-gated; None when off or on failure).
+    slots = await asyncio.to_thread(extract_slots, rq, _s)
+    if rag_trace is not None and slots is not None:
+        rag_trace.phase("slot_extraction", type="llm", input=rq, output=slots)
+
     # Expand query for better BM25 recall (adds status keywords, synonyms)
     eq = await asyncio.to_thread(expand_query, rq)
     if rag_trace is not None:
@@ -1031,6 +1179,7 @@ async def hybrid_search_and_answer(  # noqa: C901
         workspace_id=workspace_id,
         access_filter=access_filter,
         settings=_s,
+        slots=slots,
     )
     recall_ctx.hyde_embedding = hyde_embedding
 
@@ -1044,6 +1193,22 @@ async def hybrid_search_and_answer(  # noqa: C901
 
     # -- Merge and deduplicate across channels --
     merged = merge_channels([dense_results, exact_results, metadata_results, graph_results])
+
+    # MTRNIX-397 (S1): channels that returned >=1 result for THIS query. Passed to
+    # compute_signal_score so the denominator only counts channels that actually fired,
+    # preventing the signal collapsing to source-balance noise when metadata/graph are empty.
+    active_channels: set[str] | None = None
+    if _s.retrieval_scoring_normalize_active_only:
+        active_channels = {
+            name
+            for name, results in (
+                ("dense", dense_results),
+                ("exact", exact_results),
+                ("metadata", metadata_results),
+                ("graph", graph_results),
+            )
+            if results
+        }
 
     if rag_trace is not None:
         rag_trace.phase(
@@ -1083,6 +1248,7 @@ async def hybrid_search_and_answer(  # noqa: C901
             channel_scores=mr["channel_scores"],
             recency=rec,
             balance=bal,
+            active_channels=active_channels,
             **_scoring_weights,
         )
         if rag_trace is not None:
@@ -1336,6 +1502,16 @@ async def hybrid_search_and_answer(  # noqa: C901
 
     answer_with_sources = _append_sources(answer, base)
 
+    # MTRNIX-397 (H1): flag ticket numbers cited in the answer but absent from the retrieved
+    # sources (likely hallucinated). Non-destructive — logged + surfaced in the trace only.
+    ungrounded_tickets = find_ungrounded_tickets(answer, base)
+    if ungrounded_tickets:
+        logger.warning(
+            "rag_answer.ungrounded_tickets",
+            tickets=ungrounded_tickets,
+            workspace_id=workspace_id,
+        )
+
     if rag_trace is not None:
         rag_trace.phase(
             "generation",
@@ -1343,6 +1519,7 @@ async def hybrid_search_and_answer(  # noqa: C901
             model=_active_llm_model(_s),
             raw_answer=answer,
             final_answer=answer_with_sources,
+            ungrounded_tickets=ungrounded_tickets,
         )
 
     # Return full trace for benchmarker integration when requested
@@ -1392,7 +1569,7 @@ async def hybrid_search_and_answer(  # noqa: C901
         try:
             total_ms = (time.time() - start_time) * 1000
             # Count total words in source fragments sent to LLM context.
-            # Used by FinOps time-savings calculation: manual_reading_time = (words / 150 WPM) * 1.5
+            # Used by FinOps time-savings calc: manual_reading_time = (words / 150 WPM) * 1.5
             source_word_count = sum(len(f["text"].split()) for f in frags) if frags else 0
             trace_data = {
                 "query": rq,

--- a/src/metatron/storage/qdrant.py
+++ b/src/metatron/storage/qdrant.py
@@ -421,11 +421,15 @@ class QdrantVectorStore:
             logger.error("qdrant.collection.delete_error", error=str(e))
         self._ensure_collection()
 
-    def search_by_date(self, dates: list[str], limit: int = 10) -> list[dict]:
-        """Filter search by date values."""
+    def search_by_date(self, dates: list[str], limit: int = 10, key: str = "date") -> list[dict]:
+        """Filter search by date values.
+
+        ``key`` (MTRNIX-397 M5a) selects the payload field to match — defaults to ``date``
+        (document write-date); pass ``due_date`` to query Jira due dates.
+        """
         if not dates:
             return []
-        filt = Filter(must=[FieldCondition(key="date", match=MatchAny(any=dates))])
+        filt = Filter(must=[FieldCondition(key=key, match=MatchAny(any=dates))])
         results, _ = self.client.scroll(
             collection_name=self.collection_name,
             scroll_filter=filt,
@@ -910,12 +914,18 @@ class AsyncQdrantVectorStore:
         self._collection_ensured = False
         await self._ensure_collection()
 
-    async def search_by_date(self, dates: list[str], limit: int = 10) -> list[dict]:
-        """Filter search by date values."""
+    async def search_by_date(
+        self, dates: list[str], limit: int = 10, key: str = "date"
+    ) -> list[dict]:
+        """Filter search by date values.
+
+        ``key`` (MTRNIX-397 M5a) selects the payload field — defaults to ``date`` (document
+        write-date); pass ``due_date`` to query Jira due dates.
+        """
         if not dates:
             return []
         await self._ensure_collection()
-        filt = Filter(must=[FieldCondition(key="date", match=MatchAny(any=dates))])
+        filt = Filter(must=[FieldCondition(key=key, match=MatchAny(any=dates))])
         results, _ = await self.client.scroll(
             collection_name=self.collection_name,
             scroll_filter=filt,

--- a/tests/unit/retrieval/test_recall_metadata_future_fallback.py
+++ b/tests/unit/retrieval/test_recall_metadata_future_fallback.py
@@ -1,0 +1,68 @@
+"""M6 future-date fallback guard on the ASYNC metadata channel (MTRNIX-397).
+
+recall_metadata_async is the production path (hybrid_search_and_answer is async). The guard
+must only fire for FUTURE-dated queries with no hits — a historical empty-date query must NOT
+fall back to recent in-progress items. (A sync/async divergence here slipped a real bug.)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from metatron.retrieval.channels import RecallContext, recall_metadata_async
+
+
+def _ctx(dates: tuple[str, ...], *, fallback: bool) -> RecallContext:
+    return RecallContext(
+        original_query="q",
+        translated_query="q",
+        expanded_query="q",
+        detected_language="en",
+        workspace_id="TEST",
+        access_filter=None,
+        settings=SimpleNamespace(
+            recall_top_n_metadata=10,
+            retrieval_future_date_fallback_enabled=fallback,
+        ),
+        extracted_jira_keys=[],
+        extracted_title_entities=[],
+        extracted_dates=dates,
+        detected_person=[],
+        is_activity_query=False,  # force the M6 elif (not the activity status branch)
+    )
+
+
+def _store() -> AsyncMock:
+    s = AsyncMock()
+    s.search_by_date = AsyncMock(return_value=[])  # no write-date / due-date hits
+    s.search_by_status = AsyncMock(return_value=[])  # the fallback target
+    s.search_by_assignee = AsyncMock(return_value=[])
+    return s
+
+
+async def test_future_date_no_hits_triggers_fallback() -> None:
+    store = _store()
+    with patch(
+        "metatron.retrieval.channels.get_async_hybrid_store", AsyncMock(return_value=store)
+    ):
+        await recall_metadata_async(_ctx(("2099-01-01",), fallback=True))
+    store.search_by_status.assert_called()  # future + no hits + flag on → fallback fires
+
+
+async def test_historical_date_no_hits_does_not_fallback() -> None:
+    store = _store()
+    with patch(
+        "metatron.retrieval.channels.get_async_hybrid_store", AsyncMock(return_value=store)
+    ):
+        await recall_metadata_async(_ctx(("2020-01-01",), fallback=True))
+    store.search_by_status.assert_not_called()  # historical date → NO fallback (the bug)
+
+
+async def test_future_date_fallback_off_by_default() -> None:
+    store = _store()
+    with patch(
+        "metatron.retrieval.channels.get_async_hybrid_store", AsyncMock(return_value=store)
+    ):
+        await recall_metadata_async(_ctx(("2099-01-01",), fallback=False))
+    store.search_by_status.assert_not_called()  # flag off → never fallback

--- a/tests/unit/retrieval/test_scoring_normalization.py
+++ b/tests/unit/retrieval/test_scoring_normalization.py
@@ -1,0 +1,117 @@
+"""compute_signal_score — query-level normalization (MTRNIX-397, S1 / B-1).
+
+The signal score must be normalized by the weights of the channels that actually
+returned results *for the whole query* (query-level), never per-candidate — otherwise
+candidates with different active channel sets would land on different scales and the
+intra-query rank would be corrupted.
+
+Rules under test:
+- a channel (`dense`/`graph`/`metadata`) weight drops from the denominator iff that
+  channel returned 0 results for the query;
+- `metadata_weight` is kept when `exact` OR `metadata` returned (scoring uses
+  `metadata = max(exact, metadata)`);
+- `recency` and `balance` are NOT channels — never dropped;
+- `active_channels=None` reproduces the legacy all-weights denominator exactly.
+"""
+
+from __future__ import annotations
+
+import math
+
+from metatron.retrieval.scoring import compute_signal_score
+
+# Default weights (function signature): dense 0.35, graph 0.15, metadata 0.20,
+# recency 0.10, balance 0.05, freshness 0.0.
+
+
+def test_legacy_none_reproduces_all_weights_denominator() -> None:
+    """active_channels=None (and the default) must equal the pre-MTRNIX-397 formula."""
+    cs = {"dense": 0.5, "graph": 0.3, "metadata": 0.4}
+    expected = (0.35 * 0.5 + 0.15 * 0.3 + 0.20 * 0.4 + 0.10 * 0.6 + 0.05 * 0.8) / 0.85
+    got_explicit = compute_signal_score(cs, recency=0.6, balance=0.8, active_channels=None)
+    got_default = compute_signal_score(cs, recency=0.6, balance=0.8)
+    assert math.isclose(got_explicit, expected, rel_tol=1e-12)
+    assert math.isclose(got_default, expected, rel_tol=1e-12)
+
+
+def test_empty_channels_dropped_query_level() -> None:
+    """Only dense returned for the query → denominator = dense+recency+balance (0.50).
+
+    The empty metadata/graph weights leave the denominator, so a dense-only candidate
+    scores materially higher than under the legacy all-weights (0.85) denominator.
+    """
+    cs = {"dense": 0.8}  # metadata/graph absent
+    active = {"dense"}
+    expected = (0.35 * 0.8 + 0.10 * 0.6 + 0.05 * 0.5) / (0.35 + 0.10 + 0.05)
+    got = compute_signal_score(cs, recency=0.6, balance=0.5, active_channels=active)
+    assert math.isclose(got, expected, rel_tol=1e-12)
+
+    legacy = compute_signal_score(cs, recency=0.6, balance=0.5, active_channels=None)
+    assert got > legacy  # the whole point of S1
+
+
+def test_same_denominator_for_all_candidates_in_query() -> None:
+    """Two candidates with the same active set are divided by the same denominator."""
+    active = {"dense"}
+    a = compute_signal_score({"dense": 0.9}, recency=0.5, balance=0.5, active_channels=active)
+    b = compute_signal_score({"dense": 0.1}, recency=0.5, balance=0.5, active_channels=active)
+    raw_a = 0.35 * 0.9 + 0.10 * 0.5 + 0.05 * 0.5
+    raw_b = 0.35 * 0.1 + 0.10 * 0.5 + 0.05 * 0.5
+    denom = 0.35 + 0.10 + 0.05
+    assert math.isclose(a, raw_a / denom, rel_tol=1e-12)
+    assert math.isclose(b, raw_b / denom, rel_tol=1e-12)
+
+
+def test_exact_channel_retains_metadata_weight() -> None:
+    """`exact` present keeps metadata_weight in denom (metadata = max(exact, metadata))."""
+    active = {"dense", "exact"}
+    cs = {"dense": 0.0, "exact": 0.7}
+    # metadata term = max(exact, metadata) = 0.7; denom includes metadata_weight (0.20).
+    expected = (0.20 * 0.7 + 0.10 * 0.0 + 0.05 * 0.0) / (0.35 + 0.20 + 0.10 + 0.05)
+    got = compute_signal_score(cs, recency=0.0, balance=0.0, active_channels=active)
+    assert math.isclose(got, expected, rel_tol=1e-12)
+
+
+def test_metadata_channel_alone_retains_metadata_weight() -> None:
+    """`metadata` (without exact) also keeps metadata_weight."""
+    active = {"metadata"}
+    cs = {"metadata": 0.6}
+    expected = (0.20 * 0.6 + 0.10 * 1.0 + 0.05 * 1.0) / (0.20 + 0.10 + 0.05)
+    got = compute_signal_score(cs, recency=1.0, balance=1.0, active_channels=active)
+    assert math.isclose(got, expected, rel_tol=1e-12)
+
+
+def test_recency_balance_never_dropped() -> None:
+    """No channel returned, but recency/balance still form the denominator (no div-by-zero)."""
+    got = compute_signal_score({}, recency=1.0, balance=1.0, active_channels=set())
+    # denom = recency_weight + balance_weight = 0.15; raw = 0.10*1 + 0.05*1 = 0.15.
+    assert math.isclose(got, 1.0, rel_tol=1e-12)
+
+
+def test_zero_total_weight_returns_zero() -> None:
+    """Degenerate guard: all weights zero → 0.0, never a ZeroDivisionError."""
+    got = compute_signal_score(
+        {"dense": 1.0},
+        recency=1.0,
+        balance=1.0,
+        dense_weight=0.0,
+        graph_weight=0.0,
+        metadata_weight=0.0,
+        recency_weight=0.0,
+        balance_weight=0.0,
+        active_channels=set(),
+    )
+    assert got == 0.0
+
+
+def test_output_stays_in_unit_interval() -> None:
+    """Normalized output stays in [0, 1] across active-channel combinations."""
+    combos = [set(), {"dense"}, {"dense", "exact"}, {"dense", "graph", "metadata"}]
+    for active in combos:
+        score = compute_signal_score(
+            {"dense": 1.0, "graph": 1.0, "metadata": 1.0},
+            recency=1.0,
+            balance=1.0,
+            active_channels=active,
+        )
+        assert 0.0 <= score <= 1.0

--- a/tests/unit/retrieval/test_slot_extraction.py
+++ b/tests/unit/retrieval/test_slot_extraction.py
@@ -1,0 +1,167 @@
+"""Slot extraction + channel-trigger union (MTRNIX-397, B0 / M7 / E1)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from metatron.retrieval.search import (
+    _build_recall_context,
+    _extract_fast_signals,
+    _parse_slots,
+    extract_slots,
+)
+
+# -- _parse_slots (pure) ----------------------------------------------------
+
+
+def test_parse_slots_valid() -> None:
+    raw = json.dumps(
+        {
+            "date_range": ["2026-06-08", "2026-06-14"],
+            "people": ["Alice", "Bob"],
+            "jira_keys": ["mtrnix-9"],
+            "entities": ["Project X"],
+            "is_activity": True,
+            "needs_retrieval": True,
+        }
+    )
+    slots = _parse_slots(raw)
+    assert slots is not None
+    assert slots["date_range"] == ("2026-06-08", "2026-06-14")
+    assert slots["people"] == ["Alice", "Bob"]
+    assert slots["jira_keys"] == ["MTRNIX-9"]  # upper-cased
+    assert slots["entities"] == ["Project X"]
+    assert slots["is_activity"] is True
+    assert slots["needs_retrieval"] is True
+
+
+def test_parse_slots_strips_markdown_fences() -> None:
+    raw = '```json\n{"date_range": null, "people": [], "jira_keys": [], "entities": [], ' \
+        '"is_activity": false, "needs_retrieval": true}\n```'
+    slots = _parse_slots(raw)
+    assert slots is not None
+    assert slots["date_range"] is None
+    assert slots["needs_retrieval"] is True
+
+
+def test_parse_slots_malformed_returns_none() -> None:
+    assert _parse_slots("not json at all") is None
+    assert _parse_slots("") is None
+    assert _parse_slots('{"date_range": [') is None  # truncated
+
+
+def test_parse_slots_non_dict_returns_none() -> None:
+    assert _parse_slots("[1, 2, 3]") is None
+
+
+def test_parse_slots_defaults_for_missing_keys() -> None:
+    slots = _parse_slots("{}")
+    assert slots == {
+        "date_range": None,
+        "people": [],
+        "jira_keys": [],
+        "entities": [],
+        "is_activity": False,
+        "needs_retrieval": True,  # default-true: retrieve unless told otherwise
+    }
+
+
+def test_parse_slots_bad_date_range_shape_is_none() -> None:
+    slots = _parse_slots('{"date_range": ["2026-06-08"]}')  # only one element
+    assert slots is not None
+    assert slots["date_range"] is None
+
+
+# -- extract_slots (LLM wrapper, mocked) ------------------------------------
+
+
+def test_extract_slots_flag_off_skips_llm() -> None:
+    s = SimpleNamespace(retrieval_slot_extraction_enabled=False)
+    with patch("metatron.retrieval.search.chat_completion") as mock_llm:
+        assert extract_slots("next week tasks", s) is None
+        mock_llm.assert_not_called()
+
+
+def test_extract_slots_flag_on_parses() -> None:
+    s = SimpleNamespace(
+        retrieval_slot_extraction_enabled=True, retrieval_slot_extraction_timeout=6
+    )
+    payload = json.dumps(
+        {
+            "date_range": ["2026-06-08", "2026-06-14"],
+            "people": [],
+            "jira_keys": [],
+            "entities": [],
+            "is_activity": True,
+            "needs_retrieval": True,
+        }
+    )
+    with patch("metatron.retrieval.search.chat_completion", return_value=payload) as mock_llm:
+        slots = extract_slots("next week tasks", s)
+        assert slots is not None
+        assert slots["is_activity"] is True
+        assert mock_llm.call_args.kwargs["call_site"] == "slot_extraction"
+
+
+def test_extract_slots_llm_exception_returns_none() -> None:
+    s = SimpleNamespace(
+        retrieval_slot_extraction_enabled=True, retrieval_slot_extraction_timeout=6
+    )
+    with patch("metatron.retrieval.search.chat_completion", side_effect=Exception("boom")):
+        assert extract_slots("next week tasks", s) is None
+
+
+# -- _extract_fast_signals ISO range (M7) -----------------------------------
+
+
+def test_extract_fast_signals_iso_range_expands() -> None:
+    _, dates = _extract_fast_signals("tasks for the week 2026-06-08..2026-06-10")
+    assert dates is not None
+    assert "2026-06-08" in dates and "2026-06-09" in dates and "2026-06-10" in dates
+
+
+def test_extract_fast_signals_single_iso_unchanged() -> None:
+    _, dates = _extract_fast_signals("what happened on 2026-06-08")
+    assert dates == ("2026-06-08",)
+
+
+# -- _build_recall_context union (B0 / E1) ----------------------------------
+
+
+def test_build_recall_context_unions_slots() -> None:
+    slots = {
+        "date_range": ("2026-06-08", "2026-06-09"),
+        "people": ["Alice"],
+        "jira_keys": ["MTRNIX-9"],
+        "entities": ["Project X"],
+        "is_activity": True,
+        "needs_retrieval": True,
+    }
+    ctx = _build_recall_context(
+        original_query="what are the plans",  # no regex signals
+        translated_query="what are the plans",
+        expanded_query="what are the plans",
+        detected_language="en",
+        workspace_id="MTRNIX",
+        slots=slots,
+    )
+    assert "MTRNIX-9" in ctx.extracted_jira_keys
+    assert "Alice" in ctx.detected_person
+    assert "Project X" in ctx.extracted_title_entities
+    assert ctx.is_activity_query is True
+    assert ctx.extracted_dates is not None
+    assert "2026-06-08" in ctx.extracted_dates and "2026-06-09" in ctx.extracted_dates
+
+
+def test_build_recall_context_no_slots_is_regex_only() -> None:
+    ctx = _build_recall_context(
+        original_query="status of MTRNIX-104",
+        translated_query="status of MTRNIX-104",
+        expanded_query="status of MTRNIX-104",
+        detected_language="en",
+        workspace_id="MTRNIX",
+        slots=None,
+    )
+    assert "MTRNIX-104" in ctx.extracted_jira_keys  # regex floor still works

--- a/tests/unit/retrieval/test_ungrounded_tickets.py
+++ b/tests/unit/retrieval/test_ungrounded_tickets.py
@@ -1,0 +1,55 @@
+"""Anti-hallucination ticket guard (MTRNIX-397, H1)."""
+
+from __future__ import annotations
+
+from metatron.retrieval.search import find_ungrounded_tickets
+
+
+def test_no_tickets_in_answer() -> None:
+    assert find_ungrounded_tickets("A plain answer with no tickets.", []) == []
+
+
+def test_grounded_ticket_in_title_is_ok() -> None:
+    results = [{"title": "[MTRNIX-281] Analyze papers", "text": "..."}]
+    assert find_ungrounded_tickets("See MTRNIX-281 for details.", results) == []
+
+
+def test_grounded_ticket_in_text_is_ok() -> None:
+    results = [{"title": "Daily", "text": "work on MTRNIX-9 continues"}]
+    assert find_ungrounded_tickets("MTRNIX-9 is in progress.", results) == []
+
+
+def test_grounded_ticket_in_doc_label_is_ok() -> None:
+    results = [{"doc_label": "jira:MTRNIX-55", "payload": {}}]
+    assert find_ungrounded_tickets("per MTRNIX-55", results) == []
+
+
+def test_ungrounded_ticket_flagged() -> None:
+    results = [{"title": "[MTRNIX-281] Analyze papers", "text": "nothing else"}]
+    # MTRNIX-370 is not present anywhere in the sources → hallucinated.
+    assert find_ungrounded_tickets("The plan covers MTRNIX-370 and MTRNIX-281.", results) == [
+        "MTRNIX-370"
+    ]
+
+
+def test_case_insensitive_grounding() -> None:
+    results = [{"text": "mtrnix-42 done"}]
+    assert find_ungrounded_tickets("MTRNIX-42 is done", results) == []
+
+
+def test_multiple_ungrounded_sorted_unique() -> None:
+    results = [{"title": "unrelated", "text": "no keys here"}]
+    out = find_ungrounded_tickets("MTRNIX-9, MTRNIX-9, ABC-1 and MTRNIX-2", results)
+    assert out == ["ABC-1", "MTRNIX-2", "MTRNIX-9"]
+
+
+def test_grounded_via_payload_data() -> None:
+    results = [{"payload": {"data": "discussion about MTRNIX-100"}}]
+    assert find_ungrounded_tickets("MTRNIX-100 update", results) == []
+
+
+def test_substring_ticket_not_treated_as_grounded() -> None:
+    """A cited MTRNIX-2 must NOT count as grounded just because sources contain MTRNIX-281
+    (exact ticket-key set membership, not substring) — otherwise the metric lies."""
+    results = [{"title": "[MTRNIX-281] Analyze papers", "text": "MTRNIX-281 details"}]
+    assert find_ungrounded_tickets("Work on MTRNIX-2 continues.", results) == ["MTRNIX-2"]

--- a/tests/unit/test_model_tiers.py
+++ b/tests/unit/test_model_tiers.py
@@ -1,0 +1,48 @@
+"""call_site -> model tier resolution (MTRNIX-397, A)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from metatron.llm.tiers import resolve_model_for_call_site
+
+
+def _settings(provider="deepseek", heavy="deepseek-chat", fast=""):
+    return SimpleNamespace(
+        llm_provider=provider, deepseek_model=heavy, deepseek_model_fast=fast
+    )
+
+
+def test_fast_call_site_with_empty_fast_inherits_heavy() -> None:
+    s = _settings(heavy="deepseek-chat", fast="")
+    assert resolve_model_for_call_site("resolve_query", None, s) == "deepseek-chat"
+
+
+def test_fast_call_site_with_custom_heavy_inherits_it() -> None:
+    """Unset FAST + custom DEEPSEEK_MODEL => FAST inherits the custom heavy (AC: unset == identical)."""
+    s = _settings(heavy="deepseek-custom-v9", fast="")
+    assert resolve_model_for_call_site("query_classifier", None, s) == "deepseek-custom-v9"
+
+
+def test_fast_call_site_uses_fast_when_set() -> None:
+    s = _settings(heavy="deepseek-chat", fast="deepseek-flash")
+    assert resolve_model_for_call_site("slot_extraction", None, s) == "deepseek-flash"
+
+
+def test_heavy_call_site_returns_none() -> None:
+    """rag_answer (and any non-FAST call_site) uses the provider default (None)."""
+    s = _settings(fast="deepseek-flash")
+    assert resolve_model_for_call_site("rag_answer", None, s) is None
+    assert resolve_model_for_call_site("unknown_site", None, s) is None
+
+
+def test_non_deepseek_provider_is_noop() -> None:
+    s = _settings(provider="ollama", fast="deepseek-flash")
+    assert resolve_model_for_call_site("resolve_query", None, s) is None
+
+
+def test_explicit_model_always_wins() -> None:
+    s = _settings(provider="deepseek", fast="deepseek-flash")
+    assert resolve_model_for_call_site("resolve_query", "override-model", s) == "override-model"
+    s2 = _settings(provider="ollama")
+    assert resolve_model_for_call_site("rag_answer", "override-model", s2) == "override-model"

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -77,17 +77,21 @@ class TestProfileWeights:
         }
         assert set(QUERY_PROFILE_WEIGHTS[profile].keys()) == expected_keys
 
-    def test_mixed_matches_current_defaults(self) -> None:
-        """mixed profile must match compute_signal_score() defaults exactly."""
+    def test_mixed_profile_weights(self) -> None:
+        """mixed (fallback) profile weights. NOTE (MTRNIX-397): these are the grid-searched
+        values committed on develop; they intentionally diverge from compute_signal_score()'s
+        own defaults. All profile weights — mixed included — are re-derived by the Phase 6
+        grid-search re-run (S-grid); update here if that run changes them.
+        """
         from metatron.retrieval.query_classifier import QUERY_PROFILE_WEIGHTS
 
         mixed = QUERY_PROFILE_WEIGHTS["mixed"]
-        assert mixed["dense_weight"] == 0.35
-        assert mixed["graph_weight"] == 0.15
-        assert mixed["metadata_weight"] == 0.20
-        assert mixed["recency_weight"] == 0.10
+        assert mixed["dense_weight"] == 0.4
+        assert mixed["graph_weight"] == 0.0
+        assert mixed["metadata_weight"] == 0.4
+        assert mixed["recency_weight"] == 0.0
         assert mixed["balance_weight"] == 0.05
-        assert mixed["blend_weight"] == 0.30
+        assert mixed["blend_weight"] == 0.6
 
     def test_get_profile_weights_valid(self) -> None:
         from metatron.retrieval.query_classifier import get_profile_weights

--- a/tests/unit/test_search_quality_tuning.py
+++ b/tests/unit/test_search_quality_tuning.py
@@ -54,7 +54,11 @@ def test_recall_graph_caches_entity_lookups():
         detected_language="en",
         workspace_id="ws1",
         access_filter=None,
-        settings=MagicMock(recall_top_n_graph=5, recall_graph_max_depth=2),
+        settings=MagicMock(
+            recall_top_n_graph=5,
+            recall_graph_max_depth=2,
+            retrieval_graph_ner_enabled=False,  # MTRNIX-397 G1: default off → legacy NER path
+        ),
         extracted_jira_keys=["MTRNIX-104"],
         extracted_title_entities=[],
         extracted_dates=None,


### PR DESCRIPTION
## Summary
Fixes the two core RAG blockers found in trace review (channels dead + degenerate scoring), plus secondary defects. All new behavior is **flag-gated; defaults = prior behavior**.

### Blocker 2 — scoring
- **S1**: query-level signal normalization — `compute_signal_score(active_channels=…)` normalizes only over channels that actually returned results, so the score no longer collapses to `source_balance` noise when metadata/graph are empty. Default-on (inert when all weighted channels return results).
- **S2/S3**: non-zero `dense`/`recency` floors for execution/temporal (interim; per-profile sum kept 0.85). Final weights to be re-derived by grid-search on a corpus-matched eval set (deferred — see below).

### Blocker 1 — recall channels
- **B0**: FAST-LLM slot extraction (dates/people/jira-keys/entities/activity) unioned onto the regex triggers. Hardened: flag + timeout + strict JSON + regex fallback.
- **M-resolver / M7**: resolver emits ISO date **ranges**; ranges carried through recall.
- **M3**: task-tracker activity vocabulary (sprint/task/backlog/…).
- **G1 (bug)**: graph channel seeded from extracted entities instead of the dead `get_graph_entities(query)` exact-text-match path.
- **M5a / M6**: index Jira `duedate` → `due_date` payload; `search_by_date(key=)`; future-date → recent-in-progress fallback.

### Other
- **FAST/HEAVY DeepSeek tier** by `call_site` (`llm/tiers.py`): service calls → FAST, `rag_answer` → HEAVY. Empty `DEEPSEEK_MODEL_FAST` inherits heavy.
- **H1**: non-destructive anti-hallucination guard (flags ungrounded ticket refs) + answer-prompt rule.
- **logging**: force UTF-8 on stdout/stderr (kills Windows cp1251 `UnicodeEncodeError` on Unicode log content).

## Validation
Live on the MTRNIX stand: regression queries ("what are next weeks tasks", "check jira sprint for week 22", "jira+github next week activity") now return **grounded next-week Jira tasks** (with assignees/due dates) instead of digest-dominated / hallucinated answers; metadata channel fires 0→10, all 4 channels fire on multi-entity queries, `ungrounded_tickets: []`. The previously-working "what model do you use" query did not regress. New unit tests for all four mechanisms green.

## Flags (defaults = today)
`METATRON_RETRIEVAL_SCORING_NORMALIZE_ACTIVE_ONLY` (true), `…_SLOT_EXTRACTION_ENABLED` (false), `…_GRAPH_NER_ENABLED` (false), `…_FUTURE_DATE_FALLBACK_ENABLED` (false), `DEEPSEEK_MODEL_FAST` (empty=inherit). Deploy env: mtrnix/infra#4.

## Deferred (separate tickets)
- Phase 6.1 grid-search re-run — needs a corpus-matched, temporal-augmented labeled eval set.
- `workspaces.description` UndefinedColumn (breaks LLM telemetry) — pre-existing, separate.
- non-RAG bypass (2.3, product sign-off), H2 dedup / ingestion double-index, M5b sprint customfield, P1 source=memory digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)