### PR TITLE
docs: banner wording Metronix Core → Metronix Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/metronix-banner.svg" alt="Metronix Core" width="600">
+  <img src="docs/metronix-banner.svg" alt="Metronix Memory" width="600">
 </p>
 
 <p align="center">

--- a/docs/metronix-banner.svg
+++ b/docs/metronix-banner.svg
@@ -29,7 +29,7 @@
   <line x1="125" y1="42" x2="125" y2="118" stroke="rgba(253,252,252,0.12)" stroke-width="1"/>
 
   <!-- Primary text -->
-  <text x="148" y="72" fill="#fdfcfc" font-family="'Berkeley Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,monospace" font-size="28" font-weight="700" letter-spacing="-0.5">Metronix Core</text>
+  <text x="148" y="72" fill="#fdfcfc" font-family="'Berkeley Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,monospace" font-size="28" font-weight="700" letter-spacing="-0.5">Metronix Memory</text>
 
   <!-- Subtitle -->
   <text x="148" y="98" fill="#9a9898" font-family="'Berkeley Mono','JetBrains Mono','IBM Plex Mono',ui-monospace,monospace" font-size="13" font-weight="400">MTRNIX — AI Memory + Knowledge Infrastructure</text>


### PR DESCRIPTION
## Summary
Update the banner SVG title and README alt text from **Metronix Core** to **Metronix Memory**, matching the renamed repo (`mtrnix/metronix-memory`).

## Context
Captures the substantive intent of #197 (closed as superseded). #197 targeted the pre-rename path `docs/metatron-banner.svg`; PR #199 renamed it to `docs/metronix-banner.svg` and replaced the text with the literal `Metronix Core`. This adjusts that one word to the product/repo name.

Scope: banner title + README alt text only. Other `Metronix Core` mentions in README prose left as-is.