### PR TITLE
fix(installer): harden secret handling, agent-id stability, and DB-mismatch diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ SPLADE_SERVICE_URL=http://splade:8080                 # compose -> http://splade
 
 # --- Auth (JWT) — off by default, not part of the basic install ---
 AUTH_ENABLED=false                    # when true, JWT required on /api/v1/*
-AUTH_PASSWORD=                        # set only if AUTH_ENABLED=true (password for /auth/login); blank disables legacy password login
+AUTH_PASSWORD=metronix                # default admin login (admin@metronix.local) — seeded on first start; change in production
 
 # --- MCP standalone runner — only for `python -m metronix.mcp`, NOT the API mount ---
 # The API serves /mcp over streamable-http regardless of these. (Auth key is in ZONE 3.)

--- a/.env.example
+++ b/.env.example
@@ -262,8 +262,14 @@ METRONIX_MCP_API_KEY=
 # put a non-Fernet placeholder here — an invalid key crashes credential
 # encryption instead of giving that clean error.
 FERNET_KEY=
-# App secret (JWT signing). Change from the placeholder if you enable AUTH_ENABLED.
+# App secret (JWT signing, used when AUTH_ENABLED=true). install.sh rotates this
+# placeholder to a random value on a fresh install; a real value you set here is
+# preserved across --reconfigure.
 METRONIX_SECRET_KEY=develop-secret-key-change-in-prod
+# METRONIX_AGENT_ID — written by install.sh when it wires an agent (Hermes), so
+# re-runs reuse the same X-Agent-Id (and thus the same memories) even if the
+# Hermes config is reset. Not read by the backend; the id travels in the
+# X-Agent-Id request header. Leave unset; the installer manages it.
 
 # --- 4) Optional: OpenAI-compat static key (for Open WebUI / OAI clients) ---
 # Leave empty to rely on per-user mtk_* keys. If set, Open WebUI uses it.

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,9 @@ POSTGRES_HOST=postgres               # compose -> postgres
 POSTGRES_PORT=5432                    # compose -> 5432
 POSTGRES_DB=metronix                  # compose -> metronix
 POSTGRES_USER=metronix                # compose -> metronix
-POSTGRES_PASSWORD=metronix_dev        # compose pins metronix_dev (internal DB)
+# Leave blank: install.sh generates a strong value (and fills it on a copied .env);
+# a raw `docker compose up` without the installer falls back to metronix_dev.
+POSTGRES_PASSWORD=
 QDRANT_HOST=qdrant                 # compose -> qdrant
 QDRANT_HTTP_PORT=6333                 # container-internal port (leave default)
 QDRANT_GRPC_PORT=6334                 # container-internal port (leave default)
@@ -48,7 +50,7 @@ SPLADE_SERVICE_URL=http://splade:8080                 # compose -> http://splade
 
 # --- Auth (JWT) — off by default, not part of the basic install ---
 AUTH_ENABLED=false                    # when true, JWT required on /api/v1/*
-AUTH_PASSWORD=metronix                # password for /auth/login
+AUTH_PASSWORD=                        # set only if AUTH_ENABLED=true (password for /auth/login); blank disables legacy password login
 
 # --- MCP standalone runner — only for `python -m metronix.mcp`, NOT the API mount ---
 # The API serves /mcp over streamable-http regardless of these. (Auth key is in ZONE 3.)

--- a/docs/integrations/hermes/prompt-1-install.md
+++ b/docs/integrations/hermes/prompt-1-install.md
@@ -5,9 +5,9 @@ just verify it and report — do not create a duplicate.
 
 ## Parameters
 - METRONIX_URL = {{METRONIX_URL}}
-- MCP_API_KEY  = {{MCP_API_KEY}}
+- METRONIX_MCP_API_KEY  = {{METRONIX_MCP_API_KEY}}
 - AGENT_UUID   = {{AGENT_UUID}}
-- WORKSPACE_ID = {{WORKSPACE_ID}}
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
 
 ## 0. Check parameters first
 If any value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
@@ -16,13 +16,13 @@ user for it before doing anything else — never guess. Show these hints:
 - METRONIX_URL — Metronix MCP endpoint URL: server URL + /mcp. If Hermes runs in
   WSL2/Docker and Metronix is on the Windows host, use host.docker.internal
   instead of localhost. Example: http://host.docker.internal:8000/mcp
