### PR TITLE
fix(installer): harden config flow and make LLM setup scenario-driven

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,7 +135,11 @@ DEFAULT_WORKSPACE_NAME=MTRNIX
 WORKSPACE_PERSISTENCE=neo4j           # neo4j | postgres
 
 # --- Model defaults (override only if you need a specific model) ---
-OLLAMA_CHAT_MODEL=llama3.1:8b
+# OLLAMA_CHAT_MODEL: empty by default. The bundled Ollama runs embeddings only;
+# it does NOT pull a chat model unless you set one here (advanced: run a local
+# chat model in the bundled Ollama, costs a multi-GB download). For answer
+# generation prefer LLM_PROVIDER=custom with an endpoint (see ZONE 3 below).
+OLLAMA_CHAT_MODEL=
 OLLAMA_EMBED_MODEL=nomic-embed-text   # 768-dim; always used for embeddings
 METRONIX_AUX_LLM_TIMEOUT=10           # aux LLM (expansion/classifier) timeout, sec
 LLM_FALLBACK_PROVIDER=                # fallback provider if primary fails
@@ -213,27 +217,29 @@ METRONIX_SEARCH_FAST_INCLUDE_METADATA=true
 # this file to .env.
 # #############################################################################
 
-# --- 1) LLM provider + credentials -----------------------------------------
-# Used for the search answer-generation step. Embeddings always run on the
-# bundled Ollama regardless.
+# --- 1) Answer generation (chat) -------------------------------------------
+# ONLY needed if Metronix generates written answers itself. If you use Metronix
+# as a memory store behind your own agent (e.g. Hermes), the agent does the
+# answering — leave this as the default and skip it.
 #
-# ollama (built-in, works out of the box — default):
+# Embeddings ALWAYS run on the bundled Ollama (nomic-embed-text); they do NOT
+# depend on anything in this section.
+#
+# memory store (default — no answer generation here):
 #   LLM_PROVIDER=ollama
 #
-# custom: any OpenAI-compatible endpoint (DeepSeek, OpenRouter, vLLM, LocalAI, …)
+# Metronix generates answers — point it at ONE OpenAI-compatible endpoint.
+# This covers a local Ollama (via its /v1 path), a self-hosted vLLM/LocalAI,
+# or a cloud API. URL and model are required; the API key is optional
+# (leave blank for a local/internal endpoint with no auth):
 #   LLM_PROVIDER=custom
-#   LLM_PROVIDER_URL=https://your-llm-endpoint/v1
-#   LLM_PROVIDER_API_KEY=your-key
-#   LLM_PROVIDER_MODEL=deepseek-chat        # model the endpoint serves (required)
-#
-# ollama on an EXTERNAL host (NOT the bundled one — requires removing the
-# OLLAMA_HOST override in docker-compose for the API service):
-#   LLM_PROVIDER=ollama
-#   OLLAMA_HOST=http://your-ollama-host:11434
+#   LLM_PROVIDER_URL=http://host.docker.internal:11434/v1   # or https://api.deepseek.com/v1
+#   LLM_PROVIDER_MODEL=llama3.1:8b                           # or deepseek-chat (required)
+#   LLM_PROVIDER_API_KEY=                                    # optional; blank = no auth
 #
 LLM_PROVIDER=ollama
 LLM_PROVIDER_URL=
-LLM_PROVIDER_API_KEY=
+LLM_PROVIDER_API_KEY=                 # optional; blank = no auth on the endpoint
 LLM_PROVIDER_MODEL=                   # required when LLM_PROVIDER=custom
 
 OLLAMA_HOST=http://ollama:11434    # bundled stack overrides this to http://ollama:11434

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -89,7 +89,11 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # Ollama — embeddings (auto-pulls model on first start)
+  # Ollama — embeddings only (auto-pulls the embedding model on first start).
+  # The chat model is NOT pulled by default: a bare memory-store install (the
+  # common case) never generates answers locally, so pulling a multi-GB chat
+  # model would waste bandwidth and disk. A chat model is pulled only if
+  # OLLAMA_CHAT_MODEL is set non-empty in .env (advanced: run a local chat model).
   # ---------------------------------------------------------------------------
   ollama:
     image: ollama/ollama:latest
