### PR TITLE
docs: forbid agents from self-registering AGENT_UUID

### DIFF
--- a/connecting_to_agent.md
+++ b/connecting_to_agent.md
@@ -62,11 +62,17 @@ for it before doing anything else — never guess. Show these hints:
   public HTTPS URL in production).
 - METATRON_MCP_API_KEY: token from the Metatron .env (METATRON_MCP_API_KEY);
   the /mcp endpoint returns HTTP 401 without it.
-- AGENT_UUID: a stable unique id for this agent, or the id returned by
-  POST /api/v1/agents.
+- AGENT_UUID: any stable unique id for this agent, provided by the user — the user
+  can simply make one up, or create it via POST /api/v1/agents / the UI. Do NOT
+  create or register one yourself.
 - DEFAULT_WORKSPACE_ID: workspace id (Workspaces UI, or GET /api/v1/workspaces),
   usually MTRNIX for the first install. Every metatron_* call (both search/RAG and
   memory) needs it, which is why it is set now.
+
+Do NOT call POST /api/v1/agents (or otherwise hit the /api/v1/agents endpoint)
+yourself to create an agent or obtain AGENT_UUID — registering the agent and its id
+is the user's job, done out of band. If AGENT_UUID is missing, ask the user and
+wait; never self-register.
 
 1. Register Metatron as an MCP server in this runtime using:
    - URL: {{METATRON_URL}}
@@ -126,8 +132,9 @@ If either value above is still a {{...}} placeholder or empty, STOP and ask the
 user for it before doing anything else — never guess. Show these hints:
 - DEFAULT_WORKSPACE_ID: workspace id (Workspaces UI, or GET /api/v1/workspaces),
   usually MTRNIX for the first install.
-- AGENT_UUID: a stable unique id for this agent, or the id returned by
-  POST /api/v1/agents.
+- AGENT_UUID: any stable unique id for this agent, provided by the user — they can
+  make one up, or create it via POST /api/v1/agents / the UI. Do NOT create or
+  register one yourself.
 
 1. Memory policy. Durable knowledge lives in Metatron, classified by kind:
    - kind="fact" (default) — durable factual statements.
@@ -182,8 +189,9 @@ If either value above is still a {{...}} placeholder or empty, STOP and ask the
 user for it before doing anything else — never guess. Show these hints:
 - DEFAULT_WORKSPACE_ID: workspace id (Workspaces UI, or GET /api/v1/workspaces),
   usually MTRNIX for the first install.
-- AGENT_UUID: a stable unique id for this agent, or the id returned by
-  POST /api/v1/agents.
+- AGENT_UUID: any stable unique id for this agent, provided by the user — they can
+  make one up, or create it via POST /api/v1/agents / the UI. Do NOT create or
+  register one yourself.
 
 1. Inventory every place you keep durable knowledge. Do NOT stop at the first or
    most obvious location — durable knowledge is often spread across surfaces:

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -61,11 +61,16 @@ user for it before doing anything else — never guess. Show these hints:
 - MCP_API_KEY — Bearer token for /mcp (server env var METATRON_MCP_API_KEY; /mcp
   returns HTTP 401 without it; ask the Metatron admin if you don't have it).
   Example: the token from the Metatron deployment's .env
-- AGENT_UUID — agent UUID in Metatron (create via POST /api/v1/agents and take
-  the id). Example: a3c98413c3684a0992ac0e007b93f410
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can simply make one up, or create it via POST /api/v1/agents / the UI. You do NOT
+  create it. Example: a3c98413c3684a0992ac0e007b93f410
 - WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
   Every metatron_* call (search/RAG and memory) needs it, which is why it is set
   now. Example: MTRNIX
+Do NOT call POST /api/v1/agents (or otherwise hit the /api/v1/agents endpoint)
+yourself to create an agent or obtain AGENT_UUID — registering the agent and its id
+is the user's job, done out of band. If AGENT_UUID is missing, ask the user and
+wait; never self-register.
 Wait for the user's answers and fill them in before continuing.
 
 ## 1. Register Metatron as an MCP server
@@ -139,8 +144,9 @@ If either value above is still a {{...}} placeholder or empty, STOP and ask the
 user for it before doing anything else — never guess. Show these hints:
 - WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
   Example: MTRNIX
-- AGENT_UUID — agent UUID in Metatron (create via POST /api/v1/agents and take
-  the id). Example: a3c98413c3684a0992ac0e007b93f410
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
 Wait for the user's answers before continuing.
 
 ## 1. Memory policy
@@ -234,8 +240,9 @@ If either value above is still a {{...}} placeholder or empty, STOP and ask the
 user for it before doing anything else — never guess. Show these hints:
 - WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
   Example: MTRNIX
-- AGENT_UUID — agent UUID in Metatron (create via POST /api/v1/agents and take
-  the id). Example: a3c98413c3684a0992ac0e007b93f410
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
 Wait for the user's answers before continuing.
 
 ## 1. Inventory every place you keep durable knowledge


### PR DESCRIPTION
## What

Across all three setup prompts in both guides, clarifies that **`AGENT_UUID` is any stable unique string the user provides** — the user may simply make one up, or create it via `POST /api/v1/agents` / the UI — and that **the agent must never call `/api/v1/agents` itself** to register an agent or obtain an id. If `AGENT_UUID` is missing, the agent asks the user and waits; it never self-registers.

## Files

- `connecting_to_agent.md` — prompt 1 gets an explicit prohibition paragraph; prompts 2 & 3 get the softened, inline "you do NOT create it" wording.
- `docs/integrations/hermes.md` — same treatment for the Hermes-specific prompts.

## Why

The previous hint ("create via `POST /api/v1/agents`") could lead an agent to hit the registration endpoint on its own. Agent identity is the user's responsibility, assigned out of band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)