### PR TITLE
ci(security): make Trivy actually scan (build in-job, table output, report-only)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 jobs:
   trivy-scan:
@@ -43,18 +41,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Print findings as a table in the Actions log. The repository has no
+      # GitHub Advanced Security, so the Security-tab (SARIF code-scanning)
+      # upload is unavailable — the run log is where results live. Report-only:
+      # exit-code 0 never blocks a merge. scanners=vuln skips secret scanning
+      # (avoids noise from .env.example placeholders).
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'metronix-core:scan'
           scanners: 'vuln'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          format: 'table'
           exit-code: '0'
           severity: 'CRITICAL,HIGH,MEDIUM'
-
-      - name: Upload to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: trivy-container-scan

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,26 +9,45 @@ on:
 
 permissions:
   contents: read
-  packages: read        
   security-events: write
-  actions: read  
+  actions: read
+
 jobs:
   trivy-scan:
-    name: Scan image with Trivy
+    name: Build image and scan with Trivy
     runs-on: ubuntu-latest
 
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Scan image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the image from the Dockerfile and load it into the local Docker
+      # daemon (single-arch, not pushed). Scanning a locally built image avoids
+      # depending on a registry tag that may not exist: the previous config
+      # scanned a stale image name (ghcr.io/mtrnix/metronixcore:...) and died
+      # with MANIFEST_UNKNOWN before any scan ran.
+      - name: Build image (local, amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: metronix-core:scan
+          provenance: false
+          sbom: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'ghcr.io/mtrnix/metronixcore:metronixcore-develop'
+          image-ref: 'metronix-core:scan'
+          scanners: 'vuln'
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: '0'


### PR DESCRIPTION
## Problem
The `Container Security Scan` (Trivy) job had **never actually run a scan**. It pointed at `ghcr.io/mtrnix/metronixcore:metronixcore-develop`, but:
- the image is published as `ghcr.io/mtrnix/metronix-memory:...` (repo-rename leftover: `metronixcore` → `metronix-memory`), and
- the build workflow (`docker-image.yml`) is `workflow_dispatch`-only, so the tag may not exist at all.

Trivy died with `MANIFEST_UNKNOWN` at image pull, ~20s, before scanning anything. The "failure" was a CI-config bug, not a vulnerability finding.

## Fix
Build the image from the `Dockerfile` **inside the job** (single-arch amd64, `--load` into the local daemon, GHA build cache) and point Trivy at that local tag. No registry dependency, no coordination with the manual image-build workflow.

Also discovered during validation: the repo has **no GitHub Advanced Security**, so `upload-sarif` fails with *"Advanced Security must be enabled … to use code scanning"* — the Security tab is unavailable here. Dropped the SARIF upload (and the `security-events` permission); Trivy now prints a **table to the Actions run log** instead.

Behavior (per agreed defaults):
- **Report-only** — `exit-code: 0`, never blocks a merge.
- **vuln-only** — `scanners: vuln`, skips secret scanning (avoids noise from `.env.example` placeholders).

## Validated live
Ran via `workflow_dispatch` on this branch — job is **green in 2m32s**, scan executes:
```
Total: 50 (MEDIUM: 39, HIGH: 9, CRITICAL: 2)
Total:  4 (MEDIUM: 4)
```
Findings are base-image OS-package CVEs (e.g. `perl-base CVE-2026-42496`, status `fix_deferred` — no upstream fix), which is exactly why report-only is appropriate. These were previously invisible.

## Follow-ups (not in this PR)
- Triage the 2 CRITICAL / 9 HIGH later; tighten to fail-on-severity once the baseline is understood.
- The repo lacking GHAS affects any SARIF/Security-tab tooling, not just Trivy.