@@ -102,7 +106,7 @@ services:
       - metronix_full
     environment:
       OLLAMA_EMBED_MODEL: nomic-embed-text
-      OLLAMA_CHAT_MODEL: llama3.1:8b
+      OLLAMA_CHAT_MODEL: ${OLLAMA_CHAT_MODEL-}
     entrypoint: ["/bin/bash", "-c", "ollama serve & for i in $$(seq 1 30); do sleep 1; ollama list >/dev/null 2>&1 && break; done; ollama pull $$OLLAMA_EMBED_MODEL; [ -n \"$$OLLAMA_CHAT_MODEL\" ] && ollama pull $$OLLAMA_CHAT_MODEL; wait"]
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/11434 && exec 3>&-'"]

--- a/install.sh
+++ b/install.sh
@@ -9,11 +9,10 @@ EXAMPLE_FILE=".env.example"
 API_PORT=8000
 WEBUI_PORT=3080
 
-PROVIDER=""
-API_KEY=""
-OLLAMA_HOST=""
-CUSTOM_URL=""
-CUSTOM_MODEL=""
+MODE=""              # "memory" | "answers" (how Metronix is used)
+CHAT_URL=""          # OpenAI-compatible chat-model endpoint (answers mode)
+CHAT_MODEL=""        # model name the endpoint serves (answers mode)
+CHAT_API_KEY=""      # bearer token for the endpoint (optional; blank = no auth)
 ENABLE_WEBUI=false
 ASSUME_YES=false
 RECONFIGURE=false
@@ -29,38 +28,72 @@ ok()   { printf '%s\xe2\x9c\x93%s %s\n' "$C_OK" "$C_RST" "$*"; }
 warn() { printf '%s!%s %s\n' "$C_WARN" "$C_RST" "$*"; }
 err()  { printf '%s\xe2\x9c\x97%s %s\n' "$C_ERR" "$C_RST" "$*" >&2; }
 
