### PR TITLE
feat(installer): wire Hermes config via Docker yq (no host yq install)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ docs/specs/
 .env*.backup
 .env.old
 
+# Installer-generated, per-deployment artifacts
+metronix-hermes-setup.md
+
 # Data
 /data/
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ docs/specs/
 .env*.backup
 .env.old
 
-# Installer-generated, per-deployment artifacts
-metronix-hermes-setup.md
+# Installer-generated, per-deployment artifacts (contain the MCP API key)
+metronix-hermes-setup/
 
 # Data
 /data/

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -24,8 +24,16 @@ Use this after Metronix is running and `METRONIX_MCP_API_KEY` is set in `.env`.
 > validate* the config — it never rewrites the file; if `yq` isn't installed it
 > runs the `mikefarah/yq` image via Docker (already required by the installer, no
 > host install needed). If the config has an unusual layout it can't edit safely,
-> or `~/.hermes` is absent, it writes the ready-to-paste `metronix-hermes-setup.md`
-> instead. Prompts 2 and 3 below always remain manual.
+> or `~/.hermes` is absent, it writes the ready-to-paste guide instead.
+>
+> Either way, the installer ALWAYS drops all three prompts — filled in with your
+> deployment's values — into `metronix-hermes-setup/` (`1-install-mcp.md`,
+> `2-memory-source.md`, `3-migrate.md`; gitignored, since they contain the MCP
+> key). The canonical, fill-in templates for these live in
+> [`hermes/`](hermes/) (`prompt-1-install.md`, `prompt-2-memory.md`,
+> `prompt-3-migrate.md`) — that is the single source of truth; the prompt blocks
+> shown below are copies for reading. Prompts 2 and 3 always remain a manual,
+> deliberate step (paste them after restarting Hermes).
 
 ## Variables
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -17,9 +17,12 @@ Use this after Metronix is running and `METRONIX_MCP_API_KEY` is set in `.env`.
 > **Shortcut:** `./install.sh` (or `./install.sh --wire-hermes -y` to re-run just
 > this) can perform **Prompt 1** for you — it detects `~/.hermes`, fills in the
 > values from your deployment, and edits `config.yaml` + `SOUL.md` after showing a
-> diff (backup kept). If `~/.hermes` is absent or `yq` isn't installed, it writes a
-> ready-to-paste `metronix-hermes-setup.md` instead. Prompts 2 and 3 below remain
-> manual.
+> diff (backup kept). The `config.yaml` edit uses **yq** (a YAML processor) so only
+> the `mcp_servers.metronix` key changes; if `yq` isn't installed it runs the
+> `mikefarah/yq` image via Docker (already required by the installer — no host
+> install needed). If `~/.hermes` is absent (or neither yq nor Docker is available)
+> it writes a ready-to-paste `metronix-hermes-setup.md` instead. Prompts 2 and 3
+> below remain manual.
 
 ## Variables
 

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -15,14 +15,17 @@ Setup is **three prompts** you paste into Hermes, in order:
 Use this after Metronix is running and `METRONIX_MCP_API_KEY` is set in `.env`.
 
 > **Shortcut:** `./install.sh` (or `./install.sh --wire-hermes -y` to re-run just
-> this) can perform **Prompt 1** for you — it detects `~/.hermes`, fills in the
-> values from your deployment, and edits `config.yaml` + `SOUL.md` after showing a
-> diff (backup kept). The `config.yaml` edit uses **yq** (a YAML processor) so only
-> the `mcp_servers.metronix` key changes; if `yq` isn't installed it runs the
-> `mikefarah/yq` image via Docker (already required by the installer — no host
-> install needed). If `~/.hermes` is absent (or neither yq nor Docker is available)
-> it writes a ready-to-paste `metronix-hermes-setup.md` instead. Prompts 2 and 3
-> below remain manual.
+> this) can perform **Prompt 1** for you. When it detects `~/.hermes` it asks
+> whether to **(1) edit the configs for you** or **(2) just write a ready-to-paste
+> guide**. If you choose to edit, it adds only the `mcp_servers.metronix` block to
+> `config.yaml` and the `metronix-config` block to `SOUL.md` with a **minimal text
+> edit** (your formatting, comments, and other keys are left untouched), shows a
+> diff, and keeps a backup. **yq** (a YAML processor) is used only to *read and
+> validate* the config — it never rewrites the file; if `yq` isn't installed it
+> runs the `mikefarah/yq` image via Docker (already required by the installer, no
+> host install needed). If the config has an unusual layout it can't edit safely,
+> or `~/.hermes` is absent, it writes the ready-to-paste `metronix-hermes-setup.md`
+> instead. Prompts 2 and 3 below always remain manual.
 
 ## Variables
 

--- a/docs/integrations/hermes/prompt-1-install.md
+++ b/docs/integrations/hermes/prompt-1-install.md
@@ -1,0 +1,81 @@
+# Metronix MCP — install as an MCP server
+You are a Hermes Agent instance. Run this ONCE per deployment.
+If `mcp_servers.metronix` already exists in your config with the correct URL,
+just verify it and report — do not create a duplicate.
+
+## Parameters
+- METRONIX_URL = {{METRONIX_URL}}
+- MCP_API_KEY  = {{MCP_API_KEY}}
+- AGENT_UUID   = {{AGENT_UUID}}
+- WORKSPACE_ID = {{WORKSPACE_ID}}
+
+## 0. Check parameters first
+If any value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- METRONIX_URL — Metronix MCP endpoint URL: server URL + /mcp. If Hermes runs in
+  WSL2/Docker and Metronix is on the Windows host, use host.docker.internal
+  instead of localhost. Example: http://host.docker.internal:8000/mcp
+- MCP_API_KEY — Bearer token for /mcp (server env var METRONIX_MCP_API_KEY; /mcp
+  returns HTTP 401 without it; ask the Metronix admin if you don't have it).
+  Example: the token from the Metronix deployment's .env
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can simply make one up, or create it via POST /api/v1/agents / the UI. You do NOT
+  create it. Example: a3c98413c3684a0992ac0e007b93f410
+- WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Every metronix_* call (search/RAG and memory) needs it, which is why it is set
+  now. Example: MTRNIX
+Do NOT call POST /api/v1/agents (or otherwise hit the /api/v1/agents endpoint)
+yourself to create an agent or obtain AGENT_UUID — registering the agent and its id
+is the user's job, done out of band. If AGENT_UUID is missing, ask the user and
+wait; never self-register.
+Wait for the user's answers and fill them in before continuing.
+
+## 1. Register Metronix as an MCP server
+Read `~/.hermes/config.yaml`. If section `mcp_servers.metronix` is missing or has
+the wrong URL, edit the file and ensure it contains:
+
+    mcp_servers:
+      metronix:
+        url: {{METRONIX_URL}}
+        headers:
+          Authorization: "Bearer {{MCP_API_KEY}}"   # required: server returns 401 without it
+          X-Agent-Id: {{AGENT_UUID}}
+        timeout: 180
+        connect_timeout: 60
+
+The `Authorization: Bearer` header is REQUIRED — the /mcp endpoint validates
+METRONIX_MCP_API_KEY; without it every request is rejected with HTTP 401.
+The `X-Agent-Id` header is REQUIRED too — without it, server-side observability
+events for search and other no-agent_id-arg tools are dropped silently.
+
+## 2. Record that Metronix is available (SOUL.md)
+Edit the LIVE SOUL.md that Hermes actually loads — typically `/root/.hermes/SOUL.md`
+when Hermes runs as root, otherwise `~/.hermes/SOUL.md`. Do NOT edit any backup or
+copy (e.g. `SOUL.md.bak`, dated copies, files under a `backups/` dir) — those are
+not loaded. Do NOT remove or rewrite existing persona content; just APPEND this
+block at the END (clearly delimited). If a `metronix-config` block is already there
+(e.g. from a previous run), update it in place instead of appending a second copy:
+
+    --- metronix-config ---
+    Metronix MCP is available. workspace_id="{{WORKSPACE_ID}}",
+    agent_id="{{AGENT_UUID}}". You MAY use the metronix_* tools — knowledge search /
+    RAG and memory. Using Metronix for durable memory is OPTIONAL at this stage;
+    it is not yet your required store.
+    --- end metronix-config ---
+
+This is what lets Hermes use Metronix after the restart; without these params in an
+always-loaded file, the agent would not know which workspace_id / agent_id to pass.
+Prompt 2 upgrades this block to make Metronix the ONLY durable-memory store.
+
+## 3. Test, then restart
+Run `hermes mcp test metronix` from a shell to confirm the client can negotiate
+a session. If it errors, fix and retry before continuing.
+Then restart: Hermes loads the MCP client list once at startup, so the metronix_*
+tools become available only in the NEXT session. Run /quit, then `hermes` again.
+
+## Report format
+- MCP registration: ok / changes made
+- Availability note: appended to <SOUL.md path>
+- mcp test: passed / failed (error)
+- Next step: restart the session, then run prompt 2 (memory source)

--- a/docs/integrations/hermes/prompt-2-memory.md
+++ b/docs/integrations/hermes/prompt-2-memory.md
@@ -1,0 +1,84 @@
+# Metronix MCP — primary & only memory source
+You are a Hermes Agent with the Metronix MCP server registered and active (run
+prompt 1 first, then restart). Run this ONCE.
+Prompt 1 left a `metronix-config` block in your SOUL.md with the OPTIONAL wording;
+this prompt upgrades it to mandatory. If it already has the mandatory wording, just
+verify and report.
+
+## Parameters
+- WORKSPACE_ID = {{WORKSPACE_ID}}
+- AGENT_UUID   = {{AGENT_UUID}}
+
+## 0. Check parameters first
+If either value above is still a {{...}} placeholder or empty STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Example: MTRNIX
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
+Wait for the user's answers before continuing.
+
+## 1. Memory policy
+Until now (after prompt 1) using Metronix memory was optional. This prompt makes it
+mandatory: all durable knowledge lives in Metronix, NOT in Hermes' built-in files.
+- The routing rule lives in `SOUL.md` (prompt 1 created it; step 3 below upgrades
+  it), which Hermes loads on EVERY call — so the agent goes straight to Metronix
+  with no extra lookup hop.
+- Do NOT wipe or edit `~/.hermes/memories/MEMORY.md` or `USER.md` here. Migrating
+  their existing content is a separate prompt (prompt 3).
+- Metronix memory is classified by `kind`:
+  - kind="fact" — durable factual statements ("user works at Acme")
+  - kind="preference" — user preferences ("respond in Russian"). Auto-injected
+    into prompts without retrieval — pin anything truly persistent here.
+  - kind="pinned" — explicit instructions the user marked must-not-vanish.
+
+## 2. Tools you have on Metronix
+Search/document (workspace_id only):
+`metronix_search`, `metronix_search_fast`, `metronix_get`, `metronix_store`,
+`metronix_status`, `metronix_sync`.
+Memory (workspace_id + agent_id BOTH required):
+`metronix_memory_store`, `metronix_memory_search`, `metronix_memory_get_context`,
+`metronix_memory_list`, `metronix_memory_update`, `metronix_memory_delete`,
+`metronix_memory_batch_store`, `metronix_memory_review_list`,
+`metronix_memory_review_resolve`. Run `/tools` for full schemas.
+ALWAYS pass workspace_id (and agent_id for memory tools) explicitly — defaults
+will not add them for you.
+
+## 3. Upgrade the routing rule to mandatory (SOUL.md)
+Edit the LIVE SOUL.md that Hermes actually loads — typically
+`/root/.hermes/SOUL.md` when Hermes runs as root, otherwise `~/.hermes/SOUL.md`
+(expand `~` to the home of the user Hermes runs as). Do NOT edit any backup or
+copy of it (e.g. `SOUL.md.bak`, `SOUL.backup`, dated copies, files under a
+`backups/` dir) — those are not loaded and editing them does nothing.
+
+Prompt 1 wrote a `metronix-config` block with the OPTIONAL wording. Find that
+block and REPLACE its body with the mandatory rule below, leaving the agent's
+persona and everything else in the file intact. If the block isn't there (prompt 1
+was skipped), APPEND it at the END of the file:
+
+    --- metronix-config ---
+    Durable memory lives in Metronix MCP. ALWAYS use the metronix_memory_*
+    tools for it, with workspace_id="{{WORKSPACE_ID}}" and
+    agent_id="{{AGENT_UUID}}". Classify by kind:
+    fact (default) | preference (auto-injected) | pinned (must-not-vanish).
+    Do NOT use Hermes' built-in memory files for new durable knowledge, and do
+    NOT silently fall back to them. If Metronix is unreachable, say so to the
+    user instead of storing durable knowledge locally.
+    --- end metronix-config ---
+
+Do NOT touch `~/.hermes/memories/MEMORY.md` or `~/.hermes/memories/USER.md` —
+leave their existing content exactly as it is.
+
+## 4. Verify
+- `metronix_status(workspace_id="{{WORKSPACE_ID}}")` — KB connectivity
+- `metronix_memory_list(workspace_id="{{WORKSPACE_ID}}",
+  agent_id="{{AGENT_UUID}}", limit=5)` — memory channel reachable
+- confirm the live SOUL.md `metronix-config` block now has the mandatory wording
+  AND that all of its pre-existing persona content is still present and unchanged
+
+## Report format
+- SOUL.md: routing rule upgraded to mandatory; existing persona preserved
+- Verify: status ok, memory channel reachable
+- Next step: run prompt 3 if this agent has prior memory to migrate

