### PR TITLE
docs: expand Pi integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,80 +3,42 @@
 </p>
 
 <p align="center">
-  <strong>Open-source AI memory infrastructure.</strong> Ingest any data source.<br>
-  Ask questions via Hermes, Claude, Cursor, Open WebUI, or any MCP client.<br>
-  Answers grounded in your organization's real knowledge - self-hosted, always.
+  <strong>Open-source AI memory infrastructure.</strong><br>
+  Hybrid RAG, durable agent memory, MCP tools, and local-model support.
 </p>
 
 <p align="center">
-  <a href="#what-problem-does-this-solve"><strong>Problem</strong></a> |
-  <a href="#architecture">Architecture</a> |
-  <a href="#install">Install</a> |
-  <a href="#connect-an-agent">Connect an Agent</a> |
+  <a href="#install"><strong>Install</strong></a> |
+  <a href="#choose-your-runtime-guide">Runtime Guides</a> |
+  <a href="#quick-reference">Quick Reference</a> |
   <a href="#documentation">Docs</a>
 </p>
 
 ---
 
-## What Problem Does This Solve?
+## What This Is
 
-**RAG alone isn't enough.** Vector databases retrieve chunks. RAG frameworks wire plumbing. But building an AI agent that actually knows your company - Jira tickets, Confluence pages, GitHub repos, Google Drive, Slack history, uploaded files, and MCP-compatible tools - takes months of integration work.
+Metatron Core is a self-hosted backend for AI agents and chat clients:
 
-**Agent memory is still unsolved.** Every AI agent framework ships a `memory.add()` function. Fewer systems answer: "Is this fact still true? When did it last change? Who said it?" Facts go stale silently.
+- ingest company knowledge from files and connectors
+- query it through MCP, REST, or an OpenAI-compatible API
+- store durable agent memory with workspace and agent scoping
+- run on your own infra with Ollama or external model providers
 
-**Self-hosting matters.** Your data, credentials, and knowledge graph should run in your own environment when compliance or privacy requires it.
-
-**Metatron Core** is the open-source answer: hybrid RAG + persistent agent memory + freshness pipeline. Self-hosted. MCP-native. Built for AI agents, not just chatbots.
-
-| Your Agents Need | Without Metatron | With Metatron |
-|---|---|---|
-| Search company knowledge | Build separate integrations and ingestion pipelines | Connect sources and query through one RAG surface |
-| Persistent agent memory | Reset every session or store raw notes | `fact`, `preference`, and `pinned` memory records |
-| Freshness checks | Stale facts remain forever | Link, reconcile, monitor, curate, and review memory |
-| Agent-native access | Custom tools per runtime | Built-in MCP server for Cursor, Claude Desktop, Hermes, and other MCP clients |
-| Self-hosted deployment | Cloud-only memory or managed RAG | Docker Compose on your infrastructure |
-
----
-
-## Architecture
-
-Metatron Core uses a strict one-way dependency architecture - each layer only imports downward.
-
-```text
-L6  api/            REST + OpenAI-compatible API + MCP HTTP mount
-L5  channels/       Legacy Telegram, Discord, Slack integrations
-L4  agent/          Intent router and compatibility shims
-L3  services        Connectors, LLM, MCP, memory, auth, workspaces, knowledge
-L2  processing      Ingestion, retrieval, freshness pipeline
-L1  storage/        PostgreSQL, Qdrant, Neo4j, Redis clients
-L0  core/           Config, models, events, plugin interfaces
-```
-
-**[Open interactive architecture diagram](docs/architecture-diagram.html)** - works offline in a browser.
-
-### Key Pipelines
-
-| Pipeline | Flow | What it does |
-|---|---|---|
-| **Ingestion** | Fetch -> Parse -> Chunk -> Embed -> Store | Incremental sync from connectors and files. PDF, HTML, Office, text, and tabular processors. |
-| **Retrieval** | Classify -> Expand -> Recall -> Rerank -> Score -> Answer | Dense vectors + SPLADE sparse retrieval + graph context + source citations. |
-| **Freshness** | Linker -> Reconciler -> Monitor -> Curator -> DecisionEngine | Detects stale or conflicting memory and knowledge records. |
-| **Memory** | Store -> Search -> Review -> Assemble | Persistent agent memory scoped by workspace and agent. |
+If you just want to get it running, skip the theory and go straight to install.
 
 ---
 
 ## Install
 
-The primary installation sequence lives in [`manual.md`](manual.md). Use [`install.md`](install.md) if you hit errors or need detailed deployment notes.
-
-### 1. Clone the repository
+### 1. Clone
 
 ```bash
 git clone -b develop https://github.com/mtrnix/metatroncore.git
 cd metatroncore
 ```
 
-### 2. Verify Docker and Docker Compose
+### 2. Verify Docker
 
 ```bash
 docker --version
@@ -84,27 +46,61 @@ docker compose version 2>/dev/null || docker-compose --version
 docker info >/dev/null 2>&1 && echo "daemon OK" || echo "START DOCKER DAEMON"
 ```
 
-Docker installation links:
+Install Docker if needed:
 
-- Linux: <https://docs.docker.com/engine/install/>
 - macOS: <https://docs.docker.com/desktop/setup/install/mac-install/>
+- Linux: <https://docs.docker.com/engine/install/>
 - Windows: <https://docs.docker.com/desktop/setup/install/windows-install/>
 
-On macOS, Docker Desktop can lose ownership of `~/.docker` after an update. If `docker compose build` fails with `permission denied`, run:
+### Sizing
+
+Plan capacity before first boot:
+
+| Item | Typical space |
+|---|---|
+| Docker images and build cache | `6-8 GB` |
+| Postgres, Qdrant, Neo4j, Redis volumes | `2-4 GB` to start |
+| Ollama models | `2-8 GB` depending on model size |
+| Working headroom | `3-5 GB` |
+| Recommended free disk before install | `15-20 GB` |
+
+### Timing
+
+Typical install timing on a modern laptop or dev server:
+
+| Step | Typical time |
+|---|---|
+| Clone repo and create `.env` | `2-5 min` |
+| First Docker image build | `5-15 min` |
+| First container startup | `2-5 min` |
+| First Ollama model pull | `3-20 min` depending on model size and network |
+| Total first-time install | `12-45 min` |
+
+After the first install, restarts are usually much faster unless you force a full rebuild.
+
+Why Ollama is in the default stack:
+
+- Metatron uses Ollama for local embeddings out of the box
+- embeddings are what let Metatron index and retrieve your documents semantically
+- the bundled setup also supports using Ollama for local chat models if you want
+
+If you already run Ollama elsewhere, point Metatron at that host instead of using the
+bundled container.
+
+If Docker Desktop on macOS starts acting like it was raised by raccoons and `build`
+fails with `permission denied`, run:
 
 ```bash
 sudo chown -R $(whoami):staff ~/.docker
 ```
 
-Plan for about 15 GB of free disk space for images, build cache, volumes, and first-run Ollama models.
-
-### 3. Prepare `.env`
+### 3. Create `.env`
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` and choose one LLM provider.
+Pick one LLM provider.
 
 DeepSeek:
 
@@ -120,7 +116,7 @@ LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-your-openrouter-key
 ```
 
-Ollama from the built-in Compose stack:
+Built-in Ollama from the Compose stack:
 
 ```ini
 LLM_PROVIDER=ollama
@@ -141,35 +137,33 @@ CUSTOM_LLM_URL=https://your-llm-endpoint/v1
 CUSTOM_LLM_API_KEY=your-key
 ```
 
-Generate an MCP API key for agents:
+Generate an MCP API key for agent runtimes:
 
 ```bash
 openssl rand -hex 32
 ```
 
-Set it in `.env`:
+Add it to `.env`:
 
 ```ini
 METATRON_MCP_API_KEY=<paste-the-generated-token>
 ```
 
-External agents use this token when connecting to `http://localhost:8001/mcp`.
+### 4. Start the stack
 
-### 4. Launch
-
-Backend stack only:
+Backend only:
 
 ```bash
 docker compose -f docker-compose.full.yml up -d --build
 ```
 
-Backend + Open WebUI chat interface:
+Backend plus Open WebUI:
 
 ```bash
 docker compose -f docker-compose.full.yml --profile openwebui up -d --build
 ```
 
