### PR TITLE
feat(export): data export (MCP + REST) for memory and documents

### DIFF
--- a/docs/specs/2026-06-24-data-export-design.md
+++ b/docs/specs/2026-06-24-data-export-design.md
@@ -120,17 +120,23 @@ REST GET /api/v1/export/{id}/download?token=<one-time>  ─► stream applicatio
   - `render_document(doc) -> (relative_path, str)` (Markdown with YAML front matter).
   - `build_manifest(scope, files, notes) -> dict`.
 - **Archive writer** (`src/metronix/export/archive.py`): streams entries into a ZIP
-  on the mounted volume (e.g. `/data/exports/<export_id>.zip`).
+  on the mounted volume (`{export_dir}/<export_id>.zip`, default
+  `/app/data/exports`).
 - **Job store**: a PostgreSQL `export_jobs` table is the source of truth for job
-  state — `export_id` (PK), `scope`, `status` (`pending|running|ready|failed`),
-  `counts`, `size_bytes`, `archive_path`, `error`, `created_at`, `updated_at`. It
-  must be durable (survive an API restart) and readable by any worker; Redis is not
-  durable enough for this.
+  state — `export_id` (PK), `scope` (JSONB), `scope_key`, `status`
+  (`pending|running|ready|failed`), counts, `size_bytes`, `archive_path`,
+  `download_token`, `error`, `created_at`, `updated_at`. It must be durable (survive
+  an API restart) and readable by any worker; Redis is not durable enough for this.
+  A **UNIQUE partial index** on `scope_key WHERE status IN ('pending','running')`
+  lets the DB enforce one active job per scope (see Concurrency).
 - **Token store**: one-time download tokens in Redis — `export_token:<token>` →
   `{export_id, path}`, TTL (default 1 hour). The token is generated with a CSPRNG,
-  ≥128 bits of entropy (`secrets.token_urlsafe(32)`). It is consumed (deleted) on the
-  first successful download. The download route must keep the token out of access
-  logs (do not log the query string for this path).
+  ≥128 bits of entropy (`secrets.token_urlsafe(32)`). It is **minted once when the
+  build completes** and stored on the job row (`export_jobs.download_token`), so
+  repeated `status` polling reuses the same token rather than minting a new valid one
+  each call. It is consumed (deleted from Redis) on the first successful download.
+  The download route must keep the token out of access logs (do not log the query
+  string for this path).
 - **MCP tools** (`src/metronix/mcp/tools/export.py`):
   `metronix_export_data(workspace_id?, all_workspaces=false)` and
   `metronix_export_status(export_id)`.
@@ -152,8 +158,15 @@ REST GET /api/v1/export/{id}/download?token=<one-time>  ─► stream applicatio
   - REST: `all_workspaces=true` requires an admin caller (JWT workspace access `*`),
     reusing existing RBAC; a single-workspace export uses the normal
     `resolve_workspace_id` check. No new auth mechanism is introduced.
+- **Status** (`GET /export/{id}`): authorizes the caller against the *job's* scope
+  before returning anything — an `all_workspaces` export is admin-only, a
+  single-workspace export requires the caller to have access to that workspace.
+  Without this, any authenticated user could poll an arbitrary `export_id` and be
+  handed a download token for another workspace's archive. (The MCP `…_status` tool
+  runs under the single admin API key and is unrestricted.)
 - **Download** (`GET .../download?token=`): authorized **solely** by the one-time
-  token in the URL. No JWT, no API-key header.
+  token in the URL. No JWT, no API-key header. The token is the capability; it is
+  only ever handed out by the authorized `status` path above.
 
 ### Configuration
 
@@ -163,6 +176,10 @@ Add a new setting (e.g. `public_base_url`); the `download_url` is
 `{public_base_url}/api/v1/export/{export_id}/download?token=<token>`. If unset, fall
 back to the request's own base URL on the REST path; the MCP path requires it to be
 configured (no request to derive it from).
+
+`export_dir` (default `/app/data/exports`) must sit on the persistent volume —
+docker-compose mounts `full_file_data:/app/data`, so a bare `/data` would be
+ephemeral and lose archives on restart and across workers.
 
 ## Archive Layout
 
@@ -247,14 +264,18 @@ rather than relying on those defaults:
 3. Cross-reference the `agents` table only to set the `registered` flag in the
    manifest (not required for inclusion).
 4. Write all entries to the ZIP on the volume; compute counts and size.
-5. Mint a one-time token, store `{export_id, path}` in Redis with TTL; set the
-   `export_jobs` row to `status=ready` and expose the `download_url`.
+5. Mint the one-time token (store `{export_id, path}` in Redis with TTL), persist it
+   and the counts/size/path on the `export_jobs` row, and set `status=ready`. The
+   token lives on the job so `status` can return the same `download_url` on every
+   poll instead of minting a fresh token each time.
 
 ## Error Handling
 
 - **Unknown/expired `export_id`** → status `not_found` / 404.
 - **Build failure** → job `status=failed` with an error summary; surfaced via status
   tool/endpoint.
+- **Status for an export the caller can't access** → 403 (scope authorization, see
+  Surfaces) — checked before any token is minted or returned.
 - **Download with missing/used/expired token** → 404 (do not distinguish reasons, to
   avoid leaking existence).
 - **Token valid but ZIP already cleaned up** → 410 Gone.
@@ -265,12 +286,14 @@ rather than relying on those defaults:
 
 ## Concurrency & Quota
 
-- **One active job per scope:** before creating a job, check `export_jobs` for an
-  existing `pending`/`running` job with the same scope; if present, return that
-  `export_id` instead of starting another. This dedups repeated triggers and stops a
-  single agent from spawning many parallel multi-GB builds.
-- **Disk cap on `/data/exports`:** enforce a configurable ceiling; if exceeded,
-  reject new jobs with a clear error and rely on cleanup (below) to free space.
+- **One active job per scope:** `start` first checks `export_jobs` for an existing
+  `pending`/`running` job with the same `scope_key` and returns it if present. To
+  close the check-then-create race, the **UNIQUE partial index** also rejects a
+  second active insert at the DB level; `start` catches the resulting
+  `IntegrityError` and returns the winning job. This dedups repeated triggers and
+  stops a single agent from spawning many parallel multi-GB builds.
+- **Disk cap on `export_dir`:** enforce a configurable ceiling; if exceeded, reject
+  new jobs with a clear error and rely on cleanup (below) to free space.
 
 ## Token & Archive Lifecycle
 
@@ -314,5 +337,5 @@ rather than relying on those defaults:
 ## Open Items for Planning
 
 - Exact `export_jobs` columns/migration and the watchdog timeout value.
-- Default disk-cap value for `/data/exports`.
+- Default disk-cap value for `export_dir`.
 - Whether the periodic sweep is a new scheduled job or folds into an existing one.

--- a/docs/specs/2026-06-24-data-export-design.md
+++ b/docs/specs/2026-06-24-data-export-design.md
@@ -1,0 +1,229 @@
+# Data Export — Design
+
+**Date:** 2026-06-24
+**Status:** Approved (brainstorming) — ready for implementation plan
+**Branch:** `feat/data-export`
+
+## Problem
+
+A user who is leaving Metronix needs to take all of their data out before deleting
+the instance. Today there is no way to do this: data lives across PostgreSQL
+(`memory_records`, `raw_documents`), Qdrant (chunks), and Neo4j (graph), and the
+only read paths are paginated list endpoints meant for live use.
+
+The user must be able to retrieve, in human-usable form:
+
+1. **All agent memory** — one Markdown file per agent (`<agent_id>.md`), covering
+   every agent that has memory, **including unregistered agents** (agents that
+   invented their own `agent_id` and stored memory without ever being registered in
+   the `agents` table).
+2. **All ingested data** — files, connector items (Jira tasks, Confluence pages,
+   etc.) reconstructed in their **original whole form** (the full document as it was
+   fed into Metronix), **not** the embedding chunks.
+
+## Goals
+
+- Export is triggered by an agent over MCP, or by a human over REST.
+- The export is delivered as a single ZIP archive the agent/user can download,
+  unzip, and work with locally.
+- Download requires **only a one-time token embedded in the URL** — no JWT, no API
+  key header.
+- Build runs in the **background**; trigger returns immediately and the caller polls
+  for readiness.
+
+## Non-Goals
+
+- Re-emitting original uploaded-file **bytes** (PDF/DOCX). Metronix stores only the
+  extracted text of uploads (`raw_documents.content`), not the original binary. We
+  export the extracted text and flag this limitation explicitly. Connector items and
+  their full text/metadata are fully recoverable.
+- Exporting embedding vectors, Qdrant chunks, or the Neo4j graph. The source of
+  truth for both memory and documents is PostgreSQL, which is sufficient to
+  reconstruct everything in original form.
+- Deleting data (this is export only). Account/instance teardown is separate.
+
+## Key Findings From the Codebase
+
+- **MCP tools:** added as a file in `src/metronix/mcp/tools/`, decorated with
+  `@mcp.tool(...)`, exported from `src/metronix/mcp/tools/__init__.py`. Auth is a
+  single Bearer token (`METRONIX_MCP_API_KEY`) — effectively admin. `workspace_id`
+  and `agent_id` are passed as tool parameters by the caller.
+- **REST:** routers in `src/metronix/api/routes/`, registered in
+  `src/metronix/api/app.py`. Workspace access is enforced via the existing
+  `resolve_workspace_id` / `workspace_scope` dependencies (JWT, with `*` = admin).
+- **Memory:** source of truth is the PostgreSQL `memory_records` table
+  (`src/metronix/storage/memory_postgres.py`). `agent_id` is a plain `Text` column
+  with **no foreign key** — unregistered agents are first-class. Distinct agents are
+  enumerable via `SELECT DISTINCT agent_id FROM memory_records WHERE workspace_id = :ws`.
+  `MemoryPostgresStore.list_records(workspace_id, agent_id=...)` already fetches all
+  records for an agent. `list_workspaces()` already returns distinct workspace ids.
+- **Documents:** the `raw_documents` table holds the **full original content**
+  (pre-chunk) plus `title`, `url`, `author`, `source_id`, `connector_type`, and
+  `metadata` (JSONB). Connector items are fully recoverable. Chunks/embeddings live
+  in Qdrant and are not needed for export.
+- **No existing export/dump functionality.**
+
+## Architecture
+
+A single `ExportService` owns all build logic. MCP and REST are thin surfaces over
+it. Build is asynchronous; an export job has a lifecycle and a one-time download
+token minted on completion.
+
+```text
+MCP  metronix_export_data ─┐
+                           ├─► ExportService.start(scope) ─► job(export_id, status=pending)
+REST POST /api/v1/export ──┘                                      │
+                                                                  ▼ (background task)
+                                          enumerate workspaces / agents / documents
+                                          render markdown + manifest → write ZIP to volume
+                                          mint one-time token → status=ready
+MCP  metronix_export_status ─┐
+                             ├─► ExportService.status(export_id) ─► {status, download_url?, counts, size}
+REST GET /api/v1/export/{id} ┘
+
+REST GET /api/v1/export/{id}/download?token=<one-time>  ─► stream application/zip, consume token
+```
+
+### Components
+
+- **`ExportService`** (`src/metronix/export/service.py`)
+  - `start(scope) -> export_id`: create job record, set `status=pending`, schedule
+    the background build, return immediately.
+  - `status(export_id) -> ExportJob`: return current status and, when ready, the
+    `download_url`, counts, and size.
+  - `_build(export_id, scope)`: the background routine that produces the archive.
+- **Renderers** (`src/metronix/export/render.py`)
+  - `render_agent_memory(agent_id, records) -> str` (Markdown).
+  - `render_document(doc) -> (relative_path, str)` (Markdown with YAML front matter).
+  - `build_manifest(scope, files, notes) -> dict`.
+- **Archive writer** (`src/metronix/export/archive.py`): streams entries into a ZIP
+  on the mounted volume (e.g. `/data/exports/<export_id>.zip`).
+- **Token store**: one-time tokens in Redis — `export_token:<token>` →
+  `{export_id, path}`, TTL (default 1 hour). Consumed (deleted) on first successful
+  download. Job state (`status`, counts, size, error) is stored in Redis (or a small
+  PostgreSQL table) keyed by `export_id`; exact store decided during planning to
+  match existing patterns.
+- **MCP tools** (`src/metronix/mcp/tools/export.py`):
+  `metronix_export_data(workspace_id?, all_workspaces=false)` and
+  `metronix_export_status(export_id)`.
+- **REST router** (`src/metronix/api/routes/export.py`):
+  `POST /api/v1/export`, `GET /api/v1/export/{export_id}`,
+  `GET /api/v1/export/{export_id}/download`.
+
+### Surfaces and scope
+
+- **Scope** (`all_workspaces` flag): default is the caller's single `workspace_id`.
+  `all_workspaces=true` exports every workspace in one archive.
+  - MCP: freely available — the single MCP API key is already admin.
+  - REST: `all_workspaces=true` requires an admin caller (JWT workspace access `*`),
+    reusing existing RBAC; a single-workspace export uses the normal
+    `resolve_workspace_id` check. No new auth mechanism is introduced.
+- **Download** (`GET .../download?token=`): authorized **solely** by the one-time
+  token in the URL. No JWT, no API-key header.
+
+## Archive Layout
+
+```text
+metronix-export-<timestamp>.zip
+├── manifest.json
+├── <workspace_id>/
+│   ├── memory/
+│   │   ├── <safe-agent-id>.md          # one file per distinct agent_id with memory
+│   │   └── ...
+│   └── documents/
+│       ├── jira/<source_id>.md         # full original content + metadata header
+│       ├── confluence/<source_id>.md
+│       ├── uploads/<filename>.md       # extracted text only (original bytes not stored)
+│       └── <connector_type>/...
+└── (repeats per workspace when all_workspaces=true)
+```
+
+### `manifest.json`
+
+```json
+{
+  "format_version": 1,
+  "generated_at": "2026-06-24T12:00:00Z",
+  "scope": { "all_workspaces": false, "workspaces": ["<workspace_id>"] },
+  "counts": { "workspaces": 1, "agents": 12, "memory_records": 480, "documents": 1500 },
+  "agents": [
+    { "agent_id": "<real agent_id>", "file": "memory/<safe-agent-id>.md", "registered": false, "record_count": 37 }
+  ],
+  "limitations": [
+    "Uploaded files are exported as extracted text only; original binary files are not retained by Metronix."
+  ]
+}
+```
+
+### Markdown formats
+
+- **Agent memory `<agent_id>.md`**: header (real `agent_id`, workspace, record count,
+  generated-at) followed by one section per record with key fields — `kind`, `scope`,
+  `status`, `created_at`, `updated_at`, `tags`, `importance_score`, then `content`.
+- **Document `<source_id>.md`**: YAML front matter (`title`, `url`, `author`,
+  `source_id`, `connector_type`, selected `metadata`) followed by the full
+  `raw_documents.content`.
+
+## Filename Safety
+
+`agent_id` and document identifiers are arbitrary strings (unregistered agents
+invent their own; connector ids may contain unsafe characters). File/dir names are
+slugified to a filesystem-safe form; on collision a short stable hash suffix is
+appended. The **real** identifier is always preserved inside the file and in
+`manifest.json`, so slugification is never lossy.
+
+## Data Flow (build)
+
+1. Resolve scope → list of `workspace_id`s (one, or all via `list_workspaces()`).
+2. For each workspace:
+   a. `SELECT DISTINCT agent_id FROM memory_records WHERE workspace_id = :ws` →
+      every agent with memory (registered or not). For each, `list_records(ws, agent_id=...)`
+      (paginated to bound memory), render `<agent_id>.md`.
+   b. Enumerate `raw_documents` for the workspace (paginated), render one Markdown
+      file per row grouped by `connector_type`.
+3. Cross-reference the `agents` table only to set the `registered` flag in the
+   manifest (not required for inclusion).
+4. Write all entries to the ZIP on the volume; compute counts and size.
+5. Mint a one-time token, store `{export_id, path}` in Redis with TTL; set
+   `status=ready` and `download_url`.
+
+## Error Handling
+
+- **Unknown/expired `export_id`** → status `not_found` / 404.
+- **Build failure** → job `status=failed` with an error summary; surfaced via status
+  tool/endpoint.
+- **Download with missing/used/expired token** → 404 (do not distinguish reasons, to
+  avoid leaking existence).
+- **Token valid but ZIP already cleaned up** → 410 Gone.
+- **Empty workspace / no memory** → valid empty-ish archive with a manifest note, not
+  an error.
+- **Large exports** → background build avoids request timeouts; memory bounded by
+  paginating both `memory_records` and `raw_documents` and streaming into the ZIP.
+
+## Token & Archive Lifecycle
+
+- One-time token TTL: default 1 hour (configurable).
+- Token consumed on first successful download.
+- ZIP files older than the TTL are cleaned up (lazy on access and/or a periodic
+  sweep); cleanup mechanism finalized during planning.
+
+## Testing (TDD)
+
+- **Unit — renderers:** agent-memory Markdown (incl. all fields), document Markdown
+  with front matter, manifest shape, filename slugification + collision suffix.
+- **Unit — enumeration:** distinct-agent query includes unregistered agents; empty
+  workspace yields a valid manifest.
+- **Unit — token:** one-time semantics (second download → 404), TTL expiry, cleaned
+  archive → 410.
+- **Integration — REST:** `POST` returns `export_id`; polling `GET` reaches `ready`;
+  `download` streams a valid ZIP whose contents match the manifest; `all_workspaces`
+  admin gate enforced.
+- **Integration — MCP:** `metronix_export_data` returns an `export_id`;
+  `metronix_export_status` returns a working `download_url` once ready.
+
+## Open Items for Planning
+
+- Job/state store choice: Redis vs a small PostgreSQL `export_jobs` table.
+- Background execution mechanism: in-process `asyncio` task vs existing scheduler.
+- `public_base_url` configuration for building absolute `download_url`s.
+- Archive cleanup trigger (lazy vs periodic sweep).

--- a/docs/specs/2026-06-24-data-export-design.md
+++ b/docs/specs/2026-06-24-data-export-design.md
@@ -69,6 +69,29 @@ A single `ExportService` owns all build logic. MCP and REST are thin surfaces ov
 it. Build is asynchronous; an export job has a lifecycle and a one-time download
 token minted on completion.
 
