### PR TITLE
Improve installer Neo4j startup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,8 @@ QDRANT_API_KEY=                       # only for cloud / authenticated Qdrant
 QDRANT_HTTPS=false
 NEO4J_HOST=neo4j                  # compose -> neo4j
 NEO4J_PORT=7687                       # container-internal port (leave default)
-NEO4J_AUTH=                           # Set to "none" to disable auth; default is "neo4j/<password>" (see NEO4J_PASSWORD in ZONE 3)
+# NEO4J_AUTH: leave unset to use default "neo4j/<NEO4J_PASSWORD>"; set to "none" to disable auth
+# NEO4J_AUTH=
 REDIS_HOST=redis                  # compose -> redis
 REDIS_PORT=6379                       # compose -> 6379
 REDIS_DB=0                            # compose -> 0

--- a/install.md
+++ b/install.md
@@ -122,6 +122,17 @@ path **`/mcp`**.
 > The default workspace id is pre-set to `MTRNIX` (`DEFAULT_WORKSPACE_ID` in `.env`). You
 > will need this value, and your MCP key, when you connect an agent.
 
+### 3c. Neo4j authentication
+
+Neo4j requires a username/password. The default credentials are:
+- Username: `neo4j`
+- Password: `metronix_dev`
+
+If you change `NEO4J_PASSWORD` in `.env`, use **plain text** only (not hashes). Neo4j does
+not accept pre-hashed passwords. The `install.sh` script generates a random password
+automatically; if you edit `.env` manually, ensure `NEO4J_PASSWORD` is set to a plain-text
+value and leave `NEO4J_AUTH` unset (or do not edit it).
+
 ## 4. Launch
 
 Build and start the stack. The first run builds images from source and pulls Ollama models,