--- a/docs/integrations/hermes/prompt-3-migrate.md
+++ b/docs/integrations/hermes/prompt-3-migrate.md
@@ -1,0 +1,91 @@
+# Memory consolidation into Metronix
+You are an agent with the Metronix MCP server registered and active. Your task
+is to move ALL durable knowledge you currently hold into Metronix, so that
+Metronix becomes the single source of truth for long-lived memory. Run ONCE.
+Run this ONLY if you already hold durable memory.
+
+## Parameters
+- WORKSPACE_ID = {{WORKSPACE_ID}}
+- AGENT_UUID   = {{AGENT_UUID}}
+
+## 0. Check parameters first
+If either value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Example: MTRNIX
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
+Wait for the user's answers before continuing.
+
+## 1. Inventory every place you keep durable knowledge
+Before storing anything, build a complete list of where your durable memory
+currently lives. Do NOT stop at the first or most obvious location. Durable
+knowledge can be spread across many surfaces, in different forms. Consider, at
+minimum:
+  - your own native / built-in memory, in whatever form it takes;
+  - any local notes, scratch files, or working documents you read from or write to;
+  - any external or shared knowledge store you have been treating as a source of
+    truth (a separate notes system, a shared knowledge base, a wiki, a document
+    collection, etc.);
+  - pinned or "always remember" instructions the user has given you;
+  - durable facts or preferences carried over from earlier sessions.
+
+The most common failure here is migrating only user-facing notes and leaving
+structured or external knowledge behind. Completeness of THIS inventory is the
+single most important step — err on the side of including a source rather than
+skipping it. List every source you found before moving on.
+
+Do NOT migrate or remove your own persona/identity definition or the durable-
+memory routing rule itself — those are configuration, not knowledge, and must
+stay where they are.
+
+## 2. Classify each item by `kind`
+For every distinct piece of durable knowledge (skip empty entries, test/probe
+data, and anything tied to an already-finished task), decide its `kind`:
+  - kind="fact"       — a durable factual statement (default).
+  - kind="preference" — a user preference or behavioral rule (auto-injected into
+                        prompts; put anything that must always shape behavior here).
+  - kind="pinned"     — an explicit instruction the user marked must-not-vanish.
+
+## 3. Store everything into Metronix
+For each item, call:
+  metronix_memory_store(
+    workspace_id="{{WORKSPACE_ID}}",
+    agent_id="{{AGENT_UUID}}",
+    content=<the knowledge, self-contained and readable on its own>,
+    scope="per_agent",
+    source_type="conversation",
+    kind=<fact|preference|pinned>,
+    importance_score=0.7,
+  )
+Use metronix_memory_batch_store when you have more than 5 items.
+Always pass BOTH workspace_id and agent_id — defaults will not add them for you.
+Do not create duplicates: if the same fact appears in more than one source,
+store it once.
+
+## 4. Retire the originals (carefully)
+After an item is confirmed stored in Metronix:
+  - For memory you own exclusively (your own native memory, your private
+    notes/scratch files): remove the migrated entry so there is one source of
+    truth and nothing drifts. (Do NOT remove your persona/identity definition
+    or the routing rule — those are configuration, see step 1.)
+  - For shared or external sources you do NOT own exclusively (a shared
+    knowledge base, a team wiki): do NOT delete it. Leave it intact and just
+    note in your report that it has been mirrored into Metronix.
+From now on, write NEW durable knowledge to Metronix — not back into the old
+locations.
+
+## 5. Verify
+- metronix_memory_list(workspace_id="{{WORKSPACE_ID}}",
+  agent_id="{{AGENT_UUID}}", limit=10) — your migrated entries are visible.
+Check that nothing you inventoried in step 1 was left un-migrated.
+
+## Report format
+  - Sources found: <list every memory surface you discovered in step 1>
+  - Migrated: N items (X fact / Y preference / Z pinned)
+  - Skipped: M items (and why — empty, test data, finished task, duplicate)
+  - Retired: which owned sources were cleared vs. which external/shared sources
+    were left intact and mirrored
+  - Verify: memory_list returned K entries — all inventoried sources accounted for

--- a/install.sh
+++ b/install.sh
@@ -292,44 +292,69 @@ merge_soul_block() {
   fi
 }
 
-# yq is a small YAML processor ("jq for YAML"). We use it to set ONE key
-# (mcp_servers.metronix) inside the user's ~/.hermes/config.yaml while leaving
-# the rest of the file — other servers, comments, key order — untouched.
-# Hand-editing YAML from bash is too easy to corrupt, so we always use a real
-# parser. We never require a host install: if `yq` is not on PATH we run the
-# tiny mikefarah/yq image via Docker, which this installer already requires.
+# yq is a small YAML processor ("jq for YAML"). We use it ONLY to READ/validate
+# the Hermes config (never `yq -i`, which would re-serialize and reformat the
+# whole file). The actual change is a minimal text edit (see merge_hermes_config),
+# so the user's formatting, comments, and key order are left untouched. We never
+# require a host install: if `yq` is not on PATH we run the tiny mikefarah/yq
+# image via Docker (already a hard dependency of this installer).
 yq_available()    { command -v yq >/dev/null 2>&1 || command -v docker >/dev/null 2>&1; }
 yq_needs_docker() { ! command -v yq >/dev/null 2>&1; }
 
