### PR TITLE
docs: rename banner to Metronix Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/metatron-banner.svg" alt="Metatron Core" width="600">
+  <img src="docs/metatron-banner.svg" alt="Metronix Memory" width="600">
 </p>
 
 <p align="center">

--- a/docs/metatron-banner.svg
+++ b/docs/metatron-banner.svg
@@ -29,7 +29,7 @@
   <line x1="125" y1="42" x2="125" y2="118" stroke="rgba(253,252,252,0.12)" stroke-width="1"/>
 
   <!-- Primary text -->
-  <text x="148" y="72" fill="#fdfcfc" font-family="'Berkeley Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,monospace" font-size="28" font-weight="700" letter-spacing="-0.5">Metatron Core</text>
+  <text x="148" y="72" fill="#fdfcfc" font-family="'Berkeley Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,monospace" font-size="28" font-weight="700" letter-spacing="-0.5">Metronix Memory</text>
 
   <!-- Subtitle -->
   <text x="148" y="98" fill="#9a9898" font-family="'Berkeley Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,monospace" font-size="13" font-weight="400">MTRNIX — AI Memory + Knowledge Infrastructure</text>


### PR DESCRIPTION
## Summary
- update the banner SVG title text from `Metatron Core` to `Metronix Memory`
- update the README banner alt text to match

## Why
The landing banner still used the old product name even after the branding direction changed.

## Testing
- not run locally
- verified the SVG source text and README alt text changes
