### PR TITLE
fix: default install builds the knowledge graph locally (bundled Ollama pulls qwen2.5:3b)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,11 +62,16 @@ METRONIX_MCP_PORT=8765
 METRONIX_OPENWEBUI_URL=
 METRONIX_OPENWEBUI_METRONIX_URL=
 
-# --- Separate Ollama LLM instance (advanced; chat LLM on a different Ollama) ---
+# --- Local Ollama LLM (graph extraction + local answer generation) ---
+# OLLAMA_LLM_MODEL is the model the bundled Ollama auto-pulls on first start
+# (alongside the embedding model) and that the app calls for knowledge-graph
+# extraction (NER) and local answers. A small model keeps a default install
+# working with no external dependencies.
+OLLAMA_LLM_MODEL=qwen2.5:3b
+# Advanced: run the chat LLM on a DIFFERENT Ollama than embeddings.
 # If OLLAMA_LLM_HOST is empty, the main Ollama is reused.
 OLLAMA_LLM_HOST=
 OLLAMA_LLM_PORT=11434
-OLLAMA_LLM_MODEL=llama3
 OLLAMA_NUM_CTX=32768                  # context window for Ollama chat
 OLLAMA_REQUEST_TIMEOUT=               # seconds; empty = library default
 
@@ -84,7 +89,10 @@ METRONIX_FRESHNESS_RECONCILER_THRESHOLD=0.85
 METRONIX_FRESHNESS_BACKOFF_BASE_SECONDS=2.0
 METRONIX_FRESHNESS_BACKOFF_MAX_SECONDS=60.0
 METRONIX_FRESHNESS_MAX_CONSECUTIVE_ERRORS=10
-METRONIX_FRESHNESS_LLM_MODEL=qwen2.5-4b-instruct-q4
+# Aux/SLM model for query-rewrite and freshness decisions. Uses an external
+# endpoint only when *_API_BASE_URL / *_PROVIDER below are set; otherwise the
+# local OLLAMA_LLM_MODEL is used.
+METRONIX_FRESHNESS_LLM_MODEL=qwen2.5:3b
 METRONIX_FRESHNESS_LLM_PROVIDER=      # set with API_BASE_URL -> auto "custom"
 METRONIX_FRESHNESS_LLM_API_BASE_URL=
 METRONIX_FRESHNESS_LLM_API_KEY=
@@ -139,11 +147,9 @@ DEFAULT_WORKSPACE_NAME=MTRNIX
 WORKSPACE_PERSISTENCE=neo4j           # neo4j | postgres
 
 # --- Model defaults (override only if you need a specific model) ---
-# OLLAMA_CHAT_MODEL: empty by default. The bundled Ollama runs embeddings only;
-# it does NOT pull a chat model unless you set one here (advanced: run a local
-# chat model in the bundled Ollama, costs a multi-GB download). For answer
-# generation prefer LLM_PROVIDER=custom with an endpoint (see ZONE 3 below).
-OLLAMA_CHAT_MODEL=
+# The local chat/graph model lives in OLLAMA_LLM_MODEL (see the Ollama LLM
+# section above). For external answer generation use LLM_PROVIDER=custom with
+# an endpoint (see ZONE 3 below).
 OLLAMA_EMBED_MODEL=nomic-embed-text   # 768-dim; always used for embeddings
 METRONIX_AUX_LLM_TIMEOUT=10           # aux LLM (expansion/classifier) timeout, sec
 LLM_FALLBACK_PROVIDER=                # fallback provider if primary fails

--- a/.env.example
+++ b/.env.example
@@ -209,6 +209,7 @@ INGEST_EMBED_CONCURRENCY=2            # caps ingest-path embedding calls
 GRAPH_EXTRACTION_ENABLED=true
 GRAPH_EXTRACTION_WORKERS=1            # raise (e.g. 4) to speed up graph phase
 GRAPH_EXTRACTION_MIN_CHARS=100
+GRAPH_EXTRACTION_LLM_TIMEOUT=180      # per-call NER timeout (s); raise on slow local CPU, lower for fast endpoints
 
 # --- Agent memory (WS1) ---
 METRONIX_MEMORY_SESSION_TTL=14400     # session memory TTL (seconds; 4h)

--- a/.env.example
+++ b/.env.example
@@ -209,7 +209,7 @@ INGEST_EMBED_CONCURRENCY=2            # caps ingest-path embedding calls
 GRAPH_EXTRACTION_ENABLED=true
 GRAPH_EXTRACTION_WORKERS=1            # raise (e.g. 4) to speed up graph phase
 GRAPH_EXTRACTION_MIN_CHARS=100
-GRAPH_EXTRACTION_LLM_TIMEOUT=180      # per-call NER timeout (s); raise on slow local CPU, lower for fast endpoints
+GRAPH_EXTRACTION_LLM_TIMEOUT=300      # per-call NER timeout (s); raise on slow local CPU, lower for fast endpoints
 
 # --- Agent memory (WS1) ---
 METRONIX_MEMORY_SESSION_TTL=14400     # session memory TTL (seconds; 4h)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ L0  core/           Config, models, events, plugin interfaces
 Get a backend running in four steps. This is the shortest path; for the full guide
 (prerequisites, Open WebUI, ports, troubleshooting) see `[install.md](install.md)`.
 
+> **Requirements:** Docker with **≥6 GB RAM** (8 GB recommended) and ~15 GB free disk. The
+> default Docker Desktop allotment (~2 GB) is too small for the full stack plus the local
+> graph model and will OOM-kill syncs — raise it under Settings → Resources → Memory.
+
 ### 1. Clone
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Flags: `--mode memory|answers`, `--chat-url`, `--chat-model`, `--chat-api-key`, 
 cp .env.example .env
 ```
 
-For **agent memory over MCP** (Hermes, Cursor, …) you only need the MCP auth key. Embeddings for ingest come from the bundled Ollama container (`nomic-embed-text`, pulled on first
-`docker compose up`) — no chat LLM in `.env`.
+For **agent memory over MCP** (Hermes, Cursor, …) you only need the MCP auth key. Embeddings for ingest come from the bundled Ollama container (`nomic-embed-text`), and a small graph model (`qwen2.5:3b`) is pulled alongside it for knowledge-graph extraction — both on first
+`docker compose up`. No external chat LLM is required in `.env`.
 
 ```bash
 METRONIX_MCP_API_KEY=...   # generate: openssl rand -hex 32

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -89,11 +89,10 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # Ollama — embeddings only (auto-pulls the embedding model on first start).
-  # The chat model is NOT pulled by default: a bare memory-store install (the
-  # common case) never generates answers locally, so pulling a multi-GB chat
-  # model would waste bandwidth and disk. A chat model is pulled only if
-  # OLLAMA_CHAT_MODEL is set non-empty in .env (advanced: run a local chat model).
+  # Ollama — pulls two models on first start: the embedding model
+  # (OLLAMA_EMBED_MODEL) and a small chat model (OLLAMA_LLM_MODEL, default
+  # qwen2.5:3b) used for knowledge-graph extraction (NER) and local answer
+  # generation. This keeps a default install working with no external LLM.
   # ---------------------------------------------------------------------------
   ollama:
     image: ollama/ollama:latest
@@ -106,8 +105,8 @@ services:
       - metronix_full
     environment:
       OLLAMA_EMBED_MODEL: nomic-embed-text
-      OLLAMA_CHAT_MODEL: ${OLLAMA_CHAT_MODEL-}
-    entrypoint: ["/bin/bash", "-c", "ollama serve & for i in $$(seq 1 30); do sleep 1; ollama list >/dev/null 2>&1 && break; done; ollama pull $$OLLAMA_EMBED_MODEL; [ -n \"$$OLLAMA_CHAT_MODEL\" ] && ollama pull $$OLLAMA_CHAT_MODEL; wait"]
+      OLLAMA_LLM_MODEL: ${OLLAMA_LLM_MODEL:-qwen2.5:3b}
+    entrypoint: ["/bin/bash", "-c", "ollama serve & for i in $$(seq 1 30); do sleep 1; ollama list >/dev/null 2>&1 && break; done; ollama pull $$OLLAMA_EMBED_MODEL; ollama pull $$OLLAMA_LLM_MODEL; wait"]
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/11434 && exec 3>&-'"]
       interval: 10s

--- a/docs/integrations/atomic-chat.md
+++ b/docs/integrations/atomic-chat.md
@@ -38,7 +38,6 @@ OLLAMA_HOST=http://your-ollama-host:11434
 Recommended first model:
 
 ```ini
-OLLAMA_CHAT_MODEL=qwen2.5:7b-instruct
 OLLAMA_LLM_MODEL=qwen2.5:7b-instruct
 ```
 

