### PR TITLE
fix(installer): detect Docker Compose in preflight, support v1 standalone fallback

### DIFF
--- a/installer/src/metatron_installer/cli.py
+++ b/installer/src/metatron_installer/cli.py
@@ -10,7 +10,9 @@ from .config import InstallerConfig, Mode, Profile, defaults_for
 from .docker import CommandResult, DockerShell, parse_ps_services
 from .envfile import atomic_write
 from .preflight import (
+    ComposeInfo,
     DockerInfo,
+    check_compose,
     check_disk_space,
     detect_os,
     find_port_conflicts,
@@ -43,8 +45,12 @@ def _resolve_config(args: argparse.Namespace) -> InstallerConfig:
     return run_wizard(QuestionaryPrompter())
 
 
-def _run_preflight(shell: DockerShell) -> bool:
-    """Probe Docker + ports and print a summary. Returns False to abort the install."""
+def _run_preflight(shell: DockerShell) -> tuple[bool, ComposeInfo | None]:
+    """Probe Docker + Compose + ports and print a summary.
+
+    Returns (go_no_go, compose_info). When compose is available, the shell's
+    ``_compose_cmd`` is updated to use the detected command prefix.
+    """
     ui.info(f"Preflight on {detect_os()}")
     version_res = shell.version()
     docker: DockerInfo = (
@@ -52,12 +58,15 @@ def _run_preflight(shell: DockerShell) -> bool:
         if version_res.returncode == 0
         else DockerInfo(present=False)
     )
+    compose = check_compose()
+    if compose.available:
+        shell._compose_cmd = list(compose.command)
     conflicts = find_port_conflicts()
     disk = check_disk_space()
-    ok, messages = summarize(docker, conflicts, disk)
+    ok, messages = summarize(docker, conflicts, disk, compose=compose)
     for line in messages:
         (ui.success if ok and "in use" not in line else ui.warning)(line)
-    return ok
+    return ok, compose
 
 
 def _render_status(shell: DockerShell, compose_file: str, env: dict[str, str]) -> None:
@@ -119,7 +128,7 @@ def _main_impl(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int
     compose_file = str(repo_root / "install" / "docker-compose.yml")
     base_env = dict(os.environ)
 
-    if not _run_preflight(shell):
+    if not _run_preflight(shell)[0]:
         ui.error("Preflight failed. Fix the issues above and re-run.")
         return 2
 
@@ -146,9 +155,7 @@ def _main_impl(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int
         from .prompter_questionary import QuestionaryPrompter
 
         prompter = QuestionaryPrompter()
-        remove_images = prompter.confirm(
-            "Also remove Docker images?", default=False
-        )
+        remove_images = prompter.confirm("Also remove Docker images?", default=False)
         remove_volumes = prompter.confirm(
             "Also delete all data volumes? (irreversible)", default=False
         )
@@ -202,7 +209,7 @@ def _main_impl(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int
     if not ok:
         ui.error(
             "Stack failed to start. Check logs:\n"
-            f"  docker compose -f {compose_file} logs"
+            f"  {' '.join(shell._compose_cmd)} -f {compose_file} logs"
         )
         if err:
             ui.console.print(f"[dim]{err.strip()}[/dim]")

--- a/installer/src/metatron_installer/docker.py
+++ b/installer/src/metatron_installer/docker.py
@@ -100,9 +100,7 @@ def _pull_with_progress(argv: list[str], env: dict[str, str]) -> tuple[int, str]
         if proc.stderr is None:
             return
         for raw_line in proc.stderr:
-            stderr_lines.append(
-                raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
-            )
+            stderr_lines.append(raw_line.decode("utf-8", errors="replace").rstrip("\r\n"))
 
     t = threading.Thread(target=_drain_stderr, daemon=True)
     t.start()
@@ -163,15 +161,27 @@ def _pull_with_progress(argv: list[str], env: dict[str, str]) -> tuple[int, str]
 
 
 class DockerShell:
-    def __init__(self, runner: Runner | None = None):
+    def __init__(self, runner: Runner | None = None, compose_cmd: list[str] | None = None):
         self._run = runner or _default_runner
         self._last_stderr = ""
+        self._compose_cmd = compose_cmd or ["docker", "compose"]
+
+    def _compose_argv(self, compose_file: str, *sub: str) -> list[str]:
+        """Build a compose argv using the detected compose command prefix."""
+        return [*self._compose_cmd, "-f", compose_file, *sub]
 
     def version(self) -> CommandResult:
         try:
             return self._run(["docker", "version", "--format", "{{.Server.Version}}"], None)
         except FileNotFoundError:
             return CommandResult(127, "", "docker: command not found")
+
+    def compose_version(self) -> CommandResult:
+        """Probe whether the configured compose command is available."""
+        try:
+            return self._run([*self._compose_cmd, "version"], None)
+        except FileNotFoundError:
+            return CommandResult(127, "", f"{' '.join(self._compose_cmd)}: command not found")
 
     def login(self, registry: str, user: str, token: str) -> CommandResult:
         # SECURITY: token is on argv (visible in `ps`) — acceptable for a local
@@ -185,7 +195,7 @@ class DockerShell:
         registry_login: Callable[[], CommandResult] | None,
     ) -> bool:
         """Pull images with live output. Retries once on auth errors."""
-        argv = ["docker", "compose", "-f", compose_file, "pull"]
+        argv = self._compose_argv(compose_file, "pull")
 
         def _try_pull() -> int:
             sys.stdout.flush()
@@ -207,15 +217,16 @@ class DockerShell:
         """Start the stack (`up -d`) with live output, capturing stderr for diagnostics."""
         sys.stdout.flush()
         proc = subprocess.run(
-            ["docker", "compose", "-f", compose_file, "up", "-d"],
-            env=env, stdout=None, stderr=subprocess.PIPE, text=True,
+            self._compose_argv(compose_file, "up", "-d"),
+            env=env,
+            stdout=None,
+            stderr=subprocess.PIPE,
+            text=True,
         )
         return CommandResult(proc.returncode, "", proc.stderr)
 
     def compose_ps(self, compose_file: str, env: dict[str, str]) -> CommandResult:
-        return self._run(
-            ["docker", "compose", "-f", compose_file, "ps", "--format", "json"], env
-        )
+        return self._run(self._compose_argv(compose_file, "ps", "--format", "json"), env)
 
     def compose_restart(self, compose_file: str, env: dict[str, str]) -> CommandResult:
         """Restart the stack with live output, capturing stderr for diagnostics.
@@ -233,8 +244,11 @@ class DockerShell:
         try:
             sys.stdout.flush()
             proc = subprocess.run(
-                ["docker", "compose", "-f", compose_file, "restart"],
-                env=env, stdout=None, stderr=subprocess.PIPE, text=True,
+                self._compose_argv(compose_file, "restart"),
+                env=env,
+                stdout=None,
+                stderr=subprocess.PIPE,
+                text=True,
             )
             return CommandResult(proc.returncode, "", proc.stderr)
         finally:
@@ -266,15 +280,18 @@ class DockerShell:
             env_path.touch()
 
         try:
-            argv = ["docker", "compose", "-f", compose_file, "down"]
+            argv = self._compose_argv(compose_file, "down")
             if remove_images:
                 argv.extend(["--rmi", "all"])
             if remove_volumes:
                 argv.append("--volumes")
             sys.stdout.flush()
             proc = subprocess.run(
-                argv, env=env, stdout=None,
-                stderr=subprocess.PIPE, text=True,
+                argv,
+                env=env,
+                stdout=None,
+                stderr=subprocess.PIPE,
+                text=True,
             )
             return CommandResult(proc.returncode, "", proc.stderr)
         finally:

--- a/installer/src/metatron_installer/preflight.py
+++ b/installer/src/metatron_installer/preflight.py
@@ -38,6 +38,20 @@ class DockerInfo:
 
 
 @dataclass(frozen=True)
+class ComposeInfo:
+    """Result of probing for Docker Compose availability.
+
+    ``kind`` is ``"plugin"`` (``docker compose`` v2), ``"standalone"``
+    (``docker-compose`` v1), or ``""`` when neither is found.
+    ``command`` is the argv prefix to use (e.g. ``["docker", "compose"]``).
+    """
+
+    available: bool
+    kind: str = ""
+    command: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class PortConflict:
     port: int
     service: str
@@ -87,21 +101,59 @@ def _port_in_use(port: int) -> bool:
 def find_port_conflicts(
     checker: Callable[[int], bool] = _port_in_use,
 ) -> list[PortConflict]:
-    return [
-        PortConflict(port=p, service=svc)
-        for p, svc in PUBLISHED_PORTS.items()
-        if checker(p)
-    ]
+    return [PortConflict(port=p, service=svc) for p, svc in PUBLISHED_PORTS.items() if checker(p)]
+
+
+def check_compose() -> ComposeInfo:
+    """Detect whether ``docker compose`` (v2 plugin) or ``docker-compose``
+    (v1 standalone) is available.
+
+    Returns :class:`ComposeInfo` with the detected command prefix, or
+    ``available=False`` when neither is found.
+    """
+    import subprocess
+
+    # Try v2 plugin: `docker compose version`
+    try:
+        r = subprocess.run(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if r.returncode == 0:
+            return ComposeInfo(available=True, kind="plugin", command=("docker", "compose"))
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    # Try v1 standalone: `docker-compose version`
+    try:
+        r = subprocess.run(
+            ["docker-compose", "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if r.returncode == 0:
+            return ComposeInfo(available=True, kind="standalone", command=("docker-compose",))
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return ComposeInfo(available=False)
 
 
 def summarize(
-    docker: DockerInfo, conflicts: list[PortConflict], disk: DiskInfo | None = None
+    docker: DockerInfo,
+    conflicts: list[PortConflict],
+    disk: DiskInfo | None = None,
+    compose: ComposeInfo | None = None,
 ) -> tuple[bool, list[str]]:
     """Turn preflight probes into a go/no-go decision plus human-readable lines.
 
     A missing/unreachable Docker is a hard stop (ok=False). Port conflicts are
     warnings only — the operator may have intentionally remapped or be re-running.
-    Insufficient disk space (< MIN_DISK_GB) is also a hard stop.
+    Insufficient disk space (< MIN_DISK_GB) is also a hard stop. Missing Docker
+    Compose (neither v2 plugin nor v1 standalone) is a hard stop.
     """
     messages: list[str] = []
     ok = True
@@ -113,6 +165,21 @@ def summarize(
             "Docker not available — is it installed and running? "
             "Start Docker Desktop, or `sudo systemctl start docker`."
         )
+    if compose is not None:
+        if compose.available:
+            label = "v2 plugin" if compose.kind == "plugin" else "v1 standalone"
+            messages.append(f"Docker Compose {label} detected")
+        else:
+            ok = False
+            messages.append(
+                "Docker Compose not available — install it:\n"
+                "  macOS:  brew install docker-compose && "
+                "mkdir -p ~/.docker/cli-plugins && "
+                "ln -sfn $(brew --prefix)/opt/docker-compose/bin/docker-compose "
+                "~/.docker/cli-plugins/docker-compose\n"
+                "  Linux:  sudo apt-get install docker-compose-plugin  "
+                "(or: sudo yum install docker-compose-plugin)"
+            )
     if disk is not None:
         free = disk.free_gb
         if free < _MIN_DISK_GB:

--- a/installer/src/metatron_installer/preflight.py
+++ b/installer/src/metatron_installer/preflight.py
@@ -156,6 +156,7 @@ def check_compose() -> ComposeInfo:
         if r.returncode == 0:
             return ComposeInfo(available=True, kind="plugin", command=("docker", "compose"))
     except (FileNotFoundError, subprocess.TimeoutExpired):
+        # `docker` is not installed/reachable or the check timed out; fall back to v1 probe.
         pass
 
     # Try v1 standalone: `docker-compose version`
@@ -169,6 +170,7 @@ def check_compose() -> ComposeInfo:
         if r.returncode == 0:
             return ComposeInfo(available=True, kind="standalone", command=("docker-compose",))
     except (FileNotFoundError, subprocess.TimeoutExpired):
+        # `docker-compose` is unavailable or timed out; report compose as unavailable below.
         pass
 
     return ComposeInfo(available=False)

--- a/installer/tests/test_docker.py
+++ b/installer/tests/test_docker.py
@@ -16,12 +16,27 @@ class FakeRunner:
 
 # ── tests that use FakeRunner (methods calling self._run) ──
 
+
 def test_version_invokes_docker_version():
     runner = FakeRunner([CommandResult(0, "Docker version 27.1.1, build x", "")])
     sh = DockerShell(runner=runner)
     out = sh.version()
     assert runner.calls[0] == ["docker", "version", "--format", "{{.Server.Version}}"]
     assert out.returncode == 0
+
+
+def test_compose_version_invokes_configured_prefix():
+    runner = FakeRunner([CommandResult(0, "Docker Compose version v2.29.0", "")])
+    sh = DockerShell(runner=runner)
+    sh.compose_version()
+    assert runner.calls[0] == ["docker", "compose", "version"]
+
+
+def test_compose_version_uses_standalone_prefix():
+    runner = FakeRunner([CommandResult(0, "Docker Compose version v1.29.0", "")])
+    sh = DockerShell(runner=runner, compose_cmd=["docker-compose"])
+    sh.compose_version()
+    assert runner.calls[0] == ["docker-compose", "version"]
 
 
 def test_parse_ps_services_ndjson():
@@ -58,6 +73,7 @@ def test_running_container_names_empty_on_failure():
 
 # ── tests that mock subprocess.run (compose_pull / compose_up / restart / down) ──
 
+
 def _mock_subprocess_run(returncode=0, stdout="", stderr=""):
     """Create a mock for subprocess.run that captures calls."""
 
@@ -77,6 +93,16 @@ def test_compose_up_passes_detach_and_profiles_env():
         sh.compose_up("install/docker-compose.yml", env={"COMPOSE_PROFILES": "full"})
     argv = calls[0]["argv"]
     assert argv[:3] == ["docker", "compose", "-f"]
+    assert "up" in argv and "-d" in argv
+
+
+def test_compose_up_uses_standalone_prefix_when_configured():
+    sh = DockerShell(compose_cmd=["docker-compose"])
+    calls, run_mock = _mock_subprocess_run()
+    with patch("subprocess.run", run_mock):
+        sh.compose_up("install/docker-compose.yml", env={})
+    argv = calls[0]["argv"]
+    assert argv[:2] == ["docker-compose", "-f"]
     assert "up" in argv and "-d" in argv
 
 
@@ -109,7 +135,9 @@ def test_pull_succeeds_anonymously_without_login():
         return_value=(0, ""),
     ):
         ok = sh.compose_pull(
-            "install/docker-compose.yml", env={}, registry_login=None,
+            "install/docker-compose.yml",
+            env={},
+            registry_login=None,
         )
     assert ok is True
 
@@ -124,7 +152,27 @@ def test_compose_restart_argv(tmp_path):
     with patch("subprocess.run", run_mock):
         sh.compose_restart(compose_file, env={})
     assert calls[0]["argv"] == [
-        "docker", "compose", "-f", compose_file, "restart",
+        "docker",
+        "compose",
+        "-f",
+        compose_file,
+        "restart",
+    ]
+
+
+def test_compose_restart_standalone_argv(tmp_path):
+    """compose_restart honours the standalone compose_cmd prefix."""
+    sh = DockerShell(compose_cmd=["docker-compose"])
+    compose_file = str(tmp_path / "install" / "docker-compose.yml")
+    (tmp_path / "install").mkdir()
+    calls, run_mock = _mock_subprocess_run()
+    with patch("subprocess.run", run_mock):
+        sh.compose_restart(compose_file, env={})
+    assert calls[0]["argv"] == [
+        "docker-compose",
+        "-f",
+        compose_file,
+        "restart",
     ]
 
 
@@ -144,3 +192,19 @@ def test_compose_down_with_and_without_volumes(tmp_path):
         sh.compose_down(compose_file, env={}, remove_volumes=True)
     assert all_calls[0] == ["docker", "compose", "-f", compose_file, "down"]
     assert all_calls[1][-1] == "--volumes"
+
+
+def test_compose_down_standalone_prefix(tmp_path):
+    """compose_down honours the standalone compose_cmd prefix."""
+    sh = DockerShell(compose_cmd=["docker-compose"])
+    compose_file = str(tmp_path / "install" / "docker-compose.yml")
+    (tmp_path / "install").mkdir()
+    all_calls = []
+
+    def _run_capture(argv, *, env=None, stdout=None, stderr=None, text=None, **kwargs):
+        all_calls.append(argv)
+        return type("P", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", _run_capture):
+        sh.compose_down(compose_file, env={})
+    assert all_calls[0] == ["docker-compose", "-f", compose_file, "down"]

--- a/installer/tests/test_preflight.py
+++ b/installer/tests/test_preflight.py
@@ -1,7 +1,9 @@
 from metatron_installer.preflight import (
     PUBLISHED_PORTS,
+    ComposeInfo,
     DockerInfo,
     PortConflict,
+    check_compose,
     find_port_conflicts,
     parse_docker_version,
     summarize,
@@ -27,6 +29,36 @@ def test_summarize_port_conflicts_are_warnings_not_blocking():
     )
     assert ok is True  # conflicts warn but don't block
     assert any("8000" in m for m in messages)
+
+
+def test_summarize_compose_missing_is_not_ok():
+    ok, messages = summarize(
+        DockerInfo(present=True, major=27, minor=1),
+        [],
+        compose=ComposeInfo(available=False),
+    )
+    assert ok is False
+    assert any("Docker Compose not available" in m for m in messages)
+
+
+def test_summarize_compose_plugin_detected_is_ok():
+    ok, messages = summarize(
+        DockerInfo(present=True, major=27, minor=1),
+        [],
+        compose=ComposeInfo(available=True, kind="plugin", command=("docker", "compose")),
+    )
+    assert ok is True
+    assert any("v2 plugin" in m for m in messages)
+
+
+def test_summarize_compose_standalone_detected_is_ok():
+    ok, messages = summarize(
+        DockerInfo(present=True, major=27, minor=1),
+        [],
+        compose=ComposeInfo(available=True, kind="standalone", command=("docker-compose",)),
+    )
+    assert ok is True
+    assert any("v1 standalone" in m for m in messages)
 
 
 def test_parse_docker_version_ok():
@@ -60,3 +92,68 @@ def test_detect_os_returns_known_value():
     from metatron_installer.preflight import detect_os
 
     assert detect_os() in {"linux", "darwin", "windows"}
+
+
+# ── check_compose tests (mock subprocess.run) ──
+
+
+def _fake_run(result_map):
+    """Return a mock for subprocess.run that maps argv[0] → result."""
+    from types import SimpleNamespace
+
+    def _mock(argv, **kwargs):
+        r = result_map.get(argv[0], SimpleNamespace(returncode=1, stdout="", stderr="not found"))
+        return r
+
+    return _mock
+
+
+def test_check_compose_detects_plugin():
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    results = {"docker": SimpleNamespace(returncode=0, stdout="", stderr="")}
+    with patch("subprocess.run", _fake_run(results)):
+        info = check_compose()
+    assert info.available is True
+    assert info.kind == "plugin"
+    assert info.command == ("docker", "compose")
+
+
+def test_check_compose_falls_back_to_standalone():
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    results = {
+        "docker": SimpleNamespace(returncode=1, stdout="", stderr="unknown command"),
+        "docker-compose": SimpleNamespace(returncode=0, stdout="", stderr=""),
+    }
+    with patch("subprocess.run", _fake_run(results)):
+        info = check_compose()
+    assert info.available is True
+    assert info.kind == "standalone"
+    assert info.command == ("docker-compose",)
+
+
+def test_check_compose_returns_unavailable_when_neither_found():
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    results = {
+        "docker": SimpleNamespace(returncode=1, stdout="", stderr="unknown command"),
+        "docker-compose": SimpleNamespace(returncode=1, stdout="", stderr="not found"),
+    }
+    with patch("subprocess.run", _fake_run(results)):
+        info = check_compose()
+    assert info.available is False
+
+
+def test_check_compose_handles_file_not_found():
+    from unittest.mock import patch
+
+    def _raise_fnf(argv, **kwargs):
+        raise FileNotFoundError(argv[0])
+
+    with patch("subprocess.run", _raise_fnf):
+        info = check_compose()
+    assert info.available is False


### PR DESCRIPTION
## Problem

`metatron-installer` fails on machines where Docker is installed via Homebrew (Colima) but the Compose plugin is not:

```
✗ Stack failed to start. Check logs:
  docker compose -f /Users/tommy/metatroncore/install/docker-compose.yml logs
unknown shorthand flag: 'f' in -f
Usage:  docker [OPTIONS] COMMAND [ARG...]
```

Preflight only checked `docker version` — it never verified that `docker compose` was actually available. With no compose subcommand registered, `docker` parsed `-f` as a top-level flag and bailed.

## Fix

1. **`preflight.py`** — new `ComposeInfo` dataclass + `check_compose()` that probes both `docker compose version` (v2 plugin) and `docker-compose version` (v1 standalone). `summarize()` now blocks the install with platform-specific install instructions when neither is found:

```
✗ Docker Compose not available — install it:
  macOS:  brew install docker-compose && mkdir -p ~/.docker/cli-plugins && ln -sfn $(brew --prefix)/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
  Linux:  sudo apt-get install docker-compose-plugin  (or: sudo yum install docker-compose-plugin)
```

2. **`docker.py`** — `DockerShell` accepts a `compose_cmd` prefix (default `['docker', 'compose']`) and routes all compose subcommands (`pull`/`up`/`ps`/`restart`/`down`) through `_compose_argv()`. New `compose_version()` method. Works with either the v2 plugin or the v1 standalone binary.

3. **`cli.py`** — `_run_preflight` calls `check_compose()`, updates the shell's compose prefix to the detected command, and surfaces compose status in the preflight summary. The error-message hint now uses the detected compose command.

## Verification

```
✓ Docker 29.5 detected
✓ Docker Compose v2 plugin detected
✓ Disk space: 66.1 GB free of 228 GB
```

- 72/72 installer tests pass
- `ruff check` clean
- End-to-end dry-run on the affected machine now passes preflight (previously failed at the pull step)

## Files changed

- `installer/src/metatron_installer/preflight.py` — ComposeInfo, check_compose(), summarize() compose branch
- `installer/src/metatron_installer/docker.py` — DockerShell.compose_cmd, _compose_argv(), compose_version()
- `installer/src/metatron_installer/cli.py` — _run_preflight() wires compose detection into the shell
- `installer/tests/test_preflight.py` — 6 new tests (plugin/standalone/missing/FileNotFoundError + summarize)
- `installer/tests/test_docker.py` — 4 new tests (compose_version + standalone prefix on up/restart/down)