+# Prompt for a required value, re-asking until the user enters something non-blank.
+# Usage: prompt_required VAR_NAME "Prompt text: " [secret]
+# Passing "secret" as the 3rd arg hides the input (for API keys).
+prompt_required() {
+  local __var="$1" __prompt="$2" __secret="${3:-}" __input
+  while true; do
+    if [[ "$__secret" == secret ]]; then
+      read -rsp "$__prompt" __input || { echo; err "Aborted (no input)."; exit 1; }
+      echo
+    else
+      read -rp "$__prompt" __input || { err "Aborted (no input)."; exit 1; }
+    fi
+    if [[ -n "$__input" ]]; then
+      printf -v "$__var" '%s' "$__input"
+      return 0
+    fi
+    warn "This value is required — please enter it (or press Ctrl-C to abort)."
+  done
+}
+
 usage() {
   cat <<'EOF'
 Usage: ./install.sh [options]
 
 Builds and starts Metronix Core from source via docker-compose.full.yml.
 
+Vector embeddings always run locally on the bundled Ollama (model:
+nomic-embed-text), set up automatically — no configuration needed. The options
+below only concern answer generation (chat).
+
 Options:
-  --provider <name>    LLM provider: ollama (default) | custom
-  --api-key <key>      API key for the custom endpoint (provider=custom)
-  --ollama-host <url>  External Ollama host (provider=ollama; blank uses bundled Ollama)
-  --custom-url <url>   Endpoint URL, e.g. https://api.deepseek.com/v1 (provider=custom)
-  --custom-model <m>   Model name the endpoint serves, e.g. deepseek-chat (provider=custom)
-  --openwebui          Enable the Open WebUI chat interface (:3080)
-  -y, --yes            Non-interactive: use defaults/flags, never prompt
-  --reconfigure        Re-run configuration even if .env already exists
-  -h, --help           Show this help
+  --mode <memory|answers>  How Metronix is used:
+                             memory  = a memory store for your own agent (e.g.
+                                       Hermes); the agent generates its own
+                                       answers. No chat model needed. (default)
+                             answers = Metronix generates answers itself; point
+                                       it at a chat-model endpoint below.
+  --chat-url <url>         Chat-model endpoint, OpenAI-compatible (mode=answers):
+                             http://host.docker.internal:11434/v1  (local Ollama)
+                             https://api.deepseek.com/v1           (a cloud API)
+  --chat-model <name>      Model the endpoint serves, e.g. deepseek-chat, llama3.1:8b
+  --chat-api-key <key>     Bearer token for the endpoint (optional; blank = no auth)
+  --openwebui              Enable the Open WebUI chat interface (:3080)
+  -y, --yes                Non-interactive: use defaults/flags, never prompt
+  --reconfigure            Re-run configuration even if .env already exists
+  -h, --help               Show this help
+
+If --chat-url is given, --mode defaults to "answers"; otherwise "memory".
 
 Examples:
-  ./install.sh
-  ./install.sh --provider custom --custom-url https://api.deepseek.com/v1 --api-key sk-... --custom-model deepseek-chat --openwebui
-  ./install.sh --provider ollama --yes
+  ./install.sh                                    # memory store for an agent (default)
+  ./install.sh --mode answers \
+      --chat-url https://api.deepseek.com/v1 --chat-model deepseek-chat \
+      --chat-api-key sk-...
+  ./install.sh --chat-url http://host.docker.internal:11434/v1 \
+      --chat-model llama3.1:8b -y                 # local Ollama, no token
 EOF
 }
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --provider)    [[ $# -ge 2 ]] || { err "--provider requires a value"; exit 2; }; PROVIDER="$2"; shift 2 ;;
-      --api-key)     [[ $# -ge 2 ]] || { err "--api-key requires a value"; exit 2; }; API_KEY="$2"; shift 2 ;;
-      --ollama-host) [[ $# -ge 2 ]] || { err "--ollama-host requires a value"; exit 2; }; OLLAMA_HOST="$2"; shift 2 ;;
-      --custom-url)   [[ $# -ge 2 ]] || { err "--custom-url requires a value"; exit 2; }; CUSTOM_URL="$2"; shift 2 ;;
-      --custom-model) [[ $# -ge 2 ]] || { err "--custom-model requires a value"; exit 2; }; CUSTOM_MODEL="$2"; shift 2 ;;
+      --mode)         [[ $# -ge 2 ]] || { err "--mode requires a value"; exit 2; }; MODE="$2"; shift 2 ;;
+      --chat-url)     [[ $# -ge 2 ]] || { err "--chat-url requires a value"; exit 2; }; CHAT_URL="$2"; shift 2 ;;
+      --chat-model)   [[ $# -ge 2 ]] || { err "--chat-model requires a value"; exit 2; }; CHAT_MODEL="$2"; shift 2 ;;
+      --chat-api-key) [[ $# -ge 2 ]] || { err "--chat-api-key requires a value"; exit 2; }; CHAT_API_KEY="$2"; shift 2 ;;
       --openwebui)   ENABLE_WEBUI=true; shift ;;
       -y|--yes)      ASSUME_YES=true; shift ;;
       --reconfigure) RECONFIGURE=true; shift ;;
@@ -177,69 +210,125 @@ configure() {
   prev_fernet="$(get_env FERNET_KEY)"
 
   [[ -f "$EXAMPLE_FILE" ]] || { err "$EXAMPLE_FILE not found in $(pwd)"; exit 1; }
+
+  # Stage the new config in a temp file and promote it to $ENV_FILE only after
+  # everything validates. A partial or aborted run (e.g. a blank required field)
+  # must never leave a half-written .env behind — otherwise the next run sees an
+  # existing .env, skips all prompts, and launches with a broken config.
+  local final_env="$ENV_FILE"
+  ENV_FILE="$(mktemp "${final_env}.XXXXXX")"
+  trap 'rm -f "$ENV_FILE"' EXIT
   cp "$EXAMPLE_FILE" "$ENV_FILE"
 
-  if [[ -z "$PROVIDER" ]]; then
+  info "Vector embeddings run locally on the bundled Ollama (model: nomic-embed-text),"
+  info "set up automatically. The choice below is only about answer generation (chat)."
+  info ""
+
+  # Pick the scenario: pure memory store vs. Metronix generating answers itself.
+  if [[ -z "$MODE" ]]; then
     if [[ "$ASSUME_YES" == true ]]; then
-      PROVIDER="ollama"
+      # Non-interactive: a chat endpoint implies "answers"; otherwise "memory".
+      if [[ -n "$CHAT_URL" ]]; then MODE=answers; else MODE=memory; fi
     else
-      info "LLM provider(for answer and search generation):"
-      info "  1) ollama     (bundled, no API key — default)"
-      info "  2) custom     (any OpenAI-compatible endpoint — DeepSeek, OpenRouter, vLLM, ...)"
-      read -rp "Choose [1-2] (1): " ans
+      info "How will you use Metronix?"
+      info "  1) As a memory store for your own agent, e.g. Hermes   [default]"
+      info "       The agent reads/writes memories and generates its own answers."
+      info "       No chat model is needed here."
+      info "  2) Standalone — Metronix generates the answers itself"
+      info "       You will point it at a chat-model endpoint next."
+      info ""
+      read -rp "Choose 1 or 2 [default: 1]: " ans || { err "Aborted (no input)."; exit 1; }
       case "${ans:-1}" in
-        1|"") PROVIDER=ollama ;;
-        2)    PROVIDER=custom ;;
+        1|"") MODE=memory ;;
+        2)    MODE=answers ;;
         *)    err "Invalid choice: $ans"; exit 1 ;;
       esac
     fi
   fi
-  case "$PROVIDER" in
-    ollama|custom) ;;
-    *)
-      err "Unsupported provider: $PROVIDER. Supported: ollama | custom."
-      err "Use --provider custom --custom-url URL --custom-model MODEL for external endpoints."
-      exit 1
-      ;;
-  esac
-  set_env LLM_PROVIDER "$PROVIDER"
-
-  case "$PROVIDER" in
-    custom)
-      if [[ -z "$API_KEY" && "$ASSUME_YES" == false ]]; then
-        read -rsp "API key for the endpoint: " API_KEY; echo
-      fi
-      [[ -n "$API_KEY" ]] || { err "custom provider requires an API key (--api-key)"; exit 1; }
-      set_env LLM_PROVIDER_API_KEY "$API_KEY"
-      if [[ -z "$CUSTOM_URL" && "$ASSUME_YES" == false ]]; then
-        read -rp "Endpoint URL (https://host/v1, e.g. https://api.deepseek.com/v1): " CUSTOM_URL
-      fi
-      [[ -n "$CUSTOM_URL" ]] || { err "custom provider requires --custom-url"; exit 1; }
-      set_env LLM_PROVIDER_URL "$CUSTOM_URL"
-      if [[ -z "$CUSTOM_MODEL" && "$ASSUME_YES" == false ]]; then
-        read -rp "Model the endpoint serves (e.g. deepseek-chat): " CUSTOM_MODEL
-      fi
-      [[ -n "$CUSTOM_MODEL" ]] || { err "custom provider requires a model (--custom-model)"; exit 1; }
-      set_env LLM_PROVIDER_MODEL "$CUSTOM_MODEL"
-      ;;
-    ollama)
-      if [[ -z "$OLLAMA_HOST" && "$ASSUME_YES" == false ]]; then
-        read -rp "External Ollama host URL (blank = use bundled Ollama): " OLLAMA_HOST
-      fi
-      [[ -n "$OLLAMA_HOST" ]] && set_env OLLAMA_HOST "$OLLAMA_HOST"
-      ;;
+  case "$MODE" in
+    memory|answers) ;;
+    *) err "Unsupported --mode: $MODE. Use 'memory' or 'answers'."; exit 1 ;;
   esac
 