-Open WebUI is available at `http://localhost:3080` when the `openwebui` profile is enabled. First run can take 10-15 minutes while images build and models download.
+First boot can take 10-15 minutes while images build and Ollama pulls models.
 
 ### 5. Verify
 
@@ -178,222 +172,93 @@ docker compose -f docker-compose.full.yml ps
 curl http://localhost:8001/health
 ```
 
-Ports:
-
-| Service | Port |
-|---|---|
-| API | `8001` |
-| PostgreSQL | `5433` |
-| Qdrant | `6335` |
-| Neo4j bolt | `7688` |
-| Redis | `6380` |
-| Ollama | `11435` |
-| SPLADE | `8080` |
-| Open WebUI | `3080` |
-
-### Troubleshooting
-
-If installation fails, see [`install.md`](install.md) for the full deployment reference.
-
-Common commands:
-
-```bash
-# Clean up a previous run
-docker compose -f docker-compose.full.yml down
-
-# Rebuild after .env changes
-docker compose -f docker-compose.full.yml up -d --build --force-recreate
-
-# Check API logs
-docker compose -f docker-compose.full.yml logs metatron-core
-```
+If health is up, the install worked.
 
 ---
 
-## Demo
+## Choose Your Runtime Guide
 
-Open [`docs/architecture-diagram.html`](docs/architecture-diagram.html) in any browser for an interactive architecture walkthrough.
+After the backend is running, pick the client or runtime you actually want to use.
 
-After the stack is running, connect an MCP client and ask a question against your indexed knowledge base, for example:
+Priority guides:
 
-```text
-What changed in the project plan this week?
-```
+- [Hermes Agent](docs/integrations/hermes-agent.md)
+- [OpenClaw](docs/integrations/openclaw.md)
+- [Ollama + GLM or Qwen](docs/integrations/ollama-local-models.md)
+- [Claude Code](docs/integrations/claude-code.md)
+- [Codex](docs/integrations/codex.md)
+- [OpenCode](docs/integrations/opencode.md)
+- [Pi](docs/integrations/pi.md)
+- [LangChain](docs/integrations/langchain.md)
+- [Python SDK](docs/integrations/sdk-python.md)
+- [Go SDK](docs/integrations/sdk-go.md)
+- [n8n](docs/integrations/n8n.md)
+- [NanoClaw](docs/integrations/nanoclaw.md)
+- [NanoBot](docs/integrations/nanobot.md)
+- [Atomic Chat / Open WebUI + Ollama](docs/integrations/atomic-chat.md)
 
-Metatron searches your knowledge base and returns a grounded answer with citations from your real data.
+Generic MCP setup prompt:
 
----
-
-## How Metatron Compares
-
-### vs. Vector Databases
-
-| | Vector DB | Metatron |
-|---|---|---|
-| Stores vectors | Yes | Yes, using Qdrant internally |
-| Sparse retrieval | Usually add-on | Built-in SPLADE sparse retrieval |
-| Knowledge graph | No | Neo4j graph context |
-| Document ingestion | Bring your own | Connectors and processors included |
-| Agent memory | No | Built-in memory records and lifecycle |
-| MCP-native | No | Built-in MCP server |
-
-Use a vector DB alone if you are building a custom RAG stack from scratch. Use Metatron if you want ingestion, retrieval, graph context, memory, and agent access in one system.
-
-### vs. RAG Frameworks
-
-| | RAG Framework | Metatron |
-|---|---|---|
-| RAG pipeline | You build it | Built in and configurable |
-| Connectors | Community integrations | Native connector framework |
-| Agent memory | Bring another service | Built in |
-| API server | You build it | REST, OpenAI-compatible, and MCP surfaces included |
-| Time to first answer | Days or weeks | One Docker Compose stack |
-
-RAG frameworks give you building blocks. Metatron gives you an operational backend for agent knowledge and memory.
-
-### vs. Agent Memory Platforms
-
-| | Memory Platform | Metatron |
-|---|---|---|
-| Persistent memory | Yes | Yes |
-| Hybrid RAG | Often limited | Dense + SPLADE + graph |
-| Enterprise data connectors | Usually limited | Connector framework included |
-| Self-hosted deployment | Varies | Docker Compose first |
-| MCP tools | Varies | Built-in MCP server |
-
----
-
-## Features
-
-### Hybrid RAG
-
-- Dense vectors + SPLADE sparse vectors + Neo4j graph context.
-- Query expansion, classification, reranking, and source diversity.
-- Source-grounded answers with citations.
-
-### Connectors And Ingestion
-
-- Native connector framework for Confluence, Jira, Notion, GitHub, Google Drive, Slack history, and local files.
-- File upload APIs for direct ingestion.
-- MCP tools for storing and syncing external sources.
-
-### Agent Memory
-
-- `fact`, `preference`, and `pinned` memory records.
-- Workspace and agent scoping.
-- Review queue, snapshots, health checks, and freshness lifecycle support.
-
-### Consumer Surfaces
-
-### Hermes Memory: Important Distinction
-
-If you are using **Hermes Agent**, do **not** start with Hermes' "memory providers"
-screen and expect Metatron to appear there.
-
-Hermes currently has two different integration concepts:
-
-- **Memory providers** — Hermes-native provider plugins such as `honcho`, `mem0`,
-  `hindsight`, and similar providers configured via Hermes' own memory setup flow
-- **MCP servers** — external backends Hermes can call as tools
-
-**Metatron today integrates with Hermes as an MCP server, not as a Hermes-native
-memory provider plugin.**
-
-That means:
-
-- use Metatron when you want Hermes to search the KB or read/write memory through
-  MCP tools like `metatron_search`, `metatron_memory_search`, and
-  `metatron_memory_store`
-- use Hermes memory providers when you specifically want Hermes' built-in provider
-  plugin system
-- use both if you want Hermes-native memory plus Metatron as a richer external
-  knowledge and memory backend
-
-**Recommended path today:** connect Hermes to Metatron through `/mcp`.
-
-See:
-- **[Hermes Integration Guide](docs/HERMES_INTEGRATION.md)** — exact MCP setup for Hermes
-- **[Hermes memory provider docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers)** — what Hermes means by "memory providers"
-
-### Deployment
-- **Self-hosted:** Docker Compose, your hardware, your keys
-- **Full stack:** PostgreSQL + Qdrant + Neo4j + Ollama + API
-- **Planned:** Air-gapped BYOC, SOC2 compliance
-
----
-
-## Connect An Agent
-
-After Metatron is running, connect your agent through MCP.
-
-The easiest path is to give your agent the prompt from [`connecting_to_agent.md`](connecting_to_agent.md). It asks for the Metatron MCP URL, MCP API key, agent id, and workspace id, then configures and verifies the MCP connection.
-
-Runtime-specific guides:
-
-- [`docs/integrations/cursor.md`](docs/integrations/cursor.md)
-- [`docs/integrations/claude-desktop.md`](docs/integrations/claude-desktop.md)
-- [`docs/integrations/hermes.md`](docs/integrations/hermes.md)
-- [`docs/integrations/openwebui.md`](docs/integrations/openwebui.md)
-- [`docs/integrations/librechat.md`](docs/integrations/librechat.md)
-- [`docs/integrations/openclaw.md`](docs/integrations/openclaw.md)
+- [Connecting To An Agent](connecting_to_agent.md)
 
 ---
 
 ## Quick Reference
 
-### Development Commands
+External ports from `docker-compose.full.yml`:
 
-```bash
-make dev              # uvicorn --reload
-make test             # pytest unit tests
-make lint             # ruff check + format check
-make typecheck        # mypy src/metatron/
-make migrate          # alembic upgrade head
-make eval             # search quality eval
-```
+| Service | Port |
+|---|---|
+| API | `8001` |
+| PostgreSQL | `5433` |
+| Qdrant HTTP | `6335` |
+| Qdrant gRPC | `6336` |
+| Neo4j HTTP | `7475` |
+| Neo4j bolt | `7688` |
+| Redis | `6380` |
+| Ollama | `11435` |
+| SPLADE | `8080` |
+| Embedding proxy | `8002` |
+| Open WebUI | `3080` |
 
-### Important URLs
+Important URLs:
 
 | Surface | URL |
 |---|---|
-| API health | `http://localhost:8001/health` |
-| REST API | `http://localhost:8001/api/v1/*` |
-| MCP endpoint | `http://localhost:8001/mcp` |
+| Health | `http://localhost:8001/health` |
+| REST API | `http://localhost:8001/api/v1` |
+| MCP | `http://localhost:8001/mcp` |
 | OpenAI-compatible API | `http://localhost:8001/v1` |
 | Open WebUI | `http://localhost:3080` |
