### PR TITLE
Added example files and example scenario to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="docs/metronix-banner.svg" alt="Metronix Memory" width="600">
-</p>
-
 **Open-source AI memory infrastructure.**  
 Hybrid RAG, durable agent memory, MCP tools, and local-model support.
 
@@ -72,9 +68,11 @@ L0  core/           Config, models, events, plugin interfaces
 Get a backend running in four steps. This is the shortest path; for the full guide
 (prerequisites, Open WebUI, ports, troubleshooting) see `[install.md](install.md)`.
 
-> **Requirements:** Docker with **≥6 GB RAM** (8 GB recommended) and ~15 GB free disk. The
-> default Docker Desktop allotment (~2 GB) is too small for the full stack plus the local
+> **Requirements:** Docker with **≥6 GB RAM** (8 GB recommended) and ~~15 GB free disk. The
+> default Docker Desktop allotment (~~2 GB) is too small for the full stack plus the local
 > graph model and will OOM-kill syncs — raise it under Settings → Resources → Memory.
+
+
 
 ### 1. Clone
 
@@ -138,8 +136,9 @@ curl http://localhost:8000/health
 A healthy backend exposes the REST API, the OpenAI-compatible API at `:8000/v1`, and the
 MCP endpoint at `:8000/mcp` (default on the host: `http://localhost:8000/mcp` — the
 `metronix-full-api` container, path `/mcp`; from Docker network: `http://metronix-core:8000/mcp`).