+### Deployment & process model (invariant)
+
+This feature targets the **HTTP API deployment**, where the MCP server is mounted
+into the same FastAPI/uvicorn process as REST (`api/app.py:601-610` adds the `/mcp`
+route to the API app; the default docker-compose serves both `/mcp` and `/api/v1`
+on `:8001`). The standalone `python -m metronix.mcp --transport stdio` mode
+(`mcp/__main__.py`) is an **ephemeral process with no co-located REST server** and
+therefore cannot deliver a download URL — export is **out of scope for stdio-only
+MCP**; the trigger requires the HTTP API to be reachable.
+
+Even within the single API process, the build must outlive the request that
+triggered it and survive an API restart. Invariant: **trigger, build, and download
+communicate only through durable shared state — a PostgreSQL `export_jobs` row, the
+one-time token in Redis, and the ZIP on a shared volume.** Nothing is held in the
+memory of the triggering request.
+
+This resolves the background mechanism (no longer 50/50): the build runs as an
+**in-process `asyncio` task on the API process**, but its authoritative state lives
+in the `export_jobs` table — **not** FastAPI `BackgroundTasks` (which run only
+post-response, die on restart, and are unavailable on the MCP path — there is no
+`Request`). On startup the API runs a **watchdog**: any job left `running` past a
+timeout is marked `failed` so it never sticks in limbo.
+
 ```text
 MCP  metronix_export_data ─┐
                            ├─► ExportService.start(scope) ─► job(export_id, status=pending)
@@ -98,11 +121,16 @@ REST GET /api/v1/export/{id}/download?token=<one-time>  ─► stream applicatio
   - `build_manifest(scope, files, notes) -> dict`.
 - **Archive writer** (`src/metronix/export/archive.py`): streams entries into a ZIP
   on the mounted volume (e.g. `/data/exports/<export_id>.zip`).
-- **Token store**: one-time tokens in Redis — `export_token:<token>` →
-  `{export_id, path}`, TTL (default 1 hour). Consumed (deleted) on first successful
-  download. Job state (`status`, counts, size, error) is stored in Redis (or a small
-  PostgreSQL table) keyed by `export_id`; exact store decided during planning to
-  match existing patterns.
+- **Job store**: a PostgreSQL `export_jobs` table is the source of truth for job
+  state — `export_id` (PK), `scope`, `status` (`pending|running|ready|failed`),
+  `counts`, `size_bytes`, `archive_path`, `error`, `created_at`, `updated_at`. It
+  must be durable (survive an API restart) and readable by any worker; Redis is not
+  durable enough for this.
+- **Token store**: one-time download tokens in Redis — `export_token:<token>` →
+  `{export_id, path}`, TTL (default 1 hour). The token is generated with a CSPRNG,
+  ≥128 bits of entropy (`secrets.token_urlsafe(32)`). It is consumed (deleted) on the
+  first successful download. The download route must keep the token out of access
+  logs (do not log the query string for this path).
 - **MCP tools** (`src/metronix/mcp/tools/export.py`):
   `metronix_export_data(workspace_id?, all_workspaces=false)` and
   `metronix_export_status(export_id)`.
@@ -112,14 +140,29 @@ REST GET /api/v1/export/{id}/download?token=<one-time>  ─► stream applicatio
 
 ### Surfaces and scope
 
-- **Scope** (`all_workspaces` flag): default is the caller's single `workspace_id`.
-  `all_workspaces=true` exports every workspace in one archive.
-  - MCP: freely available — the single MCP API key is already admin.
+- **Scope** (`all_workspaces` flag): exports either one workspace or every workspace
+  in one archive.
+  - MCP: `metronix_export_data(workspace_id?, all_workspaces=false)`. **No silent
+    `"default"` fallback** — unlike the other MCP tools, which coerce
+    `workspace_id or "default"` (e.g. `mcp/tools/memory_store.py:91`), this tool
+    requires an explicit `workspace_id` **or** `all_workspaces=true`; otherwise it
+    returns an `INVALID_PARAMS` error. A bare call must never dump only the
+    `"default"` workspace by accident. The single MCP API key is already admin, so
+    `all_workspaces` needs no extra gate here.
   - REST: `all_workspaces=true` requires an admin caller (JWT workspace access `*`),
     reusing existing RBAC; a single-workspace export uses the normal
     `resolve_workspace_id` check. No new auth mechanism is introduced.
 - **Download** (`GET .../download?token=`): authorized **solely** by the one-time
   token in the URL. No JWT, no API-key header.
+
+### Configuration
+
+Building an absolute `download_url` needs the API's public base URL. No suitable
+setting exists today — `core/config.py` only has `freshness_llm_api_base_url:278`.
+Add a new setting (e.g. `public_base_url`); the `download_url` is
+`{public_base_url}/api/v1/export/{export_id}/download?token=<token>`. If unset, fall
+back to the request's own base URL on the REST path; the MCP path requires it to be
+configured (no request to derive it from).
 
 ## Archive Layout
 
@@ -166,26 +209,46 @@ metronix-export-<timestamp>.zip
 
 ## Filename Safety
 
-`agent_id` and document identifiers are arbitrary strings (unregistered agents
-invent their own; connector ids may contain unsafe characters). File/dir names are
-slugified to a filesystem-safe form; on collision a short stable hash suffix is
-appended. The **real** identifier is always preserved inside the file and in
-`manifest.json`, so slugification is never lossy.
+`agent_id`, `connector_type`, `source_id`, and upload filenames are all arbitrary
+strings (unregistered agents invent their own `agent_id`; connector/source ids and
+filenames may contain `/`, `..`, or other unsafe characters). **Every path segment**
+written into the archive — directory names (`<connector_type>/`) and file names
+alike — is slugified to a filesystem-safe form to prevent path traversal; on
+collision a short stable hash suffix is appended. The **real** identifier is always
+preserved inside the file and in `manifest.json`, so slugification is never lossy.
+
+### What memory is included
+
+`MemoryPostgresStore.list_records` defaults to `status=None` and `lifetime="all"`
+(`storage/memory_postgres.py:273-274`), i.e. **no filter**. Export must be explicit
+rather than relying on those defaults:
+
+- Include **persistent** records (`lifetime="persistent"`, `ttl_expires_at IS NULL`)
+  of **all lifecycle statuses** (active, stale, superseded, archived, conflicted,
+  review-needed) — "take everything I own". The record's `status` is written into the
+  `.md` so the user can see it.
+- **Exclude** session/TTL records (`ttl_expires_at IS NOT NULL`) — these are ephemeral
+  working memory, may be expired-but-not-yet-GC'd, and are not part of the durable
+  knowledge a leaving user wants.
 
 ## Data Flow (build)
 
 1. Resolve scope → list of `workspace_id`s (one, or all via `list_workspaces()`).
 2. For each workspace:
    a. `SELECT DISTINCT agent_id FROM memory_records WHERE workspace_id = :ws` →
-      every agent with memory (registered or not). For each, `list_records(ws, agent_id=...)`
-      (paginated to bound memory), render `<agent_id>.md`.
-   b. Enumerate `raw_documents` for the workspace (paginated), render one Markdown
-      file per row grouped by `connector_type`.
+      every agent with memory (registered or not). For each, page through
+      `list_records(ws, agent_id=..., lifetime="persistent")` to bound memory, render
+      `<agent_id>.md`.
+   b. Page through `raw_documents` for the workspace and render one Markdown file per
+      row grouped by `connector_type`. Use **keyset pagination** on the existing
+      stable order `(updated_at DESC, id ASC)` (`storage/postgres.py:1401`) rather
+      than `OFFSET`, so concurrent writes during a long export can't cause rows to be
+      skipped or duplicated.
 3. Cross-reference the `agents` table only to set the `registered` flag in the
    manifest (not required for inclusion).
 4. Write all entries to the ZIP on the volume; compute counts and size.
-5. Mint a one-time token, store `{export_id, path}` in Redis with TTL; set
-   `status=ready` and `download_url`.
+5. Mint a one-time token, store `{export_id, path}` in Redis with TTL; set the
+   `export_jobs` row to `status=ready` and expose the `download_url`.
 
 ## Error Handling
 
@@ -200,12 +263,21 @@ appended. The **real** identifier is always preserved inside the file and in
 - **Large exports** → background build avoids request timeouts; memory bounded by
   paginating both `memory_records` and `raw_documents` and streaming into the ZIP.
 
+## Concurrency & Quota
+
+- **One active job per scope:** before creating a job, check `export_jobs` for an
+  existing `pending`/`running` job with the same scope; if present, return that
+  `export_id` instead of starting another. This dedups repeated triggers and stops a
+  single agent from spawning many parallel multi-GB builds.
+- **Disk cap on `/data/exports`:** enforce a configurable ceiling; if exceeded,
+  reject new jobs with a clear error and rely on cleanup (below) to free space.
+
 ## Token & Archive Lifecycle
 
 - One-time token TTL: default 1 hour (configurable).
 - Token consumed on first successful download.
-- ZIP files older than the TTL are cleaned up (lazy on access and/or a periodic
-  sweep); cleanup mechanism finalized during planning.
+- ZIP files older than the TTL are cleaned up (lazy on access plus a periodic sweep
+  reusing the existing scheduler); the same sweep removes archives for `failed` jobs.
 
 ## Testing (TDD)
 
@@ -218,12 +290,29 @@ appended. The **real** identifier is always preserved inside the file and in
 - **Integration — REST:** `POST` returns `export_id`; polling `GET` reaches `ready`;
   `download` streams a valid ZIP whose contents match the manifest; `all_workspaces`
   admin gate enforced.
-- **Integration — MCP:** `metronix_export_data` returns an `export_id`;
-  `metronix_export_status` returns a working `download_url` once ready.
+- **Integration — MCP:** `metronix_export_data` requires an explicit `workspace_id`
+  or `all_workspaces=true` (bare call → `INVALID_PARAMS`, never silently `"default"`);
+  returns an `export_id`; `metronix_export_status` returns a working `download_url`
+  once ready.
+- **Restart/watchdog:** a job left `running` past the timeout is marked `failed` on
+  startup, never stuck in limbo.
+- **Concurrency:** a second trigger for the same scope returns the existing
+  `export_id` rather than starting a parallel build.
+
+## Decisions (resolved from review)
+
+- Job state store: PostgreSQL `export_jobs` table (durable, survives restart). Redis
+  holds only the short-lived one-time download token.
+- Background mechanism: in-process `asyncio` task on the API process with state in
+  `export_jobs`; **not** FastAPI `BackgroundTasks` (post-response only, die on
+  restart, unavailable on the MCP path). Startup watchdog reaps orphaned `running`
+  jobs.
+- `download_url` base: new `public_base_url` setting (none exists today); REST may
+  fall back to the request base URL, MCP requires it configured.
+- Archive cleanup: lazy-on-access plus a periodic sweep on the existing scheduler.
 
 ## Open Items for Planning
 
-- Job/state store choice: Redis vs a small PostgreSQL `export_jobs` table.
-- Background execution mechanism: in-process `asyncio` task vs existing scheduler.
-- `public_base_url` configuration for building absolute `download_url`s.
-- Archive cleanup trigger (lazy vs periodic sweep).
+- Exact `export_jobs` columns/migration and the watchdog timeout value.
+- Default disk-cap value for `/data/exports`.
+- Whether the periodic sweep is a new scheduled job or folds into an existing one.

--- a/docs/specs/2026-06-24-data-export-plan.md
+++ b/docs/specs/2026-06-24-data-export-plan.md
@@ -1,0 +1,2225 @@
+# Data Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a departing user export all of a workspace's agent memory (one Markdown file per agent, including unregistered agents) and all ingested documents in original whole form, delivered as a downloadable ZIP via a one-time-token URL, triggered over MCP or REST.
+
+**Architecture:** A single `ExportService` (in a new `src/metronix/export/` package) owns all build logic. Build runs as an in-process `asyncio` task on the API process; authoritative job state lives in a durable PostgreSQL `export_jobs` table, the one-time download token lives in Redis, and the ZIP lives on a shared volume. MCP tools and a REST router are thin surfaces over the service. The download endpoint is authorized solely by the one-time token in its URL.
+
+**Tech Stack:** Python 3.12, FastAPI, FastMCP, SQLAlchemy async, Alembic, Redis, pydantic / pydantic-settings, `zipfile` (stdlib), pytest + pytest-asyncio.
+
+## Global Constraints
+
+- Package root is `src/metronix/` (the active package; `src/metatron/` is legacy — do not touch).
+- Python `>=3.12,<3.14`. Ruff line length 99. mypy strict.
+- pytest config: `asyncio_mode=auto`; tests touching real PostgreSQL/Redis use the `integration` marker (`@pytest.mark.integration`).
+- All tool/REST identifiers use the `metronix_` / `/api/v1/` conventions already in the codebase.
+- This feature targets the HTTP API deployment (MCP mounted in the FastAPI process at `/mcp`, REST at `/api/v1`, same uvicorn). stdio-only MCP is out of scope.
+- Memory export includes **persistent** records (`ttl_expires_at IS NULL`) of **all** lifecycle statuses; session/TTL records are excluded.
+- One-time tokens: CSPRNG, ≥128 bits (`secrets.token_urlsafe(32)`); never logged.
+- Every archive path segment is slugified (path-traversal safe); the real identifier is preserved inside files and in `manifest.json`.
+- MCP `metronix_export_data` must NOT silently fall back to workspace `"default"` — it requires an explicit `workspace_id` or `all_workspaces=true`.
+
+---
+
+### Task 1: Config settings
+
+**Files:**
+- Modify: `src/metronix/core/config.py` (add fields near `freshness_llm_api_base_url:278`, mirroring its `Field(..., alias=...)` style)
+- Test: `tests/unit/test_export_config.py`
+
+**Interfaces:**
+- Produces: `Settings.public_base_url: str`, `Settings.export_dir: str`, `Settings.export_token_ttl_seconds: int`, `Settings.export_disk_cap_bytes: int`, `Settings.export_job_watchdog_seconds: int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_config.py
+from metronix.core.config import Settings
+
+
+def test_export_settings_defaults():
+    s = Settings()
+    assert s.public_base_url == ""
+    assert s.export_dir == "/data/exports"
+    assert s.export_token_ttl_seconds == 3600
+    assert s.export_disk_cap_bytes == 5_000_000_000
+    assert s.export_job_watchdog_seconds == 3600
+
+
+def test_export_settings_env_override(monkeypatch):
+    monkeypatch.setenv("METRONIX_PUBLIC_BASE_URL", "http://host:8001")
+    monkeypatch.setenv("METRONIX_EXPORT_TOKEN_TTL_SECONDS", "120")
+    s = Settings()
+    assert s.public_base_url == "http://host:8001"
+    assert s.export_token_ttl_seconds == 120
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_config.py -v`
+Expected: FAIL — `AttributeError`/missing attributes.
+
+- [ ] **Step 3: Add the fields**
+
+Add inside the `Settings` class in `src/metronix/core/config.py` (anywhere among the field declarations):
+
+```python
+    # --- Data export (one-time-token ZIP export) ---
+    public_base_url: str = Field(default="", alias="METRONIX_PUBLIC_BASE_URL")
+    export_dir: str = Field(default="/data/exports", alias="METRONIX_EXPORT_DIR")
+    export_token_ttl_seconds: int = Field(
+        default=3600, alias="METRONIX_EXPORT_TOKEN_TTL_SECONDS", ge=60
+    )
+    export_disk_cap_bytes: int = Field(
+        default=5_000_000_000, alias="METRONIX_EXPORT_DISK_CAP_BYTES", ge=0
+    )
+    export_job_watchdog_seconds: int = Field(
+        default=3600, alias="METRONIX_EXPORT_JOB_WATCHDOG_SECONDS", ge=60
+    )
+```
+
+(`Field` is already imported in `config.py`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_config.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/core/config.py tests/unit/test_export_config.py
+git commit -m "feat(export): add data-export config settings"
+```
+
+---
+
+### Task 2: Export domain models
+
+**Files:**
+- Create: `src/metronix/export/__init__.py` (empty)
+- Create: `src/metronix/export/models.py`
+- Test: `tests/unit/test_export_models.py`
+
+**Interfaces:**
+- Produces:
+  - `ExportStatus(StrEnum)`: `PENDING="pending"`, `RUNNING="running"`, `READY="ready"`, `FAILED="failed"`.
+  - `ExportScope` dataclass: `all_workspaces: bool = False`, `workspace_id: str | None = None`; methods `to_dict() -> dict`, classmethod `from_dict(d: dict) -> ExportScope`, `key() -> str` (stable dedup key).
+  - `ExportJob` dataclass: `id: str`, `scope: ExportScope`, `status: ExportStatus`, `workspace_count: int = 0`, `agent_count: int = 0`, `memory_record_count: int = 0`, `document_count: int = 0`, `size_bytes: int = 0`, `archive_path: str | None = None`, `error: str | None = None`, `created_at: datetime`, `updated_at: datetime`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_models.py
+from datetime import UTC, datetime
+
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+
+
+def test_scope_roundtrip_and_key():
+    s = ExportScope(all_workspaces=False, workspace_id="ws1")
+    assert ExportScope.from_dict(s.to_dict()) == s
+    assert s.key() == "ws:ws1"
+    assert ExportScope(all_workspaces=True).key() == "all"
+
+
+def test_job_status_enum():
+    now = datetime.now(UTC)
+    job = ExportJob(
+        id="e1",
+        scope=ExportScope(workspace_id="ws1"),
+        status=ExportStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+    )
+    assert job.status == "pending"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_models.py -v`
+Expected: FAIL — module `metronix.export.models` not found.
+
+- [ ] **Step 3: Implement the models**
+
+```python
+# src/metronix/export/models.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+
+
+class ExportStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    READY = "ready"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class ExportScope:
+    all_workspaces: bool = False
+    workspace_id: str | None = None
+
+    def to_dict(self) -> dict:
+        return {"all_workspaces": self.all_workspaces, "workspace_id": self.workspace_id}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ExportScope:
+        return cls(
+            all_workspaces=bool(d.get("all_workspaces", False)),
+            workspace_id=d.get("workspace_id"),
+        )
+
+    def key(self) -> str:
+        return "all" if self.all_workspaces else f"ws:{self.workspace_id}"
+
+
+@dataclass
+class ExportJob:
+    id: str
+    scope: ExportScope
+    status: ExportStatus
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    workspace_count: int = 0
+    agent_count: int = 0
+    memory_record_count: int = 0
+    document_count: int = 0
+    size_bytes: int = 0
+    archive_path: str | None = None
+    error: str | None = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_models.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/__init__.py src/metronix/export/models.py tests/unit/test_export_models.py
+git commit -m "feat(export): add export domain models"
+```
+
+---
+
+### Task 3: Filename slugification
+
+**Files:**
+- Create: `src/metronix/export/render.py`
+- Test: `tests/unit/test_export_slug.py`
+
+**Interfaces:**
+- Produces:
+  - `slugify_segment(raw: str, *, max_len: int = 80) -> str` — filesystem-safe single path segment; never empty, never `.`/`..`, no `/` or `\`.
+  - `unique_slug(raw: str, used: set[str], *, max_len: int = 80) -> str` — slug plus an 8-char stable hash suffix on collision; adds the result to `used`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_slug.py
+from metronix.export.render import slugify_segment, unique_slug
+
+
+def test_slug_strips_path_chars():
+    assert "/" not in slugify_segment("a/b/../c")
+    assert "\\" not in slugify_segment("a\\b")
+    assert slugify_segment("..") not in ("", ".", "..")
+
+
+def test_slug_non_empty_for_garbage():
+    assert slugify_segment("***") != ""
+    assert slugify_segment("") != ""
+
+
+def test_unique_slug_collision_suffix():
+    used: set[str] = set()
+    a = unique_slug("agent/one", used)
+    b = unique_slug("agent/one", used)  # same raw -> same slug -> collision
+    assert a != b
+    assert a in used and b in used
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_slug.py -v`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement slugification**
+
+```python
+# src/metronix/export/render.py
+from __future__ import annotations
+
+import hashlib
+import re
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def slugify_segment(raw: str, *, max_len: int = 80) -> str:
+    """Return a filesystem-safe single path segment (no separators, no traversal)."""
+    text = _UNSAFE.sub("-", (raw or "").strip())
+    text = text.strip("-._")
+    if text in ("", ".", ".."):
+        text = "item-" + hashlib.sha1((raw or "").encode("utf-8")).hexdigest()[:8]
+    return text[:max_len]
+
+
+def unique_slug(raw: str, used: set[str], *, max_len: int = 80) -> str:
+    """slugify_segment plus a stable hash suffix when the slug is already used."""
+    base = slugify_segment(raw, max_len=max_len)
+    candidate = base
+    if candidate in used:
+        suffix = hashlib.sha1((raw or "").encode("utf-8")).hexdigest()[:8]
+        candidate = f"{base[: max_len - 9]}-{suffix}"
+        n = 1
+        while candidate in used:
+            candidate = f"{base[: max_len - 11]}-{suffix}-{n}"
+            n += 1
+    used.add(candidate)
+    return candidate
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_slug.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/render.py tests/unit/test_export_slug.py
+git commit -m "feat(export): add filename slugification"
+```
+
+---
+
+### Task 4: Markdown renderers and manifest
+
+**Files:**
+- Modify: `src/metronix/export/render.py`
+- Test: `tests/unit/test_export_render.py`
+
+**Interfaces:**
+- Consumes: `MemoryRecord` and `RawDocument` from `metronix.core.models`; `slugify_segment` from Task 3.
+- Produces:
+  - `render_agent_memory(agent_id: str, workspace_id: str, records: list[MemoryRecord]) -> str`
+  - `render_document(doc: RawDocument) -> str`
+  - `build_manifest(*, generated_at: datetime, scope: ExportScope, workspaces: list[str], agents: list[dict], counts: dict, limitations: list[str]) -> dict`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_render.py
+from datetime import UTC, datetime
+
+from metronix.core.models import MemoryKind, MemoryRecord, MemoryScope, RawDocument
+from metronix.export.models import ExportScope
+from metronix.export.render import build_manifest, render_agent_memory, render_document
+
+
+def test_render_agent_memory_includes_fields_and_real_id():
+    rec = MemoryRecord(
+        workspace_id="ws1",
+        agent_id="agent/one",
+        scope=MemoryScope.PER_AGENT,
+        kind=MemoryKind.FACT,
+        content="the sky is blue",
+        tags=["color"],
+    )
+    md = render_agent_memory("agent/one", "ws1", [rec])
+    assert "agent/one" in md          # real id preserved verbatim
+    assert "the sky is blue" in md
+    assert "fact" in md and "color" in md
+
+
+def test_render_document_has_front_matter_and_full_content():
+    doc = RawDocument(
+        workspace_id="ws1",
+        connector_type="jira",
+        source_id="PROJ-1",
+        title="Bug",
+        content="full body text",
+        url="http://j/PROJ-1",
+        author="alice",
+        metadata={"status": "Open"},
+    )
+    md = render_document(doc)
+    assert md.startswith("---")        # YAML front matter
+    assert "PROJ-1" in md and "full body text" in md and "alice" in md
+
+
+def test_manifest_shape():
+    man = build_manifest(
+        generated_at=datetime(2026, 6, 24, tzinfo=UTC),
+        scope=ExportScope(workspace_id="ws1"),
+        workspaces=["ws1"],
+        agents=[{"agent_id": "agent/one", "file": "ws1/memory/agent-one.md",
+                 "registered": False, "record_count": 1}],
+        counts={"workspaces": 1, "agents": 1, "memory_records": 1, "documents": 0},
+        limitations=["uploads are text only"],
+    )
+    assert man["format_version"] == 1
+    assert man["counts"]["agents"] == 1
+    assert man["agents"][0]["agent_id"] == "agent/one"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_render.py -v`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement renderers**
+
+Append to `src/metronix/export/render.py`:
+
+```python
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from metronix.core.models import MemoryRecord, RawDocument
+    from metronix.export.models import ExportScope
+
+
+def _yaml_scalar(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def render_agent_memory(agent_id: str, workspace_id: str, records: list[MemoryRecord]) -> str:
+    lines = [
+        f"# Agent memory: {agent_id}",
+        "",
+        f"- workspace: `{workspace_id}`",
+        f"- agent_id: `{agent_id}`",
+        f"- record_count: {len(records)}",
+        "",
+    ]
+    for rec in records:
+        lines += [
+            "---",
+            "",
+            f"- kind: {rec.kind}",
+            f"- scope: {rec.scope}",
+            f"- status: {rec.status}",
+            f"- importance_score: {rec.importance_score}",
+            f"- created_at: {rec.created_at}",
+            f"- updated_at: {rec.updated_at}",
+            f"- tags: {', '.join(rec.tags) if rec.tags else '(none)'}",
+            "",
+            rec.content,
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def render_document(doc: RawDocument) -> str:
+    front = [
+        "---",
+        f"title: {_yaml_scalar(doc.title)}",
+        f"source_id: {_yaml_scalar(doc.source_id)}",
+        f"connector_type: {_yaml_scalar(doc.connector_type)}",
+        f"url: {_yaml_scalar(doc.url)}",
+        f"author: {_yaml_scalar(doc.author)}",
+        f"status: {_yaml_scalar(str(doc.status))}",
+        f"metadata: {_yaml_scalar(doc.metadata)}",
+        "---",
+        "",
+    ]
+    return "\n".join(front) + (doc.content or "")
+
+
+def build_manifest(
+    *,
+    generated_at: datetime,
+    scope: ExportScope,
+    workspaces: list[str],
+    agents: list[dict],
+    counts: dict,
+    limitations: list[str],
+) -> dict:
+    return {
+        "format_version": 1,
+        "generated_at": generated_at.isoformat(),
+        "scope": scope.to_dict(),
+        "workspaces": workspaces,
+        "counts": counts,
+        "agents": agents,
+        "limitations": limitations,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_render.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/render.py tests/unit/test_export_render.py
+git commit -m "feat(export): add markdown renderers and manifest builder"
+```
+
+---
+
+### Task 5: Archive writer
+
+**Files:**
+- Create: `src/metronix/export/archive.py`
+- Test: `tests/unit/test_export_archive.py`
+
+**Interfaces:**
+- Produces: `class ExportArchiveWriter` — `__init__(self, dest_path: str)`, context manager; `write_text(self, arcname: str, text: str) -> None`; on `__exit__` flushes and closes; property `size_bytes: int` (valid after close). Parent dir is created if missing.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_archive.py
+import zipfile
+
+from metronix.export.archive import ExportArchiveWriter
+
+
+def test_archive_writes_entries(tmp_path):
+    dest = tmp_path / "sub" / "export.zip"
+    with ExportArchiveWriter(str(dest)) as w:
+        w.write_text("manifest.json", "{}")
+        w.write_text("ws1/memory/a.md", "hello")
+    assert dest.exists()
+    with zipfile.ZipFile(dest) as z:
+        assert set(z.namelist()) == {"manifest.json", "ws1/memory/a.md"}
+        assert z.read("ws1/memory/a.md").decode() == "hello"
+
+
+def test_archive_size_after_close(tmp_path):
+    dest = tmp_path / "export.zip"
+    w = ExportArchiveWriter(str(dest))
+    with w:
+        w.write_text("a.txt", "x" * 1000)
+    assert w.size_bytes > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_archive.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the writer**
+
+```python
+# src/metronix/export/archive.py
+from __future__ import annotations
+
+import os
+import zipfile
+from types import TracebackType
+
+
+class ExportArchiveWriter:
+    """Stream text entries into a ZIP on disk. Use as a context manager."""
+
+    def __init__(self, dest_path: str) -> None:
+        self._dest = dest_path
+        os.makedirs(os.path.dirname(dest_path) or ".", exist_ok=True)
+        self._zip: zipfile.ZipFile | None = None
+        self.size_bytes = 0
+
+    def __enter__(self) -> ExportArchiveWriter:
+        self._zip = zipfile.ZipFile(self._dest, "w", compression=zipfile.ZIP_DEFLATED)
+        return self
+
+    def write_text(self, arcname: str, text: str) -> None:
+        assert self._zip is not None, "writer is closed"
+        self._zip.writestr(arcname, text)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._zip is not None:
+            self._zip.close()
+            self._zip = None
+        try:
+            self.size_bytes = os.path.getsize(self._dest)
+        except OSError:
+            self.size_bytes = 0
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_archive.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/archive.py tests/unit/test_export_archive.py
+git commit -m "feat(export): add ZIP archive writer"
+```
+
+---
+
+### Task 6: One-time download token store
+
+**Files:**
+- Create: `src/metronix/export/tokens.py`
+- Test: `tests/unit/test_export_tokens.py`
+
+**Interfaces:**
+- Consumes: `RedisStore` from `metronix.storage.redis` (has `async set(key, value, ttl)`, `async get(key)`, and `.client` for `delete`). The token store needs only `set`, `get`, and `delete`; tests inject a fake exposing those.
+- Produces: `class ExportTokenStore` — `__init__(self, redis, ttl_seconds: int)`; `async mint(self, export_id: str, path: str) -> str` (CSPRNG `secrets.token_urlsafe(32)`); `async consume(self, token: str) -> dict | None` (returns `{"export_id":..., "path":...}` and deletes it; `None` if missing). Redis key format: `export_token:<token>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_tokens.py
+import json
+
+import pytest
+
+from metronix.export.tokens import ExportTokenStore
+
+
+class FakeRedis:
+    def __init__(self):
+        self.kv: dict[str, str] = {}
+
+    async def set(self, key, value, ttl=None):
+        self.kv[key] = value if isinstance(value, str) else value.decode()
+
+    async def get(self, key):
+        return self.kv.get(key)
+
+    async def delete(self, key):
+        self.kv.pop(key, None)
+
+
+@pytest.mark.asyncio
+async def test_mint_then_consume_is_one_time():
+    store = ExportTokenStore(FakeRedis(), ttl_seconds=60)
+    token = await store.mint("exp1", "/data/exports/exp1.zip")
+    assert len(token) >= 22  # token_urlsafe(32) ~ 43 chars
+    first = await store.consume(token)
+    assert first == {"export_id": "exp1", "path": "/data/exports/exp1.zip"}
+    assert await store.consume(token) is None  # consumed
+
+
+@pytest.mark.asyncio
+async def test_consume_unknown_token():
+    store = ExportTokenStore(FakeRedis(), ttl_seconds=60)
+    assert await store.consume("nope") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_tokens.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the token store**
+
+```python
+# src/metronix/export/tokens.py
+from __future__ import annotations
+
+import json
+import secrets
+from typing import Any, Protocol
+
+
+class _RedisLike(Protocol):
+    async def set(self, key: str, value: str | bytes, ttl: int | None = ...) -> None: ...
+    async def get(self, key: str) -> str | None: ...
+    async def delete(self, key: str) -> Any: ...
+
+
+def _key(token: str) -> str:
+    return f"export_token:{token}"
+
+
+class ExportTokenStore:
+    def __init__(self, redis: _RedisLike, ttl_seconds: int) -> None:
+        self._redis = redis
+        self._ttl = ttl_seconds
+
+    async def mint(self, export_id: str, path: str) -> str:
+        token = secrets.token_urlsafe(32)
+        payload = json.dumps({"export_id": export_id, "path": path})
+        await self._redis.set(_key(token), payload, ttl=self._ttl)
+        return token
+
+    async def consume(self, token: str) -> dict | None:
+        raw = await self._redis.get(_key(token))
+        if raw is None:
+            return None
+        await self._redis.delete(_key(token))
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+```
+
+Note: `RedisStore` in `storage/redis.py` exposes `set`/`get`; add a `delete` passthrough if absent — see Task 9 (data-access additions) which adds `RedisStore.delete`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_tokens.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/tokens.py tests/unit/test_export_tokens.py
+git commit -m "feat(export): add one-time download token store"
+```
+
+---
+
+### Task 7: Alembic migration for `export_jobs`
+
+**Files:**
+- Create: `src/metronix/migrations/versions/026_export_jobs.py`
+- Test: (verified via Task 8's integration test that the table exists)
+
+**Interfaces:**
+- Produces: table `export_jobs` with columns `id TEXT PK`, `scope JSONB NOT NULL`, `scope_key TEXT NOT NULL`, `status TEXT NOT NULL`, `workspace_count INT NOT NULL DEFAULT 0`, `agent_count INT NOT NULL DEFAULT 0`, `memory_record_count INT NOT NULL DEFAULT 0`, `document_count INT NOT NULL DEFAULT 0`, `size_bytes BIGINT NOT NULL DEFAULT 0`, `archive_path TEXT NULL`, `error TEXT NULL`, `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`; partial index on `(scope_key)` where `status IN ('pending','running')`.
+
+- [ ] **Step 1: Confirm current head**
+
+Run: `python -m alembic heads`
+Expected: shows `025` as head. (If higher, set `down_revision` to the actual head.)
+
+- [ ] **Step 2: Write the migration**
+
+```python
+# src/metronix/migrations/versions/026_export_jobs.py
+"""Add export_jobs table for the data-export feature.
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-06-24
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "026"
+down_revision: str | None = "025"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "export_jobs",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("scope", postgresql.JSONB, nullable=False,
+                  server_default=sa.text("'{}'::jsonb")),
+        sa.Column("scope_key", sa.Text, nullable=False),
+        sa.Column("status", sa.Text, nullable=False),
+        sa.Column("workspace_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("agent_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("memory_record_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("document_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("size_bytes", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("archive_path", sa.Text, nullable=True),
+        sa.Column("error", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("NOW()")),
+    )
+    op.create_index(
+        "ix_export_jobs_active_scope",
+        "export_jobs",
+        ["scope_key"],
+        postgresql_where=sa.text("status IN ('pending','running')"),
+    )
+    op.create_index("ix_export_jobs_status", "export_jobs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_export_jobs_status", table_name="export_jobs")
+    op.drop_index("ix_export_jobs_active_scope", table_name="export_jobs")
+    op.drop_table("export_jobs")
+```
+
+- [ ] **Step 3: Apply and verify**
+
+Run: `python -m alembic upgrade head`
+Expected: applies `026`; no error. Verify: `python -m alembic current` shows `026`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/metronix/migrations/versions/026_export_jobs.py
+git commit -m "feat(export): add export_jobs migration"
+```
+
+---
+
+### Task 8: Export job store (PostgreSQL)
+
+**Files:**
+- Create: `src/metronix/export/jobs.py`
+- Test: `tests/integration/test_export_job_store.py`
+
+**Interfaces:**
+- Consumes: `AsyncEngine`; `ExportJob`, `ExportScope`, `ExportStatus` from Task 2.
+- Produces: `class ExportJobStore` — `__init__(self, engine: AsyncEngine)`; `async create(self, job: ExportJob) -> None`; `async get(self, export_id: str) -> ExportJob | None`; `async set_status(self, export_id: str, status: ExportStatus, *, error: str | None = None) -> None`; `async set_result(self, export_id: str, *, workspace_count: int, agent_count: int, memory_record_count: int, document_count: int, size_bytes: int, archive_path: str) -> None`; `async find_active_for_scope(self, scope: ExportScope) -> ExportJob | None`; `async reap_orphaned(self, older_than_seconds: int) -> int`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+# tests/integration/test_export_job_store.py
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metronix.core.config import Settings
+from metronix.export.jobs import ExportJobStore
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_create_get_update_dedup():
+    engine = create_async_engine(Settings().postgres_dsn, pool_pre_ping=True)
+    store = ExportJobStore(engine)
+    scope = ExportScope(workspace_id="ws_test_export")
+    job = ExportJob(id="exp-test-1", scope=scope, status=ExportStatus.PENDING)
+
+    await store.create(job)
+    got = await store.get("exp-test-1")
+    assert got is not None and got.status == ExportStatus.PENDING and got.scope == scope
+
+    active = await store.find_active_for_scope(scope)
+    assert active is not None and active.id == "exp-test-1"
+
+    await store.set_status("exp-test-1", ExportStatus.RUNNING)
+    await store.set_result("exp-test-1", workspace_count=1, agent_count=2,
+                           memory_record_count=5, document_count=3,
+                           size_bytes=999, archive_path="/data/exports/exp-test-1.zip")
+    await store.set_status("exp-test-1", ExportStatus.READY)
+    done = await store.get("exp-test-1")
+    assert done.status == ExportStatus.READY and done.size_bytes == 999
+    assert await store.find_active_for_scope(scope) is None  # ready != active
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/integration/test_export_job_store.py -v -m integration`
+Expected: FAIL — module not found. (Requires PostgreSQL up and `alembic upgrade head` applied.)
+
+- [ ] **Step 3: Implement the job store**
+
+```python
+# src/metronix/export/jobs.py
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+
+_COLS = (
+    "id, scope, scope_key, status, workspace_count, agent_count, "
+    "memory_record_count, document_count, size_bytes, archive_path, error, "
+    "created_at, updated_at"
+)
+
+
+def _row_to_job(m) -> ExportJob:
+    scope = m["scope"]
+    if isinstance(scope, str):
+        scope = json.loads(scope)
+    return ExportJob(
+        id=m["id"],
+        scope=ExportScope.from_dict(scope or {}),
+        status=ExportStatus(m["status"]),
+        workspace_count=m["workspace_count"],
+        agent_count=m["agent_count"],
+        memory_record_count=m["memory_record_count"],
+        document_count=m["document_count"],
+        size_bytes=m["size_bytes"],
+        archive_path=m["archive_path"],
+        error=m["error"],
+        created_at=m["created_at"],
+        updated_at=m["updated_at"],
+    )
+
+
+class ExportJobStore:
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def create(self, job: ExportJob) -> None:
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO export_jobs (id, scope, scope_key, status) "
+                    "VALUES (:id, CAST(:scope AS jsonb), :scope_key, :status)"
+                ),
+                {
+                    "id": job.id,
+                    "scope": json.dumps(job.scope.to_dict()),
+                    "scope_key": job.scope.key(),
+                    "status": str(job.status),
+                },
+            )
+
+    async def get(self, export_id: str) -> ExportJob | None:
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"SELECT {_COLS} FROM export_jobs WHERE id = :id"),
+                {"id": export_id},
+            )
+            row = result.fetchone()
+        return _row_to_job(row._mapping) if row else None
+
+    async def set_status(
+        self, export_id: str, status: ExportStatus, *, error: str | None = None
+    ) -> None:
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE export_jobs SET status = :status, error = :error, "
+                    "updated_at = NOW() WHERE id = :id"
+                ),
+                {"id": export_id, "status": str(status), "error": error},
+            )
+
+    async def set_result(
+        self,
+        export_id: str,
+        *,
+        workspace_count: int,
+        agent_count: int,
+        memory_record_count: int,
+        document_count: int,
+        size_bytes: int,
+        archive_path: str,
+    ) -> None:
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE export_jobs SET workspace_count = :wc, agent_count = :ac, "
+                    "memory_record_count = :mc, document_count = :dc, size_bytes = :sb, "
+                    "archive_path = :path, updated_at = NOW() WHERE id = :id"
+                ),
+                {
+                    "id": export_id,
+                    "wc": workspace_count,
+                    "ac": agent_count,
+                    "mc": memory_record_count,
+                    "dc": document_count,
+                    "sb": size_bytes,
+                    "path": archive_path,
+                },
+            )
+
+    async def find_active_for_scope(self, scope: ExportScope) -> ExportJob | None:
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    f"SELECT {_COLS} FROM export_jobs "
+                    "WHERE scope_key = :k AND status IN ('pending','running') "
+                    "ORDER BY created_at DESC LIMIT 1"
+                ),
+                {"k": scope.key()},
+            )
+            row = result.fetchone()
+        return _row_to_job(row._mapping) if row else None
+
+    async def reap_orphaned(self, older_than_seconds: int) -> int:
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    "UPDATE export_jobs SET status = 'failed', "
+                    "error = 'reaped: running past watchdog timeout', updated_at = NOW() "
+                    "WHERE status IN ('pending','running') "
+                    "AND updated_at < NOW() - make_interval(secs => :secs)"
+                ),
+                {"secs": older_than_seconds},
+            )
+            return result.rowcount or 0
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python -m pytest tests/integration/test_export_job_store.py -v -m integration`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/jobs.py tests/integration/test_export_job_store.py
+git commit -m "feat(export): add PostgreSQL export job store"
+```
+
+---
+
+### Task 9: Data-access additions (distinct agents, doc keyset, workspaces, redis delete)
+
+**Files:**
+- Modify: `src/metronix/storage/memory_postgres.py` (add `list_agent_ids`)
+- Modify: `src/metronix/storage/postgres.py` (add `list_document_workspaces`, `list_raw_documents_keyset`)
+- Modify: `src/metronix/storage/redis.py` (add `delete`)
+- Test: `tests/integration/test_export_data_access.py`
+
+**Interfaces:**
+- Produces:
+  - `MemoryPostgresStore.list_agent_ids(self, workspace_id: str) -> list[str]`
+  - `PostgresStore.list_document_workspaces(self) -> list[str]`
+  - `PostgresStore.list_raw_documents_keyset(self, workspace_id: str, *, after_updated_at, after_id: str | None, limit: int = 200) -> list[RawDocument]` — keyset page using order `(updated_at DESC, id ASC)`.
+  - `RedisStore.delete(self, key: str) -> None`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+# tests/integration/test_export_data_access.py
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metronix.core.config import Settings
+from metronix.storage.memory_postgres import MemoryPostgresStore
+from metronix.storage.postgres import PostgresStore
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_list_agent_ids_distinct():
+    engine = create_async_engine(Settings().postgres_dsn, pool_pre_ping=True)
+    store = MemoryPostgresStore(engine)
+    ids = await store.list_agent_ids("nonexistent-ws")
+    assert ids == []  # no rows, but method exists and returns a list
+
+
+@pytest.mark.asyncio
+async def test_doc_keyset_first_page_runs():
+    store = PostgresStore(Settings().postgres_dsn)
+    try:
+        page = await store.list_raw_documents_keyset(
+            "nonexistent-ws", after_updated_at=None, after_id=None, limit=10
+        )
+        assert page == []
+        assert isinstance(await store.list_document_workspaces(), list)
+    finally:
+        await store.close()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/integration/test_export_data_access.py -v -m integration`
+Expected: FAIL — methods not defined.
+
+- [ ] **Step 3a: Add `list_agent_ids` to `MemoryPostgresStore`**
+
+In `src/metronix/storage/memory_postgres.py`, next to `list_workspaces` (~line 413), add:
+
+```python
+    async def list_agent_ids(self, workspace_id: str) -> list[str]:
+        """Return distinct agent_ids that have memory in a workspace (incl. unregistered)."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT DISTINCT agent_id FROM memory_records WHERE workspace_id = :ws"),
+                {"ws": workspace_id},
+            )
+            rows = result.fetchall()
+        return [str(row[0]) for row in rows]
+```
+
+- [ ] **Step 3b: Add doc methods to `PostgresStore`**
+
+In `src/metronix/storage/postgres.py`, next to `list_raw_documents` (~line 1377), add:
+
+```python
+    async def list_document_workspaces(self) -> list[str]:
+        """Return distinct workspace_ids present in raw_documents."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT DISTINCT workspace_id FROM raw_documents")
+            )
+            return [str(r[0]) for r in result.fetchall()]
+
+    async def list_raw_documents_keyset(
+        self,
+        workspace_id: str,
+        *,
+        after_updated_at: object | None,
+        after_id: str | None,
+        limit: int = 200,
+    ) -> list[RawDocument]:
+        """Keyset page over (updated_at DESC, id ASC). Pass after_* = None for first page."""
+        params: dict = {"workspace_id": workspace_id, "limit": limit}
+        where = "workspace_id = :workspace_id"
+        if after_updated_at is not None and after_id is not None:
+            where += (
+                " AND (updated_at, id) < (:after_updated_at, :after_id)"
+            )  # DESC,ASC keyset: rows ordered after the cursor
+            params["after_updated_at"] = after_updated_at
+            params["after_id"] = after_id
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    f"SELECT * FROM raw_documents WHERE {where} "
+                    "ORDER BY updated_at DESC, id ASC LIMIT :limit"
+                ),
+                params,
+            )
+            return [self._row_to_raw_document(row) for row in result]
+```
+
+Note on the keyset predicate: the existing order is `updated_at DESC, id ASC`, which is not a single monotonic tuple, so strict tuple comparison is approximate. For the export's read-mostly use, page by `updated_at` descending and within an equal `updated_at` fall back to `id`; if exactness matters later, switch the page order to `(updated_at DESC, id DESC)` so `(updated_at, id) < (cursor)` is exact. Keep it simple here: order `updated_at DESC, id ASC`, advance the cursor with the last row's `(updated_at, id)`, and stop when a page returns fewer than `limit` rows.
+
+- [ ] **Step 3c: Add `delete` to `RedisStore`**
+
+In `src/metronix/storage/redis.py`, in the `RedisStore` class, add:
+
+```python
+    async def delete(self, key: str) -> None:
+        """Delete a key (no error if absent)."""
+        await self._client.delete(key)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python -m pytest tests/integration/test_export_data_access.py -v -m integration`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/storage/memory_postgres.py src/metronix/storage/postgres.py src/metronix/storage/redis.py tests/integration/test_export_data_access.py
+git commit -m "feat(export): add distinct-agent, doc keyset, and redis delete helpers"
+```
+
+---
+
+### Task 10: ExportService (orchestration)
+
+**Files:**
+- Create: `src/metronix/export/service.py`
+- Test: `tests/unit/test_export_service.py`
+
+**Interfaces:**
+- Consumes (via constructor injection, defined as Protocols so tests use fakes):
+  - `MemoryReader`: `async list_workspaces() -> list[str]`; `async list_agent_ids(ws: str) -> list[str]`; `async list_records(ws: str, *, agent_id: str, lifetime: str, limit: int, offset: int) -> list[MemoryRecord]`.
+  - `DocReader`: `async list_document_workspaces() -> list[str]`; `async list_raw_documents_keyset(ws: str, *, after_updated_at, after_id, limit) -> list[RawDocument]`.
+  - `RegisteredAgents`: `async registered_agent_ids(ws: str) -> set[str]`.
+  - `ExportJobStore` (Task 8), `ExportTokenStore` (Task 6).
+  - `archive_dir: str`, `public_base_url: str`, `disk_cap_bytes: int`, `new_id: Callable[[], str]` (defaults to `uuid4().hex`; injectable for deterministic tests), `now: Callable[[], datetime]` (injectable).
+- Produces: `class ExportService` — `async start(self, scope: ExportScope) -> ExportJob`; `async status(self, export_id: str) -> dict | None`; `async _build(self, export_id: str, scope: ExportScope) -> None` (also runnable directly in tests). `start()` schedules `_build` via `asyncio.create_task`. `status()` returns `{export_id, status, counts..., size_bytes, download_url?, error?}` (download_url present only when READY, minted on demand).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_service.py
+import zipfile
+from datetime import UTC, datetime
+
+import pytest
+
+from metronix.core.models import MemoryRecord, RawDocument
+from metronix.export.models import ExportScope, ExportStatus
+from metronix.export.service import ExportService
+
+
+class FakeMemory:
+    async def list_workspaces(self):
+        return ["ws1"]
+
+    async def list_agent_ids(self, ws):
+        return ["agent/one", "ghost"]
+
+    async def list_records(self, ws, *, agent_id, lifetime, limit, offset):
+        if offset > 0:
+            return []
+        return [MemoryRecord(workspace_id=ws, agent_id=agent_id, content=f"m-{agent_id}")]
+
+
+class FakeDocs:
+    async def list_document_workspaces(self):
+        return ["ws1"]
+
+    async def list_raw_documents_keyset(self, ws, *, after_updated_at, after_id, limit):
+        if after_id is not None:
+            return []
+        return [RawDocument(id="d1", workspace_id=ws, connector_type="jira",
+                            source_id="PROJ-1", content="body",
+                            updated_at=datetime(2026, 1, 1, tzinfo=UTC))]
+
+
+class FakeRegistry:
+    async def registered_agent_ids(self, ws):
+        return {"agent/one"}  # 'ghost' is unregistered
+
+
+class FakeJobs:
+    def __init__(self):
+        self.jobs = {}
+
+    async def create(self, job):
+        self.jobs[job.id] = job
+
+    async def get(self, export_id):
+        return self.jobs.get(export_id)
+
+    async def set_status(self, export_id, status, *, error=None):
+        self.jobs[export_id].status = status
+        self.jobs[export_id].error = error
+
+    async def set_result(self, export_id, **kw):
+        j = self.jobs[export_id]
+        for k, v in kw.items():
+            setattr(j, k, v)
+
+    async def find_active_for_scope(self, scope):
+        for j in self.jobs.values():
+            if j.scope.key() == scope.key() and j.status in (
+                ExportStatus.PENDING, ExportStatus.RUNNING):
+                return j
+        return None
+
+
+class FakeTokens:
+    async def mint(self, export_id, path):
+        return "tok-123"
+
+
+def _service(tmp_path, jobs):
+    return ExportService(
+        memory=FakeMemory(),
+        docs=FakeDocs(),
+        registry=FakeRegistry(),
+        job_store=jobs,
+        token_store=FakeTokens(),
+        archive_dir=str(tmp_path),
+        public_base_url="http://host:8001",
+        disk_cap_bytes=10_000_000,
+        new_id=lambda: "exp1",
+        now=lambda: datetime(2026, 6, 24, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_produces_zip_with_all_agents_and_docs(tmp_path):
+    jobs = FakeJobs()
+    svc = _service(tmp_path, jobs)
+    scope = ExportScope(workspace_id="ws1")
+    job = await svc.start(scope)
+    await svc._build(job.id, scope)  # run synchronously for assertion
+
+    done = await jobs.get(job.id)
+    assert done.status == ExportStatus.READY
+    assert done.agent_count == 2 and done.document_count == 1
+
+    with zipfile.ZipFile(done.archive_path) as z:
+        names = z.namelist()
+        assert "manifest.json" in names
+        assert any(n.startswith("ws1/memory/") for n in names)
+        assert any(n.startswith("ws1/documents/jira/") for n in names)
+        manifest = z.read("manifest.json").decode()
+    assert "ghost" in manifest  # unregistered agent included
+
+
+@pytest.mark.asyncio
+async def test_status_returns_download_url_when_ready(tmp_path):
+    jobs = FakeJobs()
+    svc = _service(tmp_path, jobs)
+    scope = ExportScope(workspace_id="ws1")
+    job = await svc.start(scope)
+    await svc._build(job.id, scope)
+    st = await svc.status(job.id)
+    assert st["status"] == "ready"
+    assert st["download_url"] == (
+        "http://host:8001/api/v1/export/exp1/download?token=tok-123")
+
+
+@pytest.mark.asyncio
+async def test_dedup_returns_existing_active_job(tmp_path):
+    jobs = FakeJobs()
+    svc = _service(tmp_path, jobs)
+    scope = ExportScope(workspace_id="ws1")
+    j1 = await svc.start(scope)
+    j2 = await svc.start(scope)  # active job exists -> returns same
+    assert j1.id == j2.id
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_service.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the service**
+
+```python
+# src/metronix/export/service.py
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any, Protocol
+from uuid import uuid4
+
+import structlog
+
+from metronix.core.models import MemoryRecord, RawDocument
+from metronix.export.archive import ExportArchiveWriter
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+from metronix.export.render import build_manifest, render_agent_memory, render_document, unique_slug
+
+logger = structlog.get_logger(__name__)
+
+_MEM_PAGE = 500
+_DOC_PAGE = 200
+_LIMITATIONS = [
+    "Uploaded files are exported as extracted text only; "
+    "original binary files are not retained by Metronix.",
+]
+
+
+class MemoryReader(Protocol):
+    async def list_workspaces(self) -> list[str]: ...
+    async def list_agent_ids(self, ws: str) -> list[str]: ...
+    async def list_records(
+        self, ws: str, *, agent_id: str, lifetime: str, limit: int, offset: int
+    ) -> list[MemoryRecord]: ...
+
+
+class DocReader(Protocol):
+    async def list_document_workspaces(self) -> list[str]: ...
+    async def list_raw_documents_keyset(
+        self, ws: str, *, after_updated_at: Any, after_id: str | None, limit: int
+    ) -> list[RawDocument]: ...
+
+
+class RegisteredAgents(Protocol):
+    async def registered_agent_ids(self, ws: str) -> set[str]: ...
+
+
+class ExportService:
+    def __init__(
+        self,
+        *,
+        memory: MemoryReader,
+        docs: DocReader,
+        registry: RegisteredAgents,
+        job_store: Any,
+        token_store: Any,
+        archive_dir: str,
+        public_base_url: str,
+        disk_cap_bytes: int,
+        new_id: Callable[[], str] | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._memory = memory
+        self._docs = docs
+        self._registry = registry
+        self._jobs = job_store
+        self._tokens = token_store
+        self._dir = archive_dir
+        self._base = public_base_url.rstrip("/")
+        self._cap = disk_cap_bytes
+        self._new_id = new_id or (lambda: uuid4().hex)
+        self._now = now or (lambda: datetime.now(UTC))
+
+    async def start(self, scope: ExportScope) -> ExportJob:
+        existing = await self._jobs.find_active_for_scope(scope)
+        if existing is not None:
+            return existing
+        if self._cap and self._dir_size() >= self._cap:
+            raise RuntimeError("export disk cap exceeded; try again after cleanup")
+        job = ExportJob(
+            id=self._new_id(),
+            scope=scope,
+            status=ExportStatus.PENDING,
+            created_at=self._now(),
+            updated_at=self._now(),
+        )
+        await self._jobs.create(job)
+        asyncio.create_task(self._build_guarded(job.id, scope), name=f"export-{job.id}")
+        return job
+
+    async def status(self, export_id: str) -> dict | None:
+        job = await self._jobs.get(export_id)
+        if job is None:
+            return None
+        out: dict = {
+            "export_id": job.id,
+            "status": str(job.status),
+            "counts": {
+                "workspaces": job.workspace_count,
+                "agents": job.agent_count,
+                "memory_records": job.memory_record_count,
+                "documents": job.document_count,
+            },
+            "size_bytes": job.size_bytes,
+        }
+        if job.status == ExportStatus.FAILED:
+            out["error"] = job.error
+        if job.status == ExportStatus.READY and job.archive_path:
+            token = await self._tokens.mint(job.id, job.archive_path)
+            out["download_url"] = (
+                f"{self._base}/api/v1/export/{job.id}/download?token={token}"
+            )
+        return out
+
+    def _dir_size(self) -> int:
+        total = 0
+        for root, _dirs, files in os.walk(self._dir):
+            for f in files:
+                try:
+                    total += os.path.getsize(os.path.join(root, f))
+                except OSError:
+                    pass
+        return total
+
+    async def _resolve_workspaces(self, scope: ExportScope) -> list[str]:
+        if not scope.all_workspaces:
+            return [scope.workspace_id or ""]
+        seen = set(await self._memory.list_workspaces())
+        seen.update(await self._docs.list_document_workspaces())
+        return sorted(seen)
+
+    async def _build_guarded(self, export_id: str, scope: ExportScope) -> None:
+        try:
+            await self._build(export_id, scope)
+        except Exception as exc:  # noqa: BLE001 — record failure, never crash the loop
+            logger.warning("export.build.failed", export_id=export_id, error=str(exc))
+            await self._jobs.set_status(export_id, ExportStatus.FAILED, error=str(exc))
+
+    async def _build(self, export_id: str, scope: ExportScope) -> None:
+        await self._jobs.set_status(export_id, ExportStatus.RUNNING)
+        workspaces = await self._resolve_workspaces(scope)
+        path = os.path.join(self._dir, f"{export_id}.zip")
+        agent_manifest: list[dict] = []
+        n_agents = n_mem = n_docs = 0
+
+        with ExportArchiveWriter(path) as zw:
+            for ws in workspaces:
+                registered = await self._registry.registered_agent_ids(ws)
+                used: set[str] = set()
+                for agent_id in await self._memory.list_agent_ids(ws):
+                    records = await self._collect_records(ws, agent_id)
+                    fname = unique_slug(agent_id, used) + ".md"
+                    arc = f"{ws}/memory/{fname}"
+                    zw.write_text(arc, render_agent_memory(agent_id, ws, records))
+                    agent_manifest.append({
+                        "agent_id": agent_id,
+                        "workspace_id": ws,
+                        "file": arc,
+                        "registered": agent_id in registered,
+                        "record_count": len(records),
+                    })
+                    n_agents += 1
+                    n_mem += len(records)
+
+                doc_used: dict[str, set[str]] = {}
+                async for doc in self._iter_docs(ws):
+                    ct = unique_slug(doc.connector_type or "unknown", set(), max_len=40)
+                    used_for_ct = doc_used.setdefault(ct, set())
+                    base = doc.source_id or doc.title or doc.id
+                    fname = unique_slug(base, used_for_ct) + ".md"
+                    zw.write_text(f"{ws}/documents/{ct}/{fname}", render_document(doc))
+                    n_docs += 1
+
+            manifest = build_manifest(
+                generated_at=self._now(),
+                scope=scope,
+                workspaces=workspaces,
+                agents=agent_manifest,
+                counts={
+                    "workspaces": len(workspaces),
+                    "agents": n_agents,
+                    "memory_records": n_mem,
+                    "documents": n_docs,
+                },
+                limitations=_LIMITATIONS,
+            )
+            zw.write_text("manifest.json", json.dumps(manifest, ensure_ascii=False, indent=2))
+
+        await self._jobs.set_result(
+            export_id,
+            workspace_count=len(workspaces),
+            agent_count=n_agents,
+            memory_record_count=n_mem,
+            document_count=n_docs,
+            size_bytes=zw.size_bytes,
+            archive_path=path,
+        )
+        await self._jobs.set_status(export_id, ExportStatus.READY)
+
+    async def _collect_records(self, ws: str, agent_id: str) -> list[MemoryRecord]:
+        out: list[MemoryRecord] = []
+        offset = 0
+        while True:
+            page = await self._memory.list_records(
+                ws, agent_id=agent_id, lifetime="persistent", limit=_MEM_PAGE, offset=offset
+            )
+            out.extend(page)
+            if len(page) < _MEM_PAGE:
+                return out
+            offset += _MEM_PAGE
+
+    async def _iter_docs(self, ws: str):
+        after_updated_at = None
+        after_id = None
+        while True:
+            page = await self._docs.list_raw_documents_keyset(
+                ws, after_updated_at=after_updated_at, after_id=after_id, limit=_DOC_PAGE
+            )
+            for doc in page:
+                yield doc
+            if len(page) < _DOC_PAGE:
+                return
+            after_updated_at = page[-1].updated_at
+            after_id = page[-1].id
+```
+
+Note: delete the bogus `from metronix.export.models import ExportджJob ...` line — it is a typo guard. The only models import needed is:
+`from metronix.export.models import ExportJob, ExportScope, ExportStatus`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_service.py -v`
+Expected: PASS (all three tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/service.py tests/unit/test_export_service.py
+git commit -m "feat(export): add ExportService orchestration"
+```
+
+---
+
+### Task 11: Service wiring helpers (concrete adapters + builder)
+
+**Files:**
+- Create: `src/metronix/export/deps.py`
+- Test: `tests/unit/test_export_deps.py`
+
+**Interfaces:**
+- Consumes: `Settings`; `MemoryPostgresStore`, `PostgresStore`, `RedisStore`; the new store methods from Task 9; `ExportJobStore`, `ExportTokenStore`, `ExportService`.
+- Produces:
+  - `class RegisteredAgentsReader` — `__init__(self, engine)`, `async registered_agent_ids(ws) -> set[str]` via `SELECT id FROM agents WHERE workspace_id = :ws` (read-only; tolerates absence of the `agents` table by returning an empty set).
+  - `build_export_service(settings: Settings) -> ExportService` — constructs all concrete stores from settings (mirrors `mcp/tools/_memory_deps.py`), cached at module level so MCP and lifespan reuse one instance per process.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_deps.py
+from metronix.core.config import Settings
+from metronix.export.deps import build_export_service
+from metronix.export.service import ExportService
+
+
+def test_build_export_service_constructs(monkeypatch, tmp_path):
+    monkeypatch.setenv("METRONIX_EXPORT_DIR", str(tmp_path))
+    svc = build_export_service(Settings())
+    assert isinstance(svc, ExportService)
+    # cached: same instance on second call
+    assert build_export_service(Settings()) is svc
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_deps.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement adapters + builder**
+
+```python
+# src/metronix/export/deps.py
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from metronix.core.config import Settings
+from metronix.export.jobs import ExportJobStore
+from metronix.export.service import ExportService
+from metronix.export.tokens import ExportTokenStore
+from metronix.storage.memory_postgres import MemoryPostgresStore
+from metronix.storage.postgres import PostgresStore
+from metronix.storage.redis import RedisStore
+
+
+class RegisteredAgentsReader:
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def registered_agent_ids(self, ws: str) -> set[str]:
+        try:
+            async with self._engine.begin() as conn:
+                result = await conn.execute(
+                    text("SELECT id FROM agents WHERE workspace_id = :ws"), {"ws": ws}
+                )
+                return {str(r[0]) for r in result.fetchall()}
+        except Exception:  # noqa: BLE001 — agents table optional; flag is best-effort
+            return set()
+
+
+_SERVICE: ExportService | None = None
+
+
+def build_export_service(settings: Settings) -> ExportService:
+    global _SERVICE  # noqa: PLW0603
+    if _SERVICE is not None:
+        return _SERVICE
+
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg_doc_store = PostgresStore(settings.postgres_dsn)
+    mem_store = MemoryPostgresStore(engine)
+    redis_store = RedisStore(settings.redis_url)
+
+    _SERVICE = ExportService(
+        memory=mem_store,
+        docs=pg_doc_store,
+        registry=RegisteredAgentsReader(engine),
+        job_store=ExportJobStore(engine),
+        token_store=ExportTokenStore(redis_store, settings.export_token_ttl_seconds),
+        archive_dir=settings.export_dir,
+        public_base_url=settings.public_base_url,
+        disk_cap_bytes=settings.export_disk_cap_bytes,
+    )
+    return _SERVICE
+```
+
+Note: `MemoryPostgresStore.list_records` already accepts `lifetime="persistent"`, `agent_id`, `limit`, `offset` (Task 9 + existing signature), satisfying the `MemoryReader` protocol. `PostgresStore` satisfies `DocReader` after Task 9.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_deps.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/export/deps.py tests/unit/test_export_deps.py
+git commit -m "feat(export): add concrete adapters and service builder"
+```
+
+---
+
+### Task 12: MCP tools
+
+**Files:**
+- Create: `src/metronix/mcp/tools/export.py`
+- Modify: `src/metronix/mcp/tools/__init__.py` (import + `__all__`)
+- Modify: `src/metronix/mcp/tools/models.py` (response models)
+- Test: `tests/unit/test_mcp_export_tools.py`
+
+**Interfaces:**
+- Consumes: `ExportScope` (Task 2), `build_export_service` (Task 11), `MCPError`/`ErrorCode`/`handle_tool_error` (`mcp/errors.py`), `get_settings`.
+- Produces: `metronix_export_data(workspace_id: str | None = None, all_workspaces: bool = False) -> dict`, `metronix_export_status(export_id: str) -> dict`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_mcp_export_tools.py
+import pytest
+
+import metronix.mcp.tools.export as export_tool
+
+
+@pytest.mark.asyncio
+async def test_export_data_requires_explicit_scope():
+    res = await export_tool.metronix_export_data()
+    assert "error" in res
+    assert res["error"]["code"] == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_export_data_starts_job(monkeypatch):
+    class FakeJob:
+        id = "exp9"
+        status = "pending"
+
+    class FakeSvc:
+        async def start(self, scope):
+            assert scope.workspace_id == "ws1"
+            return FakeJob()
+
+        async def status(self, export_id):
+            return {"export_id": export_id, "status": "pending", "counts": {}, "size_bytes": 0}
+
+    monkeypatch.setattr(export_tool, "build_export_service", lambda s: FakeSvc())
+    res = await export_tool.metronix_export_data(workspace_id="ws1")
+    assert res["export_id"] == "exp9" and res["status"] == "pending"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/unit/test_mcp_export_tools.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3a: Add response models to `models.py`**
+
+Append to `src/metronix/mcp/tools/models.py`:
+
+```python
+class ExportStartResponse(BaseModel):
+    """Response from metronix_export_data."""
+
+    export_id: str
+    status: str
+
+
+class ExportStatusResponse(BaseModel):
+    """Response from metronix_export_status."""
+
+    export_id: str
+    status: str
+    counts: dict[str, Any] = Field(default_factory=dict)
+    size_bytes: int = 0
+    download_url: str | None = None
+    error: str | None = None
+```
+
+- [ ] **Step 3b: Implement the tools**
+
+```python
+# src/metronix/mcp/tools/export.py
+from __future__ import annotations
+
+from typing import Any
+
+from metronix.core.config import get_settings
+from metronix.export.deps import build_export_service
+from metronix.export.models import ExportScope
+from metronix.mcp.errors import ErrorCode, MCPError, handle_tool_error
+from metronix.mcp.server import mcp
+
+
+@mcp.tool(
+    description=(
+        "Export ALL data for a workspace (or all workspaces) to a downloadable ZIP: "
+        "one Markdown file per agent's memory (including unregistered agents) plus "
+        "every ingested document in original whole form. Runs in the background.\n\n"
+        "**Parameters:**\n"
+        "- workspace_id: Target workspace (required unless all_workspaces=true)\n"
+        "- all_workspaces: Export every workspace in one archive (default false)\n\n"
+        "**Returns:** export_id and status. Poll metronix_export_status for the "
+        "download_url once status is 'ready'."
+    ),
+)
+async def metronix_export_data(
+    workspace_id: str | None = None,
+    all_workspaces: bool = False,
+) -> dict[str, Any]:
+    """Start a background data export. No silent 'default' workspace fallback."""
+    try:
+        if not all_workspaces and not workspace_id:
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message="metronix_export_data: workspace_id is required unless all_workspaces=true",
+                    hint="Pass an explicit workspace_id, or set all_workspaces=true to export everything",
+                ).to_dict(),
+            }
+        scope = ExportScope(all_workspaces=all_workspaces, workspace_id=workspace_id)
+        service = build_export_service(get_settings())
+        job = await service.start(scope)
+        return {"export_id": job.id, "status": str(job.status)}
+    except Exception as exc:  # noqa: BLE001
+        return {"error": handle_tool_error("metronix_export_data", exc).to_dict()}
+
+
+@mcp.tool(
+    description=(
+        "Check the status of a data export started by metronix_export_data.\n\n"
+        "**Parameters:**\n- export_id: The id returned by metronix_export_data\n\n"
+        "**Returns:** status (pending|running|ready|failed), counts, size_bytes, and "
+        "download_url when ready."
+    ),
+)
+async def metronix_export_status(export_id: str) -> dict[str, Any]:
+    """Return current export status, including a one-time download_url when ready."""
+    try:
+        if not export_id:
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message="metronix_export_status: export_id is required",
+                ).to_dict(),
+            }
+        service = build_export_service(get_settings())
+        result = await service.status(export_id)
+        if result is None:
+            return {
+                "error": MCPError(
+                    code=ErrorCode.DOCUMENT_NOT_FOUND,
+                    message=f"metronix_export_status: no export with id '{export_id}'",
+                ).to_dict(),
+            }
+        return result
+    except Exception as exc:  # noqa: BLE001
+        return {"error": handle_tool_error("metronix_export_status", exc).to_dict()}
+```
+
+- [ ] **Step 3c: Register in `__init__.py`**
+
+In `src/metronix/mcp/tools/__init__.py` add the import (alphabetical, near the others):
+
+```python
+from metronix.mcp.tools.export import metronix_export_data, metronix_export_status
+```
+
+and add to `__all__`:
+
+```python
+    "metronix_export_data",
+    "metronix_export_status",
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python -m pytest tests/unit/test_mcp_export_tools.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/mcp/tools/export.py src/metronix/mcp/tools/__init__.py src/metronix/mcp/tools/models.py tests/unit/test_mcp_export_tools.py
+git commit -m "feat(export): add metronix_export_data/status MCP tools"
+```
+
+---
+
+### Task 13: REST router (trigger, status, download)
+
+**Files:**
+- Create: `src/metronix/api/routes/export.py`
+- Modify: `src/metronix/api/app.py` (import + `include_router`)
+- Test: `tests/unit/test_export_routes.py`
+
+**Interfaces:**
+- Consumes: `ExportScope` (Task 2), `resolve_workspace_id` (`api/dependencies.py`), `require_editor`/`require_viewer` (`auth.dependencies`), `ExportService` from `request.app.state.export_service`, `ExportTokenStore` for download (`request.app.state.export_token_store`).
+- Produces: `router = APIRouter(prefix="/export", tags=["export"])` with:
+  - `POST /export` (body `{workspace_id?: str, all_workspaces?: bool}`) → `{export_id, status}`. Admin (`*`) required for `all_workspaces=true`.
+  - `GET /export/{export_id}` → status dict.
+  - `GET /export/{export_id}/download?token=...` → `StreamingResponse` of `application/zip`; token-only auth; consumes the token; 404 on missing/used token, 410 if the archive is gone.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_routes.py
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from metronix.api.routes import export as export_routes
+
+
+class FakeSvc:
+    async def start(self, scope):
+        from types import SimpleNamespace
+        return SimpleNamespace(id="exp1", status="pending")
+
+    async def status(self, export_id):
+        if export_id != "exp1":
+            return None
+        return {"export_id": "exp1", "status": "ready", "counts": {}, "size_bytes": 0,
+                "download_url": "http://h/api/v1/export/exp1/download?token=t"}
+
+
+class FakeTokens:
+    def __init__(self):
+        self.consumed = []
+
+    async def consume(self, token):
+        if token == "good":
+            return {"export_id": "exp1", "path": "/nonexistent/exp1.zip"}
+        return None
+
+
+def _app(tmp_path):
+    app = FastAPI()
+    app.state.export_service = FakeSvc()
+    app.state.export_token_store = FakeTokens()
+    # bypass auth deps with permissive overrides
+    from metronix.api.dependencies import resolve_workspace_id
+    app.dependency_overrides[resolve_workspace_id] = lambda: "ws1"
+    app.include_router(export_routes.router, prefix="/api/v1")
+    return app
+
+
+def test_post_export_starts(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.post("/api/v1/export", json={"workspace_id": "ws1"})
+    assert r.status_code == 200 and r.json()["export_id"] == "exp1"
+
+
+def test_download_unknown_token_404(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.get("/api/v1/export/exp1/download?token=bad")
+    assert r.status_code == 404
+
+
+def test_download_missing_archive_410(tmp_path):
+    client = TestClient(_app(tmp_path))
+    r = client.get("/api/v1/export/exp1/download?token=good")
+    assert r.status_code == 410
+```
+
+Note: the auth dependencies (`require_editor`, etc.) are applied in the router. For this unit test we override only `resolve_workspace_id`; if `require_editor` blocks, also override it. The implementation below keeps role deps minimal so the override suffices — see Step 3.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_routes.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the router**
+
+```python
+# src/metronix/api/routes/export.py
+from __future__ import annotations
+
+import os
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+from starlette.responses import FileResponse
+
+from metronix.api.dependencies import resolve_workspace_id
+from metronix.export.models import ExportScope
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+
+class ExportStartRequest(BaseModel):
+    workspace_id: str | None = None
+    all_workspaces: bool = False
+
+
+def _is_admin(request: Request) -> bool:
+    user = getattr(request.state, "user", {}) or {}
+    allowed = user.get("workspace_ids", [])
+    return isinstance(allowed, list) and "*" in allowed
+
+
+@router.post("")
+async def start_export(
+    body: ExportStartRequest,
+    request: Request,
+    workspace_id: Annotated[str, Depends(resolve_workspace_id)],
+) -> dict[str, Any]:
+    if body.all_workspaces and not _is_admin(request):
+        raise HTTPException(status_code=403, detail="all_workspaces requires admin access")
+    scope = ExportScope(
+        all_workspaces=body.all_workspaces,
+        workspace_id=None if body.all_workspaces else (body.workspace_id or workspace_id),
+    )
+    service = request.app.state.export_service
+    job = await service.start(scope)
+    return {"export_id": job.id, "status": str(job.status)}
+
+
+@router.get("/{export_id}")
+async def export_status(
+    export_id: str,
+    request: Request,
+    _ws: Annotated[str, Depends(resolve_workspace_id)],
+) -> dict[str, Any]:
+    result = await request.app.state.export_service.status(export_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="export not found")
+    return result
+
+
+@router.get("/{export_id}/download")
+async def download_export(
+    export_id: str,
+    request: Request,
+    token: str = Query(..., min_length=8),
+) -> FileResponse:
+    """Token-only download. No JWT/API-key. Consumes the one-time token."""
+    entry = await request.app.state.export_token_store.consume(token)
+    if entry is None or entry.get("export_id") != export_id:
+        raise HTTPException(status_code=404, detail="invalid or expired token")
+    path = entry.get("path") or ""
+    if not path or not os.path.exists(path):
+        raise HTTPException(status_code=410, detail="export archive no longer available")
+    return FileResponse(
+        path,
+        media_type="application/zip",
+        filename=f"metronix-export-{export_id}.zip",
+    )
+```
+
+Security note: this route must not log its query string (the token). The app's access-logging middleware should skip the query string for `/export/{id}/download`; verify in Task 14 wiring and, if a logging middleware records full URLs, add a path exclusion there.
+
+- [ ] **Step 3b: Register the router in `app.py`**
+
+In `src/metronix/api/app.py`, add `export` to the `from metronix.api.routes import (...)` block (alphabetical) and add next to the other memory/knowledge registrations:
+
+```python
+app.include_router(export.router, prefix="/api/v1")
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_routes.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/metronix/api/routes/export.py src/metronix/api/app.py tests/unit/test_export_routes.py
+git commit -m "feat(export): add REST trigger/status/download routes"
+```
+
+---
+
+### Task 14: Lifespan wiring — service, watchdog, cleanup sweep
+
+**Files:**
+- Modify: `src/metronix/api/app.py` (lifespan: build service, stash on `app.state`, reap orphaned jobs, start a periodic sweep)
+- Create: `src/metronix/export/cleanup.py`
+- Test: `tests/unit/test_export_cleanup.py`
+
+**Interfaces:**
+- Consumes: `Settings`, `build_export_service`, `ExportJobStore.reap_orphaned`, `ExportTokenStore`.
+- Produces:
+  - `sweep_expired_archives(export_dir: str, max_age_seconds: int, *, now_ts: float) -> int` — delete `*.zip` older than `max_age_seconds`; returns count deleted.
+  - Lifespan additions: `app.state.export_service`, `app.state.export_token_store`; on startup call `reap_orphaned(settings.export_job_watchdog_seconds)`; start an `asyncio.Task` that periodically calls `sweep_expired_archives`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_export_cleanup.py
+import os
+import time
+
+from metronix.export.cleanup import sweep_expired_archives
+
+
+def test_sweep_deletes_old_zips(tmp_path):
+    old = tmp_path / "old.zip"
+    new = tmp_path / "new.zip"
+    old.write_bytes(b"x")
+    new.write_bytes(b"y")
+    now = time.time()
+    os.utime(old, (now - 10_000, now - 10_000))
+    deleted = sweep_expired_archives(str(tmp_path), max_age_seconds=3600, now_ts=now)
+    assert deleted == 1
+    assert not old.exists() and new.exists()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python -m pytest tests/unit/test_export_cleanup.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3a: Implement the sweep**
+
+```python
+# src/metronix/export/cleanup.py
+from __future__ import annotations
+
+import os
+
+
+def sweep_expired_archives(export_dir: str, max_age_seconds: int, *, now_ts: float) -> int:
+    """Delete *.zip files in export_dir older than max_age_seconds. Returns count deleted."""
+    if not os.path.isdir(export_dir):
+        return 0
+    deleted = 0
+    for name in os.listdir(export_dir):
+        if not name.endswith(".zip"):
+            continue
+        path = os.path.join(export_dir, name)
+        try:
+            if now_ts - os.path.getmtime(path) > max_age_seconds:
+                os.remove(path)
+                deleted += 1
+        except OSError:
+            continue
+    return deleted
+```
+
+- [ ] **Step 3b: Wire into lifespan**
+
+In `src/metronix/api/app.py` lifespan (near the autosync scheduler block, ~line 231), add:
+
+```python
+    # --- Data export service + maintenance ---
+    try:
+        import asyncio as _asyncio
+        import time as _time
+
+        from metronix.export.cleanup import sweep_expired_archives
+        from metronix.export.deps import build_export_service
+
+        export_service = build_export_service(settings)
+        app.state.export_service = export_service
+        app.state.export_token_store = export_service._tokens  # shared token store
+
+        # Watchdog: fail any job left running past the timeout (e.g. a prior crash).
+        await export_service._jobs.reap_orphaned(settings.export_job_watchdog_seconds)
+
+        async def _export_sweep_loop() -> None:
+            while True:
+                try:
+                    sweep_expired_archives(
+                        settings.export_dir,
+                        settings.export_token_ttl_seconds,
+                        now_ts=_time.time(),
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("export.sweep.failed", error=str(exc))
+                await _asyncio.sleep(max(300, settings.export_token_ttl_seconds))
+
+        app.state.export_sweep_task = _asyncio.create_task(
+            _export_sweep_loop(), name="export-sweep"
+        )
+        logger.info("export.service.started")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("export.startup_failed", error=str(exc))
+```
+
+If the lifespan has a shutdown section that cancels other tasks (e.g. `autosync_task`), cancel `app.state.export_sweep_task` there too, mirroring the existing pattern.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `python -m pytest tests/unit/test_export_cleanup.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full check + commit**
+
+Run: `python -m pytest tests/unit -k export -v` (all export unit tests green)
+Run: `python -m ruff check src/metronix/export src/metronix/api/routes/export.py src/metronix/mcp/tools/export.py`
+Run: `python -m mypy src/metronix/export`
+Expected: lint + types clean (fix any issues before committing).
+
+```bash
+git add src/metronix/api/app.py src/metronix/export/cleanup.py tests/unit/test_export_cleanup.py
+git commit -m "feat(export): wire export service, watchdog, and cleanup sweep into lifespan"
+```
+
+---
+
+### Task 15: End-to-end integration test (HTTP API)
+
+**Files:**
+- Test: `tests/integration/test_export_e2e.py`
+
+**Interfaces:**
+- Consumes: the running FastAPI app (built via the app factory) with PostgreSQL + Redis up and `alembic upgrade head` applied.
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/integration/test_export_e2e.py
+import time
+import zipfile
+
+import pytest
+from starlette.testclient import TestClient
+
+from metronix.api.app import create_app
+from metronix.api.dependencies import resolve_workspace_id
+
+pytestmark = pytest.mark.integration
+
+
+def test_export_e2e_zip_downloadable(tmp_path, monkeypatch):
+    monkeypatch.setenv("METRONIX_EXPORT_DIR", str(tmp_path))
+    monkeypatch.setenv("METRONIX_PUBLIC_BASE_URL", "http://testserver")
+    app = create_app()
+    app.dependency_overrides[resolve_workspace_id] = lambda: "ws_e2e"
+    with TestClient(app) as client:
+        started = client.post("/api/v1/export", json={"workspace_id": "ws_e2e"})
+        assert started.status_code == 200
+        export_id = started.json()["export_id"]
+
+        # poll until ready
+        url = None
+        for _ in range(50):
+            st = client.get(f"/api/v1/export/{export_id}").json()
+            if st["status"] == "ready":
+                url = st["download_url"]
+                break
+            if st["status"] == "failed":
+                pytest.fail(f"export failed: {st.get('error')}")
+            time.sleep(0.2)
+        assert url is not None, "export did not become ready"
+
+        # download via the one-time URL (strip host -> path+query for TestClient)
+        path_q = url.split("testserver", 1)[1]
+        dl = client.get(path_q)
+        assert dl.status_code == 200
+        assert dl.headers["content-type"] == "application/zip"
+        zip_path = tmp_path / "downloaded.zip"
+        zip_path.write_bytes(dl.content)
+        with zipfile.ZipFile(zip_path) as z:
+            assert "manifest.json" in z.namelist()
+
+        # token is one-time: second download fails
+        again = client.get(path_q)
+        assert again.status_code == 404
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `python -m pytest tests/integration/test_export_e2e.py -v -m integration`
+Expected: PASS (PostgreSQL + Redis running, migrations applied). An empty `ws_e2e` still yields a valid ZIP with `manifest.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_export_e2e.py
+git commit -m "test(export): end-to-end HTTP export download"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Shared `ExportService` over MCP + REST → Tasks 10, 12, 13.
+- Background build, durable `export_jobs`, asyncio task (not BackgroundTasks), watchdog → Tasks 7, 8, 10, 14.
+- One-time CSPRNG token in Redis, consumed on download, token-only auth → Tasks 6, 13.
+- `public_base_url` setting + absolute download URL → Tasks 1, 10.
+- Per-agent `<agent_id>.md` incl. unregistered agents; distinct-agent enumeration → Tasks 4, 9, 10.
+- Documents in original whole form grouped by connector_type; uploads text-only limitation in manifest → Tasks 4, 9, 10.
+- Memory: persistent records, all statuses, exclude session/TTL → Task 10 (`lifetime="persistent"`).
+- Keyset pagination for docs → Tasks 9, 10.
+- Filename slugification of every path segment incl. connector_type → Tasks 3, 10.
+- MCP requires explicit workspace_id or all_workspaces (no silent "default") → Task 12.
+- Scope: single workspace default, all_workspaces (admin in REST) → Tasks 12, 13.
+- Concurrency dedup + disk cap → Tasks 8, 10.
+- Cleanup sweep + lazy expiry → Task 14.
+- Error handling (404 unknown export, 404 token, 410 archive gone, failed status) → Tasks 8, 10, 13.
+
+**Placeholder scan:** No `TBD`/`TODO`/"handle edge cases" placeholders. All code blocks are correct as-written (the earlier draft's stray `)` in `reap_orphaned` and a bogus import in `service.py` were removed). The doc keyset note in Task 9 is an explained design trade-off, not a placeholder.
+
+**Type consistency:** `ExportScope`/`ExportStatus`/`ExportJob` names and fields are consistent across Tasks 2/8/10/12/13. `ExportService` constructor kwargs in Task 10 match the builder in Task 11. `MemoryReader`/`DocReader` protocol methods match the store methods added in Task 9 (`list_agent_ids`, `list_raw_documents_keyset`, `list_document_workspaces`) and the existing `list_records`/`list_workspaces` signatures.
+
+**Known approximation:** the doc keyset predicate mixes `updated_at DESC, id ASC` with a tuple comparison (Task 9 note). It is correct enough for read-mostly export and documented; tighten to `(updated_at DESC, id DESC)` if exactness is later required.

--- a/docs/specs/2026-06-24-data-export-plan.md
+++ b/docs/specs/2026-06-24-data-export-plan.md
@@ -687,7 +687,7 @@ git commit -m "feat(export): add one-time download token store"
 ### Task 7: Alembic migration for `export_jobs`
 
 **Files:**
-- Create: `src/metronix/migrations/versions/026_export_jobs.py`
+- Create: `migrations/versions/026_export_jobs.py`
 - Test: (verified via Task 8's integration test that the table exists)
 
 **Interfaces:**
@@ -701,7 +701,7 @@ Expected: shows `025` as head. (If higher, set `down_revision` to the actual hea
 - [ ] **Step 2: Write the migration**
 
 ```python
-# src/metronix/migrations/versions/026_export_jobs.py
+# migrations/versions/026_export_jobs.py
 """Add export_jobs table for the data-export feature.
 
 Revision ID: 026
@@ -769,7 +769,7 @@ Expected: applies `026`; no error. Verify: `python -m alembic current` shows `02
 - [ ] **Step 4: Commit**
 
 ```bash
-git add src/metronix/migrations/versions/026_export_jobs.py
+git add migrations/versions/026_export_jobs.py
 git commit -m "feat(export): add export_jobs migration"
 ```
 
@@ -2222,4 +2222,41 @@ git commit -m "test(export): end-to-end HTTP export download"
 
 **Type consistency:** `ExportScope`/`ExportStatus`/`ExportJob` names and fields are consistent across Tasks 2/8/10/12/13. `ExportService` constructor kwargs in Task 10 match the builder in Task 11. `MemoryReader`/`DocReader` protocol methods match the store methods added in Task 9 (`list_agent_ids`, `list_raw_documents_keyset`, `list_document_workspaces`) and the existing `list_records`/`list_workspaces` signatures.
 
-**Known approximation:** the doc keyset predicate mixes `updated_at DESC, id ASC` with a tuple comparison (Task 9 note). It is correct enough for read-mostly export and documented; tighten to `(updated_at DESC, id DESC)` if exactness is later required.
+---
+
+## As-Built Amendments (post code-review)
+
+Code review surfaced several issues; the shipped code differs from the task code
+blocks above as follows. The design spec (`2026-06-24-data-export-design.md`)
+reflects these.
+
+1. **Keyset predicate (Task 9).** The original `(updated_at, id) < (:a, :b)`
+   row-value comparison is **wrong** for `ORDER BY updated_at DESC, id ASC` — it skips
+   and duplicates rows on `updated_at` ties. Shipped predicate:
+   `updated_at < :after_updated_at OR (updated_at = :after_updated_at AND id > :after_id)`.
+2. **Status authorization (Task 13).** `GET /export/{id}` now fetches the job via
+   `ExportService.get_job`, then calls `_authorize_job_access(request, job.scope)`
+   (admin-only for `all_workspaces`; otherwise caller must have access to the job's
+   workspace) **before** returning a download token. Closes a cross-workspace leak.
+3. **Token minted once (Tasks 7, 8, 10).** Added an `export_jobs.download_token`
+   column. `_build` mints the token at completion and `set_result` persists it;
+   `status()` returns the stored token instead of minting a fresh one per poll.
+4. **Unique active-job index (Tasks 7, 10).** `ix_export_jobs_active_scope` is
+   `unique=True`; `ExportService.start` catches `IntegrityError` and returns the race
+   winner, closing the check-then-create TOCTOU.
+5. **`export_dir` default (Task 1).** `/app/data/exports` (on the compose-mounted
+   `full_file_data:/app/data` volume), not the ephemeral `/data/exports`.
+6. **Lifespan hygiene (Task 14).** Shutdown cancels `export_sweep_task`; the route
+   uses public `ExportService.token_store` / `get_job` / `reap_orphaned_jobs`
+   accessors instead of reaching into `_tokens`/`_jobs`. `start` also guards an empty
+   `workspace_id` (no silent `ws=""` export).
+
+**Deferred follow-ups (single-worker deploy today):** reuse shared `app.state`
+engine/Redis pools instead of building new ones in `deps.py`; make the
+`build_export_service` singleton honor its `settings` arg and dispose engines on
+shutdown; add a worker lease so `reap_orphaned` doesn't fail live jobs under
+multi-worker/rolling deploys; enforce the disk cap during the build (not only at
+`start`).
+
+**Test dependency:** unit tests require `aiosqlite` (gated by
+`tests/unit/__init__.py`); not yet in `pyproject.toml` `dev` extras.

--- a/migrations/versions/026_export_jobs.py
+++ b/migrations/versions/026_export_jobs.py
@@ -1,0 +1,73 @@
+"""Add export_jobs table for the data-export feature.
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-06-24
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "026"
+down_revision: str | None = "025"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "export_jobs",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column(
+            "scope",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("scope_key", sa.Text, nullable=False),
+        sa.Column("status", sa.Text, nullable=False),
+        sa.Column("workspace_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("agent_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("memory_record_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("document_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("size_bytes", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("archive_path", sa.Text, nullable=True),
+        sa.Column("download_token", sa.Text, nullable=True),
+        sa.Column("error", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    # UNIQUE so the DB enforces at most one active (pending/running) job per scope,
+    # closing the check-then-create race in ExportService.start.
+    op.create_index(
+        "ix_export_jobs_active_scope",
+        "export_jobs",
+        ["scope_key"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending','running')"),
+    )
+    op.create_index("ix_export_jobs_status", "export_jobs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_export_jobs_status", table_name="export_jobs")
+    op.drop_index("ix_export_jobs_active_scope", table_name="export_jobs")
+    op.drop_table("export_jobs")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "ruff>=0.8,<1",
     "mypy>=1.13,<2",
     "pre-commit>=4.0,<5",
+    "aiosqlite>=0.20,<1",
 ]
 
 [project.scripts]

--- a/src/metronix/api/app.py
+++ b/src/metronix/api/app.py
@@ -25,6 +25,7 @@ from metronix.api.routes import (
     connections,
     dashboard,
     documents,
+    export,
     files,
     graph,
     health,
@@ -262,6 +263,50 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             timeout=settings.proxy_upstream_timeout_ms / 1000
         )
 
+        # --- Data export service + maintenance ---
+        app.state.export_sweep_task = None
+        try:
+            import asyncio as _asyncio
+            import time as _time
+
+            from metronix.export.cleanup import sweep_expired_archives
+            from metronix.export.deps import build_export_service
+
+            export_service = build_export_service(settings)
+            app.state.export_service = export_service
+            app.state.export_token_store = export_service.token_store
+            if not settings.public_base_url:
+                logger.warning(
+                    "export.public_base_url_unset",
+                    detail=(
+                        "METRONIX_PUBLIC_BASE_URL is empty; REST download URLs fall back "
+                        "to the request host, but MCP-returned URLs will be relative. "
+                        "Set it for MCP-driven exports."
+                    ),
+                )
+
+            # Watchdog: fail any job left running past the timeout (e.g. a prior crash).
+            await export_service.reap_orphaned_jobs(settings.export_job_watchdog_seconds)
+
+            async def _export_sweep_loop() -> None:
+                while True:
+                    try:
+                        sweep_expired_archives(
+                            settings.export_dir,
+                            settings.export_token_ttl_seconds,
+                            now_ts=_time.time(),
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("export.sweep.failed", error=str(exc))
+                    await _asyncio.sleep(max(300, settings.export_token_ttl_seconds))
+
+            app.state.export_sweep_task = _asyncio.create_task(
+                _export_sweep_loop(), name="export-sweep"
+            )
+            logger.info("export.service.started")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("export.startup_failed", error=str(exc))
+
         yield
 
     # Shutdown
@@ -288,6 +333,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     upstream_client = getattr(app.state, "upstream_llm_client", None)
     if upstream_client is not None:
         await upstream_client.aclose()
+    export_sweep_task = getattr(app.state, "export_sweep_task", None)
+    if export_sweep_task is not None and not export_sweep_task.done():
+        export_sweep_task.cancel()
+        await _asyncio.gather(export_sweep_task, return_exceptions=True)
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -400,6 +449,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(agents.router, prefix="/api/v1")
     app.include_router(snapshots.router, prefix="/api/v1")
     app.include_router(traces.router, prefix="/api/v1")
+    app.include_router(export.router, prefix="/api/v1")
 
     from metronix.api.routes.finops import router as finops_router
 

--- a/src/metronix/api/routes/export.py
+++ b/src/metronix/api/routes/export.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+from starlette.responses import FileResponse
+
+from metronix.api.dependencies import resolve_workspace_id
+from metronix.export.models import ExportScope
+
+router = APIRouter(prefix="/export", tags=["export"])
+
+
+class ExportStartRequest(BaseModel):
+    workspace_id: str | None = None
+    all_workspaces: bool = False
+
+
+def _service(request: Request) -> Any:
+    svc = getattr(request.app.state, "export_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="export service unavailable")
+    return svc
+
+
+def _token_store(request: Request) -> Any:
+    store = getattr(request.app.state, "export_token_store", None)
+    if store is None:
+        raise HTTPException(status_code=503, detail="export service unavailable")
+    return store
+
+
+def _absolutize(request: Request, result: dict[str, Any]) -> dict[str, Any]:
+    # When public_base_url is unset the service emits a relative download_url;
+    # the REST surface can fill in the host from the request itself.
+    url = result.get("download_url")
+    if isinstance(url, str) and url.startswith("/"):
+        result["download_url"] = str(request.base_url).rstrip("/") + url
+    return result
+
+
+def _allowed_workspaces(request: Request) -> list[str]:
+    user = getattr(request.state, "user", {}) or {}
+    allowed = user.get("workspace_ids", [])
+    return allowed if isinstance(allowed, list) else []
+
+
+def _is_admin(request: Request) -> bool:
+    return "*" in _allowed_workspaces(request)
+
+
+def _authorize_job_access(request: Request, scope: ExportScope) -> None:
+    """A caller may read an export only if they can access its scope.
+
+    all_workspaces exports are admin-only; single-workspace exports require the
+    caller to have access to that workspace. Without this, any authenticated user
+    could poll any export_id and receive a download token (cross-workspace leak).
+    """
+    if _is_admin(request):
+        return
+    if scope.all_workspaces or scope.workspace_id not in _allowed_workspaces(request):
+        raise HTTPException(status_code=403, detail="no access to this export")
+
+
+@router.post("")
+async def start_export(
+    body: ExportStartRequest,
+    request: Request,
+    workspace_id: Annotated[str, Depends(resolve_workspace_id)],
+) -> dict[str, Any]:
+    if body.all_workspaces and not _is_admin(request):
+        raise HTTPException(status_code=403, detail="all_workspaces requires admin access")
+    scope = ExportScope(
+        all_workspaces=body.all_workspaces,
+        workspace_id=None if body.all_workspaces else (body.workspace_id or workspace_id),
+    )
+    job = await _service(request).start(scope)
+    return {"export_id": job.id, "status": str(job.status)}
+
+
+@router.get("/{export_id}")
+async def export_status(
+    export_id: str,
+    request: Request,
+    _ws: Annotated[str, Depends(resolve_workspace_id)],
+) -> dict[str, Any]:
+    service = _service(request)
+    job = await service.get_job(export_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="export not found")
+    _authorize_job_access(request, job.scope)
+    result = await service.status(export_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="export not found")
+    return _absolutize(request, result)
+
+
+@router.get("/{export_id}/download")
+async def download_export(
+    export_id: str,
+    request: Request,
+    token: str = Query(..., min_length=8),
+) -> FileResponse:
+    """Token-only download. No JWT/API-key. Consumes the one-time token."""
+    store = _token_store(request)
+    # Validate (and check the file) BEFORE consuming, so a swept/missing archive
+    # does not burn the token and force a full re-export.
+    entry = await store.peek(token)
+    if entry is None or entry.get("export_id") != export_id:
+        raise HTTPException(status_code=404, detail="invalid or expired token")
+    path = entry.get("path") or ""
+    if not path or not os.path.exists(path):
+        raise HTTPException(status_code=410, detail="export archive no longer available")
+    # Atomic one-time consume: the loser of a concurrent download gets None.
+    consumed = await store.consume(token)
+    if consumed is None or consumed.get("export_id") != export_id:
+        raise HTTPException(status_code=404, detail="invalid or expired token")
+    return FileResponse(
+        path,
+        media_type="application/zip",
+        filename=f"metronix-export-{export_id}.zip",
+    )

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -279,6 +279,22 @@ class Settings(BaseSettings):
         default="", alias="METRONIX_FRESHNESS_LLM_API_BASE_URL"
     )
     freshness_llm_api_key: str = Field(default="", alias="METRONIX_FRESHNESS_LLM_API_KEY")
+
+    # --- Data export (one-time-token ZIP export) ---
+    public_base_url: str = Field(default="", alias="METRONIX_PUBLIC_BASE_URL")
+    # Default lives under /app/data, which docker-compose mounts as a persistent
+    # named volume (full_file_data:/app/data); /data alone is ephemeral container
+    # storage and would lose archives on restart and across workers.
+    export_dir: str = Field(default="/app/data/exports", alias="METRONIX_EXPORT_DIR")
+    export_token_ttl_seconds: int = Field(
+        default=3600, alias="METRONIX_EXPORT_TOKEN_TTL_SECONDS", ge=60
+    )
+    export_disk_cap_bytes: int = Field(
+        default=5_000_000_000, alias="METRONIX_EXPORT_DISK_CAP_BYTES", ge=0
+    )
+    export_job_watchdog_seconds: int = Field(
+        default=3600, alias="METRONIX_EXPORT_JOB_WATCHDOG_SECONDS", ge=60
+    )
     freshness_linker_threshold: float = Field(
         default=0.6, alias="METRONIX_FRESHNESS_LINKER_THRESHOLD"
     )

--- a/src/metronix/export/archive.py
+++ b/src/metronix/export/archive.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import zipfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+
+class ExportArchiveWriter:
+    """Stream text entries into a ZIP on disk. Use as a context manager."""
+
+    def __init__(self, dest_path: str) -> None:
+        self._dest = dest_path
+        os.makedirs(os.path.dirname(dest_path) or ".", exist_ok=True)
+        self._zip: zipfile.ZipFile | None = None
+        self.size_bytes = 0
+
+    def __enter__(self) -> ExportArchiveWriter:
+        self._zip = zipfile.ZipFile(self._dest, "w", compression=zipfile.ZIP_DEFLATED)
+        return self
+
+    def write_text(self, arcname: str, text: str) -> None:
+        assert self._zip is not None, "writer is closed"
+        self._zip.writestr(arcname, text)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._zip is not None:
+            self._zip.close()
+            self._zip = None
+        try:
+            self.size_bytes = os.path.getsize(self._dest)
+        except OSError:
+            self.size_bytes = 0

--- a/src/metronix/export/cleanup.py
+++ b/src/metronix/export/cleanup.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+
+
+def sweep_expired_archives(export_dir: str, max_age_seconds: int, *, now_ts: float) -> int:
+    """Delete *.zip files in export_dir older than max_age_seconds. Returns count deleted."""
+    if not os.path.isdir(export_dir):
+        return 0
+    deleted = 0
+    for name in os.listdir(export_dir):
+        if not name.endswith(".zip"):
+            continue
+        path = os.path.join(export_dir, name)
+        try:
+            if now_ts - os.path.getmtime(path) > max_age_seconds:
+                os.remove(path)
+                deleted += 1
+        except OSError:
+            continue
+    return deleted

--- a/src/metronix/export/deps.py
+++ b/src/metronix/export/deps.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from metronix.export.jobs import ExportJobStore
+from metronix.export.service import ExportService
+from metronix.export.tokens import ExportTokenStore
+from metronix.storage.memory_postgres import MemoryPostgresStore
+from metronix.storage.postgres import PostgresStore
+from metronix.storage.redis import RedisStore
+
+if TYPE_CHECKING:
+    from metronix.core.config import Settings
+
+
+class RegisteredAgentsReader:
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def registered_agent_ids(self, ws: str) -> set[str]:
+        try:
+            async with self._engine.begin() as conn:
+                result = await conn.execute(
+                    text("SELECT id FROM agents WHERE workspace_id = :ws"), {"ws": ws}
+                )
+                return {str(r[0]) for r in result.fetchall()}
+        except Exception:  # noqa: BLE001 — agents table optional; flag is best-effort
+            return set()
+
+
+_SERVICE: ExportService | None = None
+
+
+def build_export_service(settings: Settings) -> ExportService:
+    global _SERVICE  # noqa: PLW0603
+    if _SERVICE is not None:
+        return _SERVICE
+
+    engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
+    pg_doc_store = PostgresStore(settings.postgres_dsn)
+    mem_store = MemoryPostgresStore(engine)
+    redis_store = RedisStore(settings.redis_url)
+
+    _SERVICE = ExportService(
+        memory=mem_store,
+        docs=pg_doc_store,
+        registry=RegisteredAgentsReader(engine),
+        job_store=ExportJobStore(engine),
+        token_store=ExportTokenStore(redis_store, settings.export_token_ttl_seconds),
+        archive_dir=settings.export_dir,
+        public_base_url=settings.public_base_url,
+        disk_cap_bytes=settings.export_disk_cap_bytes,
+    )
+    return _SERVICE

--- a/src/metronix/export/jobs.py
+++ b/src/metronix/export/jobs.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import text
+
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+_COLS = (
+    "id, scope, scope_key, status, workspace_count, agent_count, "
+    "memory_record_count, document_count, size_bytes, archive_path, download_token, "
+    "error, created_at, updated_at"
+)
+
+
+def _row_to_job(m: Any) -> ExportJob:
+    scope = m["scope"]
+    if isinstance(scope, str):
+        scope = json.loads(scope)
+    return ExportJob(
+        id=m["id"],
+        scope=ExportScope.from_dict(scope or {}),
+        status=ExportStatus(m["status"]),
+        workspace_count=m["workspace_count"],
+        agent_count=m["agent_count"],
+        memory_record_count=m["memory_record_count"],
+        document_count=m["document_count"],
+        size_bytes=m["size_bytes"],
+        archive_path=m["archive_path"],
+        download_token=m["download_token"],
+        error=m["error"],
+        created_at=m["created_at"],
+        updated_at=m["updated_at"],
+    )
+
+
+class ExportJobStore:
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def create(self, job: ExportJob) -> None:
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO export_jobs (id, scope, scope_key, status) "
+                    "VALUES (:id, CAST(:scope AS jsonb), :scope_key, :status)"
+                ),
+                {
+                    "id": job.id,
+                    "scope": json.dumps(job.scope.to_dict()),
+                    "scope_key": job.scope.key(),
+                    "status": str(job.status),
+                },
+            )
+
+    async def get(self, export_id: str) -> ExportJob | None:
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(f"SELECT {_COLS} FROM export_jobs WHERE id = :id"),
+                {"id": export_id},
+            )
+            row = result.fetchone()
+        return _row_to_job(row._mapping) if row else None
+
+    async def set_status(
+        self, export_id: str, status: ExportStatus, *, error: str | None = None
+    ) -> None:
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE export_jobs SET status = :status, error = :error, "
+                    "updated_at = NOW() WHERE id = :id"
+                ),
+                {"id": export_id, "status": str(status), "error": error},
+            )
+
+    async def set_result(
+        self,
+        export_id: str,
+        *,
+        workspace_count: int,
+        agent_count: int,
+        memory_record_count: int,
+        document_count: int,
+        size_bytes: int,
+        archive_path: str,
+        download_token: str,
+    ) -> None:
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE export_jobs SET workspace_count = :wc, agent_count = :ac, "
+                    "memory_record_count = :mc, document_count = :dc, size_bytes = :sb, "
+                    "archive_path = :path, download_token = :token, updated_at = NOW() "
+                    "WHERE id = :id"
+                ),
+                {
+                    "id": export_id,
+                    "wc": workspace_count,
+                    "ac": agent_count,
+                    "mc": memory_record_count,
+                    "dc": document_count,
+                    "sb": size_bytes,
+                    "path": archive_path,
+                    "token": download_token,
+                },
+            )
+
+    async def find_active_for_scope(self, scope: ExportScope) -> ExportJob | None:
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    f"SELECT {_COLS} FROM export_jobs "
+                    "WHERE scope_key = :k AND status IN ('pending','running') "
+                    "ORDER BY created_at DESC LIMIT 1"
+                ),
+                {"k": scope.key()},
+            )
+            row = result.fetchone()
+        return _row_to_job(row._mapping) if row else None
+
+    async def reap_orphaned(self, older_than_seconds: int) -> int:
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    "UPDATE export_jobs SET status = 'failed', "
+                    "error = 'reaped: running past watchdog timeout', updated_at = NOW() "
+                    "WHERE status IN ('pending','running') "
+                    "AND updated_at < NOW() - make_interval(secs => :secs)"
+                ),
+                {"secs": older_than_seconds},
+            )
+            return result.rowcount or 0

--- a/src/metronix/export/models.py
+++ b/src/metronix/export/models.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+class ExportStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    READY = "ready"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class ExportScope:
+    all_workspaces: bool = False
+    workspace_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"all_workspaces": self.all_workspaces, "workspace_id": self.workspace_id}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ExportScope:
+        return cls(
+            all_workspaces=bool(d.get("all_workspaces", False)),
+            workspace_id=d.get("workspace_id"),
+        )
+
+    def key(self) -> str:
+        return "all" if self.all_workspaces else f"ws:{self.workspace_id}"
+
+
+@dataclass
+class ExportJob:
+    id: str
+    scope: ExportScope
+    status: ExportStatus
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    workspace_count: int = 0
+    agent_count: int = 0
+    memory_record_count: int = 0
+    document_count: int = 0
+    size_bytes: int = 0
+    archive_path: str | None = None
+    download_token: str | None = None
+    error: str | None = None

--- a/src/metronix/export/render.py
+++ b/src/metronix/export/render.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from metronix.core.models import MemoryRecord, RawDocument
+    from metronix.export.models import ExportScope
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def slugify_segment(raw: str, *, max_len: int = 80) -> str:
+    """Return a filesystem-safe single path segment (no separators, no traversal)."""
+    text = _UNSAFE.sub("-", (raw or "").strip())
+    text = text.strip("-._")
+    if text in ("", ".", ".."):
+        text = "item-" + hashlib.sha1((raw or "").encode("utf-8")).hexdigest()[:8]
+    return text[:max_len]
+
+
+def unique_slug(raw: str, used: set[str], *, max_len: int = 80) -> str:
+    """slugify_segment plus a stable hash suffix when the slug is already used."""
+    base = slugify_segment(raw, max_len=max_len)
+    candidate = base
+    if candidate in used:
+        suffix = hashlib.sha1((raw or "").encode("utf-8")).hexdigest()[:8]
+        candidate = f"{base[: max_len - 9]}-{suffix}"
+        n = 1
+        while candidate in used:
+            candidate = f"{base[: max_len - 11]}-{suffix}-{n}"
+            n += 1
+    used.add(candidate)
+    return candidate
+
+
+def _yaml_scalar(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def render_agent_memory(agent_id: str, workspace_id: str, records: list[MemoryRecord]) -> str:
+    lines = [
+        f"# Agent memory: {agent_id}",
+        "",
+        f"- workspace: `{workspace_id}`",
+        f"- agent_id: `{agent_id}`",
+        f"- record_count: {len(records)}",
+        "",
+    ]
+    for rec in records:
+        lines += [
+            "---",
+            "",
+            f"- kind: {rec.kind}",
+            f"- scope: {rec.scope}",
+            f"- status: {rec.status}",
+            f"- importance_score: {rec.importance_score}",
+            f"- created_at: {rec.created_at}",
+            f"- updated_at: {rec.updated_at}",
+            f"- tags: {', '.join(rec.tags) if rec.tags else '(none)'}",
+            "",
+            rec.content,
+            "",
+        ]
+    return "\n".join(lines)
+
+
+def render_document(doc: RawDocument) -> str:
+    front = [
+        "---",
+        f"title: {_yaml_scalar(doc.title)}",
+        f"source_id: {_yaml_scalar(doc.source_id)}",
+        f"connector_type: {_yaml_scalar(doc.connector_type)}",
+        f"url: {_yaml_scalar(doc.url)}",
+        f"author: {_yaml_scalar(doc.author)}",
+        f"status: {_yaml_scalar(str(doc.status))}",
+        f"metadata: {_yaml_scalar(doc.metadata)}",
+        "---",
+        "",
+    ]
+    return "\n".join(front) + (doc.content or "")
+
+
+def build_manifest(
+    *,
+    generated_at: datetime,
+    scope: ExportScope,
+    workspaces: list[str],
+    agents: list[dict[str, Any]],
+    counts: dict[str, Any],
+    limitations: list[str],
+) -> dict[str, Any]:
+    return {
+        "format_version": 1,
+        "generated_at": generated_at.isoformat(),
+        "scope": scope.to_dict(),
+        "workspaces": workspaces,
+        "counts": counts,
+        "agents": agents,
+        "limitations": limitations,
+    }

--- a/src/metronix/export/service.py
+++ b/src/metronix/export/service.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Protocol
+from uuid import uuid4
+
+import structlog
+from sqlalchemy.exc import IntegrityError
+
+from metronix.export.archive import ExportArchiveWriter
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+from metronix.export.render import (
+    build_manifest,
+    render_agent_memory,
+    render_document,
+    unique_slug,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable, Coroutine
+
+    from metronix.core.models import MemoryRecord, RawDocument
+
+logger = structlog.get_logger(__name__)
+
+_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _spawn(coro: Coroutine[Any, Any, None]) -> None:
+    """Schedule a background build task and keep a strong reference to it."""
+    task = asyncio.create_task(coro)
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+
+_MEM_PAGE = 500
+_DOC_PAGE = 200
+_CAP_CHECK_EVERY = 100
+_LIMITATIONS = [
+    "Uploaded files are exported as extracted text only; "
+    "original binary files are not retained by Metronix.",
+]
+
+
+class MemoryReader(Protocol):
+    async def list_workspaces(self) -> list[str]: ...
+    async def list_agent_ids(self, ws: str) -> list[str]: ...
+    async def list_records(
+        self, ws: str, *, agent_id: str, lifetime: str, limit: int, offset: int
+    ) -> list[MemoryRecord]: ...
+
+
+class DocReader(Protocol):
+    async def list_document_workspaces(self) -> list[str]: ...
+    async def list_raw_documents_keyset(
+        self, ws: str, *, after_updated_at: Any, after_id: str | None, limit: int
+    ) -> list[RawDocument]: ...
+
+
+class RegisteredAgents(Protocol):
+    async def registered_agent_ids(self, ws: str) -> set[str]: ...
+
+
+class ExportService:
+    def __init__(
+        self,
+        *,
+        memory: MemoryReader,
+        docs: DocReader,
+        registry: RegisteredAgents,
+        job_store: Any,
+        token_store: Any,
+        archive_dir: str,
+        public_base_url: str,
+        disk_cap_bytes: int,
+        new_id: Callable[[], str] | None = None,
+        now: Callable[[], datetime] | None = None,
+        schedule: Callable[[Coroutine[Any, Any, None]], None] | None = None,
+    ) -> None:
+        self._memory = memory
+        self._docs = docs
+        self._registry = registry
+        self._jobs = job_store
+        self._tokens = token_store
+        self._dir = archive_dir
+        self._base = public_base_url.rstrip("/")
+        self._cap = disk_cap_bytes
+        self._new_id = new_id or (lambda: uuid4().hex)
+        self._now = now or (lambda: datetime.now(UTC))
+        self._schedule = schedule or (lambda coro: _spawn(coro))
+
+    @property
+    def token_store(self) -> Any:
+        """Public accessor for the one-time download token store (used by the route)."""
+        return self._tokens
+
+    async def get_job(self, export_id: str) -> ExportJob | None:
+        """Fetch the raw job (lets the REST layer authorize against its scope)."""
+        job: ExportJob | None = await self._jobs.get(export_id)
+        return job
+
+    async def reap_orphaned_jobs(self, older_than_seconds: int) -> int:
+        """Fail jobs stuck running past the watchdog window (called on startup)."""
+        result: int = await self._jobs.reap_orphaned(older_than_seconds)
+        return result
+
+    async def start(self, scope: ExportScope) -> ExportJob:
+        if not scope.all_workspaces and not scope.workspace_id:
+            raise ValueError("workspace_id is required unless all_workspaces is set")
+        existing: ExportJob | None = await self._jobs.find_active_for_scope(scope)
+        if existing is not None:
+            return existing
+        if self._cap and await asyncio.to_thread(self._dir_size) >= self._cap:
+            raise RuntimeError("export disk cap exceeded; try again after cleanup")
+        job = ExportJob(
+            id=self._new_id(),
+            scope=scope,
+            status=ExportStatus.PENDING,
+            created_at=self._now(),
+            updated_at=self._now(),
+        )
+        try:
+            await self._jobs.create(job)
+        except IntegrityError:
+            # Lost the race against a concurrent start for the same scope — the
+            # unique partial index rejected this insert. Return the winner.
+            winner: ExportJob | None = await self._jobs.find_active_for_scope(scope)
+            if winner is not None:
+                return winner
+            raise
+        self._schedule(self._build_guarded(job.id, scope))
+        return job
+
+    async def status(self, export_id: str) -> dict[str, Any] | None:
+        job: ExportJob | None = await self._jobs.get(export_id)
+        if job is None:
+            return None
+        out: dict[str, Any] = {
+            "export_id": job.id,
+            "status": str(job.status),
+            "counts": {
+                "workspaces": job.workspace_count,
+                "agents": job.agent_count,
+                "memory_records": job.memory_record_count,
+                "documents": job.document_count,
+            },
+            "size_bytes": job.size_bytes,
+        }
+        if job.status == ExportStatus.FAILED:
+            out["error"] = job.error
+        # Token is minted once at build completion and stored on the job; status
+        # reuses it so repeated polling does not create many valid tokens.
+        if job.status == ExportStatus.READY and job.download_token:
+            out["download_url"] = (
+                f"{self._base}/api/v1/export/{job.id}/download?token={job.download_token}"
+            )
+        return out
+
+    def _dir_size(self) -> int:
+        total = 0
+        for root, _dirs, files in os.walk(self._dir):
+            for f in files:
+                with contextlib.suppress(OSError):
+                    total += os.path.getsize(os.path.join(root, f))
+        return total
+
+    async def _resolve_workspaces(self, scope: ExportScope) -> list[str]:
+        if not scope.all_workspaces:
+            return [scope.workspace_id or ""]
+        seen = set(await self._memory.list_workspaces())
+        seen.update(await self._docs.list_document_workspaces())
+        return sorted(seen)
+
+    async def _build_guarded(self, export_id: str, scope: ExportScope) -> None:
+        try:
+            await self._build(export_id, scope)
+        except Exception as exc:  # noqa: BLE001 — record failure, never crash the loop
+            logger.warning("export.build.failed", export_id=export_id, error=str(exc))
+            await self._jobs.set_status(export_id, ExportStatus.FAILED, error=str(exc))
+
+    async def _build(self, export_id: str, scope: ExportScope) -> None:
+        await self._jobs.set_status(export_id, ExportStatus.RUNNING)
+        workspaces = await self._resolve_workspaces(scope)
+        path = os.path.join(self._dir, f"{export_id}.zip")
+        agent_manifest: list[dict[str, Any]] = []
+        n_agents = n_mem = n_docs = 0
+
+        with ExportArchiveWriter(path) as zw:
+            n_writes = 0
+
+            async def write(arcname: str, text: str) -> None:
+                # zipfile compression is CPU-bound; run it off the event loop so a
+                # large export does not block the API. Writes are serialized (one
+                # to_thread at a time), so the single ZipFile stays safe.
+                nonlocal n_writes
+                await asyncio.to_thread(zw.write_text, arcname, text)
+                n_writes += 1
+                # Best-effort disk-cap guard during the build, not only at start().
+                if self._cap and n_writes % _CAP_CHECK_EVERY == 0:
+                    size = await asyncio.to_thread(os.path.getsize, path)
+                    if size >= self._cap:
+                        raise RuntimeError("export exceeded disk cap during build")
+
+            for ws in workspaces:
+                registered = await self._registry.registered_agent_ids(ws)
+                used: set[str] = set()
+                for agent_id in await self._memory.list_agent_ids(ws):
+                    records = await self._collect_records(ws, agent_id)
+                    fname = unique_slug(agent_id, used) + ".md"
+                    arc = f"{ws}/memory/{fname}"
+                    await write(arc, render_agent_memory(agent_id, ws, records))
+                    agent_manifest.append(
+                        {
+                            "agent_id": agent_id,
+                            "workspace_id": ws,
+                            "file": arc,
+                            "registered": agent_id in registered,
+                            "record_count": len(records),
+                        }
+                    )
+                    n_agents += 1
+                    n_mem += len(records)
+
+                doc_used: dict[str, set[str]] = {}
+                async for doc in self._iter_docs(ws):
+                    ct = unique_slug(doc.connector_type or "unknown", set(), max_len=40)
+                    used_for_ct = doc_used.setdefault(ct, set())
+                    base = doc.source_id or doc.title or doc.id
+                    fname = unique_slug(base, used_for_ct) + ".md"
+                    await write(f"{ws}/documents/{ct}/{fname}", render_document(doc))
+                    n_docs += 1
+
+            manifest = build_manifest(
+                generated_at=self._now(),
+                scope=scope,
+                workspaces=workspaces,
+                agents=agent_manifest,
+                counts={
+                    "workspaces": len(workspaces),
+                    "agents": n_agents,
+                    "memory_records": n_mem,
+                    "documents": n_docs,
+                },
+                limitations=_LIMITATIONS,
+            )
+            await write(
+                "manifest.json", json.dumps(manifest, ensure_ascii=False, indent=2)
+            )
+
+        token = await self._tokens.mint(export_id, path)
+        await self._jobs.set_result(
+            export_id,
+            workspace_count=len(workspaces),
+            agent_count=n_agents,
+            memory_record_count=n_mem,
+            document_count=n_docs,
+            size_bytes=zw.size_bytes,
+            archive_path=path,
+            download_token=token,
+        )
+        await self._jobs.set_status(export_id, ExportStatus.READY)
+
+    async def _collect_records(self, ws: str, agent_id: str) -> list[MemoryRecord]:
+        out: list[MemoryRecord] = []
+        offset = 0
+        while True:
+            page = await self._memory.list_records(
+                ws, agent_id=agent_id, lifetime="persistent", limit=_MEM_PAGE, offset=offset
+            )
+            out.extend(page)
+            if len(page) < _MEM_PAGE:
+                return out
+            offset += _MEM_PAGE
+
+    async def _iter_docs(self, ws: str) -> AsyncIterator[RawDocument]:
+        after_updated_at = None
+        after_id = None
+        while True:
+            page = await self._docs.list_raw_documents_keyset(
+                ws, after_updated_at=after_updated_at, after_id=after_id, limit=_DOC_PAGE
+            )
+            for doc in page:
+                yield doc
+            if len(page) < _DOC_PAGE:
+                return
+            after_updated_at = page[-1].updated_at
+            after_id = page[-1].id

--- a/src/metronix/export/service.py
+++ b/src/metronix/export/service.py
@@ -47,22 +47,31 @@ _LIMITATIONS = [
 
 
 class MemoryReader(Protocol):
-    async def list_workspaces(self) -> list[str]: ...
-    async def list_agent_ids(self, ws: str) -> list[str]: ...
+    async def list_workspaces(self) -> list[str]:
+        """Return all workspace ids that have memory."""
+
+    async def list_agent_ids(self, ws: str) -> list[str]:
+        """Return distinct agent ids with memory in a workspace (incl. unregistered)."""
+
     async def list_records(
         self, ws: str, *, agent_id: str, lifetime: str, limit: int, offset: int
-    ) -> list[MemoryRecord]: ...
+    ) -> list[MemoryRecord]:
+        """Return a page of memory records for an agent."""
 
 
 class DocReader(Protocol):
-    async def list_document_workspaces(self) -> list[str]: ...
+    async def list_document_workspaces(self) -> list[str]:
+        """Return all workspace ids that have ingested documents."""
+
     async def list_raw_documents_keyset(
         self, ws: str, *, after_updated_at: Any, after_id: str | None, limit: int
-    ) -> list[RawDocument]: ...
+    ) -> list[RawDocument]:
+        """Return a keyset page of raw documents for a workspace."""
 
 
 class RegisteredAgents(Protocol):
-    async def registered_agent_ids(self, ws: str) -> set[str]: ...
+    async def registered_agent_ids(self, ws: str) -> set[str]:
+        """Return the set of agent ids registered in the agents table."""
 
 
 class ExportService:

--- a/src/metronix/export/tokens.py
+++ b/src/metronix/export/tokens.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import secrets
+from typing import Any, Protocol
+
+
+class _RedisLike(Protocol):
+    async def set(self, key: str, value: str | bytes, ttl: int | None = ...) -> None: ...
+    async def get(self, key: str) -> str | None: ...
+    async def getdel(self, key: str) -> str | None: ...
+
+
+def _key(token: str) -> str:
+    return f"export_token:{token}"
+
+
+def _parse(raw: str | None) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+class ExportTokenStore:
+    def __init__(self, redis: _RedisLike, ttl_seconds: int) -> None:
+        self._redis = redis
+        self._ttl = ttl_seconds
+
+    async def mint(self, export_id: str, path: str) -> str:
+        token = secrets.token_urlsafe(32)
+        payload = json.dumps({"export_id": export_id, "path": path})
+        await self._redis.set(_key(token), payload, ttl=self._ttl)
+        return token
+
+    async def peek(self, token: str) -> dict[str, Any] | None:
+        """Non-destructive read — lets the caller validate before consuming."""
+        return _parse(await self._redis.get(_key(token)))
+
+    async def consume(self, token: str) -> dict[str, Any] | None:
+        """Atomically read-and-delete the token (one-time semantics).
+
+        Uses Redis GETDEL so two concurrent downloads of the same token can't both
+        succeed — exactly one gets the payload, the other gets ``None``.
+        """
+        return _parse(await self._redis.getdel(_key(token)))

--- a/src/metronix/export/tokens.py
+++ b/src/metronix/export/tokens.py
@@ -6,9 +6,14 @@ from typing import Any, Protocol
 
 
 class _RedisLike(Protocol):
-    async def set(self, key: str, value: str | bytes, ttl: int | None = ...) -> None: ...
-    async def get(self, key: str) -> str | None: ...
-    async def getdel(self, key: str) -> str | None: ...
+    async def set(self, key: str, value: str | bytes, ttl: int | None = None) -> None:
+        """Set ``key`` to ``value`` with an optional TTL in seconds."""
+
+    async def get(self, key: str) -> str | None:
+        """Return the value for ``key`` or ``None`` if absent."""
+
+    async def getdel(self, key: str) -> str | None:
+        """Atomically return and delete the value for ``key`` (Redis GETDEL)."""
 
 
 def _key(token: str) -> str:

--- a/src/metronix/mcp/tools/__init__.py
+++ b/src/metronix/mcp/tools/__init__.py
@@ -4,6 +4,7 @@ Importing this package registers all tools with the FastMCP server instance.
 Each tool lives in its own module for clarity and the <200 line rule.
 """
 
+from metronix.mcp.tools.export import metronix_export_data, metronix_export_status
 from metronix.mcp.tools.get import metronix_get
 from metronix.mcp.tools.memory_batch_store import metronix_memory_batch_store
 from metronix.mcp.tools.memory_context import metronix_memory_get_context
@@ -48,4 +49,6 @@ __all__ = [
     "metronix_source_update",
     "metronix_source_delete",
     "metronix_source_sync",
+    "metronix_export_data",
+    "metronix_export_status",
 ]

--- a/src/metronix/mcp/tools/export.py
+++ b/src/metronix/mcp/tools/export.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+from metronix.core.config import get_settings
+from metronix.export.deps import build_export_service
+from metronix.export.models import ExportScope
+from metronix.mcp.errors import ErrorCode, MCPError, handle_tool_error
+from metronix.mcp.server import mcp
+
+
+@mcp.tool(
+    description=(
+        "Export ALL data for a workspace (or all workspaces) to a downloadable ZIP: "
+        "one Markdown file per agent's memory (including unregistered agents) plus "
+        "every ingested document in original whole form. Runs in the background.\n\n"
+        "**Parameters:**\n"
+        "- workspace_id: Target workspace (required unless all_workspaces=true)\n"
+        "- all_workspaces: Export every workspace in one archive (default false)\n\n"
+        "**Returns:** export_id and status. Poll metronix_export_status for the "
+        "download_url once status is 'ready'."
+    ),
+)
+async def metronix_export_data(
+    workspace_id: str | None = None,
+    all_workspaces: bool = False,
+) -> dict[str, Any]:
+    """Start a background data export. No silent 'default' workspace fallback."""
+    try:
+        if not all_workspaces and not workspace_id:
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message=(
+                        "metronix_export_data: workspace_id is required "
+                        "unless all_workspaces=true"
+                    ),
+                    hint="Pass an explicit workspace_id, or set all_workspaces=true",
+                ).to_dict(),
+            }
+        scope = ExportScope(all_workspaces=all_workspaces, workspace_id=workspace_id)
+        service = build_export_service(get_settings())
+        job = await service.start(scope)
+        return {"export_id": job.id, "status": str(job.status)}
+    except Exception as exc:  # noqa: BLE001
+        return {"error": handle_tool_error("metronix_export_data", exc).to_dict()}
+
+
+@mcp.tool(
+    description=(
+        "Check the status of a data export started by metronix_export_data.\n\n"
+        "**Parameters:**\n- export_id: The id returned by metronix_export_data\n\n"
+        "**Returns:** status (pending|running|ready|failed), counts, size_bytes, and "
+        "download_url when ready."
+    ),
+)
+async def metronix_export_status(export_id: str) -> dict[str, Any]:
+    """Return current export status, including a one-time download_url when ready."""
+    try:
+        if not export_id:
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message="metronix_export_status: export_id is required",
+                ).to_dict(),
+            }
+        service = build_export_service(get_settings())
+        result = await service.status(export_id)
+        if result is None:
+            return {
+                "error": MCPError(
+                    code=ErrorCode.DOCUMENT_NOT_FOUND,
+                    message=f"metronix_export_status: no export with id '{export_id}'",
+                ).to_dict(),
+            }
+        return result
+    except Exception as exc:  # noqa: BLE001
+        return {"error": handle_tool_error("metronix_export_status", exc).to_dict()}

--- a/src/metronix/mcp/tools/models.py
+++ b/src/metronix/mcp/tools/models.py
@@ -333,3 +333,21 @@ class SourceSchemasResponse(BaseModel):
     """Response from metronix_source_schemas."""
 
     schemas: list[SourceSchemaDTO]
+
+
+class ExportStartResponse(BaseModel):
+    """Response from metronix_export_data."""
+
+    export_id: str
+    status: str
+
+
+class ExportStatusResponse(BaseModel):
+    """Response from metronix_export_status."""
+
+    export_id: str
+    status: str
+    counts: dict[str, Any] = Field(default_factory=dict)
+    size_bytes: int = 0
+    download_url: str | None = None
+    error: str | None = None

--- a/src/metronix/storage/memory_postgres.py
+++ b/src/metronix/storage/memory_postgres.py
@@ -424,6 +424,16 @@ class MemoryPostgresStore:
             rows = result.fetchall()
         return [str(row[0]) for row in rows]
 
+    async def list_agent_ids(self, workspace_id: str) -> list[str]:
+        """Return distinct agent_ids that have memory in a workspace (incl. unregistered)."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT DISTINCT agent_id FROM memory_records WHERE workspace_id = :ws"),
+                {"ws": workspace_id},
+            )
+            rows = result.fetchall()
+        return [str(row[0]) for row in rows]
+
     async def list_stale_candidates(
         self,
         workspace_id: str,

--- a/src/metronix/storage/postgres.py
+++ b/src/metronix/storage/postgres.py
@@ -1405,6 +1405,46 @@ class PostgresStore:
             )
             return [self._row_to_raw_document(row) for row in result]
 
+    async def list_document_workspaces(self) -> list[str]:
+        """Return distinct workspace_ids present in raw_documents."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT DISTINCT workspace_id FROM raw_documents")
+            )
+            return [str(r[0]) for r in result.fetchall()]
+
+    async def list_raw_documents_keyset(
+        self,
+        workspace_id: str,
+        *,
+        after_updated_at: object | None,
+        after_id: str | None,
+        limit: int = 200,
+    ) -> list[RawDocument]:
+        """Keyset page over (updated_at DESC, id ASC). Pass after_* = None for first page."""
+        params: dict = {"workspace_id": workspace_id, "limit": limit}
+        where = "workspace_id = :workspace_id"
+        if after_updated_at is not None and after_id is not None:
+            # Keyset for ORDER BY updated_at DESC, id ASC: the next page is rows
+            # strictly older, or same timestamp with a larger id (id ASC tiebreak).
+            # A plain row-value `(updated_at, id) < (...)` is WRONG here — it treats
+            # id as DESC and both skips and duplicates rows on updated_at ties.
+            where += (
+                " AND (updated_at < :after_updated_at "
+                "OR (updated_at = :after_updated_at AND id > :after_id))"
+            )
+            params["after_updated_at"] = after_updated_at
+            params["after_id"] = after_id
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    f"SELECT * FROM raw_documents WHERE {where} "
+                    "ORDER BY updated_at DESC, id ASC LIMIT :limit"
+                ),
+                params,
+            )
+            return [self._row_to_raw_document(row) for row in result]
+
     async def count_raw_documents(self, workspace_id: str) -> int:
         """Return the total number of raw_documents for a workspace.
 

--- a/src/metronix/storage/redis.py
+++ b/src/metronix/storage/redis.py
@@ -92,6 +92,10 @@ class RedisStore:
         """Delete one or more keys. Returns number of keys removed."""
         return await self._client.delete(*keys)  # type: ignore[return-value]
 
+    async def getdel(self, key: str) -> str | None:
+        """Atomically get a key's value and delete it (Redis 6.2+ GETDEL)."""
+        return await self._client.getdel(key)  # type: ignore[return-value]
+
     async def exists(self, key: str) -> bool:
         """Check if a key exists."""
         return bool(await self._client.exists(key))

--- a/tests/integration/test_export_data_access.py
+++ b/tests/integration/test_export_data_access.py
@@ -1,0 +1,29 @@
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metronix.core.config import Settings
+from metronix.storage.memory_postgres import MemoryPostgresStore
+from metronix.storage.postgres import PostgresStore
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_list_agent_ids_distinct():
+    engine = create_async_engine(Settings().postgres_dsn, pool_pre_ping=True)
+    store = MemoryPostgresStore(engine)
+    ids = await store.list_agent_ids("nonexistent-ws")
+    assert ids == []  # no rows, but method exists and returns a list
+
+
+@pytest.mark.asyncio
+async def test_doc_keyset_first_page_runs():
+    store = PostgresStore(Settings().postgres_dsn)
+    try:
+        page = await store.list_raw_documents_keyset(
+            "nonexistent-ws", after_updated_at=None, after_id=None, limit=10
+        )
+        assert page == []
+        assert isinstance(await store.list_document_workspaces(), list)
+    finally:
+        await store.close()

--- a/tests/integration/test_export_e2e.py
+++ b/tests/integration/test_export_e2e.py
@@ -1,0 +1,55 @@
+import time
+import zipfile
+
+import pytest
+from starlette.testclient import TestClient
+
+from metronix.api.app import create_app
+from metronix.api.dependencies import resolve_workspace_id
+
+pytestmark = pytest.mark.integration
+
+
+def test_export_e2e_zip_downloadable(tmp_path, monkeypatch):
+    monkeypatch.setenv("METRONIX_EXPORT_DIR", str(tmp_path))
+    monkeypatch.setenv("METRONIX_PUBLIC_BASE_URL", "http://testserver")
+    app = create_app()
+    app.dependency_overrides[resolve_workspace_id] = lambda: "ws_e2e"
+
+    # The status route authorizes against request.state.user; stamp an admin user
+    # so the export-scope access check passes (real deployments use auth middleware).
+    @app.middleware("http")
+    async def _fake_user(request, call_next):
+        request.state.user = {"workspace_ids": ["*"]}
+        return await call_next(request)
+
+    with TestClient(app) as client:
+        started = client.post("/api/v1/export", json={"workspace_id": "ws_e2e"})
+        assert started.status_code == 200
+        export_id = started.json()["export_id"]
+
+        # poll until ready
+        url = None
+        for _ in range(50):
+            st = client.get(f"/api/v1/export/{export_id}").json()
+            if st["status"] == "ready":
+                url = st["download_url"]
+                break
+            if st["status"] == "failed":
+                pytest.fail(f"export failed: {st.get('error')}")
+            time.sleep(0.2)
+        assert url is not None, "export did not become ready"
+
+        # download via the one-time URL (strip host -> path+query for TestClient)
+        path_q = url.split("testserver", 1)[1]
+        dl = client.get(path_q)
+        assert dl.status_code == 200
+        assert dl.headers["content-type"] == "application/zip"
+        zip_path = tmp_path / "downloaded.zip"
+        zip_path.write_bytes(dl.content)
+        with zipfile.ZipFile(zip_path) as z:
+            assert "manifest.json" in z.namelist()
+
+        # token is one-time: second download fails
+        again = client.get(path_q)
+        assert again.status_code == 404

--- a/tests/integration/test_export_job_store.py
+++ b/tests/integration/test_export_job_store.py
@@ -1,0 +1,39 @@
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from metronix.core.config import Settings
+from metronix.export.jobs import ExportJobStore
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_create_get_update_dedup():
+    engine = create_async_engine(Settings().postgres_dsn, pool_pre_ping=True)
+    store = ExportJobStore(engine)
+    scope = ExportScope(workspace_id="ws_test_export")
+    job = ExportJob(id="exp-test-1", scope=scope, status=ExportStatus.PENDING)
+
+    await store.create(job)
+    got = await store.get("exp-test-1")
+    assert got is not None and got.status == ExportStatus.PENDING and got.scope == scope
+
+    active = await store.find_active_for_scope(scope)
+    assert active is not None and active.id == "exp-test-1"
+
+    await store.set_status("exp-test-1", ExportStatus.RUNNING)
+    await store.set_result(
+        "exp-test-1",
+        workspace_count=1,
+        agent_count=2,
+        memory_record_count=5,
+        document_count=3,
+        size_bytes=999,
+        archive_path="/app/data/exports/exp-test-1.zip",
+        download_token="tok-test-1",
+    )
+    await store.set_status("exp-test-1", ExportStatus.READY)
+    done = await store.get("exp-test-1")
+    assert done.status == ExportStatus.READY and done.size_bytes == 999
+    assert await store.find_active_for_scope(scope) is None  # ready != active

--- a/tests/unit/test_export_archive.py
+++ b/tests/unit/test_export_archive.py
@@ -1,0 +1,22 @@
+import zipfile
+
+from metronix.export.archive import ExportArchiveWriter
+
+
+def test_archive_writes_entries(tmp_path):
+    dest = tmp_path / "sub" / "export.zip"
+    with ExportArchiveWriter(str(dest)) as w:
+        w.write_text("manifest.json", "{}")
+        w.write_text("ws1/memory/a.md", "hello")
+    assert dest.exists()
+    with zipfile.ZipFile(dest) as z:
+        assert set(z.namelist()) == {"manifest.json", "ws1/memory/a.md"}
+        assert z.read("ws1/memory/a.md").decode() == "hello"
+
+
+def test_archive_size_after_close(tmp_path):
+    dest = tmp_path / "export.zip"
+    w = ExportArchiveWriter(str(dest))
+    with w:
+        w.write_text("a.txt", "x" * 1000)
+    assert w.size_bytes > 0

--- a/tests/unit/test_export_cleanup.py
+++ b/tests/unit/test_export_cleanup.py
@@ -1,0 +1,16 @@
+import os
+import time
+
+from metronix.export.cleanup import sweep_expired_archives
+
+
+def test_sweep_deletes_old_zips(tmp_path):
+    old = tmp_path / "old.zip"
+    new = tmp_path / "new.zip"
+    old.write_bytes(b"x")
+    new.write_bytes(b"y")
+    now = time.time()
+    os.utime(old, (now - 10_000, now - 10_000))
+    deleted = sweep_expired_archives(str(tmp_path), max_age_seconds=3600, now_ts=now)
+    assert deleted == 1
+    assert not old.exists() and new.exists()

--- a/tests/unit/test_export_config.py
+++ b/tests/unit/test_export_config.py
@@ -1,0 +1,18 @@
+from metronix.core.config import Settings
+
+
+def test_export_settings_defaults():
+    s = Settings()
+    assert s.public_base_url == ""
+    assert s.export_dir == "/app/data/exports"
+    assert s.export_token_ttl_seconds == 3600
+    assert s.export_disk_cap_bytes == 5_000_000_000
+    assert s.export_job_watchdog_seconds == 3600
+
+
+def test_export_settings_env_override(monkeypatch):
+    monkeypatch.setenv("METRONIX_PUBLIC_BASE_URL", "http://host:8001")
+    monkeypatch.setenv("METRONIX_EXPORT_TOKEN_TTL_SECONDS", "120")
+    s = Settings()
+    assert s.public_base_url == "http://host:8001"
+    assert s.export_token_ttl_seconds == 120

--- a/tests/unit/test_export_deps.py
+++ b/tests/unit/test_export_deps.py
@@ -1,0 +1,13 @@
+import metronix.export.deps as deps
+from metronix.core.config import Settings
+from metronix.export.deps import build_export_service
+from metronix.export.service import ExportService
+
+
+def test_build_export_service_constructs(monkeypatch, tmp_path):
+    monkeypatch.setenv("METRONIX_EXPORT_DIR", str(tmp_path))
+    deps._SERVICE = None  # reset module-level cache for a clean test
+    svc = build_export_service(Settings())
+    assert isinstance(svc, ExportService)
+    # cached: same instance on second call
+    assert build_export_service(Settings()) is svc

--- a/tests/unit/test_export_models.py
+++ b/tests/unit/test_export_models.py
@@ -1,0 +1,22 @@
+from datetime import UTC, datetime
+
+from metronix.export.models import ExportJob, ExportScope, ExportStatus
+
+
+def test_scope_roundtrip_and_key():
+    s = ExportScope(all_workspaces=False, workspace_id="ws1")
+    assert ExportScope.from_dict(s.to_dict()) == s
+    assert s.key() == "ws:ws1"
+    assert ExportScope(all_workspaces=True).key() == "all"
+
+
+def test_job_status_enum():
+    now = datetime.now(UTC)
+    job = ExportJob(
+        id="e1",
+        scope=ExportScope(workspace_id="ws1"),
+        status=ExportStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+    )
+    assert job.status == "pending"

--- a/tests/unit/test_export_render.py
+++ b/tests/unit/test_export_render.py
@@ -1,0 +1,57 @@
+from datetime import UTC, datetime
+
+from metronix.core.models import MemoryKind, MemoryRecord, MemoryScope, RawDocument
+from metronix.export.models import ExportScope
+from metronix.export.render import build_manifest, render_agent_memory, render_document
+
+
+def test_render_agent_memory_includes_fields_and_real_id():
+    rec = MemoryRecord(
+        workspace_id="ws1",
+        agent_id="agent/one",
+        scope=MemoryScope.PER_AGENT,
+        kind=MemoryKind.FACT,
+        content="the sky is blue",
+        tags=["color"],
+    )
+    md = render_agent_memory("agent/one", "ws1", [rec])
+    assert "agent/one" in md  # real id preserved verbatim
+    assert "the sky is blue" in md
+    assert "fact" in md and "color" in md
+
+
+def test_render_document_has_front_matter_and_full_content():
+    doc = RawDocument(
+        workspace_id="ws1",
+        connector_type="jira",
+        source_id="PROJ-1",
+        title="Bug",
+        content="full body text",
+        url="http://j/PROJ-1",
+        author="alice",
+        metadata={"status": "Open"},
+    )
+    md = render_document(doc)
+    assert md.startswith("---")  # YAML front matter
+    assert "PROJ-1" in md and "full body text" in md and "alice" in md
+
+
+def test_manifest_shape():
+    man = build_manifest(
+        generated_at=datetime(2026, 6, 24, tzinfo=UTC),
+        scope=ExportScope(workspace_id="ws1"),
+        workspaces=["ws1"],
+        agents=[
+            {
+                "agent_id": "agent/one",
+                "file": "ws1/memory/agent-one.md",
+                "registered": False,
+                "record_count": 1,
+            }
+        ],
+        counts={"workspaces": 1, "agents": 1, "memory_records": 1, "documents": 0},
+        limitations=["uploads are text only"],
+    )
+    assert man["format_version"] == 1
+    assert man["counts"]["agents"] == 1
+    assert man["agents"][0]["agent_id"] == "agent/one"

--- a/tests/unit/test_export_routes.py
+++ b/tests/unit/test_export_routes.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.testclient import TestClient
+
+from metronix.api.routes import export as export_routes
+from metronix.api.routes.export import _authorize_job_access
+from metronix.export.models import ExportScope
+
+
+class FakeSvc:
+    async def start(self, scope):
+        return SimpleNamespace(id="exp1", status="pending")
+
+    async def get_job(self, export_id):
+        if export_id != "exp1":
+            return None
+        return SimpleNamespace(id="exp1", scope=ExportScope(workspace_id="ws1"))
+
+    async def status(self, export_id):
+        if export_id != "exp1":
+            return None
+        return {
+            "export_id": "exp1",
+            "status": "ready",
+            "counts": {},
+            "size_bytes": 0,
+            # relative — the route should absolutize it from the request host
+            "download_url": "/api/v1/export/exp1/download?token=t",
+        }
+
+
+class FakeTokens:
+    async def peek(self, token):
+        if token == "goodtoken":
+            return {"export_id": "exp1", "path": "/nonexistent/exp1.zip"}
+        return None
+
+    async def consume(self, token):
+        if token == "goodtoken":
+            return {"export_id": "exp1", "path": "/nonexistent/exp1.zip"}
+        return None
+
+
+def _app(user_workspaces=None):
+    app = FastAPI()
+    app.state.export_service = FakeSvc()
+    app.state.export_token_store = FakeTokens()
+    from metronix.api.dependencies import resolve_workspace_id
+
+    app.dependency_overrides[resolve_workspace_id] = lambda: "ws1"
+
+    if user_workspaces is not None:
+
+        @app.middleware("http")
+        async def _user(request, call_next):
+            request.state.user = {"workspace_ids": user_workspaces}
+            return await call_next(request)
+
+    app.include_router(export_routes.router, prefix="/api/v1")
+    return app
+
+
+def test_post_export_starts():
+    client = TestClient(_app())
+    r = client.post("/api/v1/export", json={"workspace_id": "ws1"})
+    assert r.status_code == 200 and r.json()["export_id"] == "exp1"
+
+
+def test_download_unknown_token_404():
+    client = TestClient(_app())
+    r = client.get("/api/v1/export/exp1/download?token=badtoken")
+    assert r.status_code == 404
+
+
+def test_download_missing_archive_410_without_consuming():
+    client = TestClient(_app())
+    r = client.get("/api/v1/export/exp1/download?token=goodtoken")
+    assert r.status_code == 410
+
+
+def test_status_authorized_absolutizes_url():
+    client = TestClient(_app(user_workspaces=["ws1"]))
+    r = client.get("/api/v1/export/exp1")
+    assert r.status_code == 200
+    assert r.json()["download_url"] == "http://testserver/api/v1/export/exp1/download?token=t"
+
+
+def test_status_foreign_workspace_403():
+    client = TestClient(_app(user_workspaces=["other"]))
+    r = client.get("/api/v1/export/exp1")
+    assert r.status_code == 403
+
+
+def test_routes_503_when_service_missing():
+    app = FastAPI()  # no export_service on state
+    from metronix.api.dependencies import resolve_workspace_id
+
+    app.dependency_overrides[resolve_workspace_id] = lambda: "ws1"
+    app.include_router(export_routes.router, prefix="/api/v1")
+    r = TestClient(app).post("/api/v1/export", json={"workspace_id": "ws1"})
+    assert r.status_code == 503
+
+
+def _req(workspace_ids):
+    return SimpleNamespace(state=SimpleNamespace(user={"workspace_ids": workspace_ids}))
+
+
+def test_authz_allows_owning_workspace():
+    _authorize_job_access(_req(["ws1"]), ExportScope(workspace_id="ws1"))  # no raise
+
+
+def test_authz_denies_foreign_workspace():
+    with pytest.raises(HTTPException) as exc:
+        _authorize_job_access(_req(["ws2"]), ExportScope(workspace_id="ws1"))
+    assert exc.value.status_code == 403
+
+
+def test_authz_all_workspaces_requires_admin():
+    with pytest.raises(HTTPException) as exc:
+        _authorize_job_access(_req(["ws1"]), ExportScope(all_workspaces=True))
+    assert exc.value.status_code == 403
+    _authorize_job_access(_req(["*"]), ExportScope(all_workspaces=True))  # admin: no raise

--- a/tests/unit/test_export_service.py
+++ b/tests/unit/test_export_service.py
@@ -1,0 +1,140 @@
+import zipfile
+from datetime import UTC, datetime
+
+import pytest
+
+from metronix.core.models import MemoryRecord, RawDocument
+from metronix.export.models import ExportScope, ExportStatus
+from metronix.export.service import ExportService
+
+
+class FakeMemory:
+    async def list_workspaces(self):
+        return ["ws1"]
+
+    async def list_agent_ids(self, ws):
+        return ["agent/one", "ghost"]
+
+    async def list_records(self, ws, *, agent_id, lifetime, limit, offset):
+        if offset > 0:
+            return []
+        return [MemoryRecord(workspace_id=ws, agent_id=agent_id, content=f"m-{agent_id}")]
+
+
+class FakeDocs:
+    async def list_document_workspaces(self):
+        return ["ws1"]
+
+    async def list_raw_documents_keyset(self, ws, *, after_updated_at, after_id, limit):
+        if after_id is not None:
+            return []
+        return [
+            RawDocument(
+                id="d1",
+                workspace_id=ws,
+                connector_type="jira",
+                source_id="PROJ-1",
+                content="body",
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        ]
+
+
+class FakeRegistry:
+    async def registered_agent_ids(self, ws):
+        return {"agent/one"}  # 'ghost' is unregistered
+
+
+class FakeJobs:
+    def __init__(self):
+        self.jobs = {}
+
+    async def create(self, job):
+        self.jobs[job.id] = job
+
+    async def get(self, export_id):
+        return self.jobs.get(export_id)
+
+    async def set_status(self, export_id, status, *, error=None):
+        self.jobs[export_id].status = status
+        self.jobs[export_id].error = error
+
+    async def set_result(self, export_id, **kw):
+        j = self.jobs[export_id]
+        for k, v in kw.items():
+            setattr(j, k, v)
+
+    async def find_active_for_scope(self, scope):
+        for j in self.jobs.values():
+            if j.scope.key() == scope.key() and j.status in (
+                ExportStatus.PENDING,
+                ExportStatus.RUNNING,
+            ):
+                return j
+        return None
+
+
+class FakeTokens:
+    async def mint(self, export_id, path):
+        return "tok-123"
+
+
+def _service(tmp_path, jobs):
+    return ExportService(
+        memory=FakeMemory(),
+        docs=FakeDocs(),
+        registry=FakeRegistry(),
+        job_store=jobs,
+        token_store=FakeTokens(),
+        archive_dir=str(tmp_path),
+        public_base_url="http://host:8001",
+        disk_cap_bytes=10_000_000,
+        new_id=lambda: "exp1",
+        now=lambda: datetime(2026, 6, 24, tzinfo=UTC),
+        schedule=lambda coro: coro.close(),  # no background build in tests
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_produces_zip_with_all_agents_and_docs(tmp_path):
+    jobs = FakeJobs()
+    svc = _service(tmp_path, jobs)
+    scope = ExportScope(workspace_id="ws1")
+    job = await svc.start(scope)
+    await svc._build(job.id, scope)  # run synchronously for assertion
+
+    done = await jobs.get(job.id)
+    assert done.status == ExportStatus.READY
+    assert done.agent_count == 2 and done.document_count == 1
+
+    with zipfile.ZipFile(done.archive_path) as z:
+        names = z.namelist()
+        assert "manifest.json" in names
+        assert any(n.startswith("ws1/memory/") for n in names)
+        assert any(n.startswith("ws1/documents/jira/") for n in names)
+        manifest = z.read("manifest.json").decode()
+    assert "ghost" in manifest  # unregistered agent included
+
+
+@pytest.mark.asyncio
+async def test_status_returns_download_url_when_ready(tmp_path):
+    jobs = FakeJobs()
+    svc = _service(tmp_path, jobs)
+    scope = ExportScope(workspace_id="ws1")
+    job = await svc.start(scope)
+    await svc._build(job.id, scope)
+    st = await svc.status(job.id)
+    assert st["status"] == "ready"
+    assert st["download_url"] == (
+        "http://host:8001/api/v1/export/exp1/download?token=tok-123"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dedup_returns_existing_active_job(tmp_path):
+    jobs = FakeJobs()
+    svc = _service(tmp_path, jobs)
+    scope = ExportScope(workspace_id="ws1")
+    j1 = await svc.start(scope)
+    j2 = await svc.start(scope)  # active job exists -> returns same
+    assert j1.id == j2.id

--- a/tests/unit/test_export_slug.py
+++ b/tests/unit/test_export_slug.py
@@ -1,0 +1,20 @@
+from metronix.export.render import slugify_segment, unique_slug
+
+
+def test_slug_strips_path_chars():
+    assert "/" not in slugify_segment("a/b/../c")
+    assert "\\" not in slugify_segment("a\\b")
+    assert slugify_segment("..") not in ("", ".", "..")
+
+
+def test_slug_non_empty_for_garbage():
+    assert slugify_segment("***") != ""
+    assert slugify_segment("") != ""
+
+
+def test_unique_slug_collision_suffix():
+    used: set[str] = set()
+    a = unique_slug("agent/one", used)
+    b = unique_slug("agent/one", used)  # same raw -> same slug -> collision
+    assert a != b
+    assert a in used and b in used

--- a/tests/unit/test_export_tokens.py
+++ b/tests/unit/test_export_tokens.py
@@ -1,0 +1,43 @@
+import pytest
+
+from metronix.export.tokens import ExportTokenStore
+
+
+class FakeRedis:
+    def __init__(self):
+        self.kv: dict[str, str] = {}
+
+    async def set(self, key, value, ttl=None):
+        self.kv[key] = value if isinstance(value, str) else value.decode()
+
+    async def get(self, key):
+        return self.kv.get(key)
+
+    async def getdel(self, key):
+        return self.kv.pop(key, None)
+
+
+@pytest.mark.asyncio
+async def test_mint_then_consume_is_one_time():
+    store = ExportTokenStore(FakeRedis(), ttl_seconds=60)
+    token = await store.mint("exp1", "/data/exports/exp1.zip")
+    assert len(token) >= 22  # token_urlsafe(32) ~ 43 chars
+    first = await store.consume(token)
+    assert first == {"export_id": "exp1", "path": "/data/exports/exp1.zip"}
+    assert await store.consume(token) is None  # consumed (atomic getdel)
+
+
+@pytest.mark.asyncio
+async def test_peek_is_non_destructive():
+    store = ExportTokenStore(FakeRedis(), ttl_seconds=60)
+    token = await store.mint("exp1", "/p/exp1.zip")
+    assert await store.peek(token) == {"export_id": "exp1", "path": "/p/exp1.zip"}
+    # peek did not consume; consume still works once
+    assert await store.consume(token) is not None
+    assert await store.peek(token) is None
+
+
+@pytest.mark.asyncio
+async def test_consume_unknown_token():
+    store = ExportTokenStore(FakeRedis(), ttl_seconds=60)
+    assert await store.consume("nope") is None

--- a/tests/unit/test_mcp_export_tools.py
+++ b/tests/unit/test_mcp_export_tools.py
@@ -1,0 +1,29 @@
+import pytest
+
+import metronix.mcp.tools.export as export_tool
+
+
+@pytest.mark.asyncio
+async def test_export_data_requires_explicit_scope():
+    res = await export_tool.metronix_export_data()
+    assert "error" in res
+    assert res["error"]["code"] == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_export_data_starts_job(monkeypatch):
+    class FakeJob:
+        id = "exp9"
+        status = "pending"
+
+    class FakeSvc:
+        async def start(self, scope):
+            assert scope.workspace_id == "ws1"
+            return FakeJob()
+
+        async def status(self, export_id):
+            return {"export_id": export_id, "status": "pending", "counts": {}, "size_bytes": 0}
+
+    monkeypatch.setattr(export_tool, "build_export_service", lambda s: FakeSvc())
+    res = await export_tool.metronix_export_data(workspace_id="ws1")
+    assert res["export_id"] == "exp9" and res["status"] == "pending"


### PR DESCRIPTION
## What

Adds a **data export** so a leaving user can take everything out: all agent memory and all ingested documents, delivered as a single ZIP via a one-time-token download URL. Triggered over MCP or REST.

- **Agent memory** → one Markdown file per agent (`<agent_id>.md`), including **unregistered agents** (enumerated from `memory_records`, not the `agents` table). Persistent records of all lifecycle statuses; session/TTL records excluded.
- **Ingested documents** → original whole form (full content + metadata front matter), grouped by `connector_type` (jira, confluence, …) — not the embedding chunks.
- **Delivery** → background build, status polling, `application/zip` download authorized solely by a one-time token in the URL.

## Surfaces (thin layers over a shared `ExportService`)

- MCP: `metronix_export_data(workspace_id?, all_workspaces=false)`, `metronix_export_status(export_id)` — no silent `"default"` workspace fallback.
- REST: `POST /api/v1/export`, `GET /api/v1/export/{id}`, `GET /api/v1/export/{id}/download?token=…`.

## Design notes

- Durable `export_jobs` table (migration **026**) with a **UNIQUE partial index** → one active job per scope (TOCTOU closed via `IntegrityError`).
- In-process `asyncio` build (not `BackgroundTasks`) + startup **watchdog**; ZIP compression offloaded with `asyncio.to_thread` so it never blocks the event loop.
- One-time CSPRNG token, **atomic GETDEL**, minted once at completion and stored on the job (polling does not mint new tokens); peek-before-consume so a missing archive doesn't burn the token.
- Scope **authorization** on status (`all_workspaces` admin-only; otherwise caller must have access to the job's workspace).
- Keyset pagination over `(updated_at DESC, id ASC)` for documents.
- New settings: `public_base_url`, `export_dir` (default `/app/data/exports`, on the persistent volume), `export_token_ttl_seconds`, `export_disk_cap_bytes`, `export_job_watchdog_seconds`.

Spec & plan: `docs/specs/2026-06-24-data-export-design.md`, `docs/specs/2026-06-24-data-export-plan.md`.

## Tests

- Unit (24+): renderers, slugification, archive writer, token store (one-time/atomic), `ExportService` orchestration, deps, cleanup, REST routes + scope authz, MCP tools. Require `aiosqlite` (added to `dev` extras).
- Integration (require PG/Redis): job store, data-access helpers, end-to-end HTTP export+download.

## Manual verification

Ran the API locally against a live Docker stack: applied migration 026, exported workspace MTRNIX — **673 documents** (jira+confluence, keyset across 4 pages, 0 duplicates / 0 skips) and **5 memory records across 2 agents** (registered + unregistered, slugified id, all statuses, session record correctly excluded); download returned a valid ZIP, second download `404` (one-time); concurrent triggers deduped to one `export_id`; UTF-8/Cyrillic preserved.

## Deferred follow-ups (single-worker deploy today)

Reuse shared `app.state` PG/Redis pools in `deps.py`; make the service singleton honor its `settings` arg + dispose engines on shutdown; worker lease for `reap_orphaned` under multi-worker; enforce disk cap mid-build beyond the periodic check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)