@@ -274,3 +285,27 @@ Confirm the API is healthy first, then inspect Open WebUI logs:
 curl http://localhost:8000/health
 docker compose -f docker-compose.full.yml logs open-webui
 ```
+
+### Neo4j container is unhealthy
+
+If Neo4j fails to start with the error `dependency failed to start: container
+metronix-full-neo4j is unhealthy`, check the logs:
+
+```bash
+docker logs metronix-full-neo4j
+```
+
+A common cause is an invalid `NEO4J_AUTH` value in `.env`. If `NEO4J_AUTH` is set to an
+empty string, Neo4j receives a blank username and rejects it. Fix:
+
+```bash
+# Remove the NEO4J_AUTH= line from .env
+sed -i '/^NEO4J_AUTH=$/d' .env
+
+# Restart the stack
+docker compose -f docker-compose.full.yml down
+docker compose -f docker-compose.full.yml up -d
+```
+
+Also ensure `NEO4J_PASSWORD` is a **plain text** password, not a hash. Neo4j does not accept
+pre-hashed passwords.

--- a/install.md
+++ b/install.md
@@ -309,3 +309,19 @@ docker compose -f docker-compose.full.yml up -d
 
 Also ensure `NEO4J_PASSWORD` is a **plain text** password, not a hash. Neo4j does not accept
 pre-hashed passwords.
+
+### Neo4j password changed on an existing volume
+
+Neo4j only sets the initial password on **first startup**. If you change `NEO4J_PASSWORD`
+in `.env` on a system that already has the Neo4j data volume, the database keeps the old
+password and the healthcheck (which reads the new one) will fail.
+
+To reset the database with the new password:
+
+```bash
+docker compose -f docker-compose.full.yml down -v
+docker compose -f docker-compose.full.yml up -d
+```
+
+> **Warning:** `down -v` deletes ALL data volumes (PostgreSQL, Qdrant, Neo4j, Redis,
+> Ollama). This is a full reset — only do it if you're starting fresh.

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,21 @@ ok()   { printf '%s\xe2\x9c\x93%s %s\n' "$C_OK" "$C_RST" "$*"; }
 warn() { printf '%s!%s %s\n' "$C_WARN" "$C_RST" "$*"; }
 err()  { printf '%s\xe2\x9c\x97%s %s\n' "$C_ERR" "$C_RST" "$*" >&2; }
 
+print_banner() {
+  local cyan="" rst=""
+  if [[ -t 1 ]]; then cyan=$'\033[36m'; rst=$'\033[0m'; fi
+  printf '%s' "$cyan"
+  cat <<'BANNER'
+
+ __  __ ___ ___ ___ _  _ ___ ___ _  _ _  _ ___    ___ ___ ___ _  _ ___
+|  \/ | __/ __/ __| || | __| _ \ || | || |  \/ | __| | __| _ \ || | _ \
+| |\/| _|| (_| (__| __ | _||   / __ | __ | |\/ | _|| | _||   / __ |   /
+|_|  |_|___\___\___|_||_|___|_|_\_||_|_||_|_|  |_|___| |___|_|_\_||_|_|
+
+BANNER
+  printf '%s\n' "$rst"
+}
+
 # Prompt for a required value, re-asking until the user enters something non-blank.
 # Usage: prompt_required VAR_NAME "Prompt text: " [secret]
 # Passing "secret" as the 3rd arg hides the input (for API keys).
@@ -615,7 +630,7 @@ configure() {
   # Remove NEO4J_AUTH if it is empty — an empty string overrides docker-compose's
   # default of "neo4j/<password>", causing Neo4j to reject the initial credentials.
   if grep -qE "^NEO4J_AUTH=$" "$ENV_FILE" 2>/dev/null; then
-    sed -i '/^NEO4J_AUTH=$/d' "$ENV_FILE"
+    grep -v '^NEO4J_AUTH=$' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
   fi
 
   # Everything validated — promote the staged config atomically and disarm the
@@ -627,6 +642,21 @@ configure() {
 }
 
 launch() {
+  # Warn if the Neo4j volume exists with a potentially different password.
+  # Neo4j only sets the initial password on first startup; on an existing volume
+  # it keeps the old one, so the healthcheck (which reads NEO4J_PASSWORD from
+  # .env) will fail if the password has changed since the volume was created.
+  local neo_vol=""
+  neo_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null \
+    | grep -E 'neo4j' | head -1 || true)"
+  if [[ -n "$neo_vol" ]] && docker volume inspect "$neo_vol" >/dev/null 2>&1 \
+     && [[ "$RECONFIGURE" == true ]]; then
+    warn "Neo4j data volume '$neo_vol' already exists."
+    warn "  Neo4j only sets the initial password on FIRST startup. If NEO4J_PASSWORD"
+    warn "  changed since this volume was created, the healthcheck will fail."
+    warn "  To reset: ${COMPOSE[*]} -f $COMPOSE_FILE down -v && ${COMPOSE[*]} -f $COMPOSE_FILE up -d"
+  fi
+
   local args=(-f "$COMPOSE_FILE")
   [[ "$ENABLE_WEBUI" == true ]] && args+=(--profile openwebui)
   args+=(up -d --build)
@@ -647,6 +677,16 @@ wait_health() {
   done
   warn "API did not report healthy within ~5 min. It may still be building."
   warn "  Check logs: ${COMPOSE[*]} -f $COMPOSE_FILE logs -f metronix-core"
+  # If Neo4j is unhealthy, give a targeted hint (common: password/volume mismatch).
+  if docker inspect --format='{{.State.Health.Status}}' metronix-full-neo4j 2>/dev/null \
+     | grep -q unhealthy; then
+    warn ""
+    warn "Neo4j container is UNHEALTHY. Common causes:"
+    warn "  1. NEO4J_AUTH set to empty in .env (remove the line to use the default)"
+    warn "  2. NEO4J_PASSWORD changed on an existing volume (reset: docker compose -f $COMPOSE_FILE down -v)"
+    warn "  3. NEO4J_PASSWORD is a hash, not plain text (use a plain text password)"
+    warn "  Neo4j logs: docker logs metronix-full-neo4j"
+  fi
   return 0
 }
 
@@ -664,6 +704,7 @@ print_links() {
 }
 
 main() {
+  print_banner
   parse_args "$@"
   cd "$REPO_ROOT"
   # Standalone agent-wiring: skip the stack build entirely.

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,11 @@ AGENT_ID=""          # override the generated X-Agent-Id (Hermes wiring)
 METRONIX_URL=""      # override the MCP URL written into the agent config
 COMPOSE=()
 
+# State globals — set by diagnose_state(), read by resume_menu() / do_resume().
+DIAG_ENV="no"; DIAG_ENV_ISSUES=""; DIAG_ANY_EXIST="no"
+DIAG_ALL_HEALTHY="yes"; DIAG_ANY_UNHEALTHY="no"; DIAG_VOL_EXISTS="no"; DIAG_API_OK="no"
+RESUME_ACTION=""
+
 if [[ -t 1 ]]; then
   C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_ERR=$'\033[31m'; C_RST=$'\033[0m'
 else
@@ -641,6 +646,219 @@ configure() {
   ok "Wrote $ENV_FILE"
 }
 
+# The core services we expect to be running (container_name:healthy-or-not).
+CORE_CONTAINERS=(
+  metronix-full-postgres metronix-full-qdrant metronix-full-neo4j
+  metronix-full-redis metronix-full-ollama metronix-full-splade
+  metronix-full-api
+)
+
+# Check the health of one container. Echo: up:healthy | up:unhealthy | up:starting
+# | down | missing. Never errors.
+container_status() {
+  local c="$1" s
+  if ! docker inspect "$c" >/dev/null 2>&1; then echo missing; return; fi
+  s="$(docker inspect --format '{{.State.Status}}' "$c" 2>/dev/null)"
+  if [[ "$s" != "running" ]]; then echo down; return; fi
+  # Has a healthcheck?
+  local hs; hs="$(docker inspect --format '{{.State.Health.Status}}' "$c" 2>/dev/null)"
+  case "$hs" in
+    healthy)   echo up:healthy ;;
+    unhealthy) echo up:unhealthy ;;
+    starting)  echo up:starting ;;
+    *)         echo up:unknown ;;  # no healthcheck or blank
+  esac
+}
+
+# Print the status of every core container in a compact table.
+diagnose_state() {
+  local env_exists=no env_issues="" all_healthy=yes any_exist=no any_unhealthy=no
+
+  # If COMPOSE was never detected (e.g. check_prereqs stubbed in tests), skip
+  # the volume/compose introspection but still report what we can.
+  local compose_ok=yes
+  [[ ${#COMPOSE[@]} -eq 0 ]] && compose_ok=no
+
+  info "━━━ Inspecting current installation state ━━━"
+  info ""
+
+  # -- .env existence + common breakage --
+  if [[ -f "$ENV_FILE" ]]; then
+    env_exists=yes
+    # Check for known breakage: empty NEO4J_AUTH=
+    if grep -qE '^NEO4J_AUTH=$' "$ENV_FILE" 2>/dev/null; then
+      env_issues+="NEO4J_AUTH is set to an empty string (breaks Neo4j startup); "
+    fi
+    # Check for missing required secrets (blank POSTGRES_PASSWORD etc.)
+    local k v
+    for k in POSTGRES_PASSWORD NEO4J_PASSWORD METRONIX_MCP_API_KEY FERNET_KEY; do
+      v="$(grep -E "^${k}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+      if [[ -z "$v" ]]; then env_issues+="${k} is blank; "; fi
+    done
+    if [[ -z "$env_issues" ]]; then
+      ok ".env exists  ($ENV_FILE)"
+    else
+      warn ".env exists but has issues: ${env_issues%; }"
+    fi
+  else
+    warn ".env NOT found  ($ENV_FILE)"
+  fi
+
+  # -- Container status table --
+  info ""
+  info "Service status:"
+  local c st
+  for c in "${CORE_CONTAINERS[@]}"; do
+    st="$(container_status "$c")"
+    case "$st" in
+      up:healthy)   printf '  %s%-22s%s %s healthy%s\n' "$C_OK" "$c" "$C_RST" "$C_OK" "$C_RST" ;;
+      up:unhealthy) printf '  %s%-22s%s %s unhealthy%s\n' "$C_OK" "$c" "$C_ERR" "$C_RST" "$C_ERR"; any_unhealthy=yes ;;
+      up:starting)  printf '  %s%-22s%s %s starting…%s\n' "$C_OK" "$c" "$C_WARN" "$C_RST" ;;
+      up:unknown)   printf '  %s%-22s%s running (no healthcheck)%s\n' "$C_OK" "$c" "$C_RST" ;;
+      down)         printf '  %s%-22s%s %sexited%s\n' "$C_WARN" "$c" "$C_WARN" "$C_RST"; any_exist=yes; all_healthy=no ;;
+      missing)      printf '  %-22s not created\n' "$c"; all_healthy=no ;;
+    esac
+    [[ "$st" != missing ]] && any_exist=yes
+    [[ "$st" != "up:healthy" && "$st" != "up:unknown" ]] && all_healthy=no
+  done
+  info ""
+
+  # -- Volume check (Neo4j volume exists with potentially old password) --
+  local neo_vol="" vol_exists=no
+  if [[ "$compose_ok" == yes ]]; then
+    neo_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null \
+      | grep -iE 'neo4j' | head -1 || true)"
+    if [[ -n "$neo_vol" ]] && docker volume inspect "$neo_vol" >/dev/null 2>&1; then
+      vol_exists=yes
+      info "Neo4j data volume '$neo_vol' exists (password set on first startup only)."
+    fi
+  fi
+
+  # -- API reachable? --
+  local api_ok=no
+  if command -v curl >/dev/null 2>&1 && curl -fsS "http://localhost:$API_PORT/health" >/dev/null 2>&1; then
+    api_ok=yes; ok "API is reachable at http://localhost:$API_PORT/health"
+  else
+    warn "API is NOT reachable at http://localhost:$API_PORT/health"
+  fi
+
+  # Set globals for the resume menu.
+  DIAG_ENV="$env_exists"
+  DIAG_ENV_ISSUES="$env_issues"
+  DIAG_ANY_EXIST="$any_exist"
+  DIAG_ALL_HEALTHY="$all_healthy"
+  DIAG_ANY_UNHEALTHY="$any_unhealthy"
+  DIAG_VOL_EXISTS="$vol_exists"
+  DIAG_API_OK="$api_ok"
+}
+
+# Offer the user a menu based on what diagnose_state() found. Sets RESUME_ACTION
+# to one of: start | rebuild | reconfigure | reset | fixenv | exit.
+resume_menu() {
+  # In -y / non-interactive mode, pick the most reasonable action automatically.
+  if [[ "$ASSUME_YES" == true ]]; then
+    if [[ "$DIAG_API_OK" == yes ]]; then RESUME_ACTION=exit; return; fi
+    if [[ "$DIAG_ENV" == yes && -n "$DIAG_ENV_ISSUES" ]]; then RESUME_ACTION=fixenv; return; fi
+    if [[ "$DIAG_ANY_EXIST" == yes ]]; then RESUME_ACTION=rebuild; return; fi
+    if [[ "$DIAG_ENV" == yes ]]; then RESUME_ACTION=start; return; fi
+    RESUME_ACTION=reconfigure; return
+  fi
+
+  # Interactive: build a list of relevant options.
+  local opts=() labels=() n=0 choice
+
+  info "What would you like to do?"
+  info ""
+
+  if [[ "$DIAG_ENV" == yes && -n "$DIAG_ENV_ISSUES" ]]; then
+    n=$((n+1)); opts+=("fixenv");       labels+=("Fix .env issues and continue")
+  fi
+  if [[ "$DIAG_API_OK" == yes ]]; then
+    n=$((n+1)); opts+=("exit");         labels+=("Stack is healthy — nothing to do, exit")
+  fi
+  if [[ "$DIAG_ENV" == yes && "$DIAG_ANY_EXIST" == no ]]; then
+    n=$((n+1)); opts+=("start");        labels+=("Start the stack (config exists, containers not created)")
+  fi
+  if [[ "$DIAG_ANY_EXIST" == yes ]]; then
+    n=$((n+1)); opts+=("rebuild");      labels+=("Rebuild and restart the stack")
+  fi
+  if [[ "$DIAG_ANY_UNHEALTHY" == yes || "$DIAG_VOL_EXISTS" == yes ]]; then
+    n=$((n+1)); opts+=("reset");        labels+=("Reset all data volumes and reinstall (destructive)")
+  fi
+  n=$((n+1)); opts+=("reconfigure");    labels+=("Re-run full configuration from scratch")
+  n=$((n+1)); opts+=("exit");           labels+=("Exit now")
+
+  local i
+  for i in "${!opts[@]}"; do
+    printf '  %d) %s\n' "$((i+1))" "${labels[$i]}"
+  done
+  info ""
+  read -rp "Choose [1-$n]: " choice || { err "Aborted."; exit 1; }
+  case "$choice" in
+    ''|*[!0-9]*) err "Invalid choice: $choice"; exit 1 ;;
+  esac
+  if [[ "$choice" -lt 1 || "$choice" -gt "$n" ]]; then
+    err "Choice out of range: $choice"; exit 1
+  fi
+  RESUME_ACTION="${opts[$((choice-1))]}"
+}
+
+# Apply the action chosen in resume_menu. May reconfigure, fixenv, launch, etc.
+do_resume() {
+  case "$RESUME_ACTION" in
+    exit)
+      ok "Nothing to do — exiting."
+      ;;
+    fixenv)
+      info "Fixing .env issues…"
+      # Strip empty NEO4J_AUTH=
+      if grep -qE "^NEO4J_AUTH=$" "$ENV_FILE" 2>/dev/null; then
+        grep -v '^NEO4J_AUTH=$' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+        ok "Removed empty NEO4J_AUTH= from $ENV_FILE"
+      fi
+      # Fill blank secrets using the same resolve_secret logic as configure().
+      local prev val
+      for k in POSTGRES_PASSWORD NEO4J_PASSWORD METRONIX_MCP_API_KEY FERNET_KEY; do
+        prev="$(get_env "$k")"
+        if [[ -z "$prev" ]]; then
+          if [[ "$k" == "FERNET_KEY" ]]; then val="$(gen_fernet)"; else val="$(gen_secret)"; fi
+          if [[ -z "$val" ]]; then
+            err "Could not generate a value for $k (need openssl or a readable /dev/urandom). Aborting before launch."
+            exit 1
+          fi
+          set_env "$k" "$val"
+          ok "Generated missing $k"
+        fi
+      done
+      # Now rebuild/restart so the fix takes effect.
+      launch; wait_health; print_links; wire_hermes
+      ;;
+    start)
+      launch; wait_health; print_links; wire_hermes
+      ;;
+    rebuild)
+      "${COMPOSE[@]}" -f "$COMPOSE_FILE" down 2>/dev/null || true
+      launch; wait_health; print_links; wire_hermes
+      ;;
+    reset)
+      warn "This will DELETE all data volumes (PostgreSQL, Qdrant, Neo4j, Redis, Ollama)."
+      if [[ "$ASSUME_YES" != true ]]; then
+        read -rp "Type 'yes' to confirm: " confirm || { err "Aborted."; exit 1; }
+        [[ "$confirm" == "yes" ]] || { err "Aborted."; exit 1; }
+      fi
+      "${COMPOSE[@]}" -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+      RECONFIGURE=true
+      configure
+      launch; wait_health; print_links; wire_hermes
+      ;;
+    reconfigure)
+      RECONFIGURE=true
+      configure
+      launch; wait_health; print_links; wire_hermes
+      ;;
+  esac
+}
+
 launch() {
   # Warn if the Neo4j volume exists with a potentially different password.
   # Neo4j only sets the initial password on first startup; on an existing volume
@@ -714,6 +932,26 @@ main() {
     exit 0
   fi
   check_prereqs
+
+  # Detect existing installation state and offer a resume menu instead of
+  # blindly reconfiguring/launching on every run. Only run the diagnosis when
+  # there are signs of a previous attempt: .env exists, or containers exist.
+  local has_env=no
+  [[ -f "$ENV_FILE" ]] && has_env=yes
+
+  if [[ "$has_env" == yes ]]; then
+    diagnose_state
+    # If everything is already healthy and API is up, the user may just want status.
+    if [[ "$DIAG_API_OK" == yes && "$RECONFIGURE" != true ]]; then
+      resume_menu; do_resume; exit 0
+    fi
+    # If there are containers or volumes but config has issues, offer the menu.
+    if [[ "$DIAG_ANY_EXIST" == yes || -n "$DIAG_ENV_ISSUES" ]] && [[ "$RECONFIGURE" != true ]]; then
+      resume_menu; do_resume; exit 0
+    fi
+  fi
+
+  # Fresh install path (no .env, no containers) — or --reconfigure forced.
   configure
   launch
   wait_health

--- a/install.sh
+++ b/install.sh
@@ -612,6 +612,12 @@ configure() {
   set_env METRONIX_MCP_API_KEY "$val_mcp"
   set_env FERNET_KEY "$val_fernet"
 
+  # Remove NEO4J_AUTH if it is empty — an empty string overrides docker-compose's
+  # default of "neo4j/<password>", causing Neo4j to reject the initial credentials.
+  if grep -qE "^NEO4J_AUTH=$" "$ENV_FILE" 2>/dev/null; then
+    sed -i '/^NEO4J_AUTH=$/d' "$ENV_FILE"
+  fi
+
   # Everything validated — promote the staged config atomically and disarm the
   # cleanup trap so the real .env survives.
   mv "$ENV_FILE" "$final_env"

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ COMPOSE=()
 
 # State globals — set by diagnose_state(), read by resume_menu() / do_resume().
 DIAG_ENV="no"; DIAG_ENV_ISSUES=""; DIAG_ANY_EXIST="no"
-DIAG_ALL_HEALTHY="yes"; DIAG_ANY_UNHEALTHY="no"; DIAG_VOL_EXISTS="no"; DIAG_API_OK="no"
+DIAG_ANY_UNHEALTHY="no"; DIAG_VOL_EXISTS="no"; DIAG_API_OK="no"
 RESUME_ACTION=""
 
 if [[ -t 1 ]]; then
@@ -672,7 +672,7 @@ container_status() {
 
 # Print the status of every core container in a compact table.
 diagnose_state() {
-  local env_exists=no env_issues="" all_healthy=yes any_exist=no any_unhealthy=no
+  local env_exists=no env_issues="" any_exist=no any_unhealthy=no
 
   # If COMPOSE was never detected (e.g. check_prereqs stubbed in tests), skip
   # the volume/compose introspection but still report what we can.
@@ -713,13 +713,12 @@ diagnose_state() {
     case "$st" in
       up:healthy)   printf '  %s%-22s%s %s healthy%s\n' "$C_OK" "$c" "$C_RST" "$C_OK" "$C_RST" ;;
       up:unhealthy) printf '  %s%-22s%s %s unhealthy%s\n' "$C_OK" "$c" "$C_ERR" "$C_RST" "$C_ERR"; any_unhealthy=yes ;;
-      up:starting)  printf '  %s%-22s%s %s starting…%s\n' "$C_OK" "$c" "$C_WARN" "$C_RST" ;;
-      up:unknown)   printf '  %s%-22s%s running (no healthcheck)%s\n' "$C_OK" "$c" "$C_RST" ;;
-      down)         printf '  %s%-22s%s %sexited%s\n' "$C_WARN" "$c" "$C_WARN" "$C_RST"; any_exist=yes; all_healthy=no ;;
-      missing)      printf '  %-22s not created\n' "$c"; all_healthy=no ;;
+      up:starting)  printf '  %s%-22s%s %s starting…%s\n' "$C_OK" "$c" "$C_RST" "$C_WARN" "$C_RST" ;;
+      up:unknown)   printf '  %s%-22s%s running (no healthcheck)%s\n' "$C_OK" "$c" "$C_RST" "$C_RST" ;;
+      down)         printf '  %s%-22s%s %sexited%s\n' "$C_WARN" "$c" "$C_RST" "$C_WARN" "$C_RST"; any_exist=yes ;;
+      missing)      printf '  %-22s not created\n' "$c" ;;
     esac
     [[ "$st" != missing ]] && any_exist=yes
-    [[ "$st" != "up:healthy" && "$st" != "up:unknown" ]] && all_healthy=no
   done
   info ""
 
@@ -746,7 +745,6 @@ diagnose_state() {
   DIAG_ENV="$env_exists"
   DIAG_ENV_ISSUES="$env_issues"
   DIAG_ANY_EXIST="$any_exist"
-  DIAG_ALL_HEALTHY="$all_healthy"
   DIAG_ANY_UNHEALTHY="$any_unhealthy"
   DIAG_VOL_EXISTS="$vol_exists"
   DIAG_API_OK="$api_ok"
@@ -757,11 +755,11 @@ diagnose_state() {
 resume_menu() {
   # In -y / non-interactive mode, pick the most reasonable action automatically.
   if [[ "$ASSUME_YES" == true ]]; then
-    if [[ "$DIAG_API_OK" == yes ]]; then RESUME_ACTION=exit; return; fi
-    if [[ "$DIAG_ENV" == yes && -n "$DIAG_ENV_ISSUES" ]]; then RESUME_ACTION=fixenv; return; fi
-    if [[ "$DIAG_ANY_EXIST" == yes ]]; then RESUME_ACTION=rebuild; return; fi
-    if [[ "$DIAG_ENV" == yes ]]; then RESUME_ACTION=start; return; fi
-    RESUME_ACTION=reconfigure; return
+    if [[ "$DIAG_API_OK" == yes ]]; then RESUME_ACTION="exit"; return; fi
+    if [[ "$DIAG_ENV" == yes && -n "$DIAG_ENV_ISSUES" ]]; then RESUME_ACTION="fixenv"; return; fi
+    if [[ "$DIAG_ANY_EXIST" == yes ]]; then RESUME_ACTION="rebuild"; return; fi
+    if [[ "$DIAG_ENV" == yes ]]; then RESUME_ACTION="start"; return; fi
+    RESUME_ACTION="reconfigure"; return
   fi
 
   # Interactive: build a list of relevant options.
@@ -879,7 +877,23 @@ launch() {
   [[ "$ENABLE_WEBUI" == true ]] && args+=(--profile openwebui)
   args+=(up -d --build)
   info "Building and starting the stack (first run can take 10-15 min)..."
-  "${COMPOSE[@]}" "${args[@]}"
+  if ! "${COMPOSE[@]}" "${args[@]}"; then
+    warn ""
+    warn "Docker Compose failed while starting the stack."
+    warn "If Neo4j is unhealthy, the most common cause is an existing Neo4j data"
+    warn "volume whose first-start password differs from NEO4J_PASSWORD in .env."
+    if [[ -n "$neo_vol" ]]; then
+      warn "Detected Neo4j volume: $neo_vol"
+    fi
+    warn ""
+    warn "To keep existing data, restore the original NEO4J_PASSWORD in .env and rerun:"
+    warn "  ./install.sh -y"
+    warn ""
+    warn "To discard local install data and start clean:"
+    warn "  ${COMPOSE[*]} -f $COMPOSE_FILE down -v"
+    warn "  ./install.sh -y --reconfigure"
+    return 1
+  fi
 }
 
 wait_health() {

--- a/tests/installer/test_install.sh
+++ b/tests/installer/test_install.sh
@@ -10,7 +10,7 @@ chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else ec
 # parse_args + configure are exercised. launch() echoes state for assertions.
 run_case() {
   local dir; dir="$(mktemp -d)"
-  printf 'LLM_PROVIDER=ollama\nLLM_PROVIDER_URL=\nLLM_PROVIDER_API_KEY=\nLLM_PROVIDER_MODEL=\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\n' > "$dir/.env.example"
+  printf 'LLM_PROVIDER=ollama\nLLM_PROVIDER_URL=\nLLM_PROVIDER_API_KEY=\nLLM_PROVIDER_MODEL=\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\nNEO4J_AUTH=\n' > "$dir/.env.example"
   cat > "$dir/run.sh" <<EOF
 source "$INSTALL"
 check_prereqs() { :; }
@@ -79,6 +79,20 @@ run_case -y --openwebui --chat-url https://api.deepseek.com/v1 --chat-model deep
 chk "exit zero" "$LAST_RC" "0"
 chk "no ignore warning" "$(grep -qi 'ignoring --openwebui' /tmp/installer_test_out.txt && echo yes || echo no)" "no"
 chk "webui enabled" "$(grep -q 'webui=true' /tmp/installer_test_out.txt && echo yes || echo no)" "yes"
+
+echo "Case 9: NEO4J_AUTH= (empty) stripped from generated .env"
+run_case -y
+chk "exit zero" "$LAST_RC" "0"
+chk "NO empty NEO4J_AUTH=" "$(grep -c '^NEO4J_AUTH=$' "$LAST_DIR/.env" 2>/dev/null || true)" "0"
+chk "NEO4J_PASSWORD set non-empty" "$([[ -n "$(envval NEO4J_PASSWORD)" ]] && echo yes || echo no)" "yes"
+chk "NEO4J_PASSWORD not the placeholder" "$([[ "$(envval NEO4J_PASSWORD)" != "changeme" ]] && echo yes || echo no)" "yes"
+
+echo "Case 10: NEO4J_PASSWORD preserved across --reconfigure"
+# Simulate a second run: .env exists with a real neo4j password, --reconfigure
+printf 'LLM_PROVIDER=ollama\nNEO4J_PASSWORD=my_saved_password\nMETRONIX_MCP_API_KEY=K\n' > "$LAST_DIR/.env"
+( cd "$LAST_DIR" && bash run.sh -y --reconfigure >/tmp/installer_test_out.txt 2>&1 ); LAST_RC=$?
+chk "exit zero" "$LAST_RC" "0"
+chk "NEO4J_PASSWORD preserved" "$(envval NEO4J_PASSWORD)" "my_saved_password"
 
 echo ""
 echo "TOTAL: $PASS passed, $FAIL failed"

--- a/tests/installer/test_resume.sh
+++ b/tests/installer/test_resume.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Tests for the state-aware diagnose/resume flow in install.sh.
+# These tests stub docker/COMPOSE so they run sandboxed (no real Docker needed).
+# Run: bash tests/installer/test_resume.sh
+set -u
+INSTALL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/install.sh"
+PASS=0; FAIL=0
+chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (got [$2] want [$3])"; FAIL=$((FAIL+1)); fi; }
+
+# Source install.sh in a controlled sandbox and run diagnose_state(),
+# stubbing docker, COMPOSE, and curl so no real services are touched.
+run_diag() {
+  local env_content="$1"; shift
+  local stubs="$1"; shift
+  local dir; dir="$(mktemp -d)"
+  [[ -n "$env_content" ]] && printf '%s' "$env_content" > "$dir/.env"
+  cat > "$dir/run.sh" <<EOF
+source "$INSTALL"
+# Stub docker so container_status() and volume checks never touch real Docker.
+docker() { echo "ERR: real docker called: \$*" >&2; return 1; }
+# Categorize COMPOSE so compose_only paths are reachable.
+COMPOSE=(echo)
+# Stub curl so the API check is deterministic.
+curl() { $stubs; }
+ENV_FILE="$dir/.env"
+COMPOSE_FILE="docker-compose.full.yml"
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+diagnose_state >/dev/null 2>&1
+echo "ENV=\$DIAG_ENV|ISSUES=\$DIAG_ENV_ISSUES|EXIST=\$DIAG_ANY_EXIST|UNHEALTHY=\$DIAG_ANY_UNHEALTHY|VOL=\$DIAG_VOL_EXISTS|API=\$DIAG_API_OK"
+EOF
+  local out; out="$( cd "$dir" && bash run.sh 2>&1 )"; LAST_OUT="$out"; LAST_DIR="$dir"
+}
+
+# ============================================================
+echo "Case R1: fresh state — no .env, no containers"
+run_diag "" 'return 1'
+chk "DIAG_ENV=no" "$(printf '%s' "$LAST_OUT" | grep -oE 'ENV=[^|]*')" "ENV=no"
+
+echo "Case R2: .env exists but with empty NEO4J_AUTH and blank secrets"
+run_diag $'NEO4J_AUTH=\nNEO4J_PASSWORD=secret123\nMETRONIX_MCP_API_KEY=k\nPOSTGRES_PASSWORD=p\nFERNET_KEY=f\n' 'return 1'
+chk "env issues include NEO4J_AUTH" "$(printf '%s' "$LAST_OUT" | grep -c 'NEO4J_AUTH is set to an empty')" "1"
+chk "DIAG_ENV=yes" "$(printf '%s' "$LAST_OUT" | grep -oE 'ENV=[^|]*')" "ENV=yes"
+
+echo "Case R3: .env healthy — all secrets set, no empty NEO4J_AUTH"
+run_diag $'NEO4J_PASSWORD=secret123\nMETRONIX_MCP_API_KEY=k\nPOSTGRES_PASSWORD=p\nFERNET_KEY=f\n' 'return 1'
+chk "no env issues" "$(printf '%s' "$LAST_OUT" | grep -oE 'ISSUES=[^|]*')" "ISSUES="
+
+echo "Case R4: .env with blank POSTGRES_PASSWORD detects issue"
+run_diag $'NEO4J_PASSWORD=x\nMETRONIX_MCP_API_KEY=k\nFERNET_KEY=f\n' 'return 1'
+chk "POSTGRES_PASSWORD blank flagged" "$(printf '%s' "$LAST_OUT" | grep -c 'POSTGRES_PASSWORD is blank')" "1"
+
+echo "Case R5: container_status() reports missing for unknown name"
+d5="$(mktemp -d)"
+cat > "$d5/r.sh" <<EOF
+source "$INSTALL"
+docker() { return 1; }
+container_status nonexistent
+EOF
+out="$(bash "$d5/r.sh" 2>&1)"; rm -rf "$d5"
+chk "missing for nonexistent container" "$out" "missing"
+
+echo "Case R6: container_status() reports up:healthy when docker says healthy"
+d6="$(mktemp -d)"
+cat > "$d6/r.sh" <<EOF
+source "$INSTALL"
+docker() {
+  case "\${3:-}" in
+    *State.Status*)   echo "running" ;;
+    *Health.Status*)  echo "healthy" ;;
+    *)                return 0 ;;
+  esac
+}
+container_status somename
+EOF
+out="$(bash "$d6/r.sh" 2>&1)"; rm -rf "$d6"
+chk "reports up:healthy" "$out" "up:healthy"
+
+# --- resume_menu tests (interactive stubbed) -------------------------------------
+# We source install.sh, set the DIAG_* globals manually, and stub read to feed
+# a choice, then check which action is selected.
+
+run_resume() {
+  local diag_env="$1"; local diag_api="$2"; local diag_exist="$3"; local diag_issues="$4"
+  local stubs="$5"; local input="$6"
+  local dir; dir="$(mktemp -d)"
+  cat > "$dir/run.sh" <<EOF
+source "$INSTALL"
+# Stub I/O
+read() { printf '%s' "$input"; }
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+# Stub the DIAG globals as if diagnose_state already ran:
+DIAG_ENV="$diag_env"; DIAG_API_OK="$diag_api"; DIAG_ANY_EXIST="$diag_exist"
+DIAG_ENV_ISSUES="$diag_issues"; DIAG_ANY_UNHEALTHY="no"; DIAG_VOL_EXISTS="no"
+RESUME_ACTION=""
+# Stub the do_resume deps
+$stubs
+resume_menu >/dev/null 2>&1
+echo "ACTION=\$RESUME_ACTION"
+EOF
+  local out; out="$( cd "$dir" && bash run.sh 2>&1 )"; LASTOUT="$out"
+}
+
+echo "Case R7: api healthy -> exit option available, choosing exit"
+run_resume "yes" "yes" "yes" "" 'ASSUME_YES=true' ''
+# In -y / non-interactive, healthy => exit
+chk "auto-action=exit" "$(printf '%s' "$LASTOUT" | grep -oE 'ACTION=[a-z]*')" "ACTION=exit"
+
+echo "Case R8: interactive menu with env issues -> fixenv first option"
+# Interactive: env has issues. Choice 1 should map to fixenv (first dynamic option).
+d8="$(mktemp -d)"
+cat > "$d8/r.sh" <<EOF
+source "$INSTALL"
+DIAG_ENV="yes"; DIAG_API_OK="no"; DIAG_ANY_EXIST="no"
+DIAG_ENV_ISSUES="NEO4J_AUTH is set to an empty string"; DIAG_ANY_UNHEALTHY="no"
+DIAG_VOL_EXISTS="no"; RESUME_ACTION=""
+ASSUME_YES=false
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+resume_menu
+echo "ACTION=\$RESUME_ACTION"
+EOF
+out="$(printf '1\n' | bash "$d8/r.sh" 2>&1)"; rm -rf "$d8"
+chk "chose fixenv when issue present" "$(printf '%s' "$out" | grep -oE 'ACTION=[a-z]*')" "ACTION=fixenv"
+
+echo "Case R9: env exists but no containers and api DOWN -> start"
+# In -y mode with env but no containers and api down -> start
+run_resume "yes" "no" "no" "" 'ASSUME_YES=true' ''
+chk "auto-action=start" "$(printf '%s' "$LASTOUT" | grep -oE 'ACTION=[a-z]*')" "ACTION=start"
+
+echo "Case R10: containers exist and api down -> rebuild"
+run_resume "yes" "no" "yes" "" 'ASSUME_YES=true' ''
+chk "auto-action=rebuild" "$(printf '%s' "$LASTOUT" | grep -oE 'ACTION=[a-z]*')" "ACTION=rebuild"
+
+echo "Case R11: fresh install (no .env) -> fresh install path, no resume"
+# If env=no, the main() never calls diagnose/resume. Check DIAG_ENV stays no.
+chk "fresh env no-diagnose" "no" "no"
+
+# --- do_resume() fixenv action --------------------------------------------------
+echo "Case R12: do_resume fixenv strips empty NEO4J_AUTH and fills secrets"
+dir12="$(mktemp -d)"
+cat > "$dir12/r.sh" <<EOF
+source "$INSTALL"
+REPO_ROOT="$dir12"
+ENV_FILE="$dir12/.env"
+get_env() { grep -E "^\$1=" "\$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- || true; }
+set_env() {
+  local k="\$1" v="\$2" tmp
+  if grep -qE "^\${k}=" "\$ENV_FILE" 2>/dev/null; then
+    awk -v k="\$k" -v v="\$v" '\$0 ~ "^" k "=" { print k "=" v; next } { print }' "\$ENV_FILE" > "\$ENV_FILE.tmp" && mv "\$ENV_FILE.tmp" "\$ENV_FILE"
+  else printf '%s=%s\n' "\$k" "\$v" >> "\$ENV_FILE"; fi
+}
+printf 'NEO4J_AUTH=\nNEO4J_PASSWORD=x\nMETRONIX_MCP_API_KEY=k\n' > "\$ENV_FILE"
+RESUME_ACTION=fixenv
+ASSUME_YES=true
+launch() { echo "LAUNCHED"; }
+wait_health() { :; }
+print_links() { :; }
+wire_hermes() { :; }
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+do_resume
+echo "ACTION_DONE"
+EOF
+out12="$(bash "$dir12/r.sh" 2>&1)"
+chk "fixenv launched stack" "$(printf '%s' "$out12" | grep -c LAUNCHED)" "1"
+chk "NEO4J_AUTH stripped" "$(grep -c '^NEO4J_AUTH=$' "$dir12/.env" 2>/dev/null || true)" "0"
+chk "POSTGRES_PASSWORD filled" "$([[ -n "$(grep '^POSTGRES_PASSWORD=' "$dir12/.env" 2>/dev/null | cut -d= -f2-)" ]] && echo yes || echo no)" "yes"
+chk "FERNET_KEY filled" "$([[ -n "$(grep '^FERNET_KEY=' "$dir12/.env" 2>/dev/null | cut -d= -f2-)" ]] && echo yes || echo no)" "yes"
+chk "NEO4J_PASSWORD preserved" "$(grep '^NEO4J_PASSWORD=' "$dir12/.env" | cut -d= -f2-)" "x"
+rm -rf "$dir12"
+
+echo ""
+echo "TOTAL: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/tests/installer/test_resume.sh
+++ b/tests/installer/test_resume.sh
@@ -130,6 +130,10 @@ echo "Case R10: containers exist and api down -> rebuild"
 run_resume "yes" "no" "yes" "" 'ASSUME_YES=true' ''
 chk "auto-action=rebuild" "$(printf '%s' "$LASTOUT" | grep -oE 'ACTION=[a-z]*')" "ACTION=rebuild"
 
+echo "Case R10b: env issues win over rebuild in -y mode"
+run_resume "yes" "no" "yes" "POSTGRES_PASSWORD is blank" 'ASSUME_YES=true' ''
+chk "auto-action=fixenv" "$(printf '%s' "$LASTOUT" | grep -oE 'ACTION=[a-z]*')" "ACTION=fixenv"
+
 echo "Case R11: fresh install (no .env) -> fresh install path, no resume"
 # If env=no, the main() never calls diagnose/resume. Check DIAG_ENV stays no.
 chk "fresh env no-diagnose" "no" "no"
@@ -166,6 +170,58 @@ chk "POSTGRES_PASSWORD filled" "$([[ -n "$(grep '^POSTGRES_PASSWORD=' "$dir12/.e
 chk "FERNET_KEY filled" "$([[ -n "$(grep '^FERNET_KEY=' "$dir12/.env" 2>/dev/null | cut -d= -f2-)" ]] && echo yes || echo no)" "yes"
 chk "NEO4J_PASSWORD preserved" "$(grep '^NEO4J_PASSWORD=' "$dir12/.env" | cut -d= -f2-)" "x"
 rm -rf "$dir12"
+
+echo "Case R13: do_resume fixenv aborts if secret generation fails"
+dir13="$(mktemp -d)"
+cat > "$dir13/r.sh" <<EOF
+source "$INSTALL"
+REPO_ROOT="$dir13"
+ENV_FILE="$dir13/.env"
+get_env() { grep -E "^\$1=" "\$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- || true; }
+set_env() {
+  local k="\$1" v="\$2"
+  printf '%s=%s\n' "\$k" "\$v" >> "\$ENV_FILE"
+}
+gen_secret() { return 1; }
+printf 'NEO4J_PASSWORD=x\nMETRONIX_MCP_API_KEY=k\nFERNET_KEY=f\n' > "\$ENV_FILE"
+RESUME_ACTION=fixenv
+ASSUME_YES=true
+launch() { echo "LAUNCHED"; }
+wait_health() { :; }
+print_links() { :; }
+wire_hermes() { :; }
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+do_resume
+EOF
+out13="$(bash "$dir13/r.sh" 2>&1)"; rc13=$?
+chk "fixenv generation failure exits nonzero" "$([[ $rc13 -ne 0 ]] && echo yes || echo no)" "yes"
+chk "fixenv generation failure does not launch" "$(printf '%s' "$out13" | grep -c LAUNCHED)" "0"
+rm -rf "$dir13"
+
+echo "Case R14: launch explains Compose startup failure"
+dir14="$(mktemp -d)"
+cat > "$dir14/r.sh" <<EOF
+source "$INSTALL"
+COMPOSE=(compose_stub)
+COMPOSE_FILE=docker-compose.full.yml
+ENABLE_WEBUI=false
+RECONFIGURE=false
+docker() {
+  if [[ "\$1 \$2" == "volume inspect" ]]; then return 1; fi
+  return 1
+}
+compose_stub() {
+  if [[ "\$*" == *"config --volumes"* ]]; then echo full_neo4j_data; return 0; fi
+  return 1
+}
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+launch
+EOF
+out14="$(bash "$dir14/r.sh" 2>&1)"; rc14=$?
+chk "launch failure exits nonzero" "$([[ $rc14 -ne 0 ]] && echo yes || echo no)" "yes"
+chk "launch failure mentions Neo4j password mismatch" "$(printf '%s' "$out14" | grep -c 'first-start password differs')" "1"
+chk "launch failure shows reset command" "$(printf '%s' "$out14" | grep -c 'down -v')" "1"
+rm -rf "$dir14"
 
 echo ""
 echo "TOTAL: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- print actionable guidance when Docker Compose fails during installer launch, especially for Neo4j first-start password mismatches
- keep non-interactive resume flow fixing broken .env before rebuilds
- cover resume behavior, secret generation failure, and Compose launch failure messaging in installer tests
- clean up ShellCheck warnings in installer status output

## Tests
- bash -n install.sh
- bash tests/installer/test_resume.sh