+
+Useful commands:
+
+```bash
+docker compose -f docker-compose.full.yml logs metatron-core
+docker compose -f docker-compose.full.yml down
+docker compose -f docker-compose.full.yml up -d --build --force-recreate
+```
 
 ---
 
 ## Documentation
 
-- [`manual.md`](manual.md) - primary step-by-step install sequence.
-- [`install.md`](install.md) - detailed deployment and troubleshooting reference.
-- [`connecting_to_agent.md`](connecting_to_agent.md) - MCP agent connection prompt.
-- [`docs/README.md`](docs/README.md) - documentation index.
-- [`docs/MCP_API.md`](docs/MCP_API.md) - MCP tool reference.
-- [`docs/API.md`](docs/API.md) - REST API reference.
-- [`docs/reference/api-openai-compat.md`](docs/reference/api-openai-compat.md) - OpenAI-compatible API reference.
-- [`docs/product/legacy.md`](docs/product/legacy.md) - legacy and compatibility surfaces.
-- [`docs/product/open-core-boundaries.md`](docs/product/open-core-boundaries.md) - open-core boundaries.
+- [manual.md](manual.md) - short install walkthrough
+- [install.md](install.md) - detailed install and troubleshooting
+- [docs/README.md](docs/README.md) - documentation index
+- [docs/MCP_API.md](docs/MCP_API.md) - MCP tool reference
+- [docs/API.md](docs/API.md) - REST and OpenAI-compatible API reference
 
 ---
 
 ## Contributing
 
-Metatron Core is open-core. Bug reports, connector additions, documentation improvements, and focused pull requests are welcome.
+Bug reports, docs fixes, connector additions, and focused pull requests are welcome.
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 
 ## License
 
-Apache License 2.0. See [`LICENSE`](LICENSE).
-
-Third-party components, connectors, and plugins may carry their own licenses.
-
----
-
-<p align="center">
-  <sub>Built for AI agents that need to know your organization - not just answer questions.</sub>
-</p>
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/docs/HERMES_INTEGRATION.md
+++ b/docs/HERMES_INTEGRATION.md
@@ -1,0 +1,7 @@
+# Hermes Integration
+
+This document exists as a compatibility shim for older links.
+
+Use the current guide:
+
+- [`integrations/hermes-agent.md`](integrations/hermes-agent.md)

