### PR TITLE
chore(oss): community-health files + repo hygiene for open-source launch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners — auto-requested as reviewers on every pull request.
+# https://docs.github.com/articles/about-code-owners
+# All org members review incoming PRs by default.
+*       @godedok @pahomm @Sergey-Vasnev @toomij99

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report a problem with Metronix Core
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for the report! Please do not include secrets (API keys, tokens) in logs you paste.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / output
+      render: shell
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Tag, release, or commit SHA you are running.
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Docker / Compose versions, how you run the stack (install.sh, manual, etc.).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/mtrnix/metronix-memory/discussions
+    about: Ask questions and discuss ideas here, not in issues.
+  - name: Security vulnerability
+    url: https://github.com/mtrnix/metronix-memory/security/advisories/new
+    about: Report security issues privately — do NOT open a public issue (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Suggest an idea or enhancement for Metronix Core
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem would this solve? What's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Thanks for contributing to Metronix! Please fill this in. -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / internal change
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Checklist
+
+- [ ] `ruff format` and `ruff check` pass locally
+- [ ] Tests added/updated and `pytest` passes (run with the service stack — see `CONTRIBUTING.md`)
+- [ ] Docs updated if behavior or config changed
+- [ ] Changes are workspace-scoped where applicable (no cross-workspace data access)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # Python dependencies (uv lockfile + pyproject).
+  - package-ecosystem: "uv"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  # GitHub Actions versions used in workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs when a PR branch is pushed again.
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ruff:
     name: ruff (format + lint)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# Local + pre-commit.ci hooks so contributors auto-fix before pushing.
+# Install once:  uv run pre-commit install
+# Run on all files:  uv run pre-commit run --all-files
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.11
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,115 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**security@mtrnix.com**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating these
+terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,47 @@ Thanks for wanting to help. Metronix Core is an open-core AI memory + knowledge 
 1. **Fork** the repo and clone your fork.
 2. **Read** [`docs/reference/architecture.md`](docs/reference/architecture.md) for
    architecture, conventions, and layer rules.
-3. **Run tests** before touching anything:
-   ```bash
-   make docker-up   # start databases
-   make test        # unit tests (no live services needed)
-   make lint        # ruff check + format
-   make typecheck   # mypy
-   ```
+3. **Run the checks** before touching anything — see
+   [Running checks locally](#running-checks-locally).
+
+## Running checks locally
+
+The same checks run on every pull request: **ruff** (lint + format) and **pytest**
+(unit suite). Run them before pushing.
+
+**Format & lint** — fast, no services needed. This is what the lint gate enforces:
+
+```bash
+make format   # ruff --fix + ruff format (auto-fixes what it can)
+make lint     # ruff check + ruff format --check (CI runs exactly this)
+```
+
+Prefer it automatic? Install the git hooks (runs ruff on every commit):
+
+```bash
+uv run pre-commit install
+```
+
+**Tests** — the unit suite talks to real databases (Postgres, Neo4j, Qdrant,
+Redis), so those must be reachable before running. The easiest, most reliable
+path is to **let the PR's `Tests` workflow run them** against ephemeral service
+containers — just push your branch.
+
+To run them locally, point the `POSTGRES_*` / `NEO4J_*` / `QDRANT_*` / `REDIS_*`
+env vars at running services, apply the schema, then run pytest. The exact
+services, env, and migration step CI uses are in
+[`.github/workflows/tests.yml`](.github/workflows/tests.yml) — mirror that:
+
+```bash
+make migrate   # alembic upgrade head — create the schema
+make test      # pytest -m "not integration"
+```
+
+> Note: `make docker-up` starts the bundled stack on non-default host ports
+> (Postgres `5433`, Neo4j `7688`, …), so set the matching `*_PORT` env vars, or
+> run plain DB containers on the default ports, before `make test`.
+
+**Type check** — `make typecheck` (mypy). Not a required gate yet.
 
 ## Architecture Constraint
 
@@ -73,12 +107,12 @@ Examples: `memory: fix preference injection order`, `connectors: add incremental
 ## Testing
 
 ```bash
-make test             # unit tests (fast, no services)
-make test-all         # unit + integration (needs docker-up)
+make test             # unit suite, -m "not integration" (needs DB services — see above)
+make test-all         # unit + integration
 ```
 
-- Unit tests go in `tests/unit/`. No live DB connections.
-- Integration tests go in `tests/integration/`. Mark with `@pytest.mark.integration`.
+- Unit tests go in `tests/unit/`; many use the DB services (see [Running checks locally](#running-checks-locally)).
+- Integration tests (and anything that needs an external LLM/embeddings) go in `tests/integration/` or are marked `@pytest.mark.integration` so the unit gate skips them.
 - New code = new tests. Bug fixes include a regression test.
 
 ## Documentation


### PR DESCRIPTION
Brings the repo up to current OSS / GitHub community-standards conventions ahead of going public.

## Added (in code)
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (enforcement → security@mtrnix.com).
- **.github/PULL_REQUEST_TEMPLATE.md** — summary / linked issue / type / checklist (ruff, tests, docs, workspace-scoping).
- **.github/ISSUE_TEMPLATE/** — bug + feature YAML forms; `config.yml` disables blank issues and routes questions to Discussions and security reports to private advisories.
- **.github/CODEOWNERS** — all org members (`@godedok @pahomm @Sergey-Vasnev @toomij99`) auto-requested as reviewers.
- **.github/dependabot.yml** — explicit config: `uv` (Python) + `github-actions` ecosystems, weekly, targeting `develop`.
- **.pre-commit-config.yaml** — ruff + ruff-format (pinned to 0.15.11, matching CI) + basic hygiene hooks.
- **lint.yml** — `concurrency` group to cancel superseded PR runs (saves minutes).

## Not in this PR (GitHub UI settings — do at launch)
- **Branch protection** on `main`/`develop`: require PR + review(s), require status checks (`ruff`, `pytest`) to pass, require conversation resolution, require up-to-date branch.
- **Fork-PR run approval** for first-time contributors (Settings → Actions).
- `tests.yml` concurrency is added in the pytest-gate PR (#221), where that workflow lives.

## Deferred (post-launch, separate tasks)
- mypy gating decision, Python-version test matrix, coverage reporting, release automation (PyPI Trusted Publishing).