### PR TITLE
Add fresh Docker reset installer option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ CHAT_API_KEY=""      # bearer token for the endpoint (optional; blank = no auth)
 ENABLE_WEBUI=false
 ASSUME_YES=false
 RECONFIGURE=false
+FRESH_DOCKER_RESET=false
 WIRE_HERMES=false    # run the Hermes wiring step (and, with -y, apply without prompt)
 AGENT_ID=""          # override the generated X-Agent-Id (Hermes wiring)
 METRONIX_URL=""      # override the MCP URL written into the agent config
@@ -102,6 +103,8 @@ Options:
                            (default http://localhost:8000/mcp)
   -y, --yes                Non-interactive: use defaults/flags, never prompt
   --reconfigure            Re-run configuration even if .env already exists
+  --fresh-docker-reset     Delete Metronix Docker containers, images, volumes,
+                           orphan containers, and build cache before reinstalling
   -h, --help               Show this help
 
 If --chat-url is given, --mode defaults to "answers"; otherwise "memory".
@@ -129,6 +132,7 @@ parse_args() {
       --openwebui)   ENABLE_WEBUI=true; shift ;;
       -y|--yes)      ASSUME_YES=true; shift ;;
       --reconfigure) RECONFIGURE=true; shift ;;
+      --fresh-docker-reset) FRESH_DOCKER_RESET=true; shift ;;
       -h|--help)     usage; exit 0 ;;
       *) err "Unknown option: $1"; usage >&2; exit 2 ;;
     esac
@@ -751,7 +755,7 @@ diagnose_state() {
 }
 
 # Offer the user a menu based on what diagnose_state() found. Sets RESUME_ACTION
