### PR TITLE
chore(dependabot): group updates to cut PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      # Batch low-risk minor/patch bumps into a single PR. Major bumps stay
+      # individual so they get reviewed on their own.
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions versions used in workflows.
   - package-ecosystem: "github-actions"
@@ -19,3 +26,8 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      # One PR for all action-version bumps (CI-only, low risk).
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adding `.github/dependabot.yml` (in #222) triggered a one-time backlog of ~18 individual Dependabot PRs (#141–143, #223–238). This adds **grouping** so future updates arrive as a few PRs instead of a flood:

- **uv**: minor/patch bumps batched into one `python-minor-patch` PR; **major** bumps stay individual (so they get reviewed on their own).
- **github-actions**: one grouped PR for all action-version bumps (CI-only, low risk).

## Cleaning up the current backlog (after this merges)
Grouping only affects future runs, so the ~18 already-open individual PRs won't auto-collapse. Options:
1. **Close them** → on its next run Dependabot re-opens them grouped per this config (cleanest).
2. **Triage as-is** → now that the ruff + pytest gates run on each, merge the green low-risk ones and close the rest.