-# run_yq_edit FILE EXPR [NAME=VALUE ...] — apply `yq -i EXPR FILE`, exporting the
-# given vars for strenv(). Uses host yq if present, else mikefarah/yq in Docker
-# (the file's directory is mounted; the container runs as the invoking user so
-# the edited file stays user-owned).
-run_yq_edit() {
-  local file="$1" expr="$2"; shift 2
+# yq_read FILE EXPR — evaluate a read-only yq expression and print the result.
+# Host yq if present, else mikefarah/yq in Docker with the file's dir mounted
+# READ-ONLY (:ro) — the file is never modified by yq.
+yq_read() {
+  local file="$1" expr="$2"
   if command -v yq >/dev/null 2>&1; then
-    env "$@" yq -i "$expr" "$file"
+    yq "$expr" "$file"
   else
-    local dir base envflags=() kv
-    dir="$(cd "$(dirname "$file")" && pwd)"; base="$(basename "$file")"
-    for kv in "$@"; do envflags+=(-e "$kv"); done
-    docker run --rm --user "$(id -u):$(id -g)" "${envflags[@]}" \
-      -v "$dir:/work" -w /work mikefarah/yq -i "$expr" "$base"
+    local dir base; dir="$(cd "$(dirname "$file")" && pwd)"; base="$(basename "$file")"
+    docker run --rm --user "$(id -u):$(id -g)" -v "$dir:/work:ro" -w /work mikefarah/yq "$expr" "$base"
   fi
 }
 
-# Set .mcp_servers.metronix in the Hermes config, preserving everything else.
-# Caller must guard with yq_available.
+# Classify a config: "has_metronix" | "has_mcp" (mcp_servers but no metronix) | "none".
+# Uses mikefarah-yq-compatible boolean reads (no jq-style if/then/else).
+hermes_mcp_state() {
+  local file="$1"
+  if [[ "$(yq_read "$file" '.mcp_servers.metronix != null' 2>/dev/null)" == "true" ]]; then
+    echo has_metronix
+  elif [[ "$(yq_read "$file" '.mcp_servers != null' 2>/dev/null)" == "true" ]]; then
+    echo has_mcp
+  else
+    echo none
+  fi
+}
+
+# Add the metronix MCP server to a Hermes config with a MINIMAL text edit (no
+# reformatting of the rest of the file). Three cases, decided by hermes_mcp_state:
+#   - has_metronix : already present -> return 1 (no change; caller skips)
+#   - has_mcp      : insert the metronix entry right after the 'mcp_servers:' line
+#   - none         : append a fresh 'mcp_servers:' section at the end
+# The caller must validate the result (yq_read) — an unusual layout (e.g. inline
+# 'mcp_servers: {}') can leave nothing inserted, which validation catches.
+# Caller must guard with yq_available (hermes_mcp_state needs yq).
 merge_hermes_config() {
-  local config="$1"
-  [[ -f "$config" ]] || printf 'mcp_servers: {}\n' > "$config"
-  run_yq_edit "$config" '
-    .mcp_servers.metronix.url = strenv(H_URL) |
-    .mcp_servers.metronix.headers.Authorization = "Bearer " + strenv(H_KEY) |
-    .mcp_servers.metronix.headers."X-Agent-Id" = strenv(H_AGENT) |
-    .mcp_servers.metronix.timeout = 180 |
-    .mcp_servers.metronix.connect_timeout = 60
-  ' "H_URL=$H_URL" "H_KEY=$H_KEY" "H_AGENT=$H_AGENT"
+  local config="$1" state ln tmp
+  state="$(hermes_mcp_state "$config")"
+  case "$state" in
+    has_metronix)
+      return 1
+      ;;
+    has_mcp)
+      ln="$(grep -nE '^mcp_servers:[[:space:]]*$' "$config" | head -1 | cut -d: -f1)"
+      [[ -n "$ln" ]] || return 0   # no plain 'mcp_servers:' line to anchor to; validation will catch it
+      tmp="$(mktemp "$(dirname "$config")/.metronix-ins.XXXXXX")"
+      { head -n "$ln" "$config"; hermes_config_block; tail -n +"$((ln + 1))" "$config"; } > "$tmp"
+      mv "$tmp" "$config"
+      ;;
+    *)
+      [[ -s "$config" ]] && printf '\n' >> "$config"
+      printf 'mcp_servers:\n' >> "$config"
+      hermes_config_block >> "$config"
+      ;;
+  esac
 }
 
 # Write the paste-ready Hermes setup doc (the universal fallback).
@@ -361,57 +386,75 @@ wire_hermes() {
     info "Hermes not found ($hermes_dir). Writing a setup guide to apply later."
     write_hermes_prompt_file "$prompt_dest"; return 0
   fi
-  if ! yq_available; then
-    info "Found Hermes at $hermes_dir, but neither 'yq' nor Docker is available to"
-    info "edit config.yaml safely — writing a setup guide instead."
-    write_hermes_prompt_file "$prompt_dest"
-    info "The guide above is already filled in for this deployment — paste it into Hermes."
-    return 0
-  fi
 
   info "Found Hermes at $hermes_dir."
   info "Metronix MCP URL: $H_URL   (use host.docker.internal if Hermes runs in WSL2/Docker)"
-  # config.yaml is edited with yq (a YAML processor — 'jq for YAML') so only the
-  # mcp_servers.metronix key changes and the rest of the file is preserved.
-  if yq_needs_docker; then
-    info "yq is not installed locally, so it runs via Docker (image mikefarah/yq,"
-    info "  pulled once) — no host install needed."
+
+  # How does the user want to connect Hermes?
+  local method
+  if [[ "$ASSUME_YES" == true ]]; then
+    if [[ "$WIRE_HERMES" == true ]]; then method=edit; else method=guide; fi
+  else
+    info "Connect Hermes to Metronix:"
+    info "  1) Edit ~/.hermes for me — add only the MCP block (minimal change)   [default]"
+    info "  2) Just write a ready-to-paste guide — I'll apply it myself"
+    read -rp "Choose 1 or 2 [default: 1]: " ans || { err "Aborted (no input)."; exit 1; }
+    case "${ans:-1}" in
+      1|"") method=edit ;;
+      2)    method=guide ;;
+      *)    err "Invalid choice: $ans"; exit 1 ;;
+    esac
   fi
 
-  # Render the proposed result into temp copies and show a diff BEFORE confirming
-  # (spec §6: backup -> diff -> confirm). No live file is touched until apply.
-  # Temps live inside ~/.hermes so they share the filesystem (atomic mv) and are
-  # reachable by Docker when yq runs in a container.
+  if [[ "$method" == guide ]]; then
+    write_hermes_prompt_file "$prompt_dest"
+    info "Paste it into Hermes (or hand it to the agent). Prompts 2/3 in"
+    info "  docs/integrations/hermes.md are the next, manual steps."
+    return 0
+  fi
+
+  # method == edit. Editing config.yaml safely needs yq (read-only) to detect the
+  # current shape and validate the result; if it isn't available, fall back.
+  if ! yq_available; then
+    warn "Editing config.yaml safely needs yq or Docker, and neither is available —"
+    warn "writing a ready-to-paste guide instead so your file isn't touched."
+    write_hermes_prompt_file "$prompt_dest"; return 0
+  fi
+  if yq_needs_docker; then
+    info "Reading/validating config.yaml with yq via Docker (image mikefarah/yq, pulled once)."
+  fi
+
+  # Build the change on temp copies (inside ~/.hermes: Docker-visible + atomic mv).
+  # config.yaml is edited as plain text (minimal diff); yq only reads/validates it.
   local tmp_cfg tmp_soul
   tmp_cfg="$(mktemp "$hermes_dir/.metronix-cfg.XXXXXX")"
   tmp_soul="$(mktemp "$hermes_dir/.metronix-soul.XXXXXX")"
-  if [[ -f "$config" ]]; then cp "$config" "$tmp_cfg"; else printf 'mcp_servers: {}\n' > "$tmp_cfg"; fi
+  [[ -f "$config" ]] && cp "$config" "$tmp_cfg"
   [[ -f "$soul" ]] && cp "$soul" "$tmp_soul"
-  merge_hermes_config "$tmp_cfg"
+
+  local cfg_changed=true
+  if merge_hermes_config "$tmp_cfg"; then
+    # We added the block — validate it parses and reads back our URL. If not, the
+    # config has an unusual layout we won't risk editing: fall back to the guide.
+    if [[ "$(yq_read "$tmp_cfg" '.mcp_servers.metronix.url' 2>/dev/null)" != "$H_URL" ]]; then
+      warn "Could not safely edit config.yaml (its structure is unusual) —"
+      warn "writing a ready-to-paste guide instead so your file isn't touched."
+      rm -f "$tmp_cfg" "$tmp_soul"
+      write_hermes_prompt_file "$prompt_dest"; return 0
+    fi
+  else
+    cfg_changed=false
+    info "Metronix is already present in config.yaml — leaving it unchanged."
+  fi
   merge_soul_block "$tmp_soul"
 
   info "Proposed changes:"
-  diff -u "$config" "$tmp_cfg" 2>/dev/null || true
+  [[ "$cfg_changed" == true ]] && { diff -u "$config" "$tmp_cfg" 2>/dev/null || true; }
   [[ -f "$soul" ]] && { diff -u "$soul" "$tmp_soul" 2>/dev/null || true; }