-# to one of: start | rebuild | reconfigure | reset | fixenv | exit.
+# to one of: start | rebuild | reconfigure | reset | freshreset | fixenv | exit.
 resume_menu() {
   # In -y / non-interactive mode, pick the most reasonable action automatically.
   if [[ "$ASSUME_YES" == true ]]; then
@@ -783,6 +787,9 @@ resume_menu() {
   if [[ "$DIAG_ANY_UNHEALTHY" == yes || "$DIAG_VOL_EXISTS" == yes ]]; then
     n=$((n+1)); opts+=("reset");        labels+=("Reset all data volumes and reinstall (destructive)")
   fi
+  if [[ "$DIAG_ANY_EXIST" == yes || "$DIAG_VOL_EXISTS" == yes ]]; then
+    n=$((n+1)); opts+=("freshreset");   labels+=("Fresh Docker reset: remove containers, images, volumes, build cache")
+  fi
   n=$((n+1)); opts+=("reconfigure");    labels+=("Re-run full configuration from scratch")
   n=$((n+1)); opts+=("exit");           labels+=("Exit now")
 
@@ -799,6 +806,22 @@ resume_menu() {
     err "Choice out of range: $choice"; exit 1
   fi
   RESUME_ACTION="${opts[$((choice-1))]}"
+}
+
+fresh_docker_reset() {
+  warn "This will DELETE Metronix Docker containers, images, volumes, orphan containers, and build cache."
+  warn "Data in PostgreSQL, Qdrant, Neo4j, Redis, Ollama, and uploaded files will be removed."
+  if [[ "$ASSUME_YES" != true ]]; then
+    read -rp "Type 'delete docker data' to confirm: " confirm || { err "Aborted."; exit 1; }
+    [[ "$confirm" == "delete docker data" ]] || { err "Aborted."; exit 1; }
+  fi
+
+  info "Removing Metronix containers, images, volumes, and orphans..."
+  "${COMPOSE[@]}" -f "$COMPOSE_FILE" down -v --rmi all --remove-orphans 2>/dev/null || true
+
+  info "Pruning Docker build cache..."
+  docker builder prune -af >/dev/null 2>&1 || warn "Could not prune Docker build cache; continuing."
+  ok "Docker resources for Metronix were reset."
 }
 
 # Apply the action chosen in resume_menu. May reconfigure, fixenv, launch, etc.
@@ -845,6 +868,12 @@ do_resume() {
         [[ "$confirm" == "yes" ]] || { err "Aborted."; exit 1; }
       fi
       "${COMPOSE[@]}" -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+      RECONFIGURE=true
+      configure
+      launch; wait_health; print_links; wire_hermes
+      ;;
+    freshreset)
+      fresh_docker_reset
       RECONFIGURE=true
       configure
       launch; wait_health; print_links; wire_hermes
@@ -946,6 +975,11 @@ main() {
     exit 0
   fi
   check_prereqs
+
+  if [[ "$FRESH_DOCKER_RESET" == true ]]; then
+    fresh_docker_reset
+    RECONFIGURE=true
+  fi
 
   # Detect existing installation state and offer a resume menu instead of
   # blindly reconfiguring/launching on every run. Only run the diagnosis when

--- a/install.sh
+++ b/install.sh
@@ -809,7 +809,8 @@ resume_menu() {
 }
 
 fresh_docker_reset() {
-  warn "This will DELETE Metronix Docker containers, images, volumes, orphan containers, and build cache."
+  warn "This will DELETE Metronix Docker containers, images, volumes, and orphan containers."
+  warn "It will ALSO prune the ENTIRE Docker build cache on this machine — not just Metronix."
   warn "Data in PostgreSQL, Qdrant, Neo4j, Redis, Ollama, and uploaded files will be removed."
   if [[ "$ASSUME_YES" != true ]]; then
     read -rp "Type 'delete docker data' to confirm: " confirm || { err "Aborted."; exit 1; }
@@ -819,7 +820,7 @@ fresh_docker_reset() {
   info "Removing Metronix containers, images, volumes, and orphans..."
   "${COMPOSE[@]}" -f "$COMPOSE_FILE" down -v --rmi all --remove-orphans 2>/dev/null || true
 
-  info "Pruning Docker build cache..."
+  info "Pruning Docker build cache (machine-wide, all projects)..."
   docker builder prune -af >/dev/null 2>&1 || warn "Could not prune Docker build cache; continuing."
   ok "Docker resources for Metronix were reset."
 }

--- a/tests/installer/test_resume.sh
+++ b/tests/installer/test_resume.sh
@@ -223,6 +223,30 @@ chk "launch failure mentions Neo4j password mismatch" "$(printf '%s' "$out14" | 
 chk "launch failure shows reset command" "$(printf '%s' "$out14" | grep -c 'down -v')" "1"
 rm -rf "$dir14"
 
+echo "Case R15: fresh Docker reset removes compose resources and prunes build cache"
+dir15="$(mktemp -d)"
+cat > "$dir15/r.sh" <<EOF
+source "$INSTALL"
+LOG="$dir15/log"
+COMPOSE=(compose_stub)
+COMPOSE_FILE=docker-compose.full.yml
+ASSUME_YES=true
+compose_stub() {
+  printf 'COMPOSE %s\n' "\$*" >> "\$LOG"
+}
+docker() {
+  printf 'DOCKER %s\n' "\$*" >> "\$LOG"
+}
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+fresh_docker_reset
+EOF
+out15="$(bash "$dir15/r.sh" 2>&1)"; rc15=$?
+chk "fresh reset exits zero" "$rc15" "0"
+chk "fresh reset compose down removes volumes/images/orphans" "$(grep -c -- 'COMPOSE -f docker-compose.full.yml down -v --rmi all --remove-orphans' "$dir15/log")" "1"
+chk "fresh reset prunes builder cache" "$(grep -c -- 'DOCKER builder prune -af' "$dir15/log")" "1"
+chk "fresh reset reports completion" "$(printf '%s' "$out15" | grep -c 'Docker resources for Metronix were reset')" "1"
+rm -rf "$dir15"
+
 echo ""
 echo "TOTAL: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/tests/installer/test_wire_hermes.sh
+++ b/tests/installer/test_wire_hermes.sh
@@ -8,9 +8,10 @@ PASS=0; FAIL=0
 chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else echo "  FAIL: $1 (got [$2] want [$3])"; FAIL=$((FAIL+1)); fi; }
 
 echo "Task1: flags parse into globals"
-out="$(bash -c "source '$INSTALL'; parse_args --wire-hermes --agent-id abc123 --metronix-url http://x:8000/mcp; echo \"\$WIRE_HERMES|\$AGENT_ID|\$METRONIX_URL\"")"
-chk "flags parsed" "$out" "true|abc123|http://x:8000/mcp"
+out="$(bash -c "source '$INSTALL'; parse_args --wire-hermes --agent-id abc123 --metronix-url http://x:8000/mcp --fresh-docker-reset; echo \"\$WIRE_HERMES|\$AGENT_ID|\$METRONIX_URL|\$FRESH_DOCKER_RESET\"")"
+chk "flags parsed" "$out" "true|abc123|http://x:8000/mcp|true"
 chk "usage lists --wire-hermes" "$(bash -c "source '$INSTALL'; usage" | grep -c -- '--wire-hermes')" "1"
+chk "usage lists --fresh-docker-reset" "$(bash -c "source '$INSTALL'; usage" | grep -c -- '--fresh-docker-reset')" "1"
 
 echo "Task2: agent id resolution"
 gid="$(bash -c "source '$INSTALL'; gen_agent_id")"


### PR DESCRIPTION
## Summary
- add --fresh-docker-reset to remove Metronix Compose containers, images, volumes, orphans, and Docker build cache before reinstalling
- expose the same fresh reset from the installer resume menu with explicit destructive confirmation
- cover flag parsing/help text and reset command behavior in installer tests

## Tests
- bash -n install.sh
- bash tests/installer/test_resume.sh
- bash tests/installer/test_wire_hermes.sh
- bash tests/installer/test_install.sh
- bash tests/installer/test_failgen.sh