### PR TITLE
fix(installer): detect 403-after-login and hint at token scopes

### DIFF
--- a/installer/src/metronix_installer/docker.py
+++ b/installer/src/metronix_installer/docker.py
@@ -10,6 +10,17 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 _AUTH_MARKERS = ("401", "denied", "unauthorized", "forbidden", "403")
+_FORBIDDEN_MARKERS = ("403", "forbidden")
+
+# Hint shown when a successful `docker login` is followed by a 403 on pull.
+# The token authenticates but lacks package-read permission.
+_TOKEN_SCOPE_HINT = (
+    "The token was accepted by `docker login` but GHCR returned 403 Forbidden.\n"
+    "This means the token is valid but lacks permission to pull packages.\n"
+    "  Classic PAT:  enable the `read:packages` scope.\n"
+    "  Fine-grained PAT:  add `Packages: Read` permission for the repo.\n"
+    "  Or use `GITHUB_TOKEN` from a repo member with package access."
+)
 
 
 def parse_ps_services(stdout: str) -> list[tuple[str, str]]:
@@ -193,8 +204,12 @@ class DockerShell:
         compose_file: str,
         env: dict[str, str],
         registry_login: Callable[[], CommandResult] | None,
-    ) -> bool:
-        """Pull images with live output. Retries once on auth errors."""
+    ) -> tuple[bool, str]:
+        """Pull images with live output. Retries once on auth errors.
+
+        Returns ``(success, error_hint)``. ``error_hint`` is empty on success
+        or a human-readable explanation of the failure mode.
+        """
         argv = self._compose_argv(compose_file, "pull")
 
         def _try_pull() -> int:
@@ -205,13 +220,20 @@ class DockerShell:
 
         rc = _try_pull()
         if rc == 0:
-            return True
+            return True, ""
         if registry_login and self._looks_like_auth_error(self._last_stderr):
             login_res = registry_login()
             if login_res.returncode != 0:
-                return False
-            return _try_pull() == 0
-        return False
+                return False, self._last_stderr
+            rc2 = _try_pull()
+            if rc2 == 0:
+                return True, ""
+            # Login succeeded but pull still fails — distinguish 403 (token
+            # scope issue) from other errors.
+            if self._looks_like_forbidden(self._last_stderr):
+                return False, _TOKEN_SCOPE_HINT
+            return False, self._last_stderr
+        return False, self._last_stderr
 
     def compose_up(self, compose_file: str, env: dict[str, str]) -> CommandResult:
         """Start the stack (`up -d`) with live output, capturing stderr for diagnostics."""
@@ -311,3 +333,8 @@ class DockerShell:
     def _looks_like_auth_error(stderr: str) -> bool:
         low = (stderr or "").lower()
         return any(marker in low for marker in _AUTH_MARKERS)
+
+    @staticmethod
+    def _looks_like_forbidden(stderr: str) -> bool:
+        low = (stderr or "").lower()
+        return any(marker in low for marker in _FORBIDDEN_MARKERS)

--- a/installer/src/metronix_installer/runner.py
+++ b/installer/src/metronix_installer/runner.py
@@ -72,7 +72,8 @@ def launch_stack(
     """Launch the Metronix stack. Returns (success, error_message)."""
     env = dict(os.environ)
     env["COMPOSE_PROFILES"] = compose_profiles
-    if not shell.compose_pull(compose_file, env, registry_login):
-        return False, shell._last_stderr or "pull failed"
+    pull_ok, pull_err = shell.compose_pull(compose_file, env, registry_login)
+    if not pull_ok:
+        return False, pull_err or shell._last_stderr or "pull failed"
     res = shell.compose_up(compose_file, env)
     return res.returncode == 0, res.stderr

--- a/installer/tests/test_docker.py
+++ b/installer/tests/test_docker.py
@@ -110,12 +110,13 @@ def test_pull_falls_back_to_login_on_auth_failure():
     sh = DockerShell(runner=runner)
 
     with patch("metronix_installer.docker._pull_with_progress", _mock_pull):
-        ok = sh.compose_pull(
+        ok, err = sh.compose_pull(
             "install/docker-compose.yml",
             env={},
             registry_login=lambda: sh.login("ghcr.io", "user", "token"),
         )
     assert ok is True
+    assert err == ""
     assert any(c[:2] == ["docker", "login"] for c in runner.calls)
 
 
@@ -125,12 +126,36 @@ def test_pull_succeeds_anonymously_without_login(monkeypatch):
         "metronix_installer.docker._pull_with_progress",
         return_value=(0, ""),
     ):
-        ok = sh.compose_pull(
+        ok, err = sh.compose_pull(
             "install/docker-compose.yml",
             env={},
             registry_login=None,
         )
     assert ok is True
+    assert err == ""
+
+
+def test_pull_403_after_login_returns_token_scope_hint():
+    """Login succeeds but pull still 403 → error hint explains token scopes."""
+    call_count = [0]
+
+    def _mock_pull(argv, env):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return 1, "denied: 401 Unauthorized"
+        return 1, "403 Forbidden"
+
+    runner = FakeRunner([CommandResult(0, "Login Succeeded", "")])
+    sh = DockerShell(runner=runner)
+    with patch("metronix_installer.docker._pull_with_progress", _mock_pull):
+        ok, err = sh.compose_pull(
+            "install/docker-compose.yml",
+            env={},
+            registry_login=lambda: sh.login("ghcr.io", "user", "token"),
+        )
+    assert ok is False
+    assert "read:packages" in err
+    assert "Fine-grained PAT" in err
 
 
 def test_compose_restart_argv(tmp_path):


### PR DESCRIPTION
## Problem

After PR #146 (compose detection), the installer now reaches the pull step. On machines where the user's GitHub token is valid but lacks package-read permission, the pull fails with 403 Forbidden after a successful `docker login`:

```
→ Registry requires authentication.
GitHub username: tommij99
GitHub token:

✗ Stack failed to start. Check logs:
  ... 403 Forbidden
```

The raw Docker error gives no clue **why** login succeeded but pull failed. The root cause is a token permission issue:
- **Classic PAT** missing the `read:packages` scope
- **Fine-grained PAT** missing `Packages: Read` permission on the repo

## Fix

`compose_pull` now returns `(bool, error_hint)` instead of `bool`. When `docker login` succeeds but the retry pull still fails with 403, the error hint explains the token-scope requirement:

```
✗ Stack failed to start. Check logs:
  docker compose -f .../docker-compose.yml logs
The token was accepted by `docker login` but GHCR returned 403 Forbidden.
This means the token is valid but lacks permission to pull packages.
  Classic PAT:  enable the `read:packages` scope.
  Fine-grained PAT:  add `Packages: Read` permission for the repo.
  Or use `GITHUB_TOKEN` from a repo member with package access.
```

New `_looks_like_forbidden` helper distinguishes 403 from generic auth errors (401/unauthorized/denied).

## Files changed

- `installer/src/metatron_installer/docker.py` — `compose_pull` returns tuple; `_looks_like_forbidden`; `_TOKEN_SCOPE_HINT`
- `installer/src/metatron_installer/runner.py` — `launch_stack` passes hint through
- `installer/tests/test_docker.py` — new `test_pull_403_after_login_returns_token_scope_hint`; updated existing tests for tuple return
- `installer/tests/test_launch.py` — updated for tuple return

## Tests

61/61 passing. `ruff check` clean.