-  if [[ "$ENABLE_WEBUI" == false && "$ASSUME_YES" == false ]]; then
-    read -rp "Enable Open WebUI chat interface (:$WEBUI_PORT)? [y/N]: " ans
-    [[ "$ans" =~ ^[Yy] ]] && ENABLE_WEBUI=true
+  if [[ "$MODE" == answers ]]; then
+    # One OpenAI-compatible endpoint covers everything: a local Ollama via its
+    # /v1 path, a self-hosted vLLM/LocalAI, or a cloud API. URL and model are
+    # required; the token is optional (blank = an internal endpoint with no auth).
+    if [[ -z "$CHAT_URL" ]]; then
+      [[ "$ASSUME_YES" == true ]] && { err "mode=answers requires a chat endpoint (--chat-url)"; exit 1; }
+      info "Chat-model endpoint (OpenAI-compatible)."
+      info "Examples: http://host.docker.internal:11434/v1 (a local Ollama), https://api.deepseek.com/v1"
+      prompt_required CHAT_URL "Endpoint URL: "
+    fi
+    if [[ -z "$CHAT_MODEL" ]]; then
+      [[ "$ASSUME_YES" == true ]] && { err "mode=answers requires a model name (--chat-model)"; exit 1; }
+      prompt_required CHAT_MODEL "Model name (e.g. llama3.1:8b, deepseek-chat): "
+    fi
+    if [[ -z "$CHAT_API_KEY" && "$ASSUME_YES" == false ]]; then
+      # Optional on purpose: a local/internal endpoint may need no authentication.
+      read -rsp "API key (leave blank for a local/internal endpoint with no auth): " CHAT_API_KEY \
+        || { echo; err "Aborted (no input)."; exit 1; }
+      echo
+    fi
+    set_env LLM_PROVIDER custom
+    set_env LLM_PROVIDER_URL "$CHAT_URL"
+    set_env LLM_PROVIDER_MODEL "$CHAT_MODEL"
+    set_env LLM_PROVIDER_API_KEY "$CHAT_API_KEY"
+    set_env OLLAMA_CHAT_MODEL ""   # bundled Ollama stays embeddings-only
+    ok "Answer generation -> $CHAT_URL (model: $CHAT_MODEL)"
+  else
+    # Memory store: the connected agent does the answering. No chat model is
+    # configured and the bundled Ollama never pulls one (embeddings only).
+    set_env LLM_PROVIDER ollama
+    set_env OLLAMA_CHAT_MODEL ""
+    ok "Memory-store mode — no answer-generation model configured."
   fi
 