-If you have installed the KnowledgeBase-UI (e.g. http://localhost:3000), log in with your Metronix credentials.
+If you have installed the KnowledgeBase-UI (e.g. [http://localhost:3000](http://localhost:3000)), log in with your Metronix credentials.
 Default credentials:
+
 ```bash
 login: admin@metronix.local
 pass: metronix
@@ -152,53 +151,6 @@ WebUI, ports, and troubleshooting.
 - [connecting_to_agent.md](connecting_to_agent.md) — connect an agent over MCP and give it
 durable memory.
 - [prompts.md](prompts.md) — the agent setup prompts, ready to paste.
-
----
-
-
-
-## Connect An Agent
-
-After Metronix is running, connect your agent through MCP. See
-[connecting_to_agent.md](connecting_to_agent.md) for the full walkthrough, which offers two
-paths:
-
-- **Prompt-based** — paste the prompts from [prompts.md](prompts.md) into your agent and it
-configures itself. The fastest path.
-- **Manual** — register the MCP connection by hand, no LLM involved (memory policy and
-migration are done via the prompts).
-
-Either way you give the agent four values: the Metronix MCP URL, the MCP API key, an agent
-id, and a workspace id.
-
-Runtime-specific guides:
-
-- [docs/integrations/cursor.md](docs/integrations/cursor.md)
-- [docs/integrations/claude-desktop.md](docs/integrations/claude-desktop.md)
-- [docs/integrations/hermes.md](docs/integrations/hermes.md)
-- [docs/integrations/openwebui.md](docs/integrations/openwebui.md)
-- [docs/integrations/librechat.md](docs/integrations/librechat.md)
-- [docs/integrations/openclaw.md](docs/integrations/openclaw.md)
-
----
-
-## Web Console (KB Admin)
-
-The optional **KB Admin Console** is the open-source web UI for administering Metronix: add and
-sync **data connectors** (Jira, Confluence, GitHub, Google Drive, Notion, Slack), register
-**chat-bot channels** (Telegram, Discord, Slack), upload files, and watch service and database
-health. It is presentation-only — everything runs through the `metronix-core` REST API.
-
-It ships as an optional service behind the `kb` Docker Compose profile:
-
-```bash
-docker compose -f docker-compose.full.yml --profile kb up -d --build   # → http://localhost:3000
-```
-
-See [frontend/README.md](frontend/README.md) for development, build, and configuration details.
-
-> The full operational **Control Center** (agent registry, workflow builder, memory inspector,
-> FinOps) is a separate product and is not part of this repository.
 
 ---
 
@@ -227,6 +179,45 @@ After the backend is running, start with the generic MCP setup guide, then pick 
 - [n8n](docs/integrations/n8n.md)
 - [NanoClaw](docs/integrations/nanoclaw.md)
 - [NanoBot](docs/integrations/nanobot.md)
+
+---
+
+
+
+## Web Console (KB Admin)
+
+The optional **KB Admin Console** is the open-source web UI for administering Metronix: add and
+sync **data connectors** (Jira, Confluence, GitHub, Google Drive, Notion, Slack), register
+**chat-bot channels** (Telegram, Discord, Slack), upload files, and watch service and database
+health. It is presentation-only — everything runs through the `metronix-core` REST API.
+
+It ships as an optional service behind the `kb` Docker Compose profile:
+
+```bash
+docker compose -f docker-compose.full.yml --profile kb up -d --build   # → http://localhost:3000
+```
+
+See [frontend/README.md](frontend/README.md) for development, build, and configuration details.
+
+> The full operational **Control Center** (agent registry, workflow builder, memory inspector,
+> FinOps) is a separate product and is not part of this repository.
+
+---
+
+
+
+### Demo: ingest a sprint backlog and query it
+
+A quick end-to-end check that Metronix ingests attached files and answers from memory:
+
+1. **Connect an agent** to Metronix MCP (see [Connecting To An Agent](connecting_to_agent.md)).
+2. **Attach the sample sprint backlog** — [examples/tasks.multi-agent-demo.json](examples/tasks.multi-agent-demo.json) — and ask the agent to ingest it into Metronix (via the KB Admin upload UI, the upload API, or the agent's `metronix_`* memory tools).
+3. **Ask:**
+  > Based on metronix memory: What is the main focus tasks for the development team?
+
+The agent should answer from ingested knowledge — Sprint 14 (**Orchestration & Reliability**), with active work on the orchestrator release candidate, supervisor loop, agent messaging, shared memory compaction, observability, and two open blockers (LLM vendor contract and security sign-off).
+
+You can also upload the same file in the KB Admin Console (**Sources → Upload**) instead of attaching it in chat.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="docs/metronix-banner.svg" alt="Metronix Memory" width="600">
+</p>
+
 **Open-source AI memory infrastructure.**  
 Hybrid RAG, durable agent memory, MCP tools, and local-model support.
 
@@ -68,8 +72,8 @@ L0  core/           Config, models, events, plugin interfaces
 Get a backend running in four steps. This is the shortest path; for the full guide
 (prerequisites, Open WebUI, ports, troubleshooting) see `[install.md](install.md)`.
 
-> **Requirements:** Docker with **≥6 GB RAM** (8 GB recommended) and ~~15 GB free disk. The
-> default Docker Desktop allotment (~~2 GB) is too small for the full stack plus the local
+> **Requirements:** Docker with **≥6 GB RAM** (8 GB recommended) and ~15 GB free disk. The
+> default Docker Desktop allotment (~2 GB) is too small for the full stack plus the local
 > graph model and will OOM-kill syncs — raise it under Settings → Resources → Memory.
 
 

--- a/examples/tasks.multi-agent-demo.json
+++ b/examples/tasks.multi-agent-demo.json
@@ -1,0 +1,378 @@
+{
+  "project": "Hermes Multi-Agent Platform",
+  "sprint": "Sprint 14 — Orchestration & Reliability",
+  "generated": "2026-06-26",
+  "team": ["Alex", "Sophia", "Marcus", "Emma", "Liam", "Claire", "David", "Nora"],
+  "tasks": [
+    {
+      "id": "MAG-401",
+      "title": "Ship orchestrator v0.9 release candidate to staging",
+      "status": "in_progress",
+      "priority": "critical",
+      "assignee": "Alex",
+      "blocker": false,
+      "labels": ["orchestrator", "release", "sprint-14"],
+      "updated": "2026-06-26"
+    },
+    {
+      "id": "MAG-402",
+      "title": "Blocked: upstream LLM provider rate-limit contract not signed",
+      "status": "in_progress",
+      "priority": "critical",
+      "assignee": "Marcus",
+      "blocker": true,
+      "labels": ["blocker", "llm", "vendor"],
+      "updated": "2026-06-18"
+    },
+    {
+      "id": "MAG-403",
+      "title": "Implement supervisor loop with max-iteration guard",
+      "status": "in_progress",
+      "priority": "high",
+      "assignee": "Sophia",
+      "blocker": false,
+      "labels": ["orchestrator", "supervisor"],
+      "updated": "2026-06-25"
+    },
+    {
+      "id": "MAG-404",
+      "title": "Agent-to-agent message bus: retry and dead-letter queue",
+      "status": "in_progress",
+      "priority": "high",
+      "assignee": "Sophia",
+      "blocker": false,
+      "labels": ["messaging", "infra"],
+      "updated": "2026-06-10"
+    },
+    {
+      "id": "MAG-405",
+      "title": "Shared memory layer: vector store compaction job",
+      "status": "in_progress",
+      "priority": "high",
+      "assignee": "Emma",
+      "blocker": false,
+      "labels": ["memory", "rag"],
+      "updated": "2026-06-24"
+    },
+    {
+      "id": "MAG-406",
+      "title": "MCP tool registry: dynamic discovery and health checks",
+      "status": "in review",
+      "priority": "high",
+      "assignee": "Liam",
+      "blocker": false,
+      "labels": ["tools", "mcp"],
+      "updated": "2026-06-26"
+    },
+    {
+      "id": "MAG-407",
+      "title": "Distributed tracing for multi-agent runs (OpenTelemetry)",
+      "status": "in review",
+      "priority": "p1",
+      "assignee": "Claire",
+      "blocker": false,
+      "labels": ["observability", "tracing"],
+      "updated": "2026-06-25"
+    },
+    {
+      "id": "MAG-408",
+      "title": "Sandbox escape regression: pending security sign-off",
+      "status": "in_progress",
+      "priority": "urgent",
+      "assignee": "David",
+      "blocker": true,
+      "labels": ["blocker", "security", "risk"],
+      "updated": "2026-06-22"
+    },
+    {
+      "id": "MAG-409",
+      "title": "E2E harness: parallel agent swarm smoke tests",
+      "status": "in_progress",
+      "priority": "high",
+      "assignee": "Nora",
+      "blocker": false,
+      "labels": ["qa", "e2e"],
+      "updated": "2026-06-26"
+    },
+    {
+      "id": "MAG-410",
+      "title": "Prompt versioning and rollback for production agents",
+      "status": "in_progress",
+      "priority": "medium",
+      "assignee": "Marcus",
+      "blocker": false,
+      "labels": ["prompts", "ops"],
+      "updated": "2026-06-23"
+    },
+    {
+      "id": "MAG-411",
+      "title": "Cost attribution per agent and per tool invocation",
+      "status": "in_progress",
+      "priority": "p1",
+      "assignee": "Claire",
+      "blocker": false,
+      "labels": ["observability", "billing"],
+      "updated": "2026-06-12"
+    },
+    {
+      "id": "MAG-412",
+      "title": "Human-in-the-loop approval gate for destructive tools",
+      "status": "in review",
+      "priority": "high",
+      "assignee": "David",
+      "blocker": false,
+      "labels": ["security", "hitl"],
+      "updated": "2026-06-20"
+    },
+    {
+      "id": "MAG-413",
+      "title": "Delegate routing: capability-based agent selection",
+      "status": "in_progress",
+      "priority": "high",
+      "assignee": "Alex",
+      "blocker": false,
+      "labels": ["orchestrator", "routing"],
+      "updated": "2026-06-25"
+    },
+    {
+      "id": "MAG-414",
+      "title": "Context window budget allocator across sub-agents",
+      "status": "todo",
+      "priority": "medium",
+      "assignee": "Emma",
+      "blocker": false,
+      "labels": ["memory", "backlog"],
+      "updated": "2026-06-15"
+    },
+    {
+      "id": "MAG-415",
+      "title": "Conflict resolution when two agents edit shared state",
+      "status": "todo",
+      "priority": "medium",
+      "assignee": "Sophia",
+      "blocker": false,
+      "labels": ["orchestrator", "backlog"],
+      "updated": "2026-06-14"
+    },
+    {
+      "id": "MAG-416",
+      "title": "Agent persona templates library (researcher, coder, reviewer)",
+      "status": "todo",
+      "priority": "low",
+      "assignee": "Marcus",
+      "blocker": false,
+      "labels": ["prompts", "backlog"],
+      "updated": "2026-06-10"
+    },
+    {
+      "id": "MAG-417",
+      "title": "WebSocket gateway for real-time agent status streaming",
+      "status": "todo",
+      "priority": "medium",
+      "assignee": "Liam",
+      "blocker": false,
+      "labels": ["infra", "backlog"],
+      "updated": "2026-06-08"
+    },
+    {
+      "id": "MAG-418",
+      "title": "Evaluation benchmark suite for delegation accuracy",
+      "status": "todo",
+      "priority": "medium",
+      "assignee": "Nora",
+      "blocker": false,
+      "labels": ["qa", "eval", "backlog"],
+      "updated": "2026-06-05"
+    },
+    {
+      "id": "MAG-419",
+      "title": "Multi-tenant isolation for agent runtimes",
+      "status": "todo",
+      "priority": "high",
+      "assignee": "David",
+      "blocker": false,
+      "labels": ["security", "backlog"],
+      "updated": "2026-06-01"
+    },
+    {
+      "id": "MAG-420",
+      "title": "Persistent run state: checkpoint and resume after crash",
+      "status": "todo",
+      "priority": "high",
+      "assignee": "Sophia",
+      "blocker": false,
+      "labels": ["orchestrator", "backlog"],
+      "updated": "2026-05-28"
+    },
+    {
+      "id": "MAG-421",
+      "title": "Skill hot-reload without orchestrator restart",
+      "status": "todo",
+      "priority": "medium",
+      "assignee": "Liam",
+      "blocker": false,
+      "labels": ["tools", "backlog"],
+      "updated": "2026-05-25"
+    },
+    {
+      "id": "MAG-422",
+      "title": "Semantic cache for repeated tool calls",
+      "status": "todo",
+      "priority": "low",
+      "assignee": "Emma",
+      "blocker": false,
+      "labels": ["memory", "backlog"],
+      "updated": "2026-05-20"
+    },
+    {
+      "id": "MAG-423",
+      "title": "Grafana dashboard: agent latency and error budget",
+      "status": "todo",
+      "priority": "medium",
+      "assignee": "Claire",
+      "blocker": false,
+      "labels": ["observability", "backlog"],
+      "updated": "2026-05-18"
+    },
+    {
+      "id": "MAG-424",
+      "title": "Circuit breaker for failing sub-agent chains",
+      "status": "todo",
+      "priority": "high",
+      "assignee": "Alex",
+      "blocker": false,
+      "labels": ["orchestrator", "reliability", "backlog"],
+      "updated": "2026-05-15"
+    },
+    {
+      "id": "MAG-425",
+      "title": "A/B testing framework for orchestration strategies",
+      "status": "todo",
+      "priority": "low",
+      "assignee": "Nora",
+      "blocker": false,
+      "labels": ["qa", "experiments", "backlog"],
+      "updated": "2026-05-10"
+    },
+    {
+      "id": "MAG-426",
+      "title": "Document agent handoff protocol (ADRs 12–15)",
+      "status": "todo",
+      "priority": "low",
+      "assignee": "Alex",
+      "blocker": false,
+      "labels": ["docs", "backlog"],
+      "updated": "2026-05-05"
+    },
+    {
+      "id": "MAG-390",
+      "title": "Merge orchestrator config schema v2",
+      "status": "done",
+      "priority": "high",
+      "assignee": "Alex",
+      "blocker": false,
+      "labels": ["orchestrator", "sprint-13"],
+      "updated": "2026-06-24"
+    },
+    {
+      "id": "MAG-391",
+      "title": "Baseline latency benchmarks for 3-agent pipeline",
+      "status": "done",
+      "priority": "medium",
+      "assignee": "Claire",
+      "blocker": false,
+      "labels": ["observability", "sprint-13"],
+      "updated": "2026-06-23"
+    },
+    {
+      "id": "MAG-392",
+      "title": "MCP auth token rotation automation",
+      "status": "done",
+      "priority": "high",
+      "assignee": "Liam",
+      "blocker": false,
+      "labels": ["tools", "security", "sprint-13"],
+      "updated": "2026-06-22"
+    },
+    {
+      "id": "MAG-393",
+      "title": "Episodic memory TTL and eviction policy",
+      "status": "done",
+      "priority": "medium",
+      "assignee": "Emma",
+      "blocker": false,
+      "labels": ["memory", "sprint-13"],
+      "updated": "2026-06-21"
+    },
+    {
+      "id": "MAG-394",
+      "title": "Fix race condition in agent spawn queue",
+      "status": "done",
+      "priority": "critical",
+      "assignee": "Sophia",
+      "blocker": false,
+      "labels": ["orchestrator", "bugfix", "sprint-13"],
+      "updated": "2026-06-20"
+    },
+    {
+      "id": "MAG-395",
+      "title": "Red-team report: prompt injection in tool outputs",
+      "status": "done",
+      "priority": "urgent",
+      "assignee": "David",
+      "blocker": false,
+      "labels": ["security", "sprint-13"],
+      "updated": "2026-06-19"
+    },
+    {
+      "id": "MAG-396",
+      "title": "Regression suite for sub-agent timeout handling",
+      "status": "done",
+      "priority": "high",
+      "assignee": "Nora",
+      "blocker": false,
+      "labels": ["qa", "sprint-13"],
+      "updated": "2026-06-18"
+    },
+    {
+      "id": "MAG-397",
+      "title": "Fallback model routing when primary LLM is down",
+      "status": "done",
+      "priority": "high",
+      "assignee": "Marcus",
+      "blocker": false,
+      "labels": ["llm", "reliability", "sprint-13"],
+      "updated": "2026-06-17"
+    },
+    {
+      "id": "MAG-398",
+      "title": "Staging load test: 50 concurrent agent swarms",
+      "status": "done",
+      "priority": "p1",
+      "assignee": "Claire",
+      "blocker": false,
+      "labels": ["perf", "sprint-13"],
+      "updated": "2026-06-16"
+    },
+    {
+      "id": "MAG-399",
+      "title": "Sprint 13 retrospective action items closed",
+      "status": "done",
+      "priority": "low",
+      "assignee": "Alex",
+      "blocker": false,
+      "labels": ["process", "sprint-13"],
+      "updated": "2026-06-15"
+    },
+    {
+      "id": "MAG-400",
+      "title": "Dependency audit: LangGraph and MCP SDK versions",
+      "status": "done",
+      "priority": "medium",
+      "assignee": "Liam",
+      "blocker": false,
+      "labels": ["deps", "sprint-13"],
+      "updated": "2026-06-14"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a hands-on demo for verifying Metronix file ingestion and memory-backed Q&A:

- `examples/tasks.multi-agent-demo.json` — sample Sprint 14 backlog for a multi-agent platform (37 tasks, mix of in-progress, blockers, review, todo, and done items; international team names).
- README — new Demo: ingest a sprint backlog and query it section under Web Console (KB Admin): connect an agent, attach/upload the sample file, then ask *"Based on metronix memory: What is the main focus tasks for the development team?"*

Gives new users a concrete end-to-end path to validate ingest → search/memory without setting up external connectors.

## Related issue
N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [x] Documentation
- [ ] CI / tooling

## Checklist

- [x] ruff format and ruff check pass locally *(no Python changes)*
- [x] Tests added/updated and pytest passes (run with the service stack — see CONTRIBUTING.md) *(not applicable — docs + sample JSON only)*
- [x] Docs updated if behavior or config changed
- [x] Changes are workspace-scoped where applicable (no cross-workspace data access) *(sample data only; no runtime changes)*
