### PR TITLE
chore: retire the develop branch — point everything at main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   # Python dependencies (uv lockfile + pyproject).
   - package-ecosystem: "uv"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     # Paused during OSS launch: 0 stops new version-update PRs while still
@@ -23,7 +23,7 @@ updates:
   # GitHub Actions versions used in workflows.
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     # Paused during OSS launch (see note above). Restore to 5 to resume.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
   push:
-    branches: [ "develop", "main" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,11 +63,11 @@ Before adding any import, verify the layer belongs below your target.
 Fork → Branch → Code → Test → Lint → PR
 ```
 
-1. **Branch** from `develop`: `feature/description` or `fix/description`
+1. **Branch** from `main`: `feature/description` or `fix/description`
 2. **Code** following existing patterns. No new dependencies without discussion.
 3. **Test** — every PR must pass `make test` and add tests for new behavior.
 4. **Lint** — run `make lint` and `make typecheck` before pushing.
-5. **PR** — open against `develop`, describe what and why, reference any issues.
+5. **PR** — open against `main`, describe what and why, reference any issues.
 
 ## Good First Issues
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Get a backend running in four steps. This is the shortest path; for the full gui
 ### 1. Clone
 
 ```bash
-git clone -b develop https://github.com/mtrnix/metronix-memory.git
+git clone https://github.com/mtrnix/metronix-memory.git
 cd metronix-memory
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,7 @@ Security coverage applies to:
 
 | Version | Support |
 |---|---|
-| `develop` (latest) | ✅ Full support — security fixes land here first |
+| `main` (latest) | ✅ Full support — security fixes land here first |
 | Latest release tag | ✅ Security backports |
 | Older releases | ❌ Upgrade to latest |
 

--- a/install.md
+++ b/install.md
@@ -91,7 +91,7 @@ Docker Desktop / OrbStack / `colima start` (macOS).
 ## 2. Clone the repository
 
 ```bash
-git clone -b develop https://github.com/mtrnix/metronix-memory.git
+git clone https://github.com/mtrnix/metronix-memory.git
 cd metronix-memory
 ```
 

--- a/tests/unit/test_query_classifier.py
+++ b/tests/unit/test_query_classifier.py
@@ -78,8 +78,8 @@ class TestProfileWeights:
         assert set(QUERY_PROFILE_WEIGHTS[profile].keys()) == expected_keys
 
     def test_mixed_profile_weights(self) -> None:
-        """mixed (fallback) profile weights. NOTE (PROJ-397): these are the grid-searched
-        values committed on develop; they intentionally diverge from compute_signal_score()'s
+        """mixed (fallback) profile weights. NOTE (PROJ-397): these are the committed
+        grid-searched values; they intentionally diverge from compute_signal_score()'s
         own defaults. All profile weights — mixed included — are re-derived by the Phase 6
         grid-search re-run (S-grid); update here if that run changes them.
         """


### PR DESCRIPTION
Prep for consolidating onto a single long-lived branch (`main`). Updates every reference to `develop` so nothing breaks when the branch is deleted.

## Changes

- **README.md / install.md** — `git clone -b develop …` → plain `git clone …` (clones the default branch, now `main`). This is the one that would otherwise **break onboarding**: `-b develop` fails once the branch is gone.
- **.github/dependabot.yml** — `target-branch: "develop"` → `"main"` for both the `uv` and `github-actions` ecosystems (otherwise Dependabot targets a non-existent branch).
- **.github/workflows/lint.yml** — push trigger `[ "develop", "main" ]` → `[ "main" ]`.
- **CONTRIBUTING.md** — "Branch from `develop`" / "open PRs against `develop`" → `main`.
- **SECURITY.md** — supported-versions table row `develop (latest)` → `main (latest)`.

## Out of scope (intentionally left)

- The placeholder secret string `develop-secret-key-change-in-prod` (not a branch).
- A docker image tag `splade-service-develop` and a `seed/` URL pointing at the separate `metronixcore` repo — unrelated to this repo's branch.

## After this merges

Delete the `develop` branch. It's already fully merged into `main`, so no history is lost.