-  set_env POSTGRES_PASSWORD "$(resolve_secret POSTGRES_PASSWORD "$prev_pg" "$(gen_secret)")"
-  set_env NEO4J_PASSWORD "$(resolve_secret NEO4J_PASSWORD "$prev_neo" "$(gen_secret)")"
-  set_env METRONIX_MCP_API_KEY "$(resolve_secret METRONIX_MCP_API_KEY "$prev_mcp" "$(gen_secret)")"
-  set_env FERNET_KEY "$(resolve_secret FERNET_KEY "$prev_fernet" "$(gen_fernet)")"
+  # Open WebUI is a chat front-end — it only works once Metronix can generate
+  # answers itself (mode=answers). In memory-store mode there is no chat model,
+  # so it is skipped entirely; a stray --openwebui there is ignored with a warning.
+  if [[ "$MODE" != answers ]]; then
+    if [[ "$ENABLE_WEBUI" == true ]]; then
+      warn "Open WebUI needs a chat model — ignoring --openwebui in memory-store mode (use --mode answers)."
+      ENABLE_WEBUI=false
+    fi
+  elif [[ "$ENABLE_WEBUI" == false && "$ASSUME_YES" == false ]]; then
+    # Answers mode: a chat UI is almost always wanted, so default to yes.
+    read -rp "Enable Open WebUI chat interface (:$WEBUI_PORT)? [Y/n]: " ans \
+      || { err "Aborted (no input)."; exit 1; }
+    [[ "$ans" =~ ^[Nn] ]] || ENABLE_WEBUI=true
+  fi
 