-
-  # Apply? -y --wire-hermes applies non-interactively; bare -y never edits ~/.hermes.
-  local do_apply=false
-  if [[ "$ASSUME_YES" == true ]]; then
-    [[ "$WIRE_HERMES" == true ]] && do_apply=true
-  else
-    read -rp "Apply these changes to ~/.hermes? [Y/n]: " ans \
-      || { err "Aborted (no input)."; exit 1; }
-    [[ "$ans" =~ ^[Nn] ]] || do_apply=true
-  fi
-
-  if [[ "$do_apply" != true ]]; then
-    rm -f "$tmp_cfg" "$tmp_soul"
-    write_hermes_prompt_file "$prompt_dest"; return 0
-  fi
 
   _backup_file "$config"
   _backup_file "$soul"
-  mv "$tmp_cfg" "$config"
+  if [[ "$cfg_changed" == true ]]; then mv "$tmp_cfg" "$config"; else rm -f "$tmp_cfg"; fi
   mv "$tmp_soul" "$soul"
   ok "Wired Metronix into Hermes (agent_id=$H_AGENT, workspace=$H_WS)."
   info "Restart Hermes: /quit, then 'hermes'. Then optionally run Prompt 2/3 from"

--- a/install.sh
+++ b/install.sh
@@ -211,9 +211,10 @@ resolve_agent_id() {
 }
 
 # --- Hermes wiring templates -------------------------------------------------
-# KEEP IN SYNC with docs/integrations/hermes.md (Prompt 1). These render the
-# CONNECTION only (MCP registration + optional availability note); never the
-# mandatory memory policy (Prompt 2) or migration (Prompt 3).
+# These two blocks are used for the in-place auto-edit of config.yaml / SOUL.md.
+# The paste-ready prompts (1/2/3) are NOT here — they live as canonical template
+# files in docs/integrations/hermes/ and are filled by write_hermes_prompt_dir.
+# KEEP the YAML/SOUL shape below in sync with docs/integrations/hermes/prompt-1-install.md.
 # Callers set H_URL / H_KEY / H_AGENT / H_WS before calling.
 
 hermes_config_block() {
@@ -239,30 +240,35 @@ required store.
 EOF
 }
 
