### PR TITLE
chore(deps): pause Dependabot version updates for OSS launch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,10 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    # Paused during OSS launch: 0 stops new version-update PRs while still
+    # allowing Dependabot security updates (CVE fixes) through. Restore to 10
+    # to resume routine bumps. See PR pausing version updates for launch week.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
@@ -23,6 +26,8 @@ updates:
     target-branch: "develop"
     schedule:
       interval: "weekly"
+    # Paused during OSS launch (see note above). Restore to 5 to resume.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## What

Sets `open-pull-requests-limit: 0` on both Dependabot ecosystems (`uv`,
`github-actions`) to **pause routine version-update PRs** during launch week.

## Why

The grouped config (#239) reduced 18 PRs to 2 grouped + 8 major bumps, but
that's still noise to triage right at launch. `limit: 0` is Dependabot's
official switch for "stop version updates, keep security updates."

## What still works

- ✅ **Dependabot security updates** (CVE fixes) — unaffected, still open PRs
- ✅ The grouping config is retained in the file

## Reversal

One line: restore `open-pull-requests-limit` to `10` (uv) / `5` (github-actions)
to resume routine bumps.

## Follow-up

The 10 currently-open version-update PRs (#240, #244–#252) will be closed
after this merges — `limit: 0` stops *new* PRs but doesn't auto-close existing
ones. The 8 major bumps (neo4j 6, redis 8, pandas 3, sentence-transformers 5, …)
should be revisited individually post-launch.