+  # Resolve secrets into plain variables first. A failed generator inside the
+  # nested $(...) of a set_env call does NOT trip `set -e` — it just yields an
+  # empty string, and set_env would happily write "KEY=" and return 0. So we
+  # compute the values, then explicitly refuse to proceed if any came out blank
+  # (e.g. neither openssl nor /dev/urandom produced output).
+  local val_pg val_neo val_mcp val_fernet
+  val_pg="$(resolve_secret POSTGRES_PASSWORD "$prev_pg" "$(gen_secret)")"
+  val_neo="$(resolve_secret NEO4J_PASSWORD "$prev_neo" "$(gen_secret)")"
+  val_mcp="$(resolve_secret METRONIX_MCP_API_KEY "$prev_mcp" "$(gen_secret)")"
+  val_fernet="$(resolve_secret FERNET_KEY "$prev_fernet" "$(gen_fernet)")"
+
+  local _pair
+  for _pair in "POSTGRES_PASSWORD:$val_pg" "NEO4J_PASSWORD:$val_neo" \
+               "METRONIX_MCP_API_KEY:$val_mcp" "FERNET_KEY:$val_fernet"; do
+    if [[ -z "${_pair#*:}" ]]; then
+      err "Could not generate a value for ${_pair%%:*} (need openssl or a readable /dev/urandom). Aborting before launch."
+      exit 1
+    fi
+  done
+
+  set_env POSTGRES_PASSWORD "$val_pg"
+  set_env NEO4J_PASSWORD "$val_neo"
+  set_env METRONIX_MCP_API_KEY "$val_mcp"
+  set_env FERNET_KEY "$val_fernet"
+
+  # Everything validated — promote the staged config atomically and disarm the
+  # cleanup trap so the real .env survives.
+  mv "$ENV_FILE" "$final_env"
+  trap - EXIT
+  ENV_FILE="$final_env"
   ok "Wrote $ENV_FILE"
 }
 