-hermes_prompt_doc() {
-  cat <<EOF
-# Connect Hermes to Metronix (paste-ready)
+# Fill a {{...}} prompt template with this deployment's values and write it to dest.
+# Templates are the single source of truth (docs/integrations/hermes/prompt-*.md);
+# the filled output contains the real MCP key, so it is per-deployment / gitignored.
+fill_template() {
+  local tmpl="$1" dest="$2" content
+  content="$(cat "$tmpl")"
+  content="${content//\{\{METRONIX_URL\}\}/$H_URL}"
+  content="${content//\{\{MCP_API_KEY\}\}/$H_KEY}"
+  content="${content//\{\{AGENT_UUID\}\}/$H_AGENT}"
+  content="${content//\{\{WORKSPACE_ID\}\}/$H_WS}"
+  printf '%s\n' "$content" > "$dest"
+}
 
-Two edits, then restart Hermes. This wires the CONNECTION only — making Metronix
-your mandatory memory store is a separate, deliberate step (see Prompt 2 in
-docs/integrations/hermes.md).
-
-## 1. ~/.hermes/config.yaml — add under \`mcp_servers:\`
-\`\`\`yaml
-mcp_servers:
-$(hermes_config_block)
-\`\`\`
-
-## 2. ~/.hermes/SOUL.md — append at the end
-\`\`\`
-$(hermes_soul_block)
-\`\`\`
-
-## 3. Restart
-Run \`/quit\`, then \`hermes\` (Hermes loads its MCP client list at startup).
-Optional next: Prompt 2 (make Metronix the only durable memory) and Prompt 3
-(migrate existing memory) from docs/integrations/hermes.md.
-EOF
+# Write all three ready-to-paste Hermes prompts (filled) into a directory.
+# Returns 1 if no templates were found (e.g. install.sh run outside the repo).
+write_hermes_prompt_dir() {
+  local dir="$1" tdir="$REPO_ROOT/docs/integrations/hermes" found=0 pair src out
+  mkdir -p "$dir"
+  for pair in "prompt-1-install.md:1-install-mcp.md" \
+              "prompt-2-memory.md:2-memory-source.md" \
+              "prompt-3-migrate.md:3-migrate.md"; do
+    src="$tdir/${pair%%:*}"; out="$dir/${pair#*:}"
+    if [[ -f "$src" ]]; then fill_template "$src" "$out"; found=$((found + 1)); fi
+  done
+  if [[ "$found" -eq 0 ]]; then
+    warn "Prompt templates not found under $tdir — run the installer from the repo checkout."
+    return 0
+  fi
+  ok "Wrote $found ready-to-paste Hermes prompt(s) to $dir/ (apply them in order: 1 -> 2 -> 3)."
 }
 
 # Ensure exactly one metronix-config block in the SOUL file. Replaces the body
@@ -357,13 +363,6 @@ merge_hermes_config() {
   esac
 }
 
-# Write the paste-ready Hermes setup doc (the universal fallback).
-write_hermes_prompt_file() {
-  local dest="$1"
-  hermes_prompt_doc > "$dest"
-  ok "Wrote a ready-to-use Hermes setup guide to $dest"
-}
-
 # Back up a file to <file>.bak-<ts> before editing.
 _backup_file() { [[ -f "$1" ]] && cp "$1" "$1.bak-$(date +%Y%m%d%H%M%S)"; }
 
@@ -376,15 +375,15 @@ wire_hermes() {
   H_AGENT="$(resolve_agent_id "$config")"
 
   # Fallback in every can't/won't-auto-edit case: write the paste-ready guide.
-  local prompt_dest="./metronix-hermes-setup.md"
+  local prompt_dir="./metronix-hermes-setup"
 
   if [[ -z "$H_KEY" ]]; then
     warn "No METRONIX_MCP_API_KEY in .env — cannot wire an agent without it."
-    write_hermes_prompt_file "$prompt_dest"; return 0
+    write_hermes_prompt_dir "$prompt_dir"; return 0
   fi
   if [[ ! -f "$config" && ! -d "$hermes_dir" ]]; then
     info "Hermes not found ($hermes_dir). Writing a setup guide to apply later."
-    write_hermes_prompt_file "$prompt_dest"; return 0
+    write_hermes_prompt_dir "$prompt_dir"; return 0
   fi
 
   info "Found Hermes at $hermes_dir."
@@ -407,9 +406,8 @@ wire_hermes() {
   fi
 
   if [[ "$method" == guide ]]; then
-    write_hermes_prompt_file "$prompt_dest"
-    info "Paste it into Hermes (or hand it to the agent). Prompts 2/3 in"
-    info "  docs/integrations/hermes.md are the next, manual steps."
+    write_hermes_prompt_dir "$prompt_dir"
+    info "Paste each into Hermes in order (1 install, 2 memory policy, 3 migrate)."
     return 0
   fi
 
@@ -418,7 +416,7 @@ wire_hermes() {
   if ! yq_available; then
     warn "Editing config.yaml safely needs yq or Docker, and neither is available —"
     warn "writing a ready-to-paste guide instead so your file isn't touched."
-    write_hermes_prompt_file "$prompt_dest"; return 0
+    write_hermes_prompt_dir "$prompt_dir"; return 0
   fi
   if yq_needs_docker; then
     info "Reading/validating config.yaml with yq via Docker (image mikefarah/yq, pulled once)."
@@ -440,7 +438,7 @@ wire_hermes() {
       warn "Could not safely edit config.yaml (its structure is unusual) —"
       warn "writing a ready-to-paste guide instead so your file isn't touched."
       rm -f "$tmp_cfg" "$tmp_soul"
-      write_hermes_prompt_file "$prompt_dest"; return 0
+      write_hermes_prompt_dir "$prompt_dir"; return 0
     fi
   else
     cfg_changed=false
@@ -456,9 +454,12 @@ wire_hermes() {
   _backup_file "$soul"
   if [[ "$cfg_changed" == true ]]; then mv "$tmp_cfg" "$config"; else rm -f "$tmp_cfg"; fi
   mv "$tmp_soul" "$soul"
-  ok "Wired Metronix into Hermes (agent_id=$H_AGENT, workspace=$H_WS)."
-  info "Restart Hermes: /quit, then 'hermes'. Then optionally run Prompt 2/3 from"
-  info "  docs/integrations/hermes.md to make Metronix your mandatory memory store."
+  ok "Wired Metronix into Hermes (agent_id=$H_AGENT, workspace=$H_WS) — prompt 1 applied."
+  # Always leave all three filled prompts on disk so 2 (mandatory memory) and 3
+  # (migrate) are ready to paste; 1 is included for reference / re-runs.
+  write_hermes_prompt_dir "$prompt_dir" || true
+  info "Restart Hermes (/quit, then 'hermes'). Then paste prompts 2 and 3 from"
+  info "  $prompt_dir/ to make Metronix the mandatory memory store and migrate existing memory."
 }
 
 # Return the value .env.example ships for a given key (empty if absent).

--- a/install.sh
+++ b/install.sh
@@ -292,20 +292,44 @@ merge_soul_block() {
   fi
 }
 
-have_yq() { command -v yq >/dev/null 2>&1; }
+# yq is a small YAML processor ("jq for YAML"). We use it to set ONE key
+# (mcp_servers.metronix) inside the user's ~/.hermes/config.yaml while leaving
+# the rest of the file — other servers, comments, key order — untouched.
+# Hand-editing YAML from bash is too easy to corrupt, so we always use a real
+# parser. We never require a host install: if `yq` is not on PATH we run the
+# tiny mikefarah/yq image via Docker, which this installer already requires.
+yq_available()    { command -v yq >/dev/null 2>&1 || command -v docker >/dev/null 2>&1; }
+yq_needs_docker() { ! command -v yq >/dev/null 2>&1; }
+
+# run_yq_edit FILE EXPR [NAME=VALUE ...] — apply `yq -i EXPR FILE`, exporting the
+# given vars for strenv(). Uses host yq if present, else mikefarah/yq in Docker
+# (the file's directory is mounted; the container runs as the invoking user so
+# the edited file stays user-owned).
+run_yq_edit() {
+  local file="$1" expr="$2"; shift 2
+  if command -v yq >/dev/null 2>&1; then
+    env "$@" yq -i "$expr" "$file"
+  else
+    local dir base envflags=() kv
+    dir="$(cd "$(dirname "$file")" && pwd)"; base="$(basename "$file")"
+    for kv in "$@"; do envflags+=(-e "$kv"); done
+    docker run --rm --user "$(id -u):$(id -g)" "${envflags[@]}" \
+      -v "$dir:/work" -w /work mikefarah/yq -i "$expr" "$base"
+  fi
+}
 
 # Set .mcp_servers.metronix in the Hermes config, preserving everything else.
-# Requires yq (mikefarah v4). Caller must guard with have_yq.
+# Caller must guard with yq_available.
 merge_hermes_config() {
   local config="$1"
   [[ -f "$config" ]] || printf 'mcp_servers: {}\n' > "$config"
-  H_URL="$H_URL" H_KEY="$H_KEY" H_AGENT="$H_AGENT" yq -i '
+  run_yq_edit "$config" '
     .mcp_servers.metronix.url = strenv(H_URL) |
     .mcp_servers.metronix.headers.Authorization = "Bearer " + strenv(H_KEY) |
     .mcp_servers.metronix.headers."X-Agent-Id" = strenv(H_AGENT) |
     .mcp_servers.metronix.timeout = 180 |
     .mcp_servers.metronix.connect_timeout = 60
-  ' "$config"
+  ' "H_URL=$H_URL" "H_KEY=$H_KEY" "H_AGENT=$H_AGENT"
 }
 
 # Write the paste-ready Hermes setup doc (the universal fallback).
@@ -337,29 +361,38 @@ wire_hermes() {
     info "Hermes not found ($hermes_dir). Writing a setup guide to apply later."
     write_hermes_prompt_file "$prompt_dest"; return 0
   fi
-  if ! have_yq; then
-    info "Found Hermes at $hermes_dir, but 'yq' is not installed — skipping the"
-    info "automatic config edit so your YAML can't be corrupted."
-    warn "To auto-wire next time: install yq (e.g. 'brew install yq', see"
-    warn "  https://github.com/mikefarah/yq#install), then re-run: ./install.sh --wire-hermes"
+  if ! yq_available; then
+    info "Found Hermes at $hermes_dir, but neither 'yq' nor Docker is available to"
+    info "edit config.yaml safely — writing a setup guide instead."
     write_hermes_prompt_file "$prompt_dest"
-    info "The guide above is already filled in for this deployment — you can paste it into Hermes now."
+    info "The guide above is already filled in for this deployment — paste it into Hermes."
     return 0
+  fi
+
+  info "Found Hermes at $hermes_dir."
+  info "Metronix MCP URL: $H_URL   (use host.docker.internal if Hermes runs in WSL2/Docker)"
+  # config.yaml is edited with yq (a YAML processor — 'jq for YAML') so only the
+  # mcp_servers.metronix key changes and the rest of the file is preserved.
+  if yq_needs_docker; then
+    info "yq is not installed locally, so it runs via Docker (image mikefarah/yq,"
+    info "  pulled once) — no host install needed."
   fi
 
   # Render the proposed result into temp copies and show a diff BEFORE confirming
   # (spec §6: backup -> diff -> confirm). No live file is touched until apply.
-  local tmp_cfg tmp_soul; tmp_cfg="$(mktemp)"; tmp_soul="$(mktemp)"
+  # Temps live inside ~/.hermes so they share the filesystem (atomic mv) and are
+  # reachable by Docker when yq runs in a container.
+  local tmp_cfg tmp_soul
+  tmp_cfg="$(mktemp "$hermes_dir/.metronix-cfg.XXXXXX")"
+  tmp_soul="$(mktemp "$hermes_dir/.metronix-soul.XXXXXX")"
   if [[ -f "$config" ]]; then cp "$config" "$tmp_cfg"; else printf 'mcp_servers: {}\n' > "$tmp_cfg"; fi
   [[ -f "$soul" ]] && cp "$soul" "$tmp_soul"
   merge_hermes_config "$tmp_cfg"
   merge_soul_block "$tmp_soul"
 
-  info "Found Hermes at $hermes_dir."
-  info "Metronix MCP URL: $H_URL   (use host.docker.internal if Hermes runs in WSL2/Docker)"
   info "Proposed changes:"
   diff -u "$config" "$tmp_cfg" 2>/dev/null || true
-  diff -u "${soul:-/dev/null}" "$tmp_soul" 2>/dev/null || true
+  [[ -f "$soul" ]] && { diff -u "$soul" "$tmp_soul" 2>/dev/null || true; }
 
   # Apply? -y --wire-hermes applies non-interactively; bare -y never edits ~/.hermes.
   local do_apply=false

--- a/tests/installer/test_wire_hermes.sh
+++ b/tests/installer/test_wire_hermes.sh
@@ -52,17 +52,33 @@ chk "orphan: top persona kept" "$(grep -c 'Persona top.' "$d/SOUL.md")" "1"
 chk "orphan: trailing persona kept" "$(grep -c 'Persona AFTER orphan opener.' "$d/SOUL.md")" "1"
 chk "orphan: a complete block now present" "$(grep -c -- '--- end metronix-config ---' "$d/SOUL.md")" "1"
 
-echo "Task5: config.yaml yq merge (skips if yq absent)"
-if bash -c "source '$INSTALL'; have_yq"; then
-  d="$(mktemp -d)"; printf 'agent: hermes\nmcp_servers:\n  other:\n    url: http://other\n' > "$d/config.yaml"
-  bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY1; H_AGENT=AID1; H_WS=MTRNIX; merge_hermes_config '$d/config.yaml'"
-  chk "metronix url set" "$(yq -r '.mcp_servers.metronix.url' "$d/config.yaml")" "http://h:8000/mcp"
-  chk "auth header set" "$(yq -r '.mcp_servers.metronix.headers.Authorization' "$d/config.yaml")" "Bearer KEY1"
-  chk "agent header set" "$(yq -r '.mcp_servers.metronix.headers.X-Agent-Id' "$d/config.yaml")" "AID1"
-  chk "other server preserved" "$(yq -r '.mcp_servers.other.url' "$d/config.yaml")" "http://other"
-  chk "top-level preserved" "$(yq -r '.agent' "$d/config.yaml")" "hermes"
+# Helper: can we actually run yq (host binary, or Docker daemon up for mikefarah/yq)?
+can_run_yq() { command -v yq >/dev/null 2>&1 || { command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; }; }
+
+echo "Task5a: merge_hermes_config builds the right Docker yq command (host yq absent)"
+if command -v yq >/dev/null 2>&1; then
+  echo "  SKIP 5a: host yq present — Docker branch not taken here"
 else
-  echo "  SKIP: yq not installed — merge_hermes_config path not exercised"
+  d="$(mktemp -d)"; printf 'mcp_servers: {}\n' > "$d/config.yaml"
+  out="$(bash -c "source '$INSTALL'; docker(){ echo DOCKER \"\$@\"; }; H_URL=http://h/v1; H_KEY=K1; H_AGENT=A1; merge_hermes_config '$d/config.yaml'")"
+  chk "5a invokes docker once" "$(printf '%s' "$out" | grep -c '^DOCKER run')" "1"
+  chk "5a passes -e H_URL" "$(printf '%s' "$out" | grep -c -- '-e H_URL=http://h/v1')" "1"
+  chk "5a passes -e H_AGENT" "$(printf '%s' "$out" | grep -c -- '-e H_AGENT=A1')" "1"
+  chk "5a runs mikefarah/yq -i" "$(printf '%s' "$out" | grep -c 'mikefarah/yq -i')" "1"
+  chk "5a mounts a work dir" "$(printf '%s' "$out" | grep -c -- '-w /work')" "1"
+fi
+
+echo "Task5b: real merge edits config (host yq or Docker), preserving other keys"
+if can_run_yq; then
+  d="$(mktemp -d)"; printf 'agent: hermes\nmcp_servers:\n  other:\n    url: http://other\n' > "$d/config.yaml"
+  bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY1; H_AGENT=AID1; H_WS=MTRNIX; merge_hermes_config '$d/config.yaml'" >/dev/null 2>&1
+  chk "5b metronix url set" "$(grep -c 'url: http://h:8000/mcp' "$d/config.yaml")" "1"
+  chk "5b auth header set" "$(grep -c 'Authorization: Bearer KEY1' "$d/config.yaml")" "1"
+  chk "5b agent header set" "$(grep -c 'X-Agent-Id: AID1' "$d/config.yaml")" "1"
+  chk "5b other server preserved" "$(grep -c 'url: http://other' "$d/config.yaml")" "1"
+  chk "5b top-level preserved" "$(grep -c '^agent: hermes' "$d/config.yaml")" "1"
+else
+  echo "  SKIP 5b: no host yq and no usable Docker — real merge not exercised"
 fi
 
 echo "Task6: prompt-file fallback"
@@ -79,15 +95,16 @@ hd="$(mktemp -d)"; work="$(mktemp -d)"
 ( cd "$work" && HOME="$hd" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; METRONIX_MCP_API_KEY=K; DEFAULT_WORKSPACE_ID=MTRNIX; get_env(){ case \$1 in METRONIX_MCP_API_KEY) echo K;; DEFAULT_WORKSPACE_ID) echo MTRNIX;; esac; }; wire_hermes" >/tmp/wh.txt 2>&1 )
 chk "absent -> prompt file" "$([[ -f "$work/metronix-hermes-setup.md" ]] && echo yes || echo no)" "yes"
 chk "absent -> no ~/.hermes" "$([[ -e "$hd/.hermes" ]] && echo yes || echo no)" "no"
-# present + -y --wire-hermes + yq -> edits applied
-if bash -c "source '$INSTALL'; have_yq"; then
+# present + -y --wire-hermes -> edits applied (real yq via host or Docker)
+if can_run_yq; then
   hd2="$(mktemp -d)"; mkdir -p "$hd2/.hermes"; printf 'agent: hermes\n' > "$hd2/.hermes/config.yaml"; printf 'Persona.\n' > "$hd2/.hermes/SOUL.md"
   ( HOME="$hd2" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; get_env(){ case \$1 in METRONIX_MCP_API_KEY) echo KEYZ;; DEFAULT_WORKSPACE_ID) echo MTRNIX;; esac; }; wire_hermes" >/tmp/wh2.txt 2>&1 )
-  chk "config wired" "$(yq -r '.mcp_servers.metronix.headers.Authorization' "$hd2/.hermes/config.yaml")" "Bearer KEYZ"
+  chk "config wired" "$(grep -c 'Authorization: Bearer KEYZ' "$hd2/.hermes/config.yaml")" "1"
   chk "soul wired" "$(grep -c -- '--- metronix-config ---' "$hd2/.hermes/SOUL.md")" "1"
   chk "backup made" "$(ls "$hd2/.hermes/"config.yaml.bak-* 2>/dev/null | wc -l | tr -d ' ')" "1"
+  chk "no leftover temp files" "$(ls "$hd2/.hermes/".metronix-* 2>/dev/null | wc -l | tr -d ' ')" "0"
 else
-  echo "  SKIP: yq not installed — apply path not exercised"
+  echo "  SKIP: no host yq and no usable Docker — apply path not exercised"
 fi
 
 echo "Task8: standalone --wire-hermes does not build the stack"

--- a/tests/installer/test_wire_hermes.sh
+++ b/tests/installer/test_wire_hermes.sh
@@ -3,6 +3,7 @@
 # The text-merge / apply paths need a usable yq or Docker and SKIP otherwise.
 set -u
 INSTALL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/install.sh"
+REPO="$(dirname "$INSTALL")"
 PASS=0; FAIL=0
 chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (got [$2] want [$3])"; FAIL=$((FAIL+1)); fi; }
 
@@ -22,17 +23,13 @@ chk "flag overrides reuse" "$r2" "override999"
 r3="$(bash -c "source '$INSTALL'; AGENT_ID=''; resolve_agent_id '$d/none.yaml'")"
 chk "generates when absent" "$(printf '%s' "$r3" | grep -cE '^[0-9a-f]{32}$')" "1"
 
-echo "Task3: templates substitute values, no placeholders"
-tpl="$(bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY123; H_AGENT=AID9; H_WS=MTRNIX; hermes_config_block; echo ---; hermes_soul_block; echo ---; hermes_prompt_doc")"
-chk "no leftover {{ }}" "$(printf '%s' "$tpl" | grep -c '{{')" "0"
-chk "config has url" "$(printf '%s' "$tpl" | grep -c 'http://h:8000/mcp')" "2"
-# hermes_prompt_doc embeds hermes_config_block + hermes_soul_block, so each
-# pattern appears twice in the combined output (once from the direct call, once
-# from the embedded expansion inside hermes_prompt_doc). Count 2 is correct.
-chk "config has bearer key" "$(printf '%s' "$tpl" | grep -c 'Bearer KEY123')" "2"
-chk "config has agent header" "$(printf '%s' "$tpl" | grep -c 'X-Agent-Id: AID9')" "2"
-chk "soul has workspace" "$(printf '%s' "$tpl" | grep -c 'workspace_id="MTRNIX"')" "2"
-chk "soul block delimited" "$(printf '%s' "$tpl" | grep -c -- '--- metronix-config ---')" "2"
+echo "Task3: auto-edit blocks render with substituted values"
+tpl="$(bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY123; H_AGENT=AID9; H_WS=MTRNIX; hermes_config_block; echo ---; hermes_soul_block")"
+chk "config has url" "$(printf '%s' "$tpl" | grep -c 'http://h:8000/mcp')" "1"
+chk "config has bearer key" "$(printf '%s' "$tpl" | grep -c 'Bearer KEY123')" "1"
+chk "config has agent header" "$(printf '%s' "$tpl" | grep -c 'X-Agent-Id: AID9')" "1"
+chk "soul has workspace" "$(printf '%s' "$tpl" | grep -c 'workspace_id="MTRNIX"')" "1"
+chk "soul block delimited" "$(printf '%s' "$tpl" | grep -c -- '--- metronix-config ---')" "1"
 
 echo "Task4: SOUL.md append/replace"
 d="$(mktemp -d)"; printf 'You are Persona.\nLine two.\n' > "$d/SOUL.md"
@@ -80,53 +77,56 @@ else
   echo "  SKIP Task5: no host yq and no usable Docker -- text merge not exercised"
 fi
 
-echo "Task6: prompt-file fallback"
+echo "Task6: prompt dir -- 3 filled prompts, no unfilled placeholders"
 d="$(mktemp -d)"
-bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY1; H_AGENT=AID1; H_WS=MTRNIX; write_hermes_prompt_file '$d/setup.md'" >/dev/null
-chk "file written" "$([[ -f "$d/setup.md" ]] && echo yes || echo no)" "yes"
-chk "contains config block" "$(grep -c 'X-Agent-Id: AID1' "$d/setup.md")" "1"
-chk "contains soul block" "$(grep -c -- '--- metronix-config ---' "$d/setup.md")" "1"
-chk "no placeholders" "$(grep -c '{{' "$d/setup.md")" "0"
+bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY1; H_AGENT=AID1; H_WS=MTRNIX; write_hermes_prompt_dir '$d/out'" >/dev/null 2>&1
+chk "3 files written" "$(ls -1 "$d/out" 2>/dev/null | wc -l | tr -d ' ')" "3"
+chk "prompt 1 filled (agent)" "$(grep -c 'X-Agent-Id: AID1' "$d/out/1-install-mcp.md")" "1"
+chk "prompt 2 present" "$([[ -f "$d/out/2-memory-source.md" ]] && echo yes || echo no)" "yes"
+chk "prompt 3 present" "$([[ -f "$d/out/3-migrate.md" ]] && echo yes || echo no)" "yes"
+chk "no unfilled real placeholders" "$(grep -rlE '\{\{(METRONIX_URL|MCP_API_KEY|AGENT_UUID|WORKSPACE_ID)\}\}' "$d/out" 2>/dev/null | wc -l | tr -d ' ')" "0"
 
 echo "Task7: orchestrator (HOME stubbed)"
 STUB_ENV='get_env(){ case $1 in METRONIX_MCP_API_KEY) echo K;; DEFAULT_WORKSPACE_ID) echo MTRNIX;; esac; }'
 
-# absent Hermes -> prompt file, no ~/.hermes created
+# absent Hermes -> prompt dir, no ~/.hermes created
 hd="$(mktemp -d)"; work="$(mktemp -d)"
 ( cd "$work" && HOME="$hd" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; $STUB_ENV; wire_hermes" >/tmp/wh.txt 2>&1 )
-chk "absent -> prompt file" "$([[ -f "$work/metronix-hermes-setup.md" ]] && echo yes || echo no)" "yes"
+chk "absent -> prompt dir" "$([[ -d "$work/metronix-hermes-setup" ]] && echo yes || echo no)" "yes"
 chk "absent -> no ~/.hermes" "$([[ -e "$hd/.hermes" ]] && echo yes || echo no)" "no"
 
 # present + interactive choice "2" -> guide only, config NOT edited (no yq needed)
 hd3="$(mktemp -d)"; w3="$(mktemp -d)"; mkdir -p "$hd3/.hermes"; printf 'agent: hermes\n' > "$hd3/.hermes/config.yaml"
 ( cd "$w3" && HOME="$hd3" bash -c "source '$INSTALL'; ASSUME_YES=false; WIRE_HERMES=false; $STUB_ENV; wire_hermes" >/tmp/wh3.txt 2>&1 <<< "2" )
-chk "choice 2 -> guide written" "$([[ -f "$w3/metronix-hermes-setup.md" ]] && echo yes || echo no)" "yes"
+chk "choice 2 -> prompt dir written" "$([[ -d "$w3/metronix-hermes-setup" ]] && echo yes || echo no)" "yes"
 chk "choice 2 -> config NOT edited" "$(grep -c 'metronix:' "$hd3/.hermes/config.yaml")" "0"
 
 # present + bare -y (no --wire-hermes) -> guide only, config NOT edited
 hd4="$(mktemp -d)"; w4="$(mktemp -d)"; mkdir -p "$hd4/.hermes"; printf 'agent: hermes\n' > "$hd4/.hermes/config.yaml"
 ( cd "$w4" && HOME="$hd4" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=false; $STUB_ENV; wire_hermes" >/tmp/wh4.txt 2>&1 )
 chk "bare -y -> config NOT edited" "$(grep -c 'metronix:' "$hd4/.hermes/config.yaml")" "0"
-chk "bare -y -> guide written" "$([[ -f "$w4/metronix-hermes-setup.md" ]] && echo yes || echo no)" "yes"
+chk "bare -y -> prompt dir written" "$([[ -d "$w4/metronix-hermes-setup" ]] && echo yes || echo no)" "yes"
 
-# present + -y --wire-hermes -> minimal edit applied (real yq via host or Docker)
+# present + -y --wire-hermes -> minimal edit applied + prompts dir written (real yq via host/Docker)
 if can_run_yq; then
-  hd2="$(mktemp -d)"; mkdir -p "$hd2/.hermes"; printf 'agent: hermes\n' > "$hd2/.hermes/config.yaml"; printf 'Persona.\n' > "$hd2/.hermes/SOUL.md"
-  ( HOME="$hd2" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; ${STUB_ENV/echo K/echo KEYZ}; wire_hermes" >/tmp/wh2.txt 2>&1 )
+  hd2="$(mktemp -d)"; w2="$(mktemp -d)"; mkdir -p "$hd2/.hermes"; printf 'agent: hermes\n' > "$hd2/.hermes/config.yaml"; printf 'Persona.\n' > "$hd2/.hermes/SOUL.md"
+  ( cd "$w2" && HOME="$hd2" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; ${STUB_ENV/echo K/echo KEYZ}; wire_hermes" >/tmp/wh2.txt 2>&1 )
   chk "config wired" "$(grep -c 'Bearer KEYZ' "$hd2/.hermes/config.yaml")" "1"
   chk "config NOT reformatted (agent line intact)" "$(grep -c '^agent: hermes' "$hd2/.hermes/config.yaml")" "1"
   chk "soul wired" "$(grep -c -- '--- metronix-config ---' "$hd2/.hermes/SOUL.md")" "1"
   chk "backup made" "$(ls "$hd2/.hermes/"config.yaml.bak-* 2>/dev/null | wc -l | tr -d ' ')" "1"
   chk "no leftover temp files" "$(ls "$hd2/.hermes/".metronix-* 2>/dev/null | wc -l | tr -d ' ')" "0"
+  chk "apply also wrote prompts dir (2 & 3 ready)" "$([[ -f "$w2/metronix-hermes-setup/2-memory-source.md" ]] && echo yes || echo no)" "yes"
 else
   echo "  SKIP: no host yq and no usable Docker -- apply path not exercised"
 fi
 
 echo "Task8: standalone --wire-hermes does not build the stack"
 hd="$(mktemp -d)"; work="$(mktemp -d)"; cp "$INSTALL" "$work/install.sh"
+mkdir -p "$work/docs/integrations/hermes"; cp "$REPO/docs/integrations/hermes/"prompt-*.md "$work/docs/integrations/hermes/"
 printf 'METRONIX_MCP_API_KEY=K\nDEFAULT_WORKSPACE_ID=MTRNIX\n' > "$work/.env"
 ( cd "$work" && HOME="$hd" bash -c "source ./install.sh; launch(){ echo BUILT; }; wait_health(){ :; }; print_links(){ :; }; check_prereqs(){ :; }; main --wire-hermes -y" >/tmp/wh5.txt 2>&1 )
 chk "standalone did NOT build" "$(grep -q BUILT /tmp/wh5.txt && echo built || echo no)" "no"
-chk "standalone wrote prompt or wired" "$([[ -f "$work/metronix-hermes-setup.md" || -f "$hd/.hermes/config.yaml" ]] && echo yes || echo no)" "yes"
+chk "standalone produced prompts or wired" "$([[ -d "$work/metronix-hermes-setup" || -f "$hd/.hermes/config.yaml" ]] && echo yes || echo no)" "yes"
 
 echo ""; echo "TOTAL: $PASS passed, $FAIL failed"; [[ $FAIL -eq 0 ]]

--- a/tests/installer/test_wire_hermes.sh
+++ b/tests/installer/test_wire_hermes.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tests for the Hermes wiring in install.sh. Sandboxed; no docker, no real ~/.hermes.
+# Tests for the Hermes wiring in install.sh. Sandboxed; no real ~/.hermes.
+# The text-merge / apply paths need a usable yq or Docker and SKIP otherwise.
 set -u
 INSTALL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/install.sh"
 PASS=0; FAIL=0
@@ -52,33 +53,31 @@ chk "orphan: top persona kept" "$(grep -c 'Persona top.' "$d/SOUL.md")" "1"
 chk "orphan: trailing persona kept" "$(grep -c 'Persona AFTER orphan opener.' "$d/SOUL.md")" "1"
 chk "orphan: a complete block now present" "$(grep -c -- '--- end metronix-config ---' "$d/SOUL.md")" "1"
 
-# Helper: can we actually run yq (host binary, or Docker daemon up for mikefarah/yq)?
+# Can we actually run yq (host binary, or Docker daemon up for mikefarah/yq)?
 can_run_yq() { command -v yq >/dev/null 2>&1 || { command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; }; }
 
-echo "Task5a: merge_hermes_config builds the right Docker yq command (host yq absent)"
-if command -v yq >/dev/null 2>&1; then
-  echo "  SKIP 5a: host yq present — Docker branch not taken here"
-else
-  d="$(mktemp -d)"; printf 'mcp_servers: {}\n' > "$d/config.yaml"
-  out="$(bash -c "source '$INSTALL'; docker(){ echo DOCKER \"\$@\"; }; H_URL=http://h/v1; H_KEY=K1; H_AGENT=A1; merge_hermes_config '$d/config.yaml'")"
-  chk "5a invokes docker once" "$(printf '%s' "$out" | grep -c '^DOCKER run')" "1"
-  chk "5a passes -e H_URL" "$(printf '%s' "$out" | grep -c -- '-e H_URL=http://h/v1')" "1"
-  chk "5a passes -e H_AGENT" "$(printf '%s' "$out" | grep -c -- '-e H_AGENT=A1')" "1"
-  chk "5a runs mikefarah/yq -i" "$(printf '%s' "$out" | grep -c 'mikefarah/yq -i')" "1"
-  chk "5a mounts a work dir" "$(printf '%s' "$out" | grep -c -- '-w /work')" "1"
-fi
-
-echo "Task5b: real merge edits config (host yq or Docker), preserving other keys"
+echo "Task5: minimal text merge -- append / insert / idempotent (gated on yq/Docker)"
 if can_run_yq; then
-  d="$(mktemp -d)"; printf 'agent: hermes\nmcp_servers:\n  other:\n    url: http://other\n' > "$d/config.yaml"
-  bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY1; H_AGENT=AID1; H_WS=MTRNIX; merge_hermes_config '$d/config.yaml'" >/dev/null 2>&1
-  chk "5b metronix url set" "$(grep -c 'url: http://h:8000/mcp' "$d/config.yaml")" "1"
-  chk "5b auth header set" "$(grep -c 'Authorization: Bearer KEY1' "$d/config.yaml")" "1"
-  chk "5b agent header set" "$(grep -c 'X-Agent-Id: AID1' "$d/config.yaml")" "1"
-  chk "5b other server preserved" "$(grep -c 'url: http://other' "$d/config.yaml")" "1"
-  chk "5b top-level preserved" "$(grep -c '^agent: hermes' "$d/config.yaml")" "1"
+  # 5a) no mcp_servers -> append block at EOF; original lines stay byte-identical
+  d="$(mktemp -d)"; printf 'agent: hermes\ntoolsets:\n- hermes-cli\n' > "$d/c.yaml"; cp "$d/c.yaml" "$d/orig"
+  bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY1; H_AGENT=AID1; merge_hermes_config '$d/c.yaml'" >/dev/null 2>&1
+  chk "5a metronix appended" "$(grep -c '^  metronix:' "$d/c.yaml")" "1"
+  chk "5a url set" "$(grep -c 'url: http://h:8000/mcp' "$d/c.yaml")" "1"
+  chk "5a NO reformat (toolsets item intact)" "$(grep -c '^- hermes-cli' "$d/c.yaml")" "1"
+  chk "5a original prefix untouched" "$(diff <(cat "$d/orig") <(head -3 "$d/c.yaml") >/dev/null 2>&1 && echo same || echo changed)" "same"
+
+  # 5b) existing mcp_servers -> insert metronix under it; siblings + non-mcp lines unchanged
+  d2="$(mktemp -d)"; printf 'agent: hermes\nmcp_servers:\n  other:\n    url: http://other\ntoolsets:\n- hermes-cli\n' > "$d2/c.yaml"
+  bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY2; H_AGENT=AID2; merge_hermes_config '$d2/c.yaml'" >/dev/null 2>&1
+  chk "5b metronix inserted" "$(grep -c '^  metronix:' "$d2/c.yaml")" "1"
+  chk "5b other server preserved" "$(grep -c 'url: http://other' "$d2/c.yaml")" "1"
+  chk "5b NO reformat (toolsets item intact)" "$(grep -c '^- hermes-cli' "$d2/c.yaml")" "1"
+
+  # 5c) idempotent: re-running makes no change, no duplicate
+  bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY2; H_AGENT=AID2; merge_hermes_config '$d2/c.yaml'" >/dev/null 2>&1
+  chk "5c single metronix entry" "$(grep -c '^  metronix:' "$d2/c.yaml")" "1"
 else
-  echo "  SKIP 5b: no host yq and no usable Docker — real merge not exercised"
+  echo "  SKIP Task5: no host yq and no usable Docker -- text merge not exercised"
 fi
 
 echo "Task6: prompt-file fallback"
@@ -90,28 +89,44 @@ chk "contains soul block" "$(grep -c -- '--- metronix-config ---' "$d/setup.md")
 chk "no placeholders" "$(grep -c '{{' "$d/setup.md")" "0"
 
 echo "Task7: orchestrator (HOME stubbed)"
+STUB_ENV='get_env(){ case $1 in METRONIX_MCP_API_KEY) echo K;; DEFAULT_WORKSPACE_ID) echo MTRNIX;; esac; }'
+
 # absent Hermes -> prompt file, no ~/.hermes created
 hd="$(mktemp -d)"; work="$(mktemp -d)"
-( cd "$work" && HOME="$hd" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; METRONIX_MCP_API_KEY=K; DEFAULT_WORKSPACE_ID=MTRNIX; get_env(){ case \$1 in METRONIX_MCP_API_KEY) echo K;; DEFAULT_WORKSPACE_ID) echo MTRNIX;; esac; }; wire_hermes" >/tmp/wh.txt 2>&1 )
+( cd "$work" && HOME="$hd" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; $STUB_ENV; wire_hermes" >/tmp/wh.txt 2>&1 )
 chk "absent -> prompt file" "$([[ -f "$work/metronix-hermes-setup.md" ]] && echo yes || echo no)" "yes"
 chk "absent -> no ~/.hermes" "$([[ -e "$hd/.hermes" ]] && echo yes || echo no)" "no"
-# present + -y --wire-hermes -> edits applied (real yq via host or Docker)
+
+# present + interactive choice "2" -> guide only, config NOT edited (no yq needed)
+hd3="$(mktemp -d)"; w3="$(mktemp -d)"; mkdir -p "$hd3/.hermes"; printf 'agent: hermes\n' > "$hd3/.hermes/config.yaml"
+( cd "$w3" && HOME="$hd3" bash -c "source '$INSTALL'; ASSUME_YES=false; WIRE_HERMES=false; $STUB_ENV; wire_hermes" >/tmp/wh3.txt 2>&1 <<< "2" )
+chk "choice 2 -> guide written" "$([[ -f "$w3/metronix-hermes-setup.md" ]] && echo yes || echo no)" "yes"
+chk "choice 2 -> config NOT edited" "$(grep -c 'metronix:' "$hd3/.hermes/config.yaml")" "0"
+
+# present + bare -y (no --wire-hermes) -> guide only, config NOT edited
+hd4="$(mktemp -d)"; w4="$(mktemp -d)"; mkdir -p "$hd4/.hermes"; printf 'agent: hermes\n' > "$hd4/.hermes/config.yaml"
+( cd "$w4" && HOME="$hd4" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=false; $STUB_ENV; wire_hermes" >/tmp/wh4.txt 2>&1 )
+chk "bare -y -> config NOT edited" "$(grep -c 'metronix:' "$hd4/.hermes/config.yaml")" "0"
+chk "bare -y -> guide written" "$([[ -f "$w4/metronix-hermes-setup.md" ]] && echo yes || echo no)" "yes"
+
+# present + -y --wire-hermes -> minimal edit applied (real yq via host or Docker)
 if can_run_yq; then
   hd2="$(mktemp -d)"; mkdir -p "$hd2/.hermes"; printf 'agent: hermes\n' > "$hd2/.hermes/config.yaml"; printf 'Persona.\n' > "$hd2/.hermes/SOUL.md"
-  ( HOME="$hd2" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; get_env(){ case \$1 in METRONIX_MCP_API_KEY) echo KEYZ;; DEFAULT_WORKSPACE_ID) echo MTRNIX;; esac; }; wire_hermes" >/tmp/wh2.txt 2>&1 )
-  chk "config wired" "$(grep -c 'Authorization: Bearer KEYZ' "$hd2/.hermes/config.yaml")" "1"
+  ( HOME="$hd2" bash -c "source '$INSTALL'; ASSUME_YES=true; WIRE_HERMES=true; ${STUB_ENV/echo K/echo KEYZ}; wire_hermes" >/tmp/wh2.txt 2>&1 )
+  chk "config wired" "$(grep -c 'Bearer KEYZ' "$hd2/.hermes/config.yaml")" "1"
+  chk "config NOT reformatted (agent line intact)" "$(grep -c '^agent: hermes' "$hd2/.hermes/config.yaml")" "1"
   chk "soul wired" "$(grep -c -- '--- metronix-config ---' "$hd2/.hermes/SOUL.md")" "1"
   chk "backup made" "$(ls "$hd2/.hermes/"config.yaml.bak-* 2>/dev/null | wc -l | tr -d ' ')" "1"
   chk "no leftover temp files" "$(ls "$hd2/.hermes/".metronix-* 2>/dev/null | wc -l | tr -d ' ')" "0"
 else
-  echo "  SKIP: no host yq and no usable Docker — apply path not exercised"
+  echo "  SKIP: no host yq and no usable Docker -- apply path not exercised"
 fi
 
 echo "Task8: standalone --wire-hermes does not build the stack"
 hd="$(mktemp -d)"; work="$(mktemp -d)"; cp "$INSTALL" "$work/install.sh"
 printf 'METRONIX_MCP_API_KEY=K\nDEFAULT_WORKSPACE_ID=MTRNIX\n' > "$work/.env"
-( cd "$work" && HOME="$hd" bash -c "source ./install.sh; launch(){ echo BUILT; }; wait_health(){ :; }; print_links(){ :; }; check_prereqs(){ :; }; main --wire-hermes -y" >/tmp/wh3.txt 2>&1 )
-chk "standalone did NOT build" "$(grep -q BUILT /tmp/wh3.txt && echo built || echo no)" "no"
+( cd "$work" && HOME="$hd" bash -c "source ./install.sh; launch(){ echo BUILT; }; wait_health(){ :; }; print_links(){ :; }; check_prereqs(){ :; }; main --wire-hermes -y" >/tmp/wh5.txt 2>&1 )
+chk "standalone did NOT build" "$(grep -q BUILT /tmp/wh5.txt && echo built || echo no)" "no"
 chk "standalone wrote prompt or wired" "$([[ -f "$work/metronix-hermes-setup.md" || -f "$hd/.hermes/config.yaml" ]] && echo yes || echo no)" "yes"
 
 echo ""; echo "TOTAL: $PASS passed, $FAIL failed"; [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Follow-up to the Hermes-wiring feature (#206). Removes the hard requirement that the host have **yq** installed for the auto-wire to fire — most users on a fresh machine lacked it, so the installer always fell through to the file-only fallback and never offered to edit `~/.hermes/config.yaml`.

## What & why

Editing `config.yaml` safely needs a real YAML processor (so only `mcp_servers.metronix` changes and the rest — other servers, comments, key order — is preserved). Hand-editing YAML from bash is too easy to corrupt. Rather than ask the user to install yq, we run the tiny `mikefarah/yq` image via **Docker, which the installer already requires** — zero host install.

- `run_yq_edit FILE EXPR [NAME=VAL ...]`: prefer a host `yq`; otherwise `docker run --rm --user $(id -u):$(id -g) -e ... -v <dir>:/work mikefarah/yq -i ...` (runs as the invoking user so the edited file stays user-owned).
- `yq_available` is now true when **yq OR docker** is present; the file-only fallback triggers only when neither exists.
- `wire_hermes` announces what yq is and that it runs via Docker when not installed locally; temp copies now live in `~/.hermes` (Docker-visible + atomic `mv`); removed the dead `${soul:-/dev/null}` fallback (review nit).
- Docs note in `docs/integrations/hermes.md` explains the yq-via-Docker behaviour.
- `.gitignore` the generated per-deployment `metronix-hermes-setup.md`.

## Tests

- **Task5a** (always runs, no Docker): asserts `merge_hermes_config` builds the correct Docker yq command (docker stubbed) — mount, `-e` env vars, `-i`, `mikefarah/yq`.
- **Task5b / Task7** (gated on a usable host-yq or Docker daemon): run the **real** edit and verify via grep that `mcp_servers.metronix` is set, other keys preserved, backup made, no leftover temp files.

Validated end-to-end locally with `mikefarah/yq` (config edited correctly, `agent:`, sibling `mcp_servers.other`, and comments all preserved).

```
bash tests/installer/test_wire_hermes.sh   # 43 passed (real Docker yq exercised)
bash tests/installer/test_install.sh       # 30 passed
bash tests/installer/test_failgen.sh       # 13 passed
shellcheck install.sh                      # clean
```

## Note

Branched from `develop` after #206 merged. Includes the small no-yq-message commit `d01d4da` that had landed directly on develop earlier (already in base).