-- MCP_API_KEY — Bearer token for /mcp (server env var METRONIX_MCP_API_KEY; /mcp
+- METRONIX_MCP_API_KEY — Bearer token for /mcp (server env var METRONIX_MCP_API_KEY; /mcp
   returns HTTP 401 without it; ask the Metronix admin if you don't have it).
   Example: the token from the Metronix deployment's .env
 - AGENT_UUID — any stable unique id for this agent, provided by the user; the user
   can simply make one up, or create it via POST /api/v1/agents / the UI. You do NOT
   create it. Example: a3c98413c3684a0992ac0e007b93f410
-- WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
   Every metronix_* call (search/RAG and memory) needs it, which is why it is set
   now. Example: MTRNIX
 Do NOT call POST /api/v1/agents (or otherwise hit the /api/v1/agents endpoint)
@@ -39,7 +39,7 @@ the wrong URL, edit the file and ensure it contains:
       metronix:
         url: {{METRONIX_URL}}
         headers:
-          Authorization: "Bearer {{MCP_API_KEY}}"   # required: server returns 401 without it
+          Authorization: "Bearer {{METRONIX_MCP_API_KEY}}"   # required: server returns 401 without it
           X-Agent-Id: {{AGENT_UUID}}
         timeout: 180
         connect_timeout: 60
@@ -58,7 +58,7 @@ block at the END (clearly delimited). If a `metronix-config` block is already th
 (e.g. from a previous run), update it in place instead of appending a second copy:
 
     --- metronix-config ---
-    Metronix MCP is available. workspace_id="{{WORKSPACE_ID}}",
+    Metronix MCP is available. workspace_id="{{DEFAULT_WORKSPACE_ID}}",
     agent_id="{{AGENT_UUID}}". You MAY use the metronix_* tools — knowledge search /
     RAG and memory. Using Metronix for durable memory is OPTIONAL at this stage;
     it is not yet your required store.

--- a/docs/integrations/hermes/prompt-2-memory.md
+++ b/docs/integrations/hermes/prompt-2-memory.md
@@ -6,14 +6,14 @@ this prompt upgrades it to mandatory. If it already has the mandatory wording, j
 verify and report.
 
 ## Parameters
-- WORKSPACE_ID = {{WORKSPACE_ID}}
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
 - AGENT_UUID   = {{AGENT_UUID}}
 
 ## 0. Check parameters first
 If either value above is still a {{...}} placeholder or empty STOP and try to find those values in .env
 If you couldn't find the values, ask the
 user for it before doing anything else — never guess. Show these hints:
-- WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
   Example: MTRNIX
 - AGENT_UUID — any stable unique id for this agent, provided by the user; the user
   can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
@@ -60,7 +60,7 @@ was skipped), APPEND it at the END of the file:
 
     --- metronix-config ---
     Durable memory lives in Metronix MCP. ALWAYS use the metronix_memory_*
-    tools for it, with workspace_id="{{WORKSPACE_ID}}" and
+    tools for it, with workspace_id="{{DEFAULT_WORKSPACE_ID}}" and
     agent_id="{{AGENT_UUID}}". Classify by kind:
     fact (default) | preference (auto-injected) | pinned (must-not-vanish).
     Do NOT use Hermes' built-in memory files for new durable knowledge, and do
@@ -72,8 +72,8 @@ Do NOT touch `~/.hermes/memories/MEMORY.md` or `~/.hermes/memories/USER.md` —
 leave their existing content exactly as it is.
 
 ## 4. Verify
-- `metronix_status(workspace_id="{{WORKSPACE_ID}}")` — KB connectivity
-- `metronix_memory_list(workspace_id="{{WORKSPACE_ID}}",
+- `metronix_status(workspace_id="{{DEFAULT_WORKSPACE_ID}}")` — KB connectivity
+- `metronix_memory_list(workspace_id="{{DEFAULT_WORKSPACE_ID}}",
   agent_id="{{AGENT_UUID}}", limit=5)` — memory channel reachable
 - confirm the live SOUL.md `metronix-config` block now has the mandatory wording
   AND that all of its pre-existing persona content is still present and unchanged

--- a/docs/integrations/hermes/prompt-3-migrate.md
+++ b/docs/integrations/hermes/prompt-3-migrate.md
@@ -5,14 +5,14 @@ Metronix becomes the single source of truth for long-lived memory. Run ONCE.
 Run this ONLY if you already hold durable memory.
 
 ## Parameters
-- WORKSPACE_ID = {{WORKSPACE_ID}}
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
 - AGENT_UUID   = {{AGENT_UUID}}
 
 ## 0. Check parameters first
 If either value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
 If you couldn't find the values, ask the
 user for it before doing anything else — never guess. Show these hints:
-- WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
   Example: MTRNIX
 - AGENT_UUID — any stable unique id for this agent, provided by the user; the user
   can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
@@ -52,7 +52,7 @@ data, and anything tied to an already-finished task), decide its `kind`:
 ## 3. Store everything into Metronix
 For each item, call:
   metronix_memory_store(
-    workspace_id="{{WORKSPACE_ID}}",
+    workspace_id="{{DEFAULT_WORKSPACE_ID}}",
     agent_id="{{AGENT_UUID}}",
     content=<the knowledge, self-contained and readable on its own>,
     scope="per_agent",
@@ -78,7 +78,7 @@ From now on, write NEW durable knowledge to Metronix — not back into the old
 locations.
 
 ## 5. Verify
-- metronix_memory_list(workspace_id="{{WORKSPACE_ID}}",
+- metronix_memory_list(workspace_id="{{DEFAULT_WORKSPACE_ID}}",
   agent_id="{{AGENT_UUID}}", limit=10) — your migrated entries are visible.
 Check that nothing you inventoried in step 1 was left un-migrated.
 

--- a/docs/integrations/hermes/prompt-4-rollback.md
+++ b/docs/integrations/hermes/prompt-4-rollback.md
@@ -1,0 +1,56 @@
+# Metronix MCP — roll back to the state after prompt 1
+You are a Hermes Agent with the Metronix MCP server registered and active. Run this
+to UNDO prompt 2: flip durable memory from mandatory back to OPTIONAL, returning the
+agent to exactly the state it was in right after prompt 1. The Metronix MCP server
+stays registered and nothing you stored in Metronix (including anything migrated in
+prompt 3) is touched — only the routing-rule wording is reverted. Run ONCE.
+
+## Parameters
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
+- AGENT_UUID           = {{AGENT_UUID}}
+
+## 0. Check parameters first
+If either value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Example: MTRNIX
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
+Wait for the user's answers before continuing.
+
+## 1. Downgrade the routing rule back to optional (SOUL.md)
+Edit the LIVE SOUL.md that Hermes actually loads — typically `/root/.hermes/SOUL.md`
+when Hermes runs as root, otherwise `~/.hermes/SOUL.md`. Do NOT edit any backup or
+copy (e.g. `SOUL.md.bak`, dated copies, files under a `backups/` dir) — those are
+not loaded.
+
+Prompt 2 replaced the `metronix-config` block with the MANDATORY wording. Find that
+block and REPLACE its body with the OPTIONAL rule below, leaving the agent's persona
+and everything else in the file intact. If the block isn't there, APPEND it at the
+END of the file:
+
+    --- metronix-config ---
+    Metronix MCP is available. workspace_id="{{DEFAULT_WORKSPACE_ID}}",
+    agent_id="{{AGENT_UUID}}". You MAY use the metronix_* tools — knowledge search /
+    RAG and memory. Using Metronix for durable memory is OPTIONAL at this stage;
+    it is not yet your required store.
+    --- end metronix-config ---
+
+This reverts ONLY what prompt 2 changed (the routing-rule wording). It does NOT
+remove the Metronix MCP server (that was prompt 1) and does NOT delete or move any
+memory already stored in Metronix, including anything migrated in prompt 3 — that
+data stays exactly where it is. Do NOT touch `~/.hermes/memories/MEMORY.md` or
+`~/.hermes/memories/USER.md`.
+
+## 2. Verify
+- confirm the `metronix-config` block now has the OPTIONAL wording and that all
+  pre-existing persona content is still present and unchanged
+- `metronix_status(workspace_id="{{DEFAULT_WORKSPACE_ID}}")` still works — the MCP
+  server is left in place
+
+## Report format
+- Routing rule: downgraded to optional (prompt 2 reverted)
+- Left intact: Metronix MCP server registration, all stored/migrated memory
+- Next step: re-run prompt 2 to make Metronix mandatory again, if desired

--- a/install.md
+++ b/install.md
@@ -106,9 +106,10 @@ LLM in `.env`.
 | **Metronix generates answers** | Same as Open WebUI — custom chat endpoint |
 
 > **`./install.sh`** copies `.env.example` and auto-generates `POSTGRES_PASSWORD`,
-> `NEO4J_PASSWORD`, `METRONIX_MCP_API_KEY`, and `FERNET_KEY`. On a manual install you can
-> leave DB passwords at the `.env.example` defaults (`metronix_dev`) unless you change them.
-> Remove any empty `NEO4J_AUTH=` line from `.env` — it breaks Neo4j startup (see
+> `NEO4J_PASSWORD`, `METRONIX_MCP_API_KEY`, `FERNET_KEY`, and `METRONIX_SECRET_KEY`. On a
+> manual install the DB passwords ship blank in `.env.example`; Docker Compose falls back to
+> `metronix_dev` for both Postgres and Neo4j unless you set them. Remove any empty
+> `NEO4J_AUTH=` line from `.env` — it breaks Neo4j startup (see
 > [Troubleshooting](#neo4j-container-is-unhealthy)).
 
 ### 3a. MCP API key (required)
@@ -246,7 +247,7 @@ and offers a menu instead of blindly overwriting config:
 |---|---|
 | Fix `.env` and restart | Blank secrets or empty `NEO4J_AUTH=` |
 | Rebuild stack | Containers exist but API is down |
-| Reset volumes (`down -v`) | Unhealthy Neo4j / password mismatch on old volume |
+| Reset volumes (`down -v`) | Unhealthy Neo4j, or a Postgres/Neo4j password mismatch on an old volume |
 | Fresh Docker reset | `--fresh-docker-reset` — removes images, volumes, build cache |
 | Reconfigure | `--reconfigure` — rewrite `.env` from scratch |
 
@@ -406,3 +407,25 @@ docker compose -f docker-compose.full.yml up -d
 
 > **Warning:** `down -v` deletes ALL data volumes (PostgreSQL, Qdrant, Neo4j, Redis,
 > Ollama). This is a full reset — only do it if you're starting fresh.
+
+### Postgres rejects the password ("password authentication failed")
+
+Like Neo4j, Postgres fixes its password on **first startup** and keeps it in its data
+volume. If `POSTGRES_PASSWORD` in `.env` later differs from that value, Postgres still
+starts (its healthcheck does not authenticate) but rejects every query with
+`password authentication failed for user "metronix"` — so the stack can look healthy while
+memory writes fail. This usually happens when `.env` is deleted or regenerated **without**
+also resetting the volume.
+
+```bash
+docker logs metronix-full-postgres | grep "password authentication failed"
+```
+
+Restore the original `POSTGRES_PASSWORD` in `.env`, or reset the data (full wipe):
+
+```bash
+docker compose -f docker-compose.full.yml down -v
+docker compose -f docker-compose.full.yml up -d --build
+```
+
+> **Warning:** `down -v` deletes ALL data volumes. Only do this when starting fresh.

--- a/install.sh
+++ b/install.sh
@@ -923,19 +923,27 @@ do_resume() {
 }
 
 launch() {
-  # Warn if the Neo4j volume exists with a potentially different password.
-  # Neo4j only sets the initial password on first startup; on an existing volume
-  # it keeps the old one, so the healthcheck (which reads NEO4J_PASSWORD from
-  # .env) will fail if the password has changed since the volume was created.
-  local neo_vol=""
-  neo_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null \
-    | grep -E 'neo4j' | head -1 || true)"
-  if [[ -n "$neo_vol" ]] && docker volume inspect "$neo_vol" >/dev/null 2>&1 \
-     && [[ "$RECONFIGURE" == true ]]; then
-    warn "Neo4j data volume '$neo_vol' already exists."
-    warn "  Neo4j only sets the initial password on FIRST startup. If NEO4J_PASSWORD"
-    warn "  changed since this volume was created, the healthcheck will fail."
-    warn "  To reset: ${COMPOSE[*]} -f $COMPOSE_FILE down -v && ${COMPOSE[*]} -f $COMPOSE_FILE up -d"
+  # Warn if a database volume already exists with a potentially different password.
+  # Postgres and Neo4j BOTH set their password only on FIRST startup; on an existing
+  # volume they keep the original. If POSTGRES_PASSWORD / NEO4J_PASSWORD in .env has
+  # changed since the volume was created, the DB rejects the new credentials —
+  # Postgres with "password authentication failed for user ...", Neo4j with an
+  # unhealthy container. (Postgres can stay up yet refuse every query, so the stack
+  # looks healthy while memory writes silently fail.)
+  local neo_vol="" pg_vol=""
+  neo_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null | grep -iE 'neo4j' | head -1 || true)"
+  pg_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null | grep -iE 'pg|postgres' | head -1 || true)"
+  if [[ "$RECONFIGURE" == true ]]; then
+    local _v _name
+    for _v in "POSTGRES_PASSWORD:$pg_vol" "NEO4J_PASSWORD:$neo_vol"; do
+      _name="${_v#*:}"
+      [[ -n "$_name" ]] || continue
+      docker volume inspect "$_name" >/dev/null 2>&1 || continue
+      warn "Database volume '$_name' already exists."
+      warn "  Its password was fixed on FIRST startup. If ${_v%%:*} in .env differs"
+      warn "  from that value, the database will reject connections."
+      warn "  To reset (DESTROYS data): ${COMPOSE[*]} -f $COMPOSE_FILE down -v && ./install.sh -y --reconfigure"
+    done
   fi
 
   local args=(-f "$COMPOSE_FILE")
@@ -961,29 +969,57 @@ launch() {
   fi
 }
 
+# Postgres (and Neo4j) only honour POSTGRES_PASSWORD / NEO4J_PASSWORD on FIRST
+# startup; on an existing volume they keep the original. If the .env password later
+# differs, Postgres ACCEPTS the container start (healthcheck = pg_isready, which does
+# not authenticate) but REJECTS every real query with "password authentication failed
+# for user metronix". The API can then report /health OK while every memory write
+# fails. Inspect the Postgres log and surface this explicitly. Returns 1 if detected.
+warn_if_db_auth_failed() {
+  local logs
+  logs="$(docker logs --tail 80 metronix-full-postgres 2>&1 || true)"
+  if printf '%s' "$logs" | grep -qi 'password authentication failed'; then
+    warn ""
+    warn "Postgres is rejecting the configured password (\"password authentication failed\")."
+    warn "  POSTGRES_PASSWORD in .env no longer matches the password its data volume was"
+    warn "  initialised with on first start. The stack can look healthy, but memory writes"
+    warn "  (and other DB access) will fail — this is the usual cause of MCP save errors."
+    warn "  Fix, restoring the original POSTGRES_PASSWORD in .env, OR reset (DESTROYS data):"
+    warn "    ${COMPOSE[*]} -f $COMPOSE_FILE down -v && ./install.sh -y --reconfigure"
+    return 1
+  fi
+  return 0
+}
+
 wait_health() {
   command -v curl >/dev/null 2>&1 || { warn "curl not found — skipping health check."; return 0; }
   info "Waiting for the API on :$API_PORT ..."
-  local _i
+  local _i healthy=no
   for _i in $(seq 1 60); do
     if curl -fsS "http://localhost:$API_PORT/health" >/dev/null 2>&1; then
       ok "API is healthy"
-      return 0
+      healthy=yes
+      break
     fi
     sleep 5
   done
-  warn "API did not report healthy within ~5 min. It may still be building."
-  warn "  Check logs: ${COMPOSE[*]} -f $COMPOSE_FILE logs -f metronix-core"
-  # If Neo4j is unhealthy, give a targeted hint (common: password/volume mismatch).
-  if docker inspect --format='{{.State.Health.Status}}' metronix-full-neo4j 2>/dev/null \
-     | grep -q unhealthy; then
-    warn ""
-    warn "Neo4j container is UNHEALTHY. Common causes:"
-    warn "  1. NEO4J_AUTH set to empty in .env (remove the line to use the default)"
-    warn "  2. NEO4J_PASSWORD changed on an existing volume (reset: docker compose -f $COMPOSE_FILE down -v)"
-    warn "  3. NEO4J_PASSWORD is a hash, not plain text (use a plain text password)"
-    warn "  Neo4j logs: docker logs metronix-full-neo4j"
+  if [[ "$healthy" == no ]]; then
+    warn "API did not report healthy within ~5 min. It may still be building."
+    warn "  Check logs: ${COMPOSE[*]} -f $COMPOSE_FILE logs -f metronix-core"
+    # If Neo4j is unhealthy, give a targeted hint (common: password/volume mismatch).
+    if docker inspect --format='{{.State.Health.Status}}' metronix-full-neo4j 2>/dev/null \
+       | grep -q unhealthy; then
+      warn ""
+      warn "Neo4j container is UNHEALTHY. Common causes:"
+      warn "  1. NEO4J_AUTH set to empty in .env (remove the line to use the default)"
+      warn "  2. NEO4J_PASSWORD changed on an existing volume (reset: docker compose -f $COMPOSE_FILE down -v)"
+      warn "  3. NEO4J_PASSWORD is a hash, not plain text (use a plain text password)"
+      warn "  Neo4j logs: docker logs metronix-full-neo4j"
+    fi
   fi
+  # Even when /health is green, Postgres may be rejecting the password on an existing
+  # volume — this is silent except in DB logs, so always check.
+  warn_if_db_auth_failed
   return 0
 }
 

--- a/install.sh
+++ b/install.sh
@@ -281,20 +281,23 @@ fill_template() {
   local tmpl="$1" dest="$2" content
   content="$(cat "$tmpl")"
   content="${content//\{\{METRONIX_URL\}\}/$H_URL}"
-  content="${content//\{\{MCP_API_KEY\}\}/$H_KEY}"
+  content="${content//\{\{METRONIX_MCP_API_KEY\}\}/$H_KEY}"
   content="${content//\{\{AGENT_UUID\}\}/$H_AGENT}"
-  content="${content//\{\{WORKSPACE_ID\}\}/$H_WS}"
+  content="${content//\{\{DEFAULT_WORKSPACE_ID\}\}/$H_WS}"
   printf '%s\n' "$content" > "$dest"
 }
 
-# Write all three ready-to-paste Hermes prompts (filled) into a directory.
+# Write the ready-to-paste Hermes prompts (filled) into a directory. Prompts 1-3
+# are the forward flow (install -> mandatory memory -> migrate); prompt 4 is an
+# optional rollback that undoes prompt 2.
 # Returns 1 if no templates were found (e.g. install.sh run outside the repo).
 write_hermes_prompt_dir() {
   local dir="$1" tdir="$REPO_ROOT/docs/integrations/hermes" found=0 pair src out
   mkdir -p "$dir"
   for pair in "prompt-1-install.md:1-install-mcp.md" \
               "prompt-2-memory.md:2-memory-source.md" \
-              "prompt-3-migrate.md:3-migrate.md"; do
+              "prompt-3-migrate.md:3-migrate.md" \
+              "prompt-4-rollback.md:4-rollback.md"; do
     src="$tdir/${pair%%:*}"; out="$dir/${pair#*:}"
     if [[ -f "$src" ]]; then fill_template "$src" "$out"; found=$((found + 1)); fi
   done
@@ -302,7 +305,7 @@ write_hermes_prompt_dir() {
     warn "Prompt templates not found under $tdir — run the installer from the repo checkout."
     return 0
   fi
-  ok "Wrote $found ready-to-paste Hermes prompt(s) to $dir/ (apply them in order: 1 -> 2 -> 3)."
+  ok "Wrote $found ready-to-paste Hermes prompt(s) to $dir/ (apply 1 -> 2 -> 3 in order; 4 is an optional rollback of 2)."
 }
 
 # Ensure exactly one metronix-config block in the SOUL file. Replaces the body

--- a/install.sh
+++ b/install.sh
@@ -510,7 +510,7 @@ configure() {
   fi
 
   if [[ "$ASSUME_YES" == false && ! -t 0 ]]; then
-    err "No terminal for interactive prompts. Re-run with -y/--yes (and pass --provider plus --custom-url/--custom-model/--api-key when using custom), or run from an interactive shell."
+    err "No terminal for interactive prompts. Re-run with -y/--yes (and, for mode=answers, pass --chat-url plus --chat-model and optionally --chat-api-key), or run from an interactive shell."
     exit 2
   fi
 
@@ -716,7 +716,7 @@ diagnose_state() {
     st="$(container_status "$c")"
     case "$st" in
       up:healthy)   printf '  %s%-22s%s %s healthy%s\n' "$C_OK" "$c" "$C_RST" "$C_OK" "$C_RST" ;;
-      up:unhealthy) printf '  %s%-22s%s %s unhealthy%s\n' "$C_OK" "$c" "$C_ERR" "$C_RST" "$C_ERR"; any_unhealthy=yes ;;
+      up:unhealthy) printf '  %s%-22s%s %sunhealthy%s\n' "$C_OK" "$c" "$C_RST" "$C_ERR" "$C_RST"; any_unhealthy=yes ;;
       up:starting)  printf '  %s%-22s%s %s starting…%s\n' "$C_OK" "$c" "$C_RST" "$C_WARN" "$C_RST" ;;
       up:unknown)   printf '  %s%-22s%s running (no healthcheck)%s\n' "$C_OK" "$c" "$C_RST" "$C_RST" ;;
       down)         printf '  %s%-22s%s %sexited%s\n' "$C_WARN" "$c" "$C_RST" "$C_WARN" "$C_RST"; any_exist=yes ;;

--- a/install.sh
+++ b/install.sh
@@ -503,6 +503,33 @@ resolve_secret() {
   fi
 }
 
+# Fill any BLANK required secret in $ENV_FILE in place, and strip an empty
+# NEO4J_AUTH= line. Idempotent: existing non-blank values are left untouched (so
+# we never rotate a live DB password). This guards every path that launches an
+# *existing* .env without a full reconfigure (resume start/rebuild, fixenv) so
+# the stack can never come up with a missing METRONIX_MCP_API_KEY / DB secret —
+# the case where wire_hermes later reports "No METRONIX_MCP_API_KEY in .env".
+# Aborts if a generator yields nothing (no openssl and no readable /dev/urandom).
+backfill_env_secrets() {
+  # An empty NEO4J_AUTH= overrides compose's default and breaks Neo4j startup.
+  if grep -qE "^NEO4J_AUTH=$" "$ENV_FILE" 2>/dev/null; then
+    grep -v '^NEO4J_AUTH=$' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+    ok "Removed empty NEO4J_AUTH= from $ENV_FILE"
+  fi
+  local k prev val
+  for k in POSTGRES_PASSWORD NEO4J_PASSWORD METRONIX_MCP_API_KEY FERNET_KEY; do
+    prev="$(get_env "$k")"
+    [[ -n "$prev" ]] && continue
+    if [[ "$k" == FERNET_KEY ]]; then val="$(gen_fernet)"; else val="$(gen_secret)"; fi
+    if [[ -z "$val" ]]; then
+      err "Could not generate a value for $k (need openssl or a readable /dev/urandom). Aborting before launch."
+      exit 1
+    fi
+    set_env "$k" "$val"
+    ok "Generated missing $k"
+  done
+}
+
 configure() {
   if [[ -f "$ENV_FILE" && "$RECONFIGURE" == false ]]; then
     ok ".env already exists — reusing it (use --reconfigure to redo)"
@@ -833,32 +860,19 @@ do_resume() {
       ;;
     fixenv)
       info "Fixing .env issues…"
-      # Strip empty NEO4J_AUTH=
-      if grep -qE "^NEO4J_AUTH=$" "$ENV_FILE" 2>/dev/null; then
-        grep -v '^NEO4J_AUTH=$' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
-        ok "Removed empty NEO4J_AUTH= from $ENV_FILE"
-      fi
-      # Fill blank secrets using the same resolve_secret logic as configure().
-      local prev val
-      for k in POSTGRES_PASSWORD NEO4J_PASSWORD METRONIX_MCP_API_KEY FERNET_KEY; do
-        prev="$(get_env "$k")"
-        if [[ -z "$prev" ]]; then
-          if [[ "$k" == "FERNET_KEY" ]]; then val="$(gen_fernet)"; else val="$(gen_secret)"; fi
-          if [[ -z "$val" ]]; then
-            err "Could not generate a value for $k (need openssl or a readable /dev/urandom). Aborting before launch."
-            exit 1
-          fi
-          set_env "$k" "$val"
-          ok "Generated missing $k"
-        fi
-      done
+      backfill_env_secrets
       # Now rebuild/restart so the fix takes effect.
       launch; wait_health; print_links; wire_hermes
       ;;
     start)
+      # Backfill any blank secret before launch: an existing .env may be missing
+      # METRONIX_MCP_API_KEY etc., which would otherwise come up but leave the
+      # agent un-wireable.
+      backfill_env_secrets
       launch; wait_health; print_links; wire_hermes
       ;;
     rebuild)
+      backfill_env_secrets
       "${COMPOSE[@]}" -f "$COMPOSE_FILE" down 2>/dev/null || true
       launch; wait_health; print_links; wire_hermes
       ;;

--- a/install.sh
+++ b/install.sh
@@ -221,16 +221,26 @@ gen_agent_id() {
   fi
 }
 
-# Resolve the agent id: explicit --agent-id wins; else reuse the X-Agent-Id
-# already in the Hermes config (keeps memories under a stable id across re-runs);
-# else generate a fresh one.
+# Resolve the agent id, in priority order:
+#   1. explicit --agent-id (operator override)
+#   2. the X-Agent-Id already in the live Hermes config (source of truth for the
+#      running agent — its memories are stored under this id)
+#   3. METRONIX_AGENT_ID persisted in .env (installer's durable record; survives a
+#      wiped/reset Hermes config so the agent keeps the same id, and thus the same
+#      memories, across re-runs)
+#   4. a freshly generated id
+# The backend never reads an agent id from env — it comes from the X-Agent-Id
+# request header — so METRONIX_AGENT_ID is purely the installer's own anchor.
+# wire_hermes() persists the resolved value back to .env.
 resolve_agent_id() {
-  local config="$1" existing
+  local config="$1" existing persisted
   if [[ -n "$AGENT_ID" ]]; then printf '%s' "$AGENT_ID"; return 0; fi
   if [[ -f "$config" ]]; then
     existing="$(grep -E '^[[:space:]]*X-Agent-Id:' "$config" 2>/dev/null | head -1 | sed -E 's/.*X-Agent-Id:[[:space:]]*//' | tr -d '"' | tr -d '[:space:]')"
     if [[ -n "$existing" ]]; then printf '%s' "$existing"; return 0; fi
   fi
+  persisted="$(get_env METRONIX_AGENT_ID)"
+  if [[ -n "$persisted" ]]; then printf '%s' "$persisted"; return 0; fi
   gen_agent_id
 }
 
@@ -397,6 +407,9 @@ wire_hermes() {
   H_WS="$(get_env DEFAULT_WORKSPACE_ID)"; H_WS="${H_WS:-MTRNIX}"
   H_URL="${METRONIX_URL:-http://localhost:8000/mcp}"
   H_AGENT="$(resolve_agent_id "$config")"
+  # Anchor the agent id in .env so re-runs reuse it even if the Hermes config is
+  # later reset — keeping the agent's memories under one stable id.
+  [[ -f "$ENV_FILE" ]] && set_env METRONIX_AGENT_ID "$H_AGENT"
 
   # Fallback in every can't/won't-auto-edit case: write the paste-ready guide.
   local prompt_dir="./metronix-hermes-setup"
@@ -542,11 +555,12 @@ configure() {
   fi
 
   # Preserve secrets across --reconfigure (don't rotate live DB passwords).
-  local prev_pg prev_neo prev_mcp prev_fernet
+  local prev_pg prev_neo prev_mcp prev_fernet prev_secret
   prev_pg="$(get_env POSTGRES_PASSWORD)"
   prev_neo="$(get_env NEO4J_PASSWORD)"
   prev_mcp="$(get_env METRONIX_MCP_API_KEY)"
   prev_fernet="$(get_env FERNET_KEY)"
+  prev_secret="$(get_env METRONIX_SECRET_KEY)"
 
   [[ -f "$EXAMPLE_FILE" ]] || { err "$EXAMPLE_FILE not found in $(pwd)"; exit 1; }
 
@@ -643,15 +657,21 @@ configure() {
   # empty string, and set_env would happily write "KEY=" and return 0. So we
   # compute the values, then explicitly refuse to proceed if any came out blank
   # (e.g. neither openssl nor /dev/urandom produced output).
-  local val_pg val_neo val_mcp val_fernet
+  # METRONIX_SECRET_KEY signs JWTs (used when AUTH_ENABLED=true). It ships with a
+  # publicly-known placeholder ("develop-secret-key-change-in-prod"), so rotate it
+  # to a random value on a fresh install. resolve_secret keeps a real user value
+  # (anything other than blank or the shipped placeholder) untouched.
+  local val_pg val_neo val_mcp val_fernet val_secret
   val_pg="$(resolve_secret POSTGRES_PASSWORD "$prev_pg" "$(gen_secret)")"
   val_neo="$(resolve_secret NEO4J_PASSWORD "$prev_neo" "$(gen_secret)")"
   val_mcp="$(resolve_secret METRONIX_MCP_API_KEY "$prev_mcp" "$(gen_secret)")"
   val_fernet="$(resolve_secret FERNET_KEY "$prev_fernet" "$(gen_fernet)")"
+  val_secret="$(resolve_secret METRONIX_SECRET_KEY "$prev_secret" "$(gen_secret)")"
 
   local _pair
   for _pair in "POSTGRES_PASSWORD:$val_pg" "NEO4J_PASSWORD:$val_neo" \
-               "METRONIX_MCP_API_KEY:$val_mcp" "FERNET_KEY:$val_fernet"; do
+               "METRONIX_MCP_API_KEY:$val_mcp" "FERNET_KEY:$val_fernet" \
+               "METRONIX_SECRET_KEY:$val_secret"; do
     if [[ -z "${_pair#*:}" ]]; then
       err "Could not generate a value for ${_pair%%:*} (need openssl or a readable /dev/urandom). Aborting before launch."
       exit 1
@@ -662,6 +682,7 @@ configure() {
   set_env NEO4J_PASSWORD "$val_neo"
   set_env METRONIX_MCP_API_KEY "$val_mcp"
   set_env FERNET_KEY "$val_fernet"
+  set_env METRONIX_SECRET_KEY "$val_secret"
 
   # Remove NEO4J_AUTH if it is empty — an empty string overrides docker-compose's
   # default of "neo4j/<password>", causing Neo4j to reject the initial credentials.

--- a/install.sh
+++ b/install.sh
@@ -705,6 +705,24 @@ CORE_CONTAINERS=(
   metronix-full-api
 )
 
+# Resolve a Compose short volume name (as printed by `config --volumes`, e.g.
+# full_neo4j_data) to the real Docker volume name. Compose prefixes volumes with
+# the project name (<project>_<short>, e.g. metronix-memory_full_neo4j_data), so a
+# bare `docker volume inspect full_neo4j_data` would miss it. Prints the real name
+# if a matching volume exists, else nothing. Prefers the project-prefixed volume.
+resolve_volume_name() {
+  local short="$1" match
+  [[ -n "$short" ]] || return 0
+  match="$(docker volume ls --format '{{.Name}}' 2>/dev/null | grep -E "_${short}\$" | head -1 || true)"
+  if [[ -z "$match" ]] && docker volume inspect "$short" >/dev/null 2>&1; then
+    match="$short"   # fallback: an unprefixed volume actually exists
+  fi
+  # Always succeed: a "no such volume" result is empty output, not a failure — else
+  # `var=$(resolve_volume_name ...)` under set -e would abort the caller (launch()).
+  [[ -n "$match" ]] && printf '%s' "$match"
+  return 0
+}
+
 # Check the health of one container. Echo: up:healthy | up:unhealthy | up:starting
 # | down | missing. Never errors.
 container_status() {
@@ -775,13 +793,16 @@ diagnose_state() {
   info ""
 
   # -- Volume check (Neo4j volume exists with potentially old password) --
-  local neo_vol="" vol_exists=no
+  local neo_vol="" neo_vol_real="" vol_exists=no
   if [[ "$compose_ok" == yes ]]; then
     neo_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null \
       | grep -iE 'neo4j' | head -1 || true)"
-    if [[ -n "$neo_vol" ]] && docker volume inspect "$neo_vol" >/dev/null 2>&1; then
-      vol_exists=yes
-      info "Neo4j data volume '$neo_vol' exists (password set on first startup only)."
+    if [[ -n "$neo_vol" ]]; then
+      neo_vol_real="$(resolve_volume_name "$neo_vol")"
+      if [[ -n "$neo_vol_real" ]]; then
+        vol_exists=yes
+        info "Neo4j data volume '$neo_vol_real' exists (password set on first startup only)."
+      fi
     fi
   fi
 
@@ -931,14 +952,13 @@ launch() {
   # unhealthy container. (Postgres can stay up yet refuse every query, so the stack
   # looks healthy while memory writes silently fail.)
   local neo_vol="" pg_vol=""
-  neo_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null | grep -iE 'neo4j' | head -1 || true)"
-  pg_vol="$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null | grep -iE 'pg|postgres' | head -1 || true)"
+  neo_vol="$(resolve_volume_name "$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null | grep -iE 'neo4j' | head -1 || true)")"
+  pg_vol="$(resolve_volume_name "$("${COMPOSE[@]}" -f "$COMPOSE_FILE" config --volumes 2>/dev/null | grep -iE 'pg|postgres' | head -1 || true)")"
   if [[ "$RECONFIGURE" == true ]]; then
     local _v _name
     for _v in "POSTGRES_PASSWORD:$pg_vol" "NEO4J_PASSWORD:$neo_vol"; do
       _name="${_v#*:}"
       [[ -n "$_name" ]] || continue
-      docker volume inspect "$_name" >/dev/null 2>&1 || continue
       warn "Database volume '$_name' already exists."
       warn "  Its password was fixed on FIRST startup. If ${_v%%:*} in .env differs"
       warn "  from that value, the database will reject connections."

--- a/tests/installer/test_install.sh
+++ b/tests/installer/test_install.sh
@@ -10,7 +10,7 @@ chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else ec
 # parse_args + configure are exercised. launch() echoes state for assertions.
 run_case() {
   local dir; dir="$(mktemp -d)"
-  printf 'LLM_PROVIDER=ollama\nLLM_PROVIDER_URL=\nLLM_PROVIDER_API_KEY=\nLLM_PROVIDER_MODEL=\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\nNEO4J_AUTH=\n' > "$dir/.env.example"
+  printf 'LLM_PROVIDER=ollama\nLLM_PROVIDER_URL=\nLLM_PROVIDER_API_KEY=\nLLM_PROVIDER_MODEL=\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\nMETRONIX_SECRET_KEY=develop-secret-key-change-in-prod\nNEO4J_AUTH=\n' > "$dir/.env.example"
   cat > "$dir/run.sh" <<EOF
 source "$INSTALL"
 check_prereqs() { :; }
@@ -93,6 +93,18 @@ printf 'LLM_PROVIDER=ollama\nNEO4J_PASSWORD=my_saved_password\nMETRONIX_MCP_API_
 ( cd "$LAST_DIR" && bash run.sh -y --reconfigure >/tmp/installer_test_out.txt 2>&1 ); LAST_RC=$?
 chk "exit zero" "$LAST_RC" "0"
 chk "NEO4J_PASSWORD preserved" "$(envval NEO4J_PASSWORD)" "my_saved_password"
+
+echo "Case 11: METRONIX_SECRET_KEY placeholder is rotated on a fresh install"
+run_case -y
+chk "exit zero" "$LAST_RC" "0"
+chk "SECRET_KEY non-empty" "$([[ -n "$(envval METRONIX_SECRET_KEY)" ]] && echo yes || echo no)" "yes"
+chk "SECRET_KEY not the shipped placeholder" "$([[ "$(envval METRONIX_SECRET_KEY)" != "develop-secret-key-change-in-prod" ]] && echo yes || echo no)" "yes"
+
+echo "Case 12: a real (non-placeholder) METRONIX_SECRET_KEY survives --reconfigure"
+printf 'LLM_PROVIDER=ollama\nNEO4J_PASSWORD=p\nMETRONIX_MCP_API_KEY=K\nMETRONIX_SECRET_KEY=my-real-prod-secret\n' > "$LAST_DIR/.env"
+( cd "$LAST_DIR" && bash run.sh -y --reconfigure >/tmp/installer_test_out.txt 2>&1 ); LAST_RC=$?
+chk "exit zero" "$LAST_RC" "0"
+chk "SECRET_KEY preserved" "$(envval METRONIX_SECRET_KEY)" "my-real-prod-secret"
 
 echo ""
 echo "TOTAL: $PASS passed, $FAIL failed"

--- a/tests/installer/test_resume.sh
+++ b/tests/installer/test_resume.sh
@@ -281,6 +281,45 @@ chk "wire_hermes saw the MCP key" "$(printf '%s' "$out16" | grep -cE 'WIRE key=\
 chk "NEO4J_PASSWORD preserved (not rotated)" "$(grep '^NEO4J_PASSWORD=' "$dir16/.env" | cut -d= -f2-)" "x"
 rm -rf "$dir16"
 
+echo "Case R17: wait_health flags a Postgres password/volume mismatch even when API is green"
+# Regression for the silent-failure case: stack looks healthy, but Postgres rejects the
+# configured password on an existing volume, so MCP memory writes fail.
+dir17="$(mktemp -d)"
+cat > "$dir17/r.sh" <<EOF
+source "$INSTALL"
+COMPOSE=(compose_stub)
+COMPOSE_FILE=docker-compose.full.yml
+compose_stub() { :; }
+curl() { return 0; }   # /health green
+docker() {
+  if [[ "\$1" == logs ]]; then echo 'FATAL: password authentication failed for user "metronix"'; return 0; fi
+  return 0
+}
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+wait_health
+EOF
+out17="$(bash "$dir17/r.sh" 2>&1)"
+chk "reports API healthy" "$(printf '%s' "$out17" | grep -c 'API is healthy')" "1"
+chk "warns about Postgres password rejection" "$(printf '%s' "$out17" | grep -c 'password authentication failed')" "1"
+chk "shows the reset command" "$(printf '%s' "$out17" | grep -c 'down -v')" "1"
+rm -rf "$dir17"
+
+echo "Case R18: wait_health stays quiet about Postgres when logs are clean"
+dir18="$(mktemp -d)"
+cat > "$dir18/r.sh" <<EOF
+source "$INSTALL"
+COMPOSE=(compose_stub)
+COMPOSE_FILE=docker-compose.full.yml
+compose_stub() { :; }
+curl() { return 0; }
+docker() { if [[ "\$1" == logs ]]; then echo 'database system is ready to accept connections'; return 0; fi; return 0; }
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+wait_health
+EOF
+out18="$(bash "$dir18/r.sh" 2>&1)"
+chk "no false Postgres warning on clean logs" "$(printf '%s' "$out18" | grep -c 'password authentication failed')" "0"
+rm -rf "$dir18"
+
 echo ""
 echo "TOTAL: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/tests/installer/test_resume.sh
+++ b/tests/installer/test_resume.sh
@@ -320,6 +320,24 @@ out18="$(bash "$dir18/r.sh" 2>&1)"
 chk "no false Postgres warning on clean logs" "$(printf '%s' "$out18" | grep -c 'password authentication failed')" "0"
 rm -rf "$dir18"
 
+echo "Case R19: resolve_volume_name maps a Compose short name to the project-prefixed volume"
+dir19="$(mktemp -d)"
+cat > "$dir19/r.sh" <<'EOF'
+source "INSTALL_PLACEHOLDER"
+docker() { if [[ "$1 $2" == "volume ls" ]]; then printf '%s\n' metronix-memory_full_neo4j_data metronix-memory_full_pg_data; return 0; fi; return 1; }
+echo "neo=[$(resolve_volume_name full_neo4j_data)]"
+echo "pg=[$(resolve_volume_name full_pg_data)]"
+echo "empty=[$(resolve_volume_name '')]"
+echo "missing=[$(resolve_volume_name full_qdrant_data)]"
+EOF
+sed -i.bak "s|INSTALL_PLACEHOLDER|$INSTALL|" "$dir19/r.sh"
+out19="$(bash "$dir19/r.sh" 2>&1)"
+chk "resolves prefixed neo4j volume" "$(printf '%s' "$out19" | grep -c 'neo=\[metronix-memory_full_neo4j_data\]')" "1"
+chk "resolves prefixed pg volume" "$(printf '%s' "$out19" | grep -c 'pg=\[metronix-memory_full_pg_data\]')" "1"
+chk "empty short -> empty" "$(printf '%s' "$out19" | grep -c 'empty=\[\]')" "1"
+chk "missing volume -> empty" "$(printf '%s' "$out19" | grep -c 'missing=\[\]')" "1"
+rm -rf "$dir19"
+
 echo ""
 echo "TOTAL: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/tests/installer/test_resume.sh
+++ b/tests/installer/test_resume.sh
@@ -247,6 +247,40 @@ chk "fresh reset prunes builder cache" "$(grep -c -- 'DOCKER builder prune -af' 
 chk "fresh reset reports completion" "$(printf '%s' "$out15" | grep -c 'Docker resources for Metronix were reset')" "1"
 rm -rf "$dir15"
 
+echo "Case R16: do_resume start backfills a blank METRONIX_MCP_API_KEY before launch"
+# Regression: an existing .env with a blank MCP key would launch a green stack
+# but leave the agent un-wireable (wire_hermes: 'No METRONIX_MCP_API_KEY in .env').
+dir16="$(mktemp -d)"
+cat > "$dir16/r.sh" <<EOF
+source "$INSTALL"
+REPO_ROOT="$dir16"
+ENV_FILE="$dir16/.env"
+get_env() { grep -E "^\$1=" "\$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- || true; }
+set_env() {
+  local k="\$1" v="\$2"
+  if grep -qE "^\${k}=" "\$ENV_FILE" 2>/dev/null; then
+    awk -v k="\$k" -v v="\$v" '\$0 ~ "^" k "=" { print k "=" v; next } { print }' "\$ENV_FILE" > "\$ENV_FILE.tmp" && mv "\$ENV_FILE.tmp" "\$ENV_FILE"
+  else printf '%s=%s\n' "\$k" "\$v" >> "\$ENV_FILE"; fi
+}
+printf 'POSTGRES_PASSWORD=p\nNEO4J_PASSWORD=x\nMETRONIX_MCP_API_KEY=\nFERNET_KEY=f\n' > "\$ENV_FILE"
+RESUME_ACTION=start
+ASSUME_YES=true
+key_at_launch=""
+launch() { key_at_launch="\$(get_env METRONIX_MCP_API_KEY)"; echo "LAUNCHED key=[\$key_at_launch]"; }
+wait_health() { :; }
+print_links() { :; }
+wire_hermes() { echo "WIRE key=[\$(get_env METRONIX_MCP_API_KEY)]"; }
+export C_OK="" C_WARN="" C_ERR="" C_RST=""
+do_resume
+EOF
+out16="$(bash "$dir16/r.sh" 2>&1)"
+chk "start launched stack" "$(printf '%s' "$out16" | grep -c LAUNCHED)" "1"
+chk "MCP key non-empty in .env after start" "$([[ -n "$(grep '^METRONIX_MCP_API_KEY=' "$dir16/.env" | cut -d= -f2-)" ]] && echo yes || echo no)" "yes"
+chk "MCP key already filled BEFORE launch ran" "$(printf '%s' "$out16" | grep -cE 'LAUNCHED key=\[.+\]')" "1"
+chk "wire_hermes saw the MCP key" "$(printf '%s' "$out16" | grep -cE 'WIRE key=\[.+\]')" "1"
+chk "NEO4J_PASSWORD preserved (not rotated)" "$(grep '^NEO4J_PASSWORD=' "$dir16/.env" | cut -d= -f2-)" "x"
+rm -rf "$dir16"
+
 echo ""
 echo "TOTAL: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/tests/installer/test_wire_hermes.sh
+++ b/tests/installer/test_wire_hermes.sh
@@ -24,6 +24,14 @@ chk "flag overrides reuse" "$r2" "override999"
 r3="$(bash -c "source '$INSTALL'; AGENT_ID=''; resolve_agent_id '$d/none.yaml'")"
 chk "generates when absent" "$(printf '%s' "$r3" | grep -cE '^[0-9a-f]{32}$')" "1"
 
+echo "Task2b: persisted METRONIX_AGENT_ID in .env is reused; live Hermes config still wins"
+da="$(mktemp -d)"; printf 'METRONIX_AGENT_ID=persistaaaabbbbccccddddeeee00001\n' > "$da/.env"
+r4="$(cd "$da" && bash -c "source '$INSTALL'; AGENT_ID=''; resolve_agent_id '$da/none.yaml'")"
+chk "reuses persisted .env id when no Hermes config" "$r4" "persistaaaabbbbccccddddeeee00001"
+r5="$(cd "$da" && bash -c "source '$INSTALL'; AGENT_ID=''; resolve_agent_id '$d/config.yaml'")"
+chk "live Hermes config id wins over persisted .env id" "$r5" "deadbeefdeadbeefdeadbeefdeadbeef"
+rm -rf "$da"
+
 echo "Task3: auto-edit blocks render with substituted values"
 tpl="$(bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY123; H_AGENT=AID9; H_WS=MTRNIX; hermes_config_block; echo ---; hermes_soul_block")"
 chk "config has url" "$(printf '%s' "$tpl" | grep -c 'http://h:8000/mcp')" "1"
@@ -129,5 +137,11 @@ printf 'METRONIX_MCP_API_KEY=K\nDEFAULT_WORKSPACE_ID=MTRNIX\n' > "$work/.env"
 ( cd "$work" && HOME="$hd" bash -c "source ./install.sh; launch(){ echo BUILT; }; wait_health(){ :; }; print_links(){ :; }; check_prereqs(){ :; }; main --wire-hermes -y" >/tmp/wh5.txt 2>&1 )
 chk "standalone did NOT build" "$(grep -q BUILT /tmp/wh5.txt && echo built || echo no)" "no"
 chk "standalone produced prompts or wired" "$([[ -d "$work/metronix-hermes-setup" || -f "$hd/.hermes/config.yaml" ]] && echo yes || echo no)" "yes"
+
+echo "Task8b: wire_hermes anchors METRONIX_AGENT_ID in .env and keeps it stable"
+agent_id1="$(grep '^METRONIX_AGENT_ID=' "$work/.env" | cut -d= -f2-)"
+chk "agent id persisted to .env" "$(printf '%s' "$agent_id1" | grep -cE '^[0-9a-f]{32}$')" "1"
+( cd "$work" && HOME="$hd" bash -c "source ./install.sh; launch(){ :; }; wait_health(){ :; }; print_links(){ :; }; check_prereqs(){ :; }; main --wire-hermes -y" >/tmp/wh6.txt 2>&1 )
+chk "agent id stable across re-run" "$(grep '^METRONIX_AGENT_ID=' "$work/.env" | cut -d= -f2-)" "$agent_id1"
 
 echo ""; echo "TOTAL: $PASS passed, $FAIL failed"; [[ $FAIL -eq 0 ]]

--- a/tests/installer/test_wire_hermes.sh
+++ b/tests/installer/test_wire_hermes.sh
@@ -86,14 +86,16 @@ else
   echo "  SKIP Task5: no host yq and no usable Docker -- text merge not exercised"
 fi
 
-echo "Task6: prompt dir -- 3 filled prompts, no unfilled placeholders"
+echo "Task6: prompt dir -- 4 filled prompts, no unfilled placeholders"
 d="$(mktemp -d)"
 bash -c "source '$INSTALL'; H_URL=http://h:8000/mcp; H_KEY=KEY1; H_AGENT=AID1; H_WS=MTRNIX; write_hermes_prompt_dir '$d/out'" >/dev/null 2>&1
-chk "3 files written" "$(ls -1 "$d/out" 2>/dev/null | wc -l | tr -d ' ')" "3"
+chk "4 files written" "$(ls -1 "$d/out" 2>/dev/null | wc -l | tr -d ' ')" "4"
 chk "prompt 1 filled (agent)" "$(grep -c 'X-Agent-Id: AID1' "$d/out/1-install-mcp.md")" "1"
 chk "prompt 2 present" "$([[ -f "$d/out/2-memory-source.md" ]] && echo yes || echo no)" "yes"
 chk "prompt 3 present" "$([[ -f "$d/out/3-migrate.md" ]] && echo yes || echo no)" "yes"
-chk "no unfilled real placeholders" "$(grep -rlE '\{\{(METRONIX_URL|MCP_API_KEY|AGENT_UUID|WORKSPACE_ID)\}\}' "$d/out" 2>/dev/null | wc -l | tr -d ' ')" "0"
+chk "prompt 4 (rollback) present" "$([[ -f "$d/out/4-rollback.md" ]] && echo yes || echo no)" "yes"
+chk "prompt 4 filled (workspace + agent)" "$([[ $(grep -c 'workspace_id="MTRNIX"' "$d/out/4-rollback.md") -ge 1 && $(grep -c 'agent_id="AID1"' "$d/out/4-rollback.md") -ge 1 ]] && echo yes || echo no)" "yes"
+chk "no unfilled real placeholders" "$(grep -rlE '\{\{(METRONIX_URL|METRONIX_MCP_API_KEY|AGENT_UUID|DEFAULT_WORKSPACE_ID)\}\}' "$d/out" 2>/dev/null | wc -l | tr -d ' ')" "0"
 
 echo "Task7: orchestrator (HOME stubbed)"
 STUB_ENV='get_env(){ case $1 in METRONIX_MCP_API_KEY) echo K;; DEFAULT_WORKSPACE_ID) echo MTRNIX;; esac; }'

--- a/uninstall.md
+++ b/uninstall.md
@@ -103,8 +103,9 @@ rm -f .env
 rm -rf metronix-hermes-setup/
 ```
 
-> Keep `.env` if you plan to reinstall and want to preserve your secrets and database
-> passwords — `./install.sh` reuses an existing `.env` unless you pass `--reconfigure`.
+> Keep `.env` if you plan to reinstall and want to preserve your secrets, database
+> passwords, and the persisted agent id (`METRONIX_AGENT_ID`) — `./install.sh` reuses an
+> existing `.env` unless you pass `--reconfigure`.
 
 ## 5. Remove the MCP agent wiring (Hermes)
 
@@ -165,9 +166,9 @@ docker compose -f docker-compose.full.yml down -v
 docker rmi metronix-memory-metronix-core:latest metronix-memory-splade:latest 2>/dev/null || true
 rm -f .env
 rm -rf metronix-hermes-setup/
-# Hermes: restore backups if present (see step 5 for the by-hand alternative)
-[ -e ~/.hermes/config.yaml.bak-* ] && cp $(ls -t ~/.hermes/config.yaml.bak-* | head -1) ~/.hermes/config.yaml
-[ -e ~/.hermes/SOUL.md.bak-*     ] && cp $(ls -t ~/.hermes/SOUL.md.bak-*     | head -1) ~/.hermes/SOUL.md
+# Hermes: restore the newest backup if present (see step 5 for the by-hand alternative)
+cfg=$(ls -t ~/.hermes/config.yaml.bak-* 2>/dev/null | head -1); [ -n "$cfg" ] && cp "$cfg" ~/.hermes/config.yaml
+soul=$(ls -t ~/.hermes/SOUL.md.bak-* 2>/dev/null | head -1); [ -n "$soul" ] && cp "$soul" ~/.hermes/SOUL.md
 ```
 
 Base images and the repo clone are left in place; remove them separately (step 3, and


### PR DESCRIPTION
Hardens `install.sh` around a set of issues surfaced while a teammate (new to the project) test-installed Metronix. The common thread: an install could reach a running stack with broken/empty credentials, and the failure was either silent or misleadingly reported.

## Changes (6 commits)

**1. Stale error text + garbled status colors** (`5228db2`)
- The no-TTY error referenced removed flags (`--provider`/`--custom-url`/…); now points at the current `--chat-url`/`--chat-model`/`--chat-api-key`.
- `diagnose_state` `up:unhealthy` line had its color args out of order (word never colored, terminal left red); matched the `healthy`/`down` ordering.

**2. Backfill blank secrets before launch on resume start/rebuild** (`38a8fd8`)
- The resume menu could launch an existing `.env` via `start`/`rebuild` without regenerating secrets. A blank `METRONIX_MCP_API_KEY` then produced a green stack that wire_hermes couldn't wire ("No METRONIX_MCP_API_KEY in .env"). Extracted `backfill_env_secrets()` (idempotent — never rotates a non-blank value) and run it before every launch path.

**3. Generate `METRONIX_SECRET_KEY`, persist agent id** (`aacb182`)
- `METRONIX_SECRET_KEY` (JWT signing) shipped a public placeholder and was never generated → now rotated on fresh install, preserved across `--reconfigure`.
- The Hermes agent id lived only in `~/.hermes/config.yaml`; a reset orphaned the agent's memories. Persist it to `.env` as `METRONIX_AGENT_ID` (installer's durable anchor; the backend still reads the id from the `X-Agent-Id` header).

**4. Blank weak default credentials in `.env.example`** (`4157afb`)
- `POSTGRES_PASSWORD=metronix_dev` was a baked-in default AND the trigger for the mismatch below (equal-to-default values get regenerated on `--reconfigure`). Blanked it: the installer generates a strong value; raw `docker compose` still falls back to `metronix_dev` via `${POSTGRES_PASSWORD:-metronix_dev}` (both postgres and api services use the same expansion). `AUTH_PASSWORD` blanked too (only used when `AUTH_ENABLED=true`).

**5. Detect Postgres password/volume mismatch** (`97712aa`)
- Root cause of "MCP connects but nothing saves": Postgres rejects the password (`password authentication failed for user "metronix"`) when `POSTGRES_PASSWORD` diverged from the value its volume was initialised with. `pg_isready` doesn't authenticate, so the stack looks healthy while every write fails. `launch()` now warns about the Postgres volume (not just Neo4j) on `--reconfigure`, and `wait_health()` greps the Postgres log for the auth-failed line even when `/health` is green and prints the fix.

## Tests
All installer tests pass: `test_install` 41, `test_resume` 36, `test_wire_hermes` 52, `test_failgen` 13. `shellcheck -S style install.sh` clean. New regression cases: resume R16 (backfill on start), R17/R18 (Postgres mismatch detection), install Case 11/12 (secret-key rotate vs preserve), wire_hermes Task2b/8b (agent-id fallback + persistence).

## Notes / deferred
- agent_id stays installer-generated + `.env`-anchored (interim); registering via `POST /api/v1/agents` is the longer-term option.
- `METRONIX_OPENAI_COMPAT_KEY` left as-is (blanking breaks the bundled Open WebUI); revisit separately.