--- a/tests/installer/test_failgen.sh
+++ b/tests/installer/test_failgen.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Verify install.sh aborts (and never launches) when secret generation fails.
+# Run: bash tests/installer/test_failgen.sh
+set -u
+INSTALL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/install.sh"
+PASS=0; FAIL=0
+chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (got [$2] want [$3])"; FAIL=$((FAIL+1)); fi; }
+
+run_case() {
+  local override="$1"; shift
+  local dir; dir="$(mktemp -d)"
+  printf 'LLM_PROVIDER=ollama\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\n' > "$dir/.env.example"
+  cat > "$dir/run.sh" <<EOF
+source "$INSTALL"
+check_prereqs() { :; }
+launch() { echo "LAUNCHED"; }
+wait_health() { :; }
+print_links() { :; }
+$override
+REPO_ROOT="$dir"
+main "\$@"
+EOF
+  ( cd "$dir" && bash run.sh "$@" >/tmp/installer_failgen_out.txt 2>&1 ); LAST_RC=$?; LAST_DIR="$dir"
+}
+
+abort_checks() {
+  chk "exit nonzero (aborted)" "$([[ $LAST_RC -ne 0 ]] && echo yes || echo no)" "yes"
+  chk "did NOT launch"         "$(grep -q LAUNCHED /tmp/installer_failgen_out.txt && echo launched || echo no)" "no"
+  chk "no .env left"           "$([[ -f "$LAST_DIR/.env" ]] && echo exists || echo absent)" "absent"
+}
+
+echo "Scenario A: gen_secret hard-FAILS (returns non-zero, empty output)"
+run_case 'gen_secret() { return 1; }' -y
+abort_checks
+
+echo "Scenario B: gen_secret returns 0 but EMPTY string"
+run_case 'gen_secret() { printf ""; return 0; }' -y
+abort_checks
+
+echo "Scenario C: gen_fernet fails -> must also abort"
+run_case 'gen_fernet() { return 1; }' -y
+abort_checks
+
+echo "Scenario D: happy path still works (real generators)"
+run_case ':' -y
+chk "exit zero"   "$LAST_RC" "0"
+chk "launched"    "$(grep -q LAUNCHED /tmp/installer_failgen_out.txt && echo launched || echo no)" "launched"
+chk ".env exists" "$([[ -f "$LAST_DIR/.env" ]] && echo exists || echo absent)" "exists"
+if [[ -f "$LAST_DIR/.env" ]]; then
+  plen=$(grep '^POSTGRES_PASSWORD=' "$LAST_DIR/.env" | cut -d= -f2- | tr -d '\n' | wc -c | tr -d ' ')
+  chk "POSTGRES_PASSWORD non-empty" "$([[ $plen -gt 0 ]] && echo yes || echo no)" "yes"
+fi
+
+echo ""
+echo "TOTAL: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/installer/test_install.sh
+++ b/tests/installer/test_install.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Behaviour tests for install.sh configure() — sandboxed, no docker required.
+# Run: bash tests/installer/test_install.sh
+set -u
+INSTALL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/install.sh"
+PASS=0; FAIL=0
+chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (got [$2] want [$3])"; FAIL=$((FAIL+1)); fi; }
+
+# Run install.sh in a throwaway dir with the heavy steps stubbed, so only
+# parse_args + configure are exercised. launch() echoes state for assertions.
+run_case() {
+  local dir; dir="$(mktemp -d)"
+  printf 'LLM_PROVIDER=ollama\nLLM_PROVIDER_URL=\nLLM_PROVIDER_API_KEY=\nLLM_PROVIDER_MODEL=\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\n' > "$dir/.env.example"
+  cat > "$dir/run.sh" <<EOF
+source "$INSTALL"
+check_prereqs() { :; }
+launch() { echo "LAUNCHED webui=\$ENABLE_WEBUI"; }
+wait_health() { :; }
+print_links() { :; }
+REPO_ROOT="$dir"
+main "\$@"
+EOF
+  ( cd "$dir" && bash run.sh "$@" >/tmp/installer_test_out.txt 2>&1 ); LAST_RC=$?; LAST_DIR="$dir"
+}
+envval()   { grep "^$1=" "$LAST_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-; }
+launched() { grep -q LAUNCHED /tmp/installer_test_out.txt && echo yes || echo no; }
+has_env()  { [[ -f "$LAST_DIR/.env" ]] && echo yes || echo no; }
+
+echo "Case 1: default -y -> memory mode"
+run_case -y
+chk "exit zero" "$LAST_RC" "0"
+chk "launched" "$(launched)" "yes"
+chk "LLM_PROVIDER=ollama" "$(envval LLM_PROVIDER)" "ollama"
+chk "OLLAMA_CHAT_MODEL empty" "$(envval OLLAMA_CHAT_MODEL)" ""
+chk "no leftover staging" "$(ls "$LAST_DIR"/.env.?????? 2>/dev/null | wc -l | tr -d ' ')" "0"
+
+echo "Case 2: answers via flags (url+model+key)"
+run_case -y --mode answers --chat-url https://api.deepseek.com/v1 --chat-model deepseek-chat --chat-api-key sk-xyz
+chk "exit zero" "$LAST_RC" "0"
+chk "launched" "$(launched)" "yes"
+chk "LLM_PROVIDER=custom" "$(envval LLM_PROVIDER)" "custom"
+chk "URL set" "$(envval LLM_PROVIDER_URL)" "https://api.deepseek.com/v1"
+chk "MODEL set" "$(envval LLM_PROVIDER_MODEL)" "deepseek-chat"
+chk "API key set" "$(envval LLM_PROVIDER_API_KEY)" "sk-xyz"
+chk "OLLAMA_CHAT_MODEL stays empty" "$(envval OLLAMA_CHAT_MODEL)" ""
+
+echo "Case 3: --chat-url implies answers; no key = blank (optional)"
+run_case -y --chat-url http://host.docker.internal:11434/v1 --chat-model llama3.1:8b
+chk "exit zero" "$LAST_RC" "0"
+chk "LLM_PROVIDER=custom (inferred)" "$(envval LLM_PROVIDER)" "custom"
+chk "URL set" "$(envval LLM_PROVIDER_URL)" "http://host.docker.internal:11434/v1"
+chk "API key blank (optional)" "$(envval LLM_PROVIDER_API_KEY)" ""
+
+echo "Case 4: --mode answers WITHOUT --chat-url -> abort, no .env"
+run_case -y --mode answers --chat-model x
+chk "exit nonzero" "$([[ $LAST_RC -ne 0 ]] && echo yes || echo no)" "yes"
+chk "did not launch" "$(launched)" "no"
+chk "no .env left" "$(has_env)" "no"
+
+echo "Case 5: answers, url given but model missing -> abort, no .env"
+run_case -y --mode answers --chat-url https://api.deepseek.com/v1
+chk "exit nonzero" "$([[ $LAST_RC -ne 0 ]] && echo yes || echo no)" "yes"
+chk "no .env left" "$(has_env)" "no"
+
+echo "Case 6: bad --mode -> abort"
+run_case -y --mode bogus
+chk "exit nonzero" "$([[ $LAST_RC -ne 0 ]] && echo yes || echo no)" "yes"
+chk "no .env left" "$(has_env)" "no"
+
+echo "Case 7: --openwebui in memory mode -> ignored with warning, still launches"
+run_case -y --openwebui
+chk "exit zero" "$LAST_RC" "0"
+chk "launched" "$(launched)" "yes"
+chk "warns about ignoring" "$(grep -qi 'ignoring --openwebui' /tmp/installer_test_out.txt && echo yes || echo no)" "yes"
+chk "webui disabled" "$(grep -q 'webui=false' /tmp/installer_test_out.txt && echo yes || echo no)" "yes"
+
+echo "Case 8: --openwebui in answers mode -> honored"
+run_case -y --openwebui --chat-url https://api.deepseek.com/v1 --chat-model deepseek-chat
+chk "exit zero" "$LAST_RC" "0"
+chk "no ignore warning" "$(grep -qi 'ignoring --openwebui' /tmp/installer_test_out.txt && echo yes || echo no)" "no"
+chk "webui enabled" "$(grep -q 'webui=true' /tmp/installer_test_out.txt && echo yes || echo no)" "yes"
+
+echo ""
+echo "TOTAL: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Reworks the `install.sh` interactive flow to be safer and built around how Metronix is actually used (a memory store behind an agent vs. standalone answer generation), and stops the bundled Ollama from downloading a chat model nobody asked for.

## Why

- A blank required field (or any aborted run) left a half-written `.env` behind, because `.env` was copied from the example **before** the prompts. The next run saw an existing `.env`, skipped all prompts, and launched with a broken config — "installation just continued".
- A failed secret generator silently produced an empty value: a non-zero `$(...)` nested inside a `set_env` argument does **not** trip `set -e`, so `KEY=` was written and the stack launched with blank secrets.
- The provider question (`ollama` / `custom`) exposed internal jargon and forced an LLM choice even for the common case — Metronix used purely as MCP memory behind an agent (e.g. Hermes), where **no chat model is needed at all** (verified: memory store/search and `metronix_search_fast` never call the chat LLM; embeddings always run on the bundled Ollama independently).
- The bundled Ollama always pulled a multi-GB chat model (`llama3.1:8b`) even when it was never used.

## Changes

**`install.sh`**
- **Atomic `.env`**: config is staged in a temp file and promoted only after full validation; a `trap` removes the staging file on any abort. No more half-written `.env` reuse.
- **Re-prompt** required interactive fields instead of aborting the whole run; EOF on a prompt exits with a clear message.
- **Refuse to launch** if any generated secret is empty.
- **Scenario-first question** instead of provider jargon:
  - `memory` (default) — memory store for your own agent; no chat model configured.
  - `answers` — Metronix generates answers itself → one **OpenAI-compatible** endpoint (URL + model required, API key optional, blank = no-auth internal endpoint). Covers a local Ollama via `/v1`, self-hosted vLLM/LocalAI, or a cloud API.
- **Open WebUI** offered only in `answers` mode (defaults to yes); skipped in `memory` mode, and a stray `--openwebui` there is ignored with a warning.
- New flags `--mode` / `--chat-url` / `--chat-model` / `--chat-api-key` replace `--provider` / `--custom-url` / `--custom-model` / `--api-key` / `--ollama-host`.

**`docker-compose.full.yml`**
- Bundled Ollama pulls embeddings only; `OLLAMA_CHAT_MODEL` defaults to empty (`${OLLAMA_CHAT_MODEL-}`) so a memory-store install no longer downloads a chat model.

**`.env.example`**
- `OLLAMA_CHAT_MODEL` empty by default; LLM section rewritten around the memory-vs-answers model and the optional API key.

**`tests/installer/`**
- Sandboxed bash tests (no docker required): `test_install.sh` (30 checks — modes, required-field aborts, atomic write, Open WebUI gating) and `test_failgen.sh` (13 checks — secret-generation failure handling).

## Testing

```
bash tests/installer/test_install.sh    # 30 passed
bash tests/installer/test_failgen.sh    # 13 passed
bash -n install.sh                      # syntax OK
docker compose -f docker-compose.full.yml config   # parses; OLLAMA_CHAT_MODEL renders ""
```

## Follow-up / to verify on a real run

Confirm `CustomProvider` works against an Ollama `/v1` endpoint end-to-end. If not, the native `ollama` provider can be restored as a fallback path.