--- a/docs/integrations/ollama-local-models.md
+++ b/docs/integrations/ollama-local-models.md
@@ -37,14 +37,12 @@ OLLAMA_HOST=http://your-ollama-host:11434
 Metronix Memory supports setting a dedicated Ollama chat model:
 
 ```ini
-OLLAMA_CHAT_MODEL=qwen2.5:7b-instruct
 OLLAMA_LLM_MODEL=qwen2.5:7b-instruct
 ```
 
 or:
 
 ```ini
-OLLAMA_CHAT_MODEL=glm4:9b
 OLLAMA_LLM_MODEL=glm4:9b
 ```
 

--- a/install.md
+++ b/install.md
@@ -190,17 +190,20 @@ with the rest of the stack — no extra `.env` setup. On first launch its entryp
 `ollama pull nomic-embed-text`. That embedding model is required for **data ingest**
 (indexing documents, memory records, and connector content into Qdrant).
 
-This is **not** a chat LLM and is separate from [§3b](#3b-optional-chat-llm-open-webui-or-answer-generation).
-By default no chat model is downloaded (`OLLAMA_CHAT_MODEL` empty). The first
-`docker compose up` may take extra time while the embedding model downloads.
+The entrypoint also pulls a small chat model — `qwen2.5:3b` (`OLLAMA_LLM_MODEL`) — used
+by default for **knowledge-graph extraction** (entity/relationship NER during ingest) and
+local answer generation, so a default install builds the graph with no external LLM. This
+is separate from the external answer-generation endpoint in
+[§3b](#3b-optional-chat-llm-open-webui-or-answer-generation). The first `docker compose up`
+may take extra time while both models download.
 
-Inside the Docker network the service is `ollama:11434`. Metronix uses it for vector embeddings only.
+Inside the Docker network the service is `ollama:11434`.
 
 ## 4. Launch
 
 Build and start the stack. The first run builds images from source and pulls the Ollama
-**embedding** model (`nomic-embed-text`), which takes about **10–15 minutes**. Subsequent
-runs are fast.
+**embedding** model (`nomic-embed-text`) plus the small **graph** model (`qwen2.5:3b`),
+which takes about **10–15 minutes**. Subsequent runs are fast.
 
 **Backend only** — PostgreSQL, Qdrant, Neo4j, Redis, Ollama (for embeddings), SPLADE, embedding proxy, and the Metronix API:
 

--- a/install.md
+++ b/install.md
@@ -55,6 +55,10 @@ After that, see [Ports](#ports), [Common operations](#common-operations), and
 - **Docker Compose v2** (`docker compose`) or the legacy `docker-compose` binary.
 - **~15 GB free disk space** — images, build cache, volumes, and first-run Ollama model
 downloads.
+- **≥6 GB RAM available to Docker** (8 GB recommended), 4 CPUs. The full stack plus the
+local graph model (`qwen2.5:3b`, ~1.9 GB) does not fit in Docker Desktop's default ~2 GB —
+raise it under **Settings → Resources → Memory**, or a sync may be OOM-killed mid-run
+("Sync interrupted (API restart)").
 - **Python 3.12+** — only if you intend to run tests or develop locally; not required to
 run the stack.
 

--- a/install.sh
+++ b/install.sh
@@ -580,8 +580,10 @@ configure() {
   trap 'rm -f "$ENV_FILE"' EXIT
   cp "$EXAMPLE_FILE" "$ENV_FILE"
 
-  info "Vector embeddings run locally on the bundled Ollama (model: nomic-embed-text),"
-  info "set up automatically. The choice below is only about answer generation (chat)."
+  info "Vector embeddings run locally on the bundled Ollama (model: nomic-embed-text)."
+  info "Knowledge-graph extraction and local answers run on the bundled Ollama (model: qwen2.5:3b),"
+  info "pulled automatically on first start. No external LLM is required by default."
+  info "The choice below is only about answer generation (chat)."
   info ""
 
   # Pick the scenario: pure memory store vs. Metronix generating answers itself.
@@ -634,14 +636,12 @@ configure() {
     set_env LLM_PROVIDER_URL "$CHAT_URL"
     set_env LLM_PROVIDER_MODEL "$CHAT_MODEL"
     set_env LLM_PROVIDER_API_KEY "$CHAT_API_KEY"
-    set_env OLLAMA_CHAT_MODEL ""   # bundled Ollama stays embeddings-only
     ok "Answer generation -> $CHAT_URL (model: $CHAT_MODEL)"
   else
-    # Memory store: the connected agent does the answering. No chat model is
-    # configured and the bundled Ollama never pulls one (embeddings only).
+    # Memory store: the connected agent does the answering. The bundled Ollama
+    # still runs a small local model (OLLAMA_LLM_MODEL) for graph extraction.
     set_env LLM_PROVIDER ollama
-    set_env OLLAMA_CHAT_MODEL ""
-    ok "Memory-store mode — no answer-generation model configured."
+    ok "Memory-store mode — answers come from the connected agent."
   fi
 
   # Open WebUI is a chat front-end — it only works once Metronix can generate

--- a/migrations/versions/027_graph_failed.py
+++ b/migrations/versions/027_graph_failed.py
@@ -1,0 +1,74 @@
+"""Add graph-extraction failure tracking to raw_documents.
+
+When LLM-based graph extraction (NER) exhausts its retries for a document, the
+document was previously left ``graph_synced=false`` and retried forever by the
+sweeper — a document that structurally never fits the timeout becomes a
+CPU-burning loop that can stall the rest of the backlog.
+
+This migration adds an explicit terminal failure state so such a document is
+parked instead of looped:
+
+- ``graph_failed`` — set true after extraction gives up; excluded from the
+  unsynced backlog so the sweeper stops retrying it automatically.
+- ``graph_error`` — the last error message, for visibility / UI.
+- ``graph_failed_at`` — when it was parked.
+
+A failed document is re-armed by clearing ``graph_failed`` (the "retry failed"
+admin action), which puts it back in the unsynced backlog.
+
+Revision ID: 027
+Revises: 026
+Create Date: 2026-06-30
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "027"
+down_revision: str | None = "026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "raw_documents",
+        sa.Column("graph_failed", sa.Boolean, nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "raw_documents",
+        sa.Column("graph_error", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "raw_documents",
+        sa.Column("graph_failed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Re-create the unsynced-graph partial index so it covers the sweeper's
+    # query (NOT graph_synced AND NOT graph_failed) — parked failures drop out.
+    op.drop_index("ix_raw_docs_graph_unsynced", table_name="raw_documents")
+    op.create_index(
+        "ix_raw_docs_graph_unsynced",
+        "raw_documents",
+        ["workspace_id"],
+        postgresql_where=sa.text("NOT graph_synced AND NOT graph_failed"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_raw_docs_graph_unsynced", table_name="raw_documents")
+    op.create_index(
+        "ix_raw_docs_graph_unsynced",
+        "raw_documents",
+        ["workspace_id"],
+        postgresql_where=sa.text("NOT graph_synced"),
+    )
+    op.drop_column("raw_documents", "graph_failed_at")
+    op.drop_column("raw_documents", "graph_error")
+    op.drop_column("raw_documents", "graph_failed")

--- a/src/metronix/api/graph_sweep.py
+++ b/src/metronix/api/graph_sweep.py
@@ -79,6 +79,20 @@ class GraphSweeper:
         if not workspaces:
             return
 
+        # Defer to active syncs: a running connector sync embeds (Phase 1) and
+        # then runs its own graph phase (Phase 4) after embeddings finish.
+        # Sweeping the same workspace meanwhile only contends for CPU / the local
+        # LLM, so skip workspaces with an in-progress sync — the next tick (or that
+        # sync's own Phase 4) picks up the backlog.
+        busy = set(await self._store.list_workspaces_with_running_sync())
+        if busy:
+            skipped = [w for w in workspaces if w in busy]
+            workspaces = [w for w in workspaces if w not in busy]
+            if skipped:
+                logger.info("graph_sweep.tick.deferred_to_sync", workspaces=skipped)
+        if not workspaces:
+            return
+
         # Imported lazily to avoid importing the heavy ingestion pipeline at
         # module load (and to keep the L6->L2 edge explicit).
         from metronix.ingestion.pipeline import process_all_unsynced_graphs

--- a/src/metronix/api/routes/graph.py
+++ b/src/metronix/api/routes/graph.py
@@ -94,6 +94,60 @@ async def graph_overview(
     )
 
 
+class GraphRetryResponse(BaseModel):
+    requeued: int
+    scope: str
+
+
+def _get_postgres_store(request: Request):
+    """Return the app-wide PostgresStore, creating it on first use (mirrors admin)."""
+    from metronix.storage.postgres import PostgresStore
+
+    store = getattr(request.app.state, "postgres", None)
+    if store is None:
+        settings = request.app.state.settings
+        store = PostgresStore(settings.postgres_dsn)
+        request.app.state.postgres = store
+    return store
+
+
+@router.get("/failed-count")
+async def graph_failed_count(
+    request: Request,
+    workspace_id: str = Query(..., description="Workspace ID"),
+) -> dict[str, int]:
+    """How many documents are parked as graph_failed in this workspace."""
+    store = _get_postgres_store(request)
+    return {"failed": await store.count_graph_failed(workspace_id)}
+
+
+@router.post("/retry-failed", response_model=GraphRetryResponse)
+async def graph_retry_failed(
+    request: Request,
+    workspace_id: str = Query(..., description="Workspace ID"),
+) -> GraphRetryResponse:
+    """Re-arm graph_failed documents — they re-enter the backlog and the sweeper
+    re-attempts extraction on its next tick."""
+    store = _get_postgres_store(request)
+    count = await store.reset_graph_failed(workspace_id)
+    logger.info("api.graph.retry_failed", workspace_id=workspace_id, requeued=count)
+    return GraphRetryResponse(requeued=count, scope="failed")
+
+
+@router.post("/retry-all", response_model=GraphRetryResponse)
+async def graph_retry_all(
+    request: Request,
+    workspace_id: str = Query(..., description="Workspace ID"),
+) -> GraphRetryResponse:
+    """Re-extract the whole workspace graph: clear graph_synced and graph_failed
+    for every document so the sweeper rebuilds entities from scratch (Neo4j nodes
+    are merged idempotently; the graph store is not cleared)."""
+    store = _get_postgres_store(request)
+    count = await store.reset_all_graph(workspace_id)
+    logger.info("api.graph.retry_all", workspace_id=workspace_id, requeued=count)
+    return GraphRetryResponse(requeued=count, scope="all")
+
+
 @router.get("/expand/{entity_id}", response_model=GraphResponse)
 async def graph_expand(
     request: Request,

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -544,6 +544,22 @@ class Settings(BaseSettings):
             return f"{host}:{self.ollama_llm_port}"
         return f"http://{host}:{self.ollama_llm_port}"
 
+    def model_for_provider(self, provider: str) -> str:
+        """Return the configured model name for an LLM provider, or "".
+
+        Single source of truth for the provider -> model-attribute mapping
+        (previously inlined in retrieval/search.py as _PROVIDER_MODEL_ATTR).
+        """
+        attr = {
+            "ollama": "ollama_llm_model",
+            "deepseek": "deepseek_model",
+            "openrouter": "openrouter_model",
+            "custom": "custom_llm_model",
+        }.get(provider, "")
+        if not attr:
+            return ""
+        return getattr(self, attr, "") or ""
+
     @field_validator("log_level")
     @classmethod
     def validate_log_level(cls, v: str) -> str:

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -275,9 +275,7 @@ class Settings(BaseSettings):
     freshness_decision_confidence_threshold: float = Field(
         default=0.7, alias="METRONIX_FRESHNESS_DECISION_CONFIDENCE_THRESHOLD"
     )
-    freshness_llm_model: str = Field(
-        default="qwen2.5:3b", alias="METRONIX_FRESHNESS_LLM_MODEL"
-    )
+    freshness_llm_model: str = Field(default="qwen2.5:3b", alias="METRONIX_FRESHNESS_LLM_MODEL")
     freshness_llm_provider: str = Field(default="", alias="METRONIX_FRESHNESS_LLM_PROVIDER")
     freshness_llm_api_base_url: str = Field(
         default="", alias="METRONIX_FRESHNESS_LLM_API_BASE_URL"

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -112,13 +112,12 @@ class Settings(BaseSettings):
 
     # --- Ollama (embeddings) ---
     ollama_host: str = Field("http://localhost:11434", alias="OLLAMA_HOST")
-    ollama_chat_model: str = Field("llama3.1:8b", alias="OLLAMA_CHAT_MODEL")
     ollama_embed_model: str = Field("nomic-embed-text", alias="OLLAMA_EMBED_MODEL")
 
     # --- Ollama (LLM, separate from embeddings) ---
     ollama_llm_host: str = Field("", alias="OLLAMA_LLM_HOST")
     ollama_llm_port: int = Field(11434, alias="OLLAMA_LLM_PORT")
-    ollama_llm_model: str = Field("llama3", alias="OLLAMA_LLM_MODEL")
+    ollama_llm_model: str = Field("qwen2.5:3b", alias="OLLAMA_LLM_MODEL")
 
     # --- LLM provider selection ---
     llm_provider: str = Field("ollama", alias="LLM_PROVIDER")
@@ -277,7 +276,7 @@ class Settings(BaseSettings):
         default=0.7, alias="METRONIX_FRESHNESS_DECISION_CONFIDENCE_THRESHOLD"
     )
     freshness_llm_model: str = Field(
-        default="qwen2.5-4b-instruct-q4", alias="METRONIX_FRESHNESS_LLM_MODEL"
+        default="qwen2.5:3b", alias="METRONIX_FRESHNESS_LLM_MODEL"
     )
     freshness_llm_provider: str = Field(default="", alias="METRONIX_FRESHNESS_LLM_PROVIDER")
     freshness_llm_api_base_url: str = Field(

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -195,6 +195,10 @@ class Settings(BaseSettings):
     graph_extraction_enabled: bool = Field(True, alias="GRAPH_EXTRACTION_ENABLED")
     graph_extraction_workers: int = Field(1, alias="GRAPH_EXTRACTION_WORKERS")
     graph_extraction_min_chars: int = Field(100, alias="GRAPH_EXTRACTION_MIN_CHARS")
+    # Per-call timeout (seconds) for the NER/extraction LLM call. Local CPU
+    # inference of a small model over a full document can take minutes, so the
+    # default is generous; raise it on slow hardware, lower it for fast endpoints.
+    graph_extraction_llm_timeout: int = Field(180, alias="GRAPH_EXTRACTION_LLM_TIMEOUT")
 
     # --- Embedding cache ---
     embedding_cache_ttl: int = Field(3600, alias="EMBEDDING_CACHE_TTL")

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -198,7 +198,7 @@ class Settings(BaseSettings):
     # Per-call timeout (seconds) for the NER/extraction LLM call. Local CPU
     # inference of a small model over a full document can take minutes, so the
     # default is generous; raise it on slow hardware, lower it for fast endpoints.
-    graph_extraction_llm_timeout: int = Field(180, alias="GRAPH_EXTRACTION_LLM_TIMEOUT")
+    graph_extraction_llm_timeout: int = Field(300, alias="GRAPH_EXTRACTION_LLM_TIMEOUT")
 
     # --- Embedding cache ---
     embedding_cache_ttl: int = Field(3600, alias="EMBEDDING_CACHE_TTL")

--- a/src/metronix/ingestion/pipeline.py
+++ b/src/metronix/ingestion/pipeline.py
@@ -432,6 +432,8 @@ async def process_unsynced_graphs(
     """
     import json
 
+    from metronix.storage.neo4j_graph import GraphExtractionError
+
     ok_count = 0
     error_count = 0
     skipped = 0
@@ -525,6 +527,26 @@ async def process_unsynced_graphs(
             )
             ok_count += 1
             consecutive_errors = 0  # Reset on success
+
+        except GraphExtractionError as e:
+            # The LLM gave up on THIS document after its retries (e.g. repeated
+            # timeouts). Park it as graph_failed so the sweeper stops looping on
+            # it — it does not indicate Neo4j is down, so don't trip the
+            # consecutive-error circuit breaker. Re-arm via reset_graph_failed.
+            error_count += 1
+            consecutive_errors = 0
+            logger.warning(
+                "process_unsynced_graphs.doc_failed",
+                source_id=row.get("source_id"),
+                error=str(e)[:200],
+            )
+            with contextlib.suppress(Exception):
+                await store.mark_documents_graph_failed(
+                    workspace_id=workspace_id,
+                    connector_type=row["connector_type"],
+                    source_ids=[row["source_id"]],
+                    error=str(e),
+                )
 
         except Exception as e:
             error_count += 1

--- a/src/metronix/mcp/config.py
+++ b/src/metronix/mcp/config.py
@@ -72,13 +72,29 @@ def load_stdio_config(config_path: Path = CONFIG_PATH) -> dict[str, Any]:
 
 
 def get_default_workspace_id(config_path: Path = CONFIG_PATH) -> str:
-    """Get the default workspace ID from config.
+    """Get the default workspace ID for MCP calls.
 
-    Returns:
-        Workspace ID string, defaults to "default" if not configured.
+    Resolution order: the MCP stdio config file's ``workspace_id``, then the
+    server's configured ``DEFAULT_WORKSPACE_ID``. The latter is the same default
+    the REST API and UI use, so MCP-ingested data and memory land in that
+    workspace instead of a stray literal ``"default"`` workspace the UI never
+    shows.
     """
+    from metronix.core.config import get_settings
+
+    fallback = get_settings().default_workspace_id
     try:
         config = load_stdio_config(config_path)
-        return config.get("workspace_id", "default")
+        return config.get("workspace_id") or fallback
     except FileNotFoundError:
-        return "default"
+        return fallback
+
+
+def resolve_workspace_id(workspace_id: str | None) -> str:
+    """Resolve an explicit ``workspace_id``, falling back to the configured default.
+
+    MCP tools call this so an omitted ``workspace_id`` routes to the server's
+    ``DEFAULT_WORKSPACE_ID`` rather than a literal ``"default"`` — keeping
+    MCP-driven ingestion/memory in the same workspace as the REST API and UI.
+    """
+    return workspace_id or get_default_workspace_id()

--- a/src/metronix/mcp/tools/_source_deps.py
+++ b/src/metronix/mcp/tools/_source_deps.py
@@ -38,7 +38,9 @@ def resolve(workspace_id: str | None) -> tuple[str, PostgresStore, str]:
     ``"MTRNIX"`` and would split-brain with metronix_search/status). Raises
     ``ValueError`` when the Fernet key is unset.
     """
-    ws_id = workspace_id or "default"
+    from metronix.mcp.config import resolve_workspace_id
+
+    ws_id = resolve_workspace_id(workspace_id)
     store = get_store()
     key = get_settings().fernet_key
     if not key:

--- a/src/metronix/mcp/tools/get.py
+++ b/src/metronix/mcp/tools/get.py
@@ -29,7 +29,9 @@ async def metronix_get(
         if not doc_label:
             raise ValueError("doc_label is required")
 
-        store = get_hybrid_store(workspace_id or "default")
+        from metronix.mcp.config import resolve_workspace_id
+
+        store = get_hybrid_store(resolve_workspace_id(workspace_id))
         results = store.search_by_doc_labels([doc_label], limit=1)
 
         if not results:

--- a/src/metronix/mcp/tools/memory_batch_store.py
+++ b/src/metronix/mcp/tools/memory_batch_store.py
@@ -100,7 +100,9 @@ async def metronix_memory_batch_store(
                 ).to_dict(),
             }
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)
 
         results: list[MemoryBatchStoreResult] = []

--- a/src/metronix/mcp/tools/memory_delete.py
+++ b/src/metronix/mcp/tools/memory_delete.py
@@ -38,7 +38,9 @@ async def metronix_memory_delete(
                 ).to_dict(),
             }
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)
         deleted = await service.delete(ws_id, record_id)
 

--- a/src/metronix/mcp/tools/memory_list.py
+++ b/src/metronix/mcp/tools/memory_list.py
@@ -97,7 +97,9 @@ async def metronix_memory_list(
                 ).to_dict(),
             }
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         limit = min(max(1, int(limit)), 100)
         offset = max(0, int(offset))
 

--- a/src/metronix/mcp/tools/memory_review_list.py
+++ b/src/metronix/mcp/tools/memory_review_list.py
@@ -43,7 +43,9 @@ async def metronix_memory_review_list(
 ) -> dict[str, Any]:
     """Paginated enumeration of ``memory_record`` review entries."""
     try:
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         limit = min(max(1, int(limit)), 100)
         offset = max(0, int(offset))
 

--- a/src/metronix/mcp/tools/memory_review_resolve.py
+++ b/src/metronix/mcp/tools/memory_review_resolve.py
@@ -73,7 +73,9 @@ async def metronix_memory_review_resolve(
                 ).to_dict(),
             }
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)
 
         try:

--- a/src/metronix/mcp/tools/memory_search.py
+++ b/src/metronix/mcp/tools/memory_search.py
@@ -98,7 +98,9 @@ async def metronix_memory_search(
                 ).to_dict(),
             }
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         top_k = min(max(1, int(top_k)), 50)
 
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)

--- a/src/metronix/mcp/tools/memory_store.py
+++ b/src/metronix/mcp/tools/memory_store.py
@@ -96,7 +96,9 @@ async def metronix_memory_store(
                 ).to_dict(),
             }
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         record = MemoryRecord(
             workspace_id=ws_id,
             agent_id=agent_id,

--- a/src/metronix/mcp/tools/memory_update.py
+++ b/src/metronix/mcp/tools/memory_update.py
@@ -64,7 +64,9 @@ async def metronix_memory_update(
                 ).to_dict(),
             }
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
 
         validated_kind: MemoryKind | None = None
         if kind is not None:

--- a/src/metronix/mcp/tools/search.py
+++ b/src/metronix/mcp/tools/search.py
@@ -41,9 +41,11 @@ async def metronix_search(
         limit = min(max(1, limit), 100)  # noqa: F841 — accepted for forward-compat
 
         # hybrid_search_and_answer returns str (answer with sources appended)
+        from metronix.mcp.config import resolve_workspace_id
+
         answer = await hybrid_search_and_answer(
             query,
-            workspace_id=workspace_id or "default",
+            workspace_id=resolve_workspace_id(workspace_id),
             source="mcp",
         )
 

--- a/src/metronix/mcp/tools/search_fast.py
+++ b/src/metronix/mcp/tools/search_fast.py
@@ -62,7 +62,9 @@ async def metronix_search_fast(
         from metronix.retrieval.search import fast_search
 
         top_k = min(max(1, int(top_k)), 50)
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
 
         start = time.perf_counter()
         hits = await fast_search(query, workspace_id=ws_id, top_k=top_k)

--- a/src/metronix/mcp/tools/source_create.py
+++ b/src/metronix/mcp/tools/source_create.py
@@ -17,7 +17,7 @@ from metronix.mcp.server import mcp
         "| slack_history are accepted but NOT implemented — sync will fail.\n"
         "- name: human-friendly label\n"
         "- config: connector config dict (e.g. url, username, api_token)\n"
-        "- workspace_id: target workspace (optional, defaults to 'default')\n\n"
+        "- workspace_id: target workspace (optional; uses the server default)\n\n"
         "Channels (telegram/discord/slack) are rejected. The new source is "
         "auto-scheduled for nightly sync; trigger an immediate sync with "
         "metronix_source_sync.\n\n"

--- a/src/metronix/mcp/tools/source_delete.py
+++ b/src/metronix/mcp/tools/source_delete.py
@@ -13,7 +13,7 @@ from metronix.mcp.server import mcp
         "Delete a data source (connection) and its encrypted credentials.\n\n"
         "**Parameters:**\n"
         "- connection_id: the source to delete (required)\n"
-        "- workspace_id: target workspace (optional, defaults to 'default')\n\n"
+        "- workspace_id: target workspace (optional; uses the server default)\n\n"
         "**Returns:** {success, connection_id}. Already-ingested documents are "
         "not removed by this call."
     ),

--- a/src/metronix/mcp/tools/source_list.py
+++ b/src/metronix/mcp/tools/source_list.py
@@ -12,7 +12,7 @@ from metronix.mcp.server import mcp
     description=(
         "List configured data sources (connections) for a workspace.\n\n"
         "**Parameters:**\n"
-        "- workspace_id: Target workspace (optional, defaults to 'default')\n\n"
+        "- workspace_id: Target workspace (optional; uses the server default)\n\n"
         "**Returns:** sources[] with masked secrets (last 4 chars shown), plus "
         "status, enabled, error_message, last_synced_at, sync_cron, next_run_at. "
         "Poll this after metronix_source_sync to observe sync status."

--- a/src/metronix/mcp/tools/source_sync.py
+++ b/src/metronix/mcp/tools/source_sync.py
@@ -23,7 +23,7 @@ _SCAFFOLD_CONNECTORS = frozenset({"github", "gdrive", "slack_history", "files"})
         "may take up to ~1 hour for large sources; this tool returns immediately.\n\n"
         "**Parameters:**\n"
         "- connection_id: the source to sync (required)\n"
-        "- workspace_id: target workspace (optional, defaults to 'default')\n"
+        "- workspace_id: target workspace (optional; uses the server default)\n"
         "- force_full: ignore the incremental watermark and refetch everything\n\n"
         "**Returns:** {status: 'sync_started', sync_id, connection_id, "
         "connector_type}. Poll metronix_source_list to observe completion "

--- a/src/metronix/mcp/tools/source_update.py
+++ b/src/metronix/mcp/tools/source_update.py
@@ -13,7 +13,7 @@ from metronix.mcp.server import mcp
         "Update a data source's name, enabled flag, and/or config.\n\n"
         "**Parameters:**\n"
         "- connection_id: the source to update (required)\n"
-        "- workspace_id: target workspace (optional, defaults to 'default')\n"
+        "- workspace_id: target workspace (optional; uses the server default)\n"
         "- name / enabled / config: fields to change (omit to leave unchanged)\n\n"
         "When updating config, send the FULL config dict. To keep a secret "
         "unchanged, pass its masked value (the '***...' string from "

--- a/src/metronix/mcp/tools/status.py
+++ b/src/metronix/mcp/tools/status.py
@@ -24,9 +24,10 @@ async def metronix_status(
     """Check system health and status."""
     try:
         from metronix.core.config import Settings
+        from metronix.mcp.config import resolve_workspace_id
         from metronix.storage.qdrant import get_hybrid_store
 
-        ws_id = workspace_id or "default"
+        ws_id = resolve_workspace_id(workspace_id)
         settings = Settings()
 
         try:

--- a/src/metronix/mcp/tools/store.py
+++ b/src/metronix/mcp/tools/store.py
@@ -45,7 +45,9 @@ async def metronix_store(
         if not doc_label:
             doc_label = f"MEM-{uuid.uuid4().hex[:8].upper()}"
 
-        ws_id = workspace_id or "default"
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
         doc = Document(
             title=title or doc_label,
             content=content,

--- a/src/metronix/mcp/tools/sync.py
+++ b/src/metronix/mcp/tools/sync.py
@@ -26,9 +26,10 @@ async def metronix_sync(
 ) -> dict[str, Any]:
     """Trigger document sync from configured MCP sources."""
     try:
+        from metronix.mcp.config import resolve_workspace_id
         from metronix.mcp.sync import MCPSyncManager
 
-        ws_id = workspace_id or "default"
+        ws_id = resolve_workspace_id(workspace_id)
         sync_manager = MCPSyncManager()
 
         details: list[SyncSourceResult] = []

--- a/src/metronix/memory/query_rewrite.py
+++ b/src/metronix/memory/query_rewrite.py
@@ -61,9 +61,17 @@ class QueryRewriter:
 
     def _default_provider_factory(self) -> LLMProvider:
         s = self._settings
+        if s.freshness_llm_provider:
+            # Dedicated aux/SLM endpoint explicitly configured.
+            return create_provider(
+                provider_name=s.freshness_llm_provider,
+                model=s.freshness_llm_model,
+            )
+        # Fall back to the main provider AND its own configured model, so an
+        # all-local install requests the model that is actually pulled.
         return create_provider(
-            provider_name=s.freshness_llm_provider or s.llm_provider,
-            model=s.freshness_llm_model,
+            provider_name=s.llm_provider,
+            model=s.model_for_provider(s.llm_provider),
         )
 
     async def rewrite(

--- a/src/metronix/retrieval/search.py
+++ b/src/metronix/retrieval/search.py
@@ -79,6 +79,7 @@ from metronix.storage.graph_ops import (  # TODO: async migration
 logger = structlog.get_logger()
 _s = Settings()
 
+
 # Maps the active LLM provider to the Settings attribute holding its model name,
 # so the rag_trace generation phase records the real model (Settings has no
 # single ``llm_model`` field — the name is provider-specific).

--- a/src/metronix/retrieval/search.py
+++ b/src/metronix/retrieval/search.py
@@ -82,17 +82,9 @@ _s = Settings()
 # Maps the active LLM provider to the Settings attribute holding its model name,
 # so the rag_trace generation phase records the real model (Settings has no
 # single ``llm_model`` field — the name is provider-specific).
-_PROVIDER_MODEL_ATTR = {
-    "ollama": "ollama_llm_model",
-    "deepseek": "deepseek_model",
-    "openrouter": "openrouter_model",
-    "custom": "custom_llm_model",
-}
-
-
 def _active_llm_model(settings: Settings) -> str:
     """Resolve the configured model name for the active provider (best-effort)."""
-    return getattr(settings, _PROVIDER_MODEL_ATTR.get(settings.llm_provider, ""), "") or ""
+    return settings.model_for_provider(settings.llm_provider)
 
 
 _MAX_TOTAL, _MAX_FRAG = _s.search_max_total_chars, _s.search_max_fragment_chars

--- a/src/metronix/storage/neo4j_graph.py
+++ b/src/metronix/storage/neo4j_graph.py
@@ -181,6 +181,10 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
     except Exception:
         pass  # telemetry is best-effort; never block the NER path
 
+    from metronix.core.config import get_settings
+
+    ner_timeout = get_settings().graph_extraction_llm_timeout
+
     content = ""
     for attempt in range(3):
         try:
@@ -197,7 +201,7 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
                 ],
                 temperature=0.1,
                 json_mode=True,
-                timeout=120,
+                timeout=ner_timeout,
                 call_site="ner_extraction",
             )
             break
@@ -212,8 +216,13 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
                 )
                 time.sleep(wait)
             else:
+                # Hard LLM failure (timeout / connection / 5xx) after all retries.
+                # Raise instead of returning empty entities: the document must NOT
+                # be marked graph_synced, so the sweep retries it once the model or
+                # resources recover. Swallowing here silently produced an empty
+                # knowledge graph for a sync that otherwise looked successful.
                 logger.error("graph.extract.failed", error=str(e))
-                return {"entities": [], "relationships": []}
+                raise
 
     content = content.strip()
     if "<think>" in content:

--- a/src/metronix/storage/neo4j_graph.py
+++ b/src/metronix/storage/neo4j_graph.py
@@ -25,6 +25,16 @@ logger = structlog.get_logger()
 
 DEFAULT_WORKSPACE_ID = "MTRNIX"
 
+
+class GraphExtractionError(Exception):
+    """LLM-based graph extraction (NER) gave up after exhausting its retries.
+
+    Distinct from Neo4j/connection errors: this signals the *document* could not
+    be extracted (e.g. the LLM timed out repeatedly), so callers should park it
+    as ``graph_failed`` rather than retry it forever.
+    """
+
+
 _driver = None
 _driver_lock = Lock()
 
@@ -217,12 +227,11 @@ def extract_graph_from_text(text: str, max_text_length: int = 8000) -> dict:
                 time.sleep(wait)
             else:
                 # Hard LLM failure (timeout / connection / 5xx) after all retries.
-                # Raise instead of returning empty entities: the document must NOT
-                # be marked graph_synced, so the sweep retries it once the model or
-                # resources recover. Swallowing here silently produced an empty
-                # knowledge graph for a sync that otherwise looked successful.
+                # Raise a typed error instead of returning empty entities: callers
+                # park the document as graph_failed (terminal) rather than marking
+                # it graph_synced with an empty graph or retrying it forever.
                 logger.error("graph.extract.failed", error=str(e))
-                raise
+                raise GraphExtractionError(str(e)) from e
 
     content = content.strip()
     if "<think>" in content:

--- a/src/metronix/storage/postgres.py
+++ b/src/metronix/storage/postgres.py
@@ -1193,6 +1193,21 @@ class PostgresStore:
             )
             return [row._mapping["workspace_id"] for row in result]
 
+    async def list_workspaces_with_running_sync(self) -> list[str]:
+        """Return workspace ids with an in-progress sync (``sync_logs.status='running'``).
+
+        The graph sweeper uses this to defer graph extraction while a connector
+        sync is embedding (Phase 1): that sync runs its own graph phase (Phase 4)
+        after embeddings finish, so sweeping the same workspace concurrently only
+        contends for CPU / the local LLM. Stuck ``running`` rows are reset on
+        startup by ``recover_interrupted_syncs``, bounding staleness.
+        """
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("SELECT DISTINCT workspace_id FROM sync_logs WHERE status = 'running'")
+            )
+            return [row._mapping["workspace_id"] for row in result]
+
     async def mark_documents_synced(
         self,
         doc_ids: list[str],

--- a/src/metronix/storage/postgres.py
+++ b/src/metronix/storage/postgres.py
@@ -1121,6 +1121,10 @@ class PostgresStore:
         if target not in ("qdrant", "graph"):
             raise ValueError(f"Invalid sync target: {target}")
 
+        # Parked graph failures are excluded so the sweeper stops auto-retrying
+        # them; they re-enter the backlog only via reset_graph_failed.
+        failed_clause = "AND NOT graph_failed" if target == "graph" else ""
+
         logger.info(
             "postgres.raw_documents.unsynced",
             workspace_id=workspace_id,
@@ -1134,6 +1138,7 @@ class PostgresStore:
                     SELECT * FROM raw_documents
                     WHERE workspace_id = :workspace_id
                       AND NOT {target}_synced
+                      {failed_clause}
                     ORDER BY fetched_at
                     LIMIT :limit
                 """),
@@ -1188,7 +1193,7 @@ class PostgresStore:
                 text("""
                     SELECT DISTINCT workspace_id
                     FROM raw_documents
-                    WHERE NOT graph_synced
+                    WHERE NOT graph_synced AND NOT graph_failed
                 """)
             )
             return [row._mapping["workspace_id"] for row in result]
@@ -1283,6 +1288,94 @@ class PostgresStore:
                     "source_ids": source_ids,
                 },
             )
+
+    async def mark_documents_graph_failed(
+        self,
+        workspace_id: str,
+        connector_type: str,
+        source_ids: list[str],
+        error: str,
+    ) -> None:
+        """Park documents whose graph extraction gave up after all retries.
+
+        Sets ``graph_failed=true`` (terminal) so the sweeper stops auto-retrying
+        them; ``reset_graph_failed`` re-arms them. ``graph_synced`` is left false.
+        """
+        if not source_ids:
+            return
+        logger.info(
+            "postgres.raw_documents.mark_graph_failed",
+            workspace_id=workspace_id,
+            count=len(source_ids),
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text("""
+                    UPDATE raw_documents
+                    SET graph_failed = true,
+                        graph_failed_at = NOW(),
+                        graph_error = :error
+                    WHERE workspace_id = :workspace_id
+                      AND connector_type = :connector_type
+                      AND source_id = ANY(:source_ids)
+                """),
+                {
+                    "workspace_id": workspace_id,
+                    "connector_type": connector_type,
+                    "source_ids": source_ids,
+                    "error": error[:1000],
+                },
+            )
+
+    async def count_graph_failed(self, workspace_id: str) -> int:
+        """Number of documents parked as graph_failed in a workspace."""
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT count(*) FROM raw_documents WHERE workspace_id = :ws AND graph_failed"
+                ),
+                {"ws": workspace_id},
+            )
+            return int(result.scalar() or 0)
+
+    async def reset_graph_failed(self, workspace_id: str) -> int:
+        """Re-arm graph_failed documents for retry (back into the unsynced backlog).
+
+        Returns the number of documents re-armed.
+        """
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    UPDATE raw_documents
+                    SET graph_failed = false,
+                        graph_failed_at = NULL,
+                        graph_error = NULL
+                    WHERE workspace_id = :ws AND graph_failed
+                """),
+                {"ws": workspace_id},
+            )
+            return result.rowcount
+
+    async def reset_all_graph(self, workspace_id: str) -> int:
+        """Re-extract the whole workspace graph: clear graph_synced AND graph_failed.
+
+        Returns the number of documents reset. Existing Neo4j nodes are merged
+        (idempotent) on re-extraction; this does not clear the graph store.
+        """
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                text("""
+                    UPDATE raw_documents
+                    SET graph_synced = false,
+                        graph_synced_at = NULL,
+                        graph_failed = false,
+                        graph_failed_at = NULL,
+                        graph_error = NULL
+                    WHERE workspace_id = :ws
+                """),
+                {"ws": workspace_id},
+            )
+            return result.rowcount
 
     async def get_raw_document(
         self,

--- a/tests/installer/test_failgen.sh
+++ b/tests/installer/test_failgen.sh
@@ -9,7 +9,7 @@ chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else ec
 run_case() {
   local override="$1"; shift
   local dir; dir="$(mktemp -d)"
-  printf 'LLM_PROVIDER=ollama\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\n' > "$dir/.env.example"
+  printf 'LLM_PROVIDER=ollama\nOLLAMA_LLM_MODEL=qwen2.5:3b\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\n' > "$dir/.env.example"
   cat > "$dir/run.sh" <<EOF
 source "$INSTALL"
 check_prereqs() { :; }

--- a/tests/installer/test_install.sh
+++ b/tests/installer/test_install.sh
@@ -10,7 +10,7 @@ chk() { if [[ "$2" == "$3" ]]; then echo "  PASS: $1"; PASS=$((PASS+1)); else ec
 # parse_args + configure are exercised. launch() echoes state for assertions.
 run_case() {
   local dir; dir="$(mktemp -d)"
-  printf 'LLM_PROVIDER=ollama\nLLM_PROVIDER_URL=\nLLM_PROVIDER_API_KEY=\nLLM_PROVIDER_MODEL=\nOLLAMA_CHAT_MODEL=\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\nMETRONIX_SECRET_KEY=develop-secret-key-change-in-prod\nNEO4J_AUTH=\n' > "$dir/.env.example"
+  printf 'LLM_PROVIDER=ollama\nLLM_PROVIDER_URL=\nLLM_PROVIDER_API_KEY=\nLLM_PROVIDER_MODEL=\nOLLAMA_LLM_MODEL=qwen2.5:3b\nPOSTGRES_PASSWORD=changeme\nNEO4J_PASSWORD=changeme\nMETRONIX_MCP_API_KEY=changeme\nFERNET_KEY=changeme\nMETRONIX_SECRET_KEY=develop-secret-key-change-in-prod\nNEO4J_AUTH=\n' > "$dir/.env.example"
   cat > "$dir/run.sh" <<EOF
 source "$INSTALL"
 check_prereqs() { :; }
@@ -31,7 +31,7 @@ run_case -y
 chk "exit zero" "$LAST_RC" "0"
 chk "launched" "$(launched)" "yes"
 chk "LLM_PROVIDER=ollama" "$(envval LLM_PROVIDER)" "ollama"
-chk "OLLAMA_CHAT_MODEL empty" "$(envval OLLAMA_CHAT_MODEL)" ""
+chk "OLLAMA_LLM_MODEL default kept" "$(envval OLLAMA_LLM_MODEL)" "qwen2.5:3b"
 chk "no leftover staging" "$(ls "$LAST_DIR"/.env.?????? 2>/dev/null | wc -l | tr -d ' ')" "0"
 
 echo "Case 2: answers via flags (url+model+key)"
@@ -42,7 +42,7 @@ chk "LLM_PROVIDER=custom" "$(envval LLM_PROVIDER)" "custom"
 chk "URL set" "$(envval LLM_PROVIDER_URL)" "https://api.deepseek.com/v1"
 chk "MODEL set" "$(envval LLM_PROVIDER_MODEL)" "deepseek-chat"
 chk "API key set" "$(envval LLM_PROVIDER_API_KEY)" "sk-xyz"
-chk "OLLAMA_CHAT_MODEL stays empty" "$(envval OLLAMA_CHAT_MODEL)" ""
+chk "OLLAMA_LLM_MODEL default kept" "$(envval OLLAMA_LLM_MODEL)" "qwen2.5:3b"
 
 echo "Case 3: --chat-url implies answers; no key = blank (optional)"
 run_case -y --chat-url http://host.docker.internal:11434/v1 --chat-model llama3.1:8b

--- a/tests/unit/core/test_default_ollama_model.py
+++ b/tests/unit/core/test_default_ollama_model.py
@@ -1,0 +1,20 @@
+"""Default local Ollama model is the small graph/NER model.
+
+Asserts on the declared field defaults (env-independent) — the repo `.env`
+may override the runtime value, but the code default is what we ship.
+"""
+
+from metronix.core.config import Settings
+
+
+def test_default_ollama_llm_model_is_qwen() -> None:
+    assert Settings.model_fields["ollama_llm_model"].default == "qwen2.5:3b"
+
+
+def test_default_freshness_model_is_qwen() -> None:
+    assert Settings.model_fields["freshness_llm_model"].default == "qwen2.5:3b"
+
+
+def test_ollama_chat_model_field_removed() -> None:
+    # The redundant pull-only variable is gone.
+    assert "ollama_chat_model" not in Settings.model_fields

--- a/tests/unit/core/test_model_for_provider.py
+++ b/tests/unit/core/test_model_for_provider.py
@@ -1,0 +1,18 @@
+"""Settings.model_for_provider() — provider -> model-name resolution."""
+
+from metronix.core.config import Settings
+
+
+def test_ollama_maps_to_ollama_llm_model() -> None:
+    s = Settings(LLM_PROVIDER="ollama", OLLAMA_LLM_MODEL="qwen2.5:3b")
+    assert s.model_for_provider("ollama") == "qwen2.5:3b"
+
+
+def test_deepseek_maps_to_deepseek_model() -> None:
+    s = Settings(DEEPSEEK_MODEL="deepseek-chat")
+    assert s.model_for_provider("deepseek") == "deepseek-chat"
+
+
+def test_unknown_provider_returns_empty_string() -> None:
+    s = Settings()
+    assert s.model_for_provider("nope") == ""

--- a/tests/unit/mcp/tools/test_memory_review_list.py
+++ b/tests/unit/mcp/tools/test_memory_review_list.py
@@ -95,10 +95,10 @@ class TestMemoryReviewList:
 
             await metronix_memory_review_list()
 
-        # Factory called with "default".
-        patched.call_args.args[0] if patched.call_args.args else None
-        # Simpler: assert service.list_review_entries's first positional arg.
-        assert service.list_review_entries.await_args.args[0] == "default"
+        # An omitted workspace resolves to the server default, not literal "default".
+        from metronix.mcp.config import get_default_workspace_id
+
+        assert service.list_review_entries.await_args.args[0] == get_default_workspace_id()
 
     async def test_service_failure_wrapped_in_internal_error(self) -> None:
         service = AsyncMock()

--- a/tests/unit/mcp/tools/test_memory_review_list.py
+++ b/tests/unit/mcp/tools/test_memory_review_list.py
@@ -88,7 +88,7 @@ class TestMemoryReviewList:
         service = AsyncMock()
         service.list_review_entries = AsyncMock(return_value=([], 0))
 
-        with _patch_service(service) as patched:
+        with _patch_service(service):
             from metronix.mcp.tools.memory_review_list import (
                 metronix_memory_review_list,
             )

--- a/tests/unit/test_graph_extraction_failure.py
+++ b/tests/unit/test_graph_extraction_failure.py
@@ -1,0 +1,41 @@
+"""extract_graph_from_text: configurable NER timeout + raise-on-hard-failure.
+
+A hard LLM failure (timeout / connection / 5xx) must propagate as an exception
+so callers leave the document graph_synced=false and the sweep retries it —
+rather than silently returning empty entities and marking the doc done, which
+produced an empty knowledge graph for a sync that otherwise looked successful.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import metronix.storage.neo4j_graph as ng
+from metronix.core.config import get_settings
+
+
+def test_passes_configured_timeout_to_llm(monkeypatch):
+    captured: dict = {}
+
+    def _fake_chat_completion(*args, **kwargs):
+        captured.update(kwargs)
+        return '{"entities": [], "relationships": []}'
+
+    monkeypatch.setattr(ng, "chat_completion", _fake_chat_completion)
+
+    ng.extract_graph_from_text("Some document text about Qdrant and Neo4j.")
+
+    assert captured["timeout"] == get_settings().graph_extraction_llm_timeout
+
+
+def test_raises_on_hard_llm_failure(monkeypatch):
+    # Never sleep between retries (keep the test fast).
+    monkeypatch.setattr(ng.time, "sleep", lambda *_: None)
+
+    def _always_fails(*args, **kwargs):
+        raise RuntimeError("Ollama error: 500 Server Error")
+
+    monkeypatch.setattr(ng, "chat_completion", _always_fails)
+
+    with pytest.raises(RuntimeError, match="500 Server Error"):
+        ng.extract_graph_from_text("Some document text.")

--- a/tests/unit/test_graph_extraction_failure.py
+++ b/tests/unit/test_graph_extraction_failure.py
@@ -1,15 +1,17 @@
-"""extract_graph_from_text: configurable NER timeout + raise-on-hard-failure.
+"""Graph extraction failure handling: configurable timeout, typed give-up, parking.
 
-A hard LLM failure (timeout / connection / 5xx) must propagate as an exception
-so callers leave the document graph_synced=false and the sweep retries it —
-rather than silently returning empty entities and marking the doc done, which
-produced an empty knowledge graph for a sync that otherwise looked successful.
+A hard LLM failure (timeout / connection / 5xx) raises GraphExtractionError so
+callers park the document as graph_failed (terminal) instead of silently
+returning empty entities or retrying it forever.
 """
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
+import metronix.ingestion.pipeline as pipeline
 import metronix.storage.neo4j_graph as ng
 from metronix.core.config import get_settings
 
@@ -28,8 +30,13 @@ def test_passes_configured_timeout_to_llm(monkeypatch):
     assert captured["timeout"] == get_settings().graph_extraction_llm_timeout
 
 
-def test_raises_on_hard_llm_failure(monkeypatch):
-    # Never sleep between retries (keep the test fast).
+def test_default_timeout_is_300() -> None:
+    from metronix.core.config import Settings
+
+    assert Settings.model_fields["graph_extraction_llm_timeout"].default == 300
+
+
+def test_raises_graph_extraction_error_on_hard_failure(monkeypatch):
     monkeypatch.setattr(ng.time, "sleep", lambda *_: None)
 
     def _always_fails(*args, **kwargs):
@@ -37,5 +44,39 @@ def test_raises_on_hard_llm_failure(monkeypatch):
 
     monkeypatch.setattr(ng, "chat_completion", _always_fails)
 
-    with pytest.raises(RuntimeError, match="500 Server Error"):
+    with pytest.raises(ng.GraphExtractionError, match="500 Server Error"):
         ng.extract_graph_from_text("Some document text.")
+
+
+async def test_process_unsynced_graphs_parks_failed_doc(monkeypatch):
+    """A GraphExtractionError parks the doc as graph_failed and does NOT mark it synced."""
+    store = AsyncMock()
+    store.get_unsynced_documents = AsyncMock(
+        return_value=[
+            {
+                "connector_type": "confluence",
+                "source_id": "doc1",
+                "title": "T",
+                "content": "non-empty content",
+                "url": "",
+                "author": "",
+                "metadata": {},
+            }
+        ]
+    )
+    store.mark_documents_synced_by_source = AsyncMock()
+    store.mark_documents_graph_failed = AsyncMock()
+
+    monkeypatch.setattr(ng, "close_graph_driver", lambda: None)
+
+    def _raise_extraction_error(*args, **kwargs):
+        raise ng.GraphExtractionError("Ollama error: timeout")
+
+    monkeypatch.setattr(pipeline, "_write_graph_strict", _raise_extraction_error)
+
+    result = await pipeline.process_unsynced_graphs("MTRNIX", store, batch_size=10)
+
+    assert result["errors"] == 1
+    store.mark_documents_graph_failed.assert_awaited_once()
+    # The doc must NOT be marked graph_synced when extraction gave up.
+    store.mark_documents_synced_by_source.assert_not_awaited()

--- a/tests/unit/test_graph_sweep.py
+++ b/tests/unit/test_graph_sweep.py
@@ -15,11 +15,15 @@ from metronix.api.graph_sweep import GraphSweeper
 
 
 class _Store:
-    def __init__(self, workspaces: list[str]) -> None:
+    def __init__(self, workspaces: list[str], running: list[str] | None = None) -> None:
         self._workspaces = workspaces
+        self._running = running or []
 
     async def list_workspaces_with_unsynced_graphs(self) -> list[str]:
         return self._workspaces
+
+    async def list_workspaces_with_running_sync(self) -> list[str]:
+        return self._running
 
 
 async def test_tick_processes_each_unsynced_workspace_throttled(monkeypatch):
@@ -54,6 +58,22 @@ async def test_tick_noop_when_no_unsynced_workspaces(monkeypatch):
     await sweeper.tick()
 
     assert called["n"] == 0
+
+
+async def test_tick_skips_workspace_with_running_sync(monkeypatch):
+    processed: list[str] = []
+
+    async def _fake_process(workspace_id, store, max_rounds=10, recovery_delay=30):
+        processed.append(workspace_id)
+        return {"ok": 1, "errors": 0}
+
+    monkeypatch.setattr(pipeline_mod, "process_all_unsynced_graphs", _fake_process)
+
+    # WS1 has a sync running -> deferred; only WS2 is swept this tick.
+    sweeper = GraphSweeper(_Store(["WS1", "WS2"], running=["WS1"]), MagicMock())
+    await sweeper.tick()
+
+    assert processed == ["WS2"]
 
 
 async def test_tick_continues_past_a_failing_workspace(monkeypatch):

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -7,10 +7,12 @@ from pathlib import Path
 
 import pytest
 
+from metronix.core.config import get_settings
 from metronix.mcp.config import (
     MCPServerConfig,
     get_default_workspace_id,
     load_stdio_config,
+    resolve_workspace_id,
 )
 
 
@@ -62,10 +64,24 @@ class TestGetDefaultWorkspaceId:
         config_file.write_text(json.dumps({"workspace_id": "my-ws"}))
         assert get_default_workspace_id(config_file) == "my-ws"
 
-    def test_returns_default_when_missing(self, tmp_path: Path) -> None:
-        assert get_default_workspace_id(tmp_path / "nope.json") == "default"
+    def test_falls_back_to_server_default_when_missing(self, tmp_path: Path) -> None:
+        # Fallback is the server's configured default workspace, not a literal
+        # "default" — so MCP-ingested data lands where the REST API / UI look.
+        assert (
+            get_default_workspace_id(tmp_path / "nope.json") == get_settings().default_workspace_id
+        )
 
-    def test_returns_default_when_key_absent(self, tmp_path: Path) -> None:
+    def test_falls_back_to_server_default_when_key_absent(self, tmp_path: Path) -> None:
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({"other": "value"}))
-        assert get_default_workspace_id(config_file) == "default"
+        assert get_default_workspace_id(config_file) == get_settings().default_workspace_id
+
+
+class TestResolveWorkspaceId:
+    def test_explicit_workspace_wins(self) -> None:
+        assert resolve_workspace_id("ws-explicit") == "ws-explicit"
+
+    def test_none_or_empty_defers_to_default(self) -> None:
+        # None/empty must resolve to the configured default, never literal "default".
+        assert resolve_workspace_id(None) == get_default_workspace_id()
+        assert resolve_workspace_id("") == get_default_workspace_id()

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -209,7 +209,9 @@ class TestMemoryDelete:
         assert "error" not in out
         assert out["success"] is True
         assert out["found"] is True
-        service.delete.assert_awaited_once_with("default", "rec-42")
+        from metronix.mcp.config import get_default_workspace_id
+
+        service.delete.assert_awaited_once_with(get_default_workspace_id(), "rec-42")
 
     async def test_memory_delete_not_found(self) -> None:
         service = AsyncMock()

--- a/tests/unit/test_mcp_source_deps.py
+++ b/tests/unit/test_mcp_source_deps.py
@@ -1,5 +1,6 @@
 import pytest
 
+from metronix.mcp.config import get_default_workspace_id
 from metronix.mcp.tools import _source_deps
 
 
@@ -8,13 +9,14 @@ class _FakeSettings:
     fernet_key = "test-key"
 
 
-def test_resolve_defaults_workspace_to_literal_default(monkeypatch):
+def test_resolve_defaults_workspace_to_server_default(monkeypatch):
     monkeypatch.setattr(_source_deps, "get_settings", lambda: _FakeSettings())
     monkeypatch.setattr(_source_deps, "PostgresStore", lambda dsn: ("store", dsn))
     _source_deps._reset_cache_for_tests()
 
     ws_id, store, key = _source_deps.resolve(None)
-    assert ws_id == "default"
+    # An omitted workspace resolves to the server default, not a literal "default".
+    assert ws_id == get_default_workspace_id()
     assert key == "test-key"
 
 

--- a/tests/unit/test_query_rewrite.py
+++ b/tests/unit/test_query_rewrite.py
@@ -1,9 +1,34 @@
 """Query rewrite stage (PROJ-372 P2)."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from metronix.core.config import Settings
 from metronix.memory.query_rewrite import QueryRewriter, _needs_rewrite, last_user_message
+
+
+def test_factory_falls_back_to_main_provider_model() -> None:
+    # No dedicated freshness provider -> use main provider (ollama) + its model.
+    s = Settings(
+        LLM_PROVIDER="ollama",
+        OLLAMA_LLM_MODEL="qwen2.5:3b",
+        METRONIX_FRESHNESS_LLM_PROVIDER="",
+    )
+    rw = QueryRewriter(settings=s)
+    with patch("metronix.memory.query_rewrite.create_provider") as cp:
+        rw._default_provider_factory()
+    cp.assert_called_once_with(provider_name="ollama", model="qwen2.5:3b")
+
+
+def test_factory_uses_dedicated_freshness_provider() -> None:
+    s = Settings(
+        LLM_PROVIDER="ollama",
+        METRONIX_FRESHNESS_LLM_PROVIDER="custom",
+        METRONIX_FRESHNESS_LLM_MODEL="my-slm",
+    )
+    rw = QueryRewriter(settings=s)
+    with patch("metronix.memory.query_rewrite.create_provider") as cp:
+        rw._default_provider_factory()
+    cp.assert_called_once_with(provider_name="custom", model="my-slm")
 
 
 def test_last_user_message() -> None:


### PR DESCRIPTION
## Problem

On a default install the Knowledge Graph never builds — the dashboard shows
"No graph data available for this workspace" even though documents/chunks ingest fine.

Root cause: the bundled Ollama pulls only the embedding model. Graph entity
extraction (NER) calls the chat model `OLLAMA_LLM_MODEL` (default `llama3`),
which was never pulled → every `/api/chat` call 404s → **zero `:Entity` nodes** →
the `/api/v1/graph/overview` query (which selects only `:Entity`) returns empty.
The failure is silent (the extractor swallows the error and marks docs
`graph_synced=true`).

### Regression
Commit `56e981e` (#205) made the bundled Ollama "embeddings-only"
(`OLLAMA_CHAT_MODEL=""`), but `GRAPH_EXTRACTION_ENABLED=true` is on by default —
so memory mode promises a graph with no model to build it. Before #205 the
compose pulled `OLLAMA_CHAT_MODEL: llama3.1:8b` by default.

### Two-variable confusion
`OLLAMA_CHAT_MODEL` was pull-only (compose entrypoint), `OLLAMA_LLM_MODEL` is what
the app actually calls — different defaults, never agreed. This PR consolidates to
a single `OLLAMA_LLM_MODEL`.

## Changes

- **`docker-compose.full.yml`** — bundled Ollama now pulls `OLLAMA_LLM_MODEL`
  (default `qwen2.5:3b`) alongside the embedding model, always.
- **`core/config.py`** — `ollama_llm_model` default → `qwen2.5:3b`; removed the
  unused `ollama_chat_model` field; added `Settings.model_for_provider()` (single
  source of truth for provider→model mapping, reused in `retrieval/search.py`).
- **`.env.example`** — one `OLLAMA_LLM_MODEL=qwen2.5:3b` with docs; dropped `OLLAMA_CHAT_MODEL`.
- **`install.sh`** — no longer writes `OLLAMA_CHAT_MODEL`; informs the user the
  graph/local answers run on `qwen2.5:3b`. No new flags or prompts.
- **Freshness / query-rewrite coherence** — `query_rewrite` now falls back to the
  main provider's own model (not the freshness model name), so an all-local install
  no longer requests a non-pulled model; `freshness_llm_model` default → `qwen2.5:3b`
  (was the invalid Ollama tag `qwen2.5-4b-instruct-q4`).
- **Docs** — `install.md`, `README.md`, and two integration guides updated to note
  the default graph model and drop the retired `OLLAMA_CHAT_MODEL`.

## Tests

- New: `Settings.model_for_provider()`, default-model assertions, query-rewrite
  provider/model resolution (fallback vs dedicated freshness provider).
- Updated installer shell tests to assert `OLLAMA_LLM_MODEL` instead of the retired var.
- Green: targeted unit tests (22), search/retrieval subset (298), installer suites (41+13).
- The remaining full-suite failures (19 failed / 134 errors) are pre-existing and
  environment-bound (services not reachable from the host + a polluted local `.env`);
  confirmed identical on `develop`. None touch files changed here.

## Notes / follow-ups (not in this PR)
- A polluted local `.env` (inline comments leaking in as values for
  `LLM_PROVIDER_API_KEY`, `LLM_FALLBACK_PROVIDER`, `METRONIX_FRESHNESS_LLM_PROVIDER`)
  breaks several `Settings()`-based tests — worth a separate look.
- Recommended fast-follow: a startup/`/admin/status` health check that the configured
  `OLLAMA_LLM_MODEL` is reachable, so a missing model is loud rather than silently
  producing an empty graph.

## Backward compatibility
`OLLAMA_CHAT_MODEL` is removed; any pre-existing `.env` setting it has no effect.
Acceptable for the open-source release where installs are fresh.