--- a/docs/OPENCLAW_INTEGRATION.md
+++ b/docs/OPENCLAW_INTEGRATION.md
@@ -1,0 +1,7 @@
+# OpenClaw Integration
+
+This document exists as a compatibility shim for older links.
+
+Use the current guide:
+
+- [`integrations/openclaw.md`](integrations/openclaw.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,51 @@
-# Metatron Core Documentation
+# Documentation Index
 
-Start here:
+## Start Here
 
-- [`../manual.md`](../manual.md) — main step-by-step installation sequence.
-- [`../install.md`](../install.md) — detailed deployment and troubleshooting reference.
-- [`../connecting_to_agent.md`](../connecting_to_agent.md) — prompt-driven MCP agent setup.
+- [`../README.md`](../README.md) - main install-first overview
+- [`../manual.md`](../manual.md) - short install walkthrough
+- [`../install.md`](../install.md) - detailed install reference
+- [`../connecting_to_agent.md`](../connecting_to_agent.md) - generic MCP setup prompt
+
+## Runtime Guides
+
+Priority order:
+
+- [`integrations/hermes-agent.md`](integrations/hermes-agent.md)
+- [`integrations/openclaw.md`](integrations/openclaw.md)
+- [`integrations/ollama-local-models.md`](integrations/ollama-local-models.md)
+- [`integrations/claude-code.md`](integrations/claude-code.md)
+- [`integrations/codex.md`](integrations/codex.md)
+- [`integrations/opencode.md`](integrations/opencode.md)
+- [`integrations/pi.md`](integrations/pi.md)
+- [`integrations/langchain.md`](integrations/langchain.md)
+- [`integrations/sdk-python.md`](integrations/sdk-python.md)
+- [`integrations/sdk-go.md`](integrations/sdk-go.md)
+- [`integrations/n8n.md`](integrations/n8n.md)
+- [`integrations/nanoclaw.md`](integrations/nanoclaw.md)
+- [`integrations/nanobot.md`](integrations/nanobot.md)
+- [`integrations/atomic-chat.md`](integrations/atomic-chat.md)
+
+Additional guides:
+
+- [`integrations/claude-desktop.md`](integrations/claude-desktop.md)
+- [`integrations/cursor.md`](integrations/cursor.md)
+- [`integrations/librechat.md`](integrations/librechat.md)
+- [`integrations/openwebui.md`](integrations/openwebui.md)
+- [`integrations/mcp-reference.md`](integrations/mcp-reference.md)
 
 ## Guides
 
-- [`guides/ingestion.md`](guides/ingestion.md) — get data into Metatron.
-- [`guides/memory.md`](guides/memory.md) — agent memory concepts and APIs.
-- [`guides/connectors.md`](guides/connectors.md) — connector configuration overview.
-- [`guides/agents-and-workspaces.md`](guides/agents-and-workspaces.md) — identity and isolation model.
-
-## Integrations
-
-- [`integrations/cursor.md`](integrations/cursor.md)
-- [`integrations/claude-desktop.md`](integrations/claude-desktop.md)
-- [`integrations/hermes.md`](integrations/hermes.md)
-- [`integrations/openwebui.md`](integrations/openwebui.md)
-- [`integrations/librechat.md`](integrations/librechat.md)
-- [`integrations/openclaw.md`](integrations/openclaw.md)
-- [`integrations/mcp-reference.md`](integrations/mcp-reference.md)
+- [`guides/ingestion.md`](guides/ingestion.md)
+- [`guides/memory.md`](guides/memory.md)
+- [`guides/connectors.md`](guides/connectors.md)
+- [`guides/agents-and-workspaces.md`](guides/agents-and-workspaces.md)
 
 ## Reference
 
-- [`API.md`](API.md) — REST and OpenAI-compatible API reference.
-- [`MCP_API.md`](MCP_API.md) — MCP tool reference.
+- [`API.md`](API.md)
+- [`MCP_API.md`](MCP_API.md)
+- [`reference/api-openai-compat.md`](reference/api-openai-compat.md)
 - [`reference/architecture.md`](reference/architecture.md)
 - [`reference/configuration.md`](reference/configuration.md)
 - [`product/open-core-boundaries.md`](product/open-core-boundaries.md)

--- a/docs/integrations/atomic-chat.md
+++ b/docs/integrations/atomic-chat.md
@@ -1,0 +1,70 @@
+# Atomic Chat / Open WebUI + Ollama
+
+## Recommended path
+
+If you want a local self-hosted chat UI quickly, the easiest route is:
+
+- Metatron Core
+- built-in or external Ollama
+- Open WebUI
+
+That is the practical "Atomic Chat" equivalent in this repo today.
+
+## Start the stack
+
+```bash
+docker compose -f docker-compose.full.yml --profile openwebui up -d --build
+```
+
+Open:
+
+```text
+http://localhost:3080
+```
+
+## Ollama setup
+
+Built-in Ollama:
+
+```ini
+LLM_PROVIDER=ollama
+```
+
+External Ollama:
+
+```ini
+LLM_PROVIDER=ollama
+OLLAMA_HOST=http://your-ollama-host:11434
+```
+
+Recommended first model:
+
+```ini
+OLLAMA_CHAT_MODEL=qwen2.5:7b-instruct
+OLLAMA_LLM_MODEL=qwen2.5:7b-instruct
+```
+
+## Internal wiring
+
+Inside Docker, Open WebUI talks to:
+
+```text
+http://metatron-core:8000/v1
+```
+
+From your host machine, Metatron is exposed at:
+
+```text
+http://localhost:8001/v1
+```
+
+## Verify
+
+1. Confirm `curl http://localhost:8001/health`
+2. Open `http://localhost:3080`
+3. Send a test question through the UI
+
+## Recommendation
+
+If you want the shortest path to "local model + memory + chat UI," this is it.
+Not glamorous, but neither is a forklift, and forklifts get work done.

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,0 +1,45 @@
+# Claude Code
+
+## Recommended mode
+
+Use Metatron through MCP.
+
+## What you need
+
+- Metatron running
+- `METATRON_MCP_API_KEY`
+- a stable Claude Code agent id
+- a workspace id
+
+## Connection values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-claude-code-agent-id>
+```
+
+## Setup
+
+Add Metatron as an MCP server in Claude Code using the values above.
+
+Claude Code's exact config surface may vary by version, but the required Metatron side is
+simple and stable: MCP URL plus the two headers.
+
+If Claude Code supports agent-assisted MCP setup, use the prompt from:
+
+- [`../../connecting_to_agent.md`](../../connecting_to_agent.md)
+
+## Verify
+
+Run:
+
+```text
+metatron_status(workspace_id="MTRNIX")
+metatron_memory_list(workspace_id="MTRNIX", agent_id="<stable-claude-code-agent-id>", limit=5)
+```
+
+## Recommendation
+
+Use one stable `X-Agent-Id` per long-lived Claude Code agent. Otherwise memory history gets
+fragmented into a tiny graveyard of almost-identical identities.

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -1,0 +1,45 @@
+# Codex
+
+## Recommended mode
+
+Use Metatron through MCP.
+
+## What you need
+
+- Metatron running
+- `METATRON_MCP_API_KEY`
+- a stable Codex agent id
+- a workspace id
+
+## Connection values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-codex-agent-id>
+```
+
+## Setup
+
+Register Metatron as an MCP server in Codex with the values above.
+
+If your Codex surface prefers an OpenAI-compatible chat endpoint instead of MCP, you can
+also use:
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+MCP is still the better fit if you want memory tools, source sync, and explicit search
+tooling rather than just chat completions.
+
+## Verify
+
+Start with:
+
+```text
+metatron_status(workspace_id="MTRNIX")
+metatron_memory_search(workspace_id="MTRNIX", agent_id="<stable-codex-agent-id>", query="test")
+```

--- a/docs/integrations/hermes-agent.md
+++ b/docs/integrations/hermes-agent.md
@@ -1,0 +1,53 @@
+# Hermes Agent
+
+## Recommended mode
+
+Use Metatron as an HTTP MCP server.
+
+This is the important distinction: Metatron is not a Hermes-native memory provider plugin.
+It is an external MCP backend Hermes can call for search, memory, and retrieval.
+
+## What you need
+
+- Metatron running locally or remotely
+- `METATRON_MCP_API_KEY` from the Metatron `.env`
+- a stable Hermes agent id
+- a workspace id such as `MTRNIX`
+
+## Connection values
+
+```text
+URL:          http://localhost:8001/mcp
+Authorization: Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:    <stable-hermes-agent-id>
+```
+
+## Example Hermes config
+
+```yaml
+mcp_servers:
+  metatron:
+    url: http://localhost:8001/mcp
+    headers:
+      Authorization: "Bearer <METATRON_MCP_API_KEY>"
+      X-Agent-Id: "<AGENT_UUID>"
+    timeout: 180
+    connect_timeout: 60
+```
+
+Restart Hermes after changing MCP configuration.
+
+## Verify
+
+Call:
+
+```text
+metatron_status(workspace_id="MTRNIX")
+metatron_memory_list(workspace_id="MTRNIX", agent_id="<AGENT_UUID>", limit=5)
+```
+
+## Recommendation
+
+If you already use Hermes-native memory providers, keep them separate mentally.
+Metatron is the durable shared memory and knowledge backend. Treat it like the source of
+truth you can inspect, not an invisible sidecar.

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -1,25 +1,8 @@
 # Hermes Integration
 
-Hermes can connect to Metatron through MCP.
+This guide moved.
 
-Example server configuration:
+Use:
 
-```yaml
-mcp_servers:
-  metatron:
-    url: http://localhost:8001/mcp
-    headers:
-      Authorization: "Bearer <METATRON_MCP_API_KEY>"
-      X-Agent-Id: "<AGENT_UUID>"
-    timeout: 180
-    connect_timeout: 60
-```
-
-Restart Hermes after changing MCP configuration. Then verify:
-
-```text
-metatron_status(workspace_id="MTRNIX")
-metatron_memory_list(workspace_id="MTRNIX", agent_id="<AGENT_UUID>", limit=5)
-```
-
-For prompt-driven setup, paste the prompt from `../../connecting_to_agent.md`.
+- [`hermes-agent.md`](hermes-agent.md) for the current Hermes Agent setup guide
+- [`../../connecting_to_agent.md`](../../connecting_to_agent.md) for generic MCP setup

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,0 +1,36 @@
+# LangChain
+
+## Recommended mode
+
+Use Metatron's OpenAI-compatible API for chat, or call REST/MCP directly for advanced
+memory workflows.
+
+## Chat setup
+
+Use:
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+This gives LangChain a RAG-backed chat surface over your Metatron workspace.
+
+## When to use MCP too
+
+Use MCP if you want explicit tools for:
+
+- memory store and search
+- source sync
+- status checks
+- low-level retrieval flows
+
+## Recommendation
+
+For a first integration:
+
+1. Use the OpenAI-compatible endpoint for `ChatOpenAI` style flows.
+2. Add MCP or REST later if you need durable memory control outside chat.
+
+That keeps the first version simple and avoids building a tiny distributed system by accident.

--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -1,0 +1,36 @@
+# n8n
+
+## Recommended mode
+
+Use Metatron through HTTP nodes first.
+
+That usually means:
+
+- OpenAI-compatible API for chat
+- REST API for uploads, memory inspection, or admin workflows
+
+## Chat setup
+
+Use an HTTP Request node or OpenAI-compatible node with:
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+## REST base
+
+```text
+http://localhost:8001/api/v1
+```
+
+## When to use MCP
+
+Use MCP only if your n8n flow or plugin stack already supports external MCP servers cleanly.
+Otherwise HTTP is the pragmatic path.
+
+## Recommendation
+
+In n8n, boring usually wins. A stable HTTP workflow beats a theoretically elegant MCP setup
+that nobody wants to debug on a Friday.

--- a/docs/integrations/nanobot.md
+++ b/docs/integrations/nanobot.md
@@ -1,0 +1,27 @@
+# NanoBot
+
+## Recommended mode
+
+Use Metatron through MCP if NanoBot supports external MCP servers. Otherwise use the
+OpenAI-compatible endpoint for chat-style access.
+
+## MCP values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-nanobot-agent-id>
+```
+
+## OpenAI-compatible values
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+## Recommendation
+
+If NanoBot is supposed to remember things durably, pick MCP. If it's just a chat shell,
+`/v1` is enough to get moving.

--- a/docs/integrations/nanoclaw.md
+++ b/docs/integrations/nanoclaw.md
@@ -1,0 +1,33 @@
+# NanoClaw
+
+## Recommended mode
+
+Use Metatron through MCP.
+
+## Connection values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-nanoclaw-agent-id>
+```
+
+## Important distinction
+
+NanoClaw may already have its own provider and memory model. Metatron does not automatically
+replace or migrate that state.
+
+Supported path today:
+
+- keep NanoClaw's native runtime behavior
+- connect NanoClaw to Metatron as an external MCP server
+- use Metatron for durable memory and knowledge retrieval
+
+## Verify
+
+```text
+metatron_status(workspace_id="MTRNIX")
+metatron_memory_list(workspace_id="MTRNIX", agent_id="<stable-nanoclaw-agent-id>", limit=5)
+```
+
+Then store a tiny test fact and confirm it is searchable.

--- a/docs/integrations/ollama-local-models.md
+++ b/docs/integrations/ollama-local-models.md
@@ -1,0 +1,85 @@
+# Ollama + GLM or Qwen
+
+## Recommended path
+
+Use Ollama as the local model host and point Metatron at it with `LLM_PROVIDER=ollama`.
+
+If you want the safer first setup, start with Qwen. GLM may work fine, but Qwen is the
+lower-drama option for local instruction models.
+
+## Option A: bundled Ollama
+
+Use the built-in Ollama service from `docker-compose.full.yml`:
+
+```ini
+LLM_PROVIDER=ollama
+```
+
+Start the stack:
+
+```bash
+docker compose -f docker-compose.full.yml up -d --build
+```
+
+This exposes Ollama on host port `11435`.
+
+## Option B: external Ollama
+
+If Ollama already runs outside the Compose stack:
+
+```ini
+LLM_PROVIDER=ollama
+OLLAMA_HOST=http://your-ollama-host:11434
+```
+
+## Pick a chat model
+
+Metatron supports setting a dedicated Ollama chat model:
+
+```ini
+OLLAMA_CHAT_MODEL=qwen2.5:7b-instruct
+OLLAMA_LLM_MODEL=qwen2.5:7b-instruct
+```
+
+or:
+
+```ini
+OLLAMA_CHAT_MODEL=glm4:9b
+OLLAMA_LLM_MODEL=glm4:9b
+```
+
+The exact tag depends on what you pulled into Ollama.
+
+## Pull models
+
+Examples:
+
+```bash
+ollama pull qwen2.5:7b-instruct
+ollama pull nomic-embed-text
+```
+
+or:
+
+```bash
+ollama pull glm4:9b
+ollama pull nomic-embed-text
+```
+
+## Verify
+
+Check the API:
+
+```bash
+curl http://localhost:8001/health
+curl http://localhost:11435/api/tags
+```
+
+## Recommendation
+
+Start with:
+
+- embedding model: `nomic-embed-text`
+- chat model: `qwen2.5:7b-instruct`
+
+Once the stack is stable, try GLM if you want. First make it boring, then make it fancy.

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -1,14 +1,42 @@
-# OpenClaw Integration
+# OpenClaw
 
-OpenClaw should connect to Metatron through MCP when MCP client support is available.
+## Recommended mode
 
-Use:
+Use Metatron through MCP.
+
+## What you need
+
+- Metatron running
+- `METATRON_MCP_API_KEY`
+- a stable `X-Agent-Id`
+- a workspace id
+
+## Connection values
 
 ```text
-URL: http://localhost:8001/mcp
-Authorization: Bearer <METATRON_MCP_API_KEY>
-X-Agent-Id: <stable-agent-id>
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-openclaw-agent-id>
 ```
 
-Verify with `metatron_status` and memory list/search tools. See `mcp-reference.md`
-for tool details.
+## Setup
+
+Add Metatron as an external MCP server in OpenClaw using the values above. If OpenClaw
+loads MCP servers only at startup, restart it after saving the config.
+
+## Verify
+
+Use these first:
+
+```text
+metatron_status(workspace_id="MTRNIX")
+metatron_memory_list(workspace_id="MTRNIX", agent_id="<stable-openclaw-agent-id>", limit=5)
+```
+
+Then store a small test fact and search for it.
+
+## Notes
+
+Metatron gives OpenClaw a better memory and knowledge surface. It does not magically
+replace every internal runtime abstraction OpenClaw may already have. Software rarely
+works by telepathy, despite the optimism of many integration docs.

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -1,0 +1,36 @@
+# OpenCode
+
+## Recommended mode
+
+Use Metatron through MCP.
+
+If OpenCode only needs chat completions, the OpenAI-compatible endpoint also works. But if
+you want durable memory and explicit retrieval tools, MCP is the stronger integration.
+
+## MCP connection values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-opencode-agent-id>
+```
+
+## OpenAI-compatible fallback
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+## Recommended setup flow
+
+1. Start with MCP.
+2. Verify `metatron_status`.
+3. Verify `metatron_memory_list`.
+4. Only fall back to the OpenAI-compatible endpoint if OpenCode does not expose MCP cleanly.
+
+## Why
+
+OpenAI-compatible chat is easy, but it turns everything into "one more completion call."
+MCP keeps the useful parts explicit: search, memory, sync, review. Less mystery meat.

--- a/docs/integrations/pi.md
+++ b/docs/integrations/pi.md
@@ -1,0 +1,38 @@
+# Pi
+
+## Recommended mode
+
+Use whichever surface Pi supports best:
+
+- MCP if Pi supports external MCP servers
+- OpenAI-compatible API if Pi only supports custom chat providers
+
+## MCP values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-pi-agent-id>
+```
+
+## OpenAI-compatible values
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+## Recommendation
+
+If Pi supports both, choose MCP first. If it only supports chat providers, use `/v1`.
+
+## Verify
+
+- MCP path: run `metatron_status`
+- OpenAI-compatible path: send one test chat request against `metatron-rag-<workspace_id>`
+
+## Note
+
+This guide assumes Pi is acting as a client runtime. If you meant a different "Pi," rename
+the guide later before future-us has to become archaeologists.

--- a/docs/integrations/pi.md
+++ b/docs/integrations/pi.md
@@ -2,20 +2,233 @@
 
 ## Recommended mode
 
-Use whichever surface Pi supports best:
+Use Metatron through MCP via Pi's MCP adapter.
 
-- MCP if Pi supports external MCP servers
-- OpenAI-compatible API if Pi only supports custom chat providers
+If Pi supports `pi install npm:pi-mcp-adapter`, that is the clean path. The adapter lets Pi
+talk to Metatron's HTTP MCP endpoint instead of pretending Metatron is a chat-only provider.
 
-## MCP values
+## What you need
+
+- Metatron running locally or remotely
+- `METATRON_MCP_API_KEY` from the Metatron `.env`
+- a stable Pi agent id
+- a workspace id such as `MTRNIX`
+
+## Start Metatron first
+
+Pi cannot connect to an MCP endpoint that does not exist yet, which sounds obvious until
+it is midnight and everyone starts blaming JSON.
+
+This repo's bootstrap script installs prerequisites and checks Docker:
+
+```bash
+./install/bootstrap.sh
+```
+
+Then start Metatron:
+
+```bash
+docker compose -f docker-compose.full.yml up -d --build
+curl http://localhost:8001/health
+```
+
+If health is down, fix that before touching Pi MCP config. Otherwise you are debugging an
+empty socket with strong opinions.
+
+## Install the Pi MCP adapter
+
+```bash
+pi install npm:pi-mcp-adapter
+```
+
+Restart Pi after installation if it only loads adapters at startup.
+
+## Connection values
 
 ```text
 URL:            http://localhost:8001/mcp
 Authorization:  Bearer <METATRON_MCP_API_KEY>
 X-Agent-Id:     <stable-pi-agent-id>
+Timeout:        180
+Connect timeout: 60
 ```
 
-## OpenAI-compatible values
+## Pi config checklist
+
+However Pi exposes MCP adapter configuration, make sure the Metatron entry includes:
+
+- the MCP URL above
+- the `Authorization` header
+- the `X-Agent-Id` header
+- one stable agent id reused across sessions
+
+Do not rotate the Pi agent id casually unless you enjoy debugging a memory system that now
+thinks each reboot is a new life form.
+
+## Where Pi reads instructions
+
+Pi has two separate prompt layers:
+
+- `AGENTS.md` for project instructions and working conventions
+- `.pi/SYSTEM.md` when you want to replace the default system prompt for this project
+
+Pi's current docs say it loads `AGENTS.md` or `CLAUDE.md` from:
+
+- `~/.pi/agent/AGENTS.md` for global instructions
+- parent directories, walking up from the current working directory
+- the current directory
+
+Pi also supports:
+
+- `.pi/SYSTEM.md` for project system prompt replacement
+- `~/.pi/agent/SYSTEM.md` for global system prompt replacement
+- `APPEND_SYSTEM.md` to append instead of replace
+
+Source: [Pi usage docs](https://pi.dev/docs/latest/usage#context-files)
+
+## Example project `.mcp.json`
+
+Pi's MCP setup UI shows that it can import project `.mcp.json` files. A reasonable
+Metatron config to try is:
+
+```json
+{
+  "mcpServers": {
+    "metatron": {
+      "url": "http://localhost:8001/mcp",
+      "headers": {
+        "Authorization": "Bearer <METATRON_MCP_API_KEY>",
+        "X-Agent-Id": "<stable-pi-agent-id>"
+      },
+      "timeout": 180,
+      "connect_timeout": 60
+    }
+  }
+}
+```
+
+If Pi rejects `url` or `headers`, use the adapter-managed import path from `/mcp setup` and
+let Pi write its compatibility layer. Pi is the one holding the map there.
+
+## Prompt to paste into Pi
+
+```text
+You are configuring Pi to use Metatron Core over MCP through Pi's MCP adapter.
+
+Run setup once. If Pi already has a working Metatron MCP configuration, verify it and report
+the result instead of creating a duplicate entry.
+
+If the MCP adapter is not installed, install it first with:
+
+pi install npm:pi-mcp-adapter
+
+Ask the user for any missing values:
+
+- METATRON_URL: Metatron MCP endpoint, for example http://localhost:8001/mcp
+- METATRON_MCP_API_KEY: token from the Metatron .env file
+- AGENT_UUID: stable unique id for this Pi agent
+- DEFAULT_WORKSPACE_ID: workspace id, usually MTRNIX for the first install
+
+Configure Pi's MCP adapter to register Metatron with:
+
+- URL: {{METATRON_URL}}
+- Header: Authorization: Bearer {{METATRON_MCP_API_KEY}}
+- Header: X-Agent-Id: {{AGENT_UUID}}
+- Timeout: 180 seconds
+- Connect timeout: 60 seconds
+
+The Authorization header is required. The Metatron /mcp endpoint rejects requests without
+the configured METATRON_MCP_API_KEY.
+
+The X-Agent-Id header is required for agent-scoped memory and observability. Use the same
+AGENT_UUID in memory tool arguments.
+
+After registration, restart Pi if adapters or MCP servers are loaded only at startup.
+
+When tools are available, verify:
+
+1. Call metatron_status with workspace_id="{{DEFAULT_WORKSPACE_ID}}".
+2. Call metatron_memory_list with workspace_id="{{DEFAULT_WORKSPACE_ID}}",
+   agent_id="{{AGENT_UUID}}", limit=5.
+3. If Pi has existing durable memory in its built-in memory store, migrate non-stale entries
+   into Metatron:
+   - user preferences -> kind="preference"
+   - factual durable statements -> kind="fact"
+   - explicit always-remember instructions -> kind="pinned"
+   Use metatron_memory_store or metatron_memory_batch_store.
+4. Keep only a small configuration rule in built-in memory:
+   "Durable memory lives in Metatron MCP. Use workspace_id={{DEFAULT_WORKSPACE_ID}}
+   and agent_id={{AGENT_UUID}}. Do not silently fall back to built-in durable memory
+   if Metatron is unreachable."
+
+Report back in four lines:
+
+- MCP adapter: installed / already present
+- MCP registration: ok / changes made
+- Verification: metatron_status ok / failed with error
+- Memory: memory_list returned N records
+```
+
+## Example `AGENTS.md`
+
+Use `AGENTS.md` for project-local working rules and for reminding Pi how Metatron should be
+used during normal work.
+
+```md
+# Project Instructions
+
+Use Metatron as the durable memory and retrieval backend for this project.
+
+## MCP rules
+
+- Prefer the `metatron` MCP server for durable memory and explicit retrieval.
+- Use `workspace_id="MTRNIX"` unless the user specifies another workspace.
+- Use `agent_id="<stable-pi-agent-id>"` consistently across sessions.
+- Do not silently fall back to built-in durable memory if Metatron is unreachable.
+
+## Verification rules
+
+- Before claiming Metatron is configured, call `metatron_status`.
+- When memory behavior matters, verify with `metatron_memory_list` or `metatron_memory_search`.
+
+## Working style
+
+- Keep answers concise by default.
+- Surface uncertainty explicitly.
+- Prefer inspecting repo files before making assumptions.
+```
+
+## Example `.pi/SYSTEM.md`
+
+Use `.pi/SYSTEM.md` only if you want Pi's project system prompt to explicitly encode the
+Metatron workflow. This replaces the default project system prompt layer, so keep it tight.
+
+```md
+You are Pi operating in this repository with Metatron as the external MCP memory and
+retrieval backend.
+
+Behavior rules:
+
+- Treat Metatron as the source of truth for durable memory and shared knowledge.
+- Use the configured `metatron` MCP server for search, memory inspection, and memory writes.
+- Use `workspace_id="MTRNIX"` unless the user specifies another workspace.
+- Use the stable configured Pi agent id consistently.
+- If Metatron is unavailable, say so plainly instead of pretending memory succeeded.
+- Verify important claims with Metatron tools when possible.
+
+When configuring the environment:
+
+- Check that `http://localhost:8001/health` responds before debugging MCP settings.
+- Check that the MCP endpoint is `http://localhost:8001/mcp`.
+- Ensure the `Authorization` and `X-Agent-Id` headers are present.
+```
+
+If you want to keep Pi's default system prompt and merely add the Metatron policy, use
+`APPEND_SYSTEM.md` instead of `.pi/SYSTEM.md`.
+
+## OpenAI-compatible fallback
+
+If Pi cannot use MCP cleanly even with the adapter, use the OpenAI-compatible endpoint:
 
 ```text
 Base URL: http://localhost:8001/v1
@@ -23,16 +236,22 @@ Model:    metatron-rag-<workspace_id>
 Key:      <METATRON_OPENAI_COMPAT_KEY>
 ```
 
-## Recommendation
+This works for chat, but MCP is the better fit if you want durable memory, retrieval tools,
+and explicit sync operations instead of stuffing everything through one completion endpoint.
 
-If Pi supports both, choose MCP first. If it only supports chat providers, use `/v1`.
+## Verify manually
 
-## Verify
+Call:
 
-- MCP path: run `metatron_status`
-- OpenAI-compatible path: send one test chat request against `metatron-rag-<workspace_id>`
+```text
+metatron_status(workspace_id="MTRNIX")
+metatron_memory_list(workspace_id="MTRNIX", agent_id="<stable-pi-agent-id>", limit=5)
+```
 
-## Note
+Useful Pi commands after setup:
 
-This guide assumes Pi is acting as a client runtime. If you meant a different "Pi," rename
-the guide later before future-us has to become archaeologists.
+```text
+/mcp
+/mcp status
+/mcp reconnect
+```

--- a/docs/integrations/sdk-go.md
+++ b/docs/integrations/sdk-go.md
@@ -1,0 +1,36 @@
+# Go SDK
+
+## Recommended surfaces
+
+Use:
+
+- `/v1` for chat-style integrations
+- `/api/v1` for direct application control
+- `/mcp` for tool-driven agent runtimes
+
+## OpenAI-compatible values
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+## REST base URL
+
+```text
+http://localhost:8001/api/v1
+```
+
+## MCP values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-go-agent-id>
+```
+
+## Recommendation
+
+If you're writing a service in Go, use REST or `/v1` first. Reach for MCP when you need
+explicit agent tools and durable memory behavior, not just plain request-response chat.

--- a/docs/integrations/sdk-python.md
+++ b/docs/integrations/sdk-python.md
@@ -1,0 +1,36 @@
+# Python SDK
+
+## Recommended surfaces
+
+Pick the simplest interface that matches the job:
+
+- OpenAI-compatible API for chat-style usage
+- REST API for app integration
+- MCP for tool-driven agent runtimes
+
+## OpenAI-compatible values
+
+```text
+Base URL: http://localhost:8001/v1
+Model:    metatron-rag-<workspace_id>
+Key:      <METATRON_OPENAI_COMPAT_KEY>
+```
+
+## REST base URL
+
+```text
+http://localhost:8001/api/v1
+```
+
+## MCP values
+
+```text
+URL:            http://localhost:8001/mcp
+Authorization:  Bearer <METATRON_MCP_API_KEY>
+X-Agent-Id:     <stable-python-agent-id>
+```
+
+## Recommendation
+
+If you are writing an application backend, start with REST or `/v1`.
+If you are wiring an autonomous agent, start with MCP.

--- a/install.md
+++ b/install.md
@@ -1,26 +1,26 @@
-# Metronix Core Deployment Reference
+# Metronix Core Install Reference
 
-Use [`manual.md`](manual.md) for the short step-by-step install sequence. This file is the
-detailed reference for deployment options, environment variables, ports, verification, and
-troubleshooting.
+This file is the detailed installation and troubleshooting reference.
+
+For the short walkthrough, use [`manual.md`](manual.md). For runtime-specific setup, use
+the guides under [`docs/integrations/`](docs/integrations/).
 
 ## Canonical Compose File
 
-The canonical Docker Compose file is:
+Use:
 
 ```bash
 docker-compose.full.yml
 ```
 
-Do not use the old `docker-compose.yml` or `install/docker-compose.yml` paths.
+Do not use older compose paths from historical docs or stale examples.
 
 ## Prerequisites
 
-- Docker Engine or Docker Desktop.
-- Docker Compose v2 plugin, or legacy `docker-compose`.
-- Python 3.12+ for local development and tests.
-- Around 15 GB of free disk space for images, volumes, build cache, and first-run Ollama
-  model downloads.
+- Docker Engine or Docker Desktop
+- Docker Compose v2 plugin or legacy `docker-compose`
+- About 15 GB of free disk space
+- Enough patience for first-run image builds and Ollama pulls
 
 Verify Docker:
 
@@ -30,44 +30,44 @@ docker compose version 2>/dev/null || docker-compose --version
 docker info >/dev/null 2>&1 && echo "daemon OK" || echo "START DOCKER DAEMON"
 ```
 
-## Environment
+## `.env` Setup
 
-Create `.env`:
+Create the file:
 
 ```bash
 cp .env.example .env
 ```
 
-Set one LLM provider.
+Choose one model provider.
 
-DeepSeek:
+### DeepSeek
 
 ```ini
 LLM_PROVIDER=deepseek
 DEEPSEEK_API_KEY=sk-your-deepseek-key
 ```
 
-OpenRouter:
+### OpenRouter
 
 ```ini
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-your-openrouter-key
 ```
 
-Built-in Ollama from Compose:
+### Built-in Ollama
 
 ```ini
 LLM_PROVIDER=ollama
 ```
 
-External Ollama:
+### External Ollama
 
 ```ini
 LLM_PROVIDER=ollama
 OLLAMA_HOST=http://your-ollama-host:11434
 ```
 
-Custom OpenAI-compatible provider:
+### Custom OpenAI-compatible provider
 
 ```ini
 LLM_PROVIDER=custom
@@ -75,73 +75,100 @@ CUSTOM_LLM_URL=https://your-llm-endpoint/v1
 CUSTOM_LLM_API_KEY=your-key
 ```
 
-Generate and set an MCP API key:
+### MCP authentication
+
+Generate a token:
 
 ```bash
 openssl rand -hex 32
 ```
 
+Add it to `.env`:
+
 ```ini
 METATRON_MCP_API_KEY=<paste-the-generated-token>
 ```
 
-External agents use this token when connecting to `/mcp`.
+Metatron expects:
 
-## Launch Profiles
+```text
+Authorization: Bearer <METATRON_MCP_API_KEY>
+```
 
-Backend stack:
+for HTTP MCP clients.
+
+## Launch Modes
+
+### Backend only
 
 ```bash
 docker compose -f docker-compose.full.yml up -d --build
 ```
 
-Backend + Open WebUI:
+### Backend plus Open WebUI
 
 ```bash
 docker compose -f docker-compose.full.yml --profile openwebui up -d --build
 ```
 
-First startup can take 10-15 minutes while images build and local models download.
+First startup may take 10-15 minutes.
 
-## Ports
+## External Ports
+
+These are the exposed host ports from `docker-compose.full.yml`.
 
 | Service | Port |
 |---|---|
 | API | `8001` |
 | PostgreSQL | `5433` |
-| Qdrant | `6335` |
+| Qdrant HTTP | `6335` |
 | Qdrant gRPC | `6336` |
 | Neo4j HTTP | `7475` |
 | Neo4j bolt | `7688` |
 | Redis | `6380` |
+| Ollama | `11435` |
 | SPLADE | `8080` |
 | Embedding proxy | `8002` |
-| Ollama | `11435` |
 | Open WebUI | `3080` |
 
-## Verify
+## Important URLs
+
+| Surface | URL |
+|---|---|
+| Health | `http://localhost:8001/health` |
+| Ready | `http://localhost:8001/ready` |
+| REST API | `http://localhost:8001/api/v1` |
+| MCP | `http://localhost:8001/mcp` |
+| OpenAI-compatible API | `http://localhost:8001/v1` |
+| Open WebUI | `http://localhost:3080` |
+
+Inside Docker, Open WebUI talks to Metatron at:
+
+```text
+http://metatron-core:8000/v1
+```
+
+That is the internal container URL, not the host URL. This distinction causes an
+embarrassing number of avoidable setup mistakes.
+
+## Verification
+
+Check container status:
 
 ```bash
 docker compose -f docker-compose.full.yml ps
+```
+
+Check API health:
+
+```bash
 curl http://localhost:8001/health
 ```
 
-Open WebUI, when enabled:
+Check readiness:
 
-```text
-http://localhost:3080
-```
-
-MCP endpoint:
-
-```text
-http://localhost:8001/mcp
-```
-
-OpenAI-compatible API:
-
-```text
-http://localhost:8001/v1
+```bash
+curl http://localhost:8001/ready
 ```
 
 ## Common Operations
@@ -158,13 +185,13 @@ Restart the API:
 docker compose -f docker-compose.full.yml restart metatron-core
 ```
 
-Rebuild after `.env` or source changes:
+Rebuild after config or code changes:
 
 ```bash
 docker compose -f docker-compose.full.yml up -d --build --force-recreate
 ```
 
-Stop the stack:
+Stop:
 
 ```bash
 docker compose -f docker-compose.full.yml down
@@ -178,7 +205,7 @@ docker compose -f docker-compose.full.yml down -v
 
 ## Troubleshooting
 
-### Docker daemon is not running
+### Docker daemon not running
 
 Linux:
 
@@ -186,70 +213,67 @@ Linux:
 sudo systemctl start docker
 ```
 
-macOS or Windows: start Docker Desktop. On macOS you can also use OrbStack or Colima.
+macOS: launch Docker Desktop, OrbStack, or `colima start`.
 
-### Docker permission denied on Linux
+### macOS Docker permission weirdness
+
+```bash
+sudo chown -R $(whoami):staff ~/.docker
+```
+
+### Linux Docker permissions
 
 ```bash
 sudo usermod -aG docker $USER
 newgrp docker
 ```
 
-Or prefix Docker commands with `sudo`.
-
-### Docker build permission denied on macOS
-
-Docker Desktop can lose ownership of `~/.docker` after an update:
-
-```bash
-sudo chown -R $(whoami):staff ~/.docker
-```
-
 ### Port already in use
-
-Stop any previous Metronix run:
 
 ```bash
 docker compose -f docker-compose.full.yml down
-```
-
-Check the occupied port:
-
-```bash
 sudo lsof -i :8001
 ```
 
-On Windows PowerShell:
+### MCP returns `401`
 
-```powershell
-netstat -ano | findstr :8001
-```
-
-### MCP returns 401
-
-Check that the agent configuration uses:
+Make sure your client sends:
 
 ```text
 Authorization: Bearer <METATRON_MCP_API_KEY>
 ```
 
-The token must match the value in the server `.env`.
+and that the token matches `.env`.
 
-### Open WebUI cannot reach Metatron
+### Open WebUI cannot connect
 
-Verify the API health endpoint first:
+Check API health first:
 
 ```bash
 curl http://localhost:8001/health
 ```
 
-Then inspect Open WebUI logs:
+Then inspect logs:
 
 ```bash
 docker compose -f docker-compose.full.yml logs open-webui
 ```
 
-## Agent Setup
+## Next Step
 
-For MCP agent setup, use [`connecting_to_agent.md`](connecting_to_agent.md). Runtime-specific
-guides live under [`docs/integrations/`](docs/integrations/).
+Use the runtime guide that matches your client:
+
+- [`docs/integrations/hermes-agent.md`](docs/integrations/hermes-agent.md)
+- [`docs/integrations/openclaw.md`](docs/integrations/openclaw.md)
+- [`docs/integrations/ollama-local-models.md`](docs/integrations/ollama-local-models.md)
+- [`docs/integrations/claude-code.md`](docs/integrations/claude-code.md)
+- [`docs/integrations/codex.md`](docs/integrations/codex.md)
+- [`docs/integrations/opencode.md`](docs/integrations/opencode.md)
+- [`docs/integrations/pi.md`](docs/integrations/pi.md)
+- [`docs/integrations/langchain.md`](docs/integrations/langchain.md)
+- [`docs/integrations/sdk-python.md`](docs/integrations/sdk-python.md)
+- [`docs/integrations/sdk-go.md`](docs/integrations/sdk-go.md)
+- [`docs/integrations/n8n.md`](docs/integrations/n8n.md)
+- [`docs/integrations/nanoclaw.md`](docs/integrations/nanoclaw.md)
+- [`docs/integrations/nanobot.md`](docs/integrations/nanobot.md)
+- [`docs/integrations/atomic-chat.md`](docs/integrations/atomic-chat.md)

--- a/manual.md
+++ b/manual.md
@@ -1,13 +1,16 @@
-# Metronix Core — Manual Install (backend only, optional Open WebUI)
+# Metronix Core Manual Install
 
-## 1. Clone the repository
+This is the short version. If you want the full deployment reference, troubleshooting, or
+port details, use [`install.md`](install.md).
+
+## 1. Clone
 
 ```bash
 git clone -b develop https://github.com/mtrnix/metatroncore.git
 cd metatroncore
 ```
 
-## 2. Verify Docker and Docker Compose
+## 2. Verify Docker
 
 ```bash
 docker --version
@@ -15,155 +18,116 @@ docker compose version 2>/dev/null || docker-compose --version
 docker info >/dev/null 2>&1 && echo "daemon OK" || echo "START DOCKER DAEMON"
 ```
 
-### macOS — check buildx cache permissions
+If Docker is missing:
 
-Docker Desktop can lose ownership of `~/.docker` after an update, causing
-`permission denied` on `docker compose build`. Check and fix **before** step 4:
+- macOS: <https://docs.docker.com/desktop/setup/install/mac-install/>
+- Linux: <https://docs.docker.com/engine/install/>
+- Windows: <https://docs.docker.com/desktop/setup/install/windows-install/>
+
+On macOS, if `docker compose build` fails with `permission denied`, fix Docker Desktop's
+ownership drift:
 
 ```bash
-ls -ld ~/.docker/buildx 2>/dev/null || echo "OK (no buildx yet)"
-# If you got "permission denied" above:
 sudo chown -R $(whoami):staff ~/.docker
 ```
 
-If Docker is missing:
-- **Linux:** https://docs.docker.com/engine/install/
-- **macOS:** https://docs.docker.com/desktop/setup/install/mac-install/
-- **Windows:** https://docs.docker.com/desktop/setup/install/windows-install/
-
-Daemon not responding: `sudo systemctl start docker` (Linux) or launch Docker Desktop /
-OrbStack / `colima start` (macOS).
-
-Free disk space: about 15 GB (images + build + volumes + Ollama models on first run).
-
-## 3. Prepare .env
+## 3. Create `.env`
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` and set:
+Pick one provider.
 
-### 3a. LLM provider + API key
+DeepSeek:
 
-Pick one provider, set `LLM_PROVIDER` and the corresponding key.
-
-deepseek:
 ```ini
 LLM_PROVIDER=deepseek
 DEEPSEEK_API_KEY=sk-your-deepseek-key
 ```
 
-openrouter:
+OpenRouter:
+
 ```ini
 LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-your-openrouter-key
 ```
 
-ollama (external host):
+Built-in Ollama:
+
+```ini
+LLM_PROVIDER=ollama
+```
+
+External Ollama:
+
 ```ini
 LLM_PROVIDER=ollama
 OLLAMA_HOST=http://your-ollama-host:11434
 ```
 
-ollama (built-in, works out of the box with docker-compose.full.yml):
-```ini
-LLM_PROVIDER=ollama
-```
+Custom OpenAI-compatible provider:
 
-custom:
 ```ini
 LLM_PROVIDER=custom
 CUSTOM_LLM_URL=https://your-llm-endpoint/v1
 CUSTOM_LLM_API_KEY=your-key
 ```
 
-### 3b. MCP auth
-
-Controls access to the MCP server endpoint (`/mcp`). MCP is the primary integration
-path for AI agents (Hermes, Cursor, Claude Desktop). The key is a token **you create**
-— any string, like a password. Generate a strong one:
+Create an MCP key:
 
 ```bash
 openssl rand -hex 32
 ```
 
-Set it in `.env`:
+Add it to `.env`:
 
 ```ini
 METATRON_MCP_API_KEY=<paste-the-generated-token>
 ```
 
-External agents use this token to authenticate when connecting to
-`http://localhost:8001/mcp`. Without it, MCP connections are rejected.
+## 4. Start
 
-## 4. Launch
-
-### Option A — backend only (postgres, qdrant, neo4j, redis, ollama, splade, metatron-core)
+Backend only:
 
 ```bash
 docker compose -f docker-compose.full.yml up -d --build
 ```
 
-### Option B — backend + Open WebUI (chat interface at :3080)
+Backend plus Open WebUI:
 
 ```bash
 docker compose -f docker-compose.full.yml --profile openwebui up -d --build
 ```
 
-Open `http://localhost:3080` — no login required. Open WebUI connects to Metatron
-automatically via the pre-configured `OPENAI_API_BASE_URL`.
+## 5. Verify
 
-First run builds images from source and pulls Ollama models (about 10-15 minutes).
-
-Verify:
 ```bash
 docker compose -f docker-compose.full.yml ps
 curl http://localhost:8001/health
 ```
 
-Ports: API `:8001` | PostgreSQL `:5433` | Qdrant `:6335` | Neo4j bolt `:7688` |
-Redis `:6380` | Ollama `:11435` | SPLADE `:8080` | Open WebUI `:3080` (option B)
+If Open WebUI is enabled, open:
 
-For a detailed deployment reference, other profiles, and troubleshooting, see
-[`install.md`](install.md).
-
-## 5. Troubleshooting
-
-### Docker on macOS — permission denied
-
-See step 2 — `~/.docker` ownership check. Fix: `sudo chown -R $(whoami):staff ~/.docker`.
-
-### Permission denied (Linux)
-
-If `docker compose` fails with «permission denied»:
-
-```bash
-sudo usermod -aG docker $USER
-newgrp docker
+```text
+http://localhost:3080
 ```
 
-Or prefix commands with `sudo docker compose ...`.
+## 6. Pick a runtime guide
 
-### Daemon not responding
+Once the backend is running, choose the integration you actually care about:
 
-```bash
-# Linux
-sudo systemctl start docker
-
-# macOS — launch Docker Desktop / OrbStack, or
-colima start
-```
-
-### Port already in use
-
-```bash
-docker compose -f docker-compose.full.yml down   # clean up previous run
-sudo lsof -i :8001                                # check what occupies the port
-```
-
-### Rebuild after .env changes
-
-```bash
-docker compose -f docker-compose.full.yml up -d --build --force-recreate
-```
+- [`docs/integrations/hermes-agent.md`](docs/integrations/hermes-agent.md)
+- [`docs/integrations/openclaw.md`](docs/integrations/openclaw.md)
+- [`docs/integrations/ollama-local-models.md`](docs/integrations/ollama-local-models.md)
+- [`docs/integrations/claude-code.md`](docs/integrations/claude-code.md)
+- [`docs/integrations/codex.md`](docs/integrations/codex.md)
+- [`docs/integrations/opencode.md`](docs/integrations/opencode.md)
+- [`docs/integrations/pi.md`](docs/integrations/pi.md)
+- [`docs/integrations/langchain.md`](docs/integrations/langchain.md)
+- [`docs/integrations/sdk-python.md`](docs/integrations/sdk-python.md)
+- [`docs/integrations/sdk-go.md`](docs/integrations/sdk-go.md)
+- [`docs/integrations/n8n.md`](docs/integrations/n8n.md)
+- [`docs/integrations/nanoclaw.md`](docs/integrations/nanoclaw.md)
+- [`docs/integrations/nanobot.md`](docs/integrations/nanobot.md)
+- [`docs/integrations/atomic-chat.md`](docs/integrations/atomic-chat.md)


### PR DESCRIPTION
## Summary
- expand the Pi integration guide around MCP adapter setup
- add Pi-specific setup prompt plus example 
- document Pi context files with example  and 

## Testing
- not run (docs-only change)
