### PR TITLE
Claude code integration in install.sh script and documentation added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ docs/specs/
 
 # Installer-generated, per-deployment artifacts (contain the MCP API key)
 metronix-hermes-setup/
+metronix-claude-code-setup/
 metronix-agent-setup/
 
 # Data

--- a/connecting_to_agent.md
+++ b/connecting_to_agent.md
@@ -62,7 +62,7 @@ the concrete paths — use it alongside whichever path you choose below:
   `file`, `terminal`, and `code_execution` toolsets for prompt-based setup (enabled by
   default after Hermes *Full Setup*)
 - **Claude Code** — [`docs/integrations/claude-code.md`](docs/integrations/claude-code.md) —
-  auto-wireable via `./install.sh --wire-claude` (runs `claude mcp add`); has shell access,
+  auto-connectable via `./install.sh --connect-claude` (runs `claude mcp add`); has shell access,
   so prompt-based setup works directly
 - **Cursor** — [`docs/integrations/cursor.md`](docs/integrations/cursor.md)
 - **Claude Desktop** — [`docs/integrations/claude-desktop.md`](docs/integrations/claude-desktop.md)

--- a/connecting_to_agent.md
+++ b/connecting_to_agent.md
@@ -61,6 +61,9 @@ the concrete paths — use it alongside whichever path you choose below:
 - **Hermes** — [`docs/integrations/hermes.md`](docs/integrations/hermes.md) — requires
   `file`, `terminal`, and `code_execution` toolsets for prompt-based setup (enabled by
   default after Hermes *Full Setup*)
+- **Claude Code** — [`docs/integrations/claude-code.md`](docs/integrations/claude-code.md) —
+  auto-wireable via `./install.sh --wire-claude` (runs `claude mcp add`); has shell access,
+  so prompt-based setup works directly
 - **Cursor** — [`docs/integrations/cursor.md`](docs/integrations/cursor.md)
 - **Claude Desktop** — [`docs/integrations/claude-desktop.md`](docs/integrations/claude-desktop.md)
 - **LibreChat** — [`docs/integrations/librechat.md`](docs/integrations/librechat.md)
@@ -153,6 +156,7 @@ locations — confirm exact, version-specific paths in the
 |---|---|---|
 | **Cursor** | `~/.cursor/mcp.json` (global) or `<project>/.cursor/mcp.json` | `<project>/.cursor/rules/*.mdc` |
 | **Claude Desktop** | macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`; Windows: `%APPDATA%\Claude\claude_desktop_config.json` | No per-turn system file — use your own long-lived instruction store |
+| **Claude Code** | `~/.claude.json` (`--scope user`, default) or `<project>/.mcp.json` (`--scope project`/`local`); managed via `claude mcp add` | `~/.claude/CLAUDE.md` (user scope) or `<project>/CLAUDE.md` (project/local scope) |
 | **Hermes** | `~/.hermes/config.yaml` (YAML) | `~/.hermes/SOUL.md` (or `/root/.hermes/SOUL.md` when running as root) |
 | **LibreChat** | `librechat.yaml` (`mcpServers:`) | Agent / custom instructions |
 | **OpenClaw** | see [`docs/integrations/openclaw.md`](docs/integrations/openclaw.md) | see its guide |

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -26,8 +26,8 @@ X-Agent-Id:     <stable-claude-code-agent-id>
 
 ### Automatic (installer)
 
-`./install.sh --wire-claude` (interactive, offered at the end of a normal
-install) or `./install.sh --wire-claude -y` (non-interactive, requires an
+`./install.sh --connect-claude` (interactive, offered at the end of a normal
+install) or `./install.sh --connect-claude -y` (non-interactive, requires an
 existing `.env`) runs `claude mcp add` for you. If the `claude` CLI isn't on
 PATH, it falls back to a validated, backed-up edit of `~/.claude.json` via
 `jq`. Either way, if it can't safely apply the change it writes ready-to-paste

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -2,7 +2,10 @@
 
 ## Recommended mode
 
-Use Metronix Memory through MCP.
+Use Metronix Memory through MCP, registered with the `claude` CLI's built-in
+`claude mcp add` command. Claude Code manages its own MCP config
+(`~/.claude.json`, or `.mcp.json` for project/local scope) — there is no file
+you need to hand-edit in the common case.
 
 ## What you need
 
@@ -21,14 +24,65 @@ X-Agent-Id:     <stable-claude-code-agent-id>
 
 ## Setup
 
-Add Metronix Memory as an MCP server in Claude Code using the values above.
+### Automatic (installer)
 
-Claude Code's exact config surface may vary by version, but the required Metronix Memory side is
-simple and stable: MCP URL plus the two headers.
+`./install.sh --wire-claude` (interactive, offered at the end of a normal
+install) or `./install.sh --wire-claude -y` (non-interactive, requires an
+existing `.env`) runs `claude mcp add` for you. If the `claude` CLI isn't on
+PATH, it falls back to a validated, backed-up edit of `~/.claude.json` via
+`jq`. Either way, if it can't safely apply the change it writes ready-to-paste
+prompts to `metronix-claude-code-setup/` instead of touching your files.
 
-If Claude Code supports agent-assisted MCP setup, use the prompt from:
+### By hand
 
-- [`../../connecting_to_agent.md`](../../connecting_to_agent.md)
+```bash
+claude mcp add --transport http --scope user metronix \
+  http://localhost:8000/mcp \
+  --header "Authorization: Bearer <METRONIX_MCP_API_KEY>" \
+  --header "X-Agent-Id: <stable-claude-code-agent-id>"
+```
+
+`--scope` controls where the server is registered:
+
+| Scope | Where it's stored | Use when |
+|---|---|---|
+| `user` (recommended) | `~/.claude.json`, top-level | You want Metronix available in every project on this machine. |
+| `project` | `./.mcp.json`, typically committed to git | You want to share the MCP server with your team via the repo. **Puts the Bearer token in version control — avoid unless the endpoint is not sensitive, or use a secrets-injection workaround.** |
+| `local` | `~/.claude.json`, scoped to this project only | Private to you, this project only. |
+
+Run `claude mcp list` afterward to confirm `metronix` shows as connected.
+
+If the `claude` CLI is unavailable, add the entry to `~/.claude.json` directly
+(back it up first):
+
+```json
+{
+  "mcpServers": {
+    "metronix": {
+      "type": "http",
+      "url": "http://localhost:8000/mcp",
+      "headers": {
+        "Authorization": "Bearer <METRONIX_MCP_API_KEY>",
+        "X-Agent-Id": "<stable-claude-code-agent-id>"
+      }
+    }
+  }
+}
+```
+
+Merge this into the existing `mcpServers` object — don't overwrite unrelated
+keys (session history, project state, etc.) elsewhere in the file.
+
+### Agent-assisted setup
+
+Claude Code has shell access, so it can run the setup itself. Use the prompts
+in [`../../connecting_to_agent.md`](../../connecting_to_agent.md), or the
+filled versions the installer writes to `metronix-claude-code-setup/`. Prompt 1
+has Claude Code run `claude mcp add` (or edit `~/.claude.json` as a fallback);
+prompt 2 records the memory policy in `CLAUDE.md`.
+
+**Restart Claude Code** after registering the MCP server — it loads MCP
+servers only at startup.
 
 ## Verify
 
@@ -47,7 +101,12 @@ metronix_memory_list(workspace_id="MTRNIX", agent_id="<stable-claude-code-agent-
 
 **Authentication errors:** Confirm the `Authorization: Bearer <key>` header is set correctly. The key must match `METRONIX_MCP_API_KEY` in `.env`.
 
+**`claude mcp add` reports metronix already exists:** Remove it first with `claude mcp remove metronix`, or edit the entry directly in `~/.claude.json` / `.mcp.json`.
+
+**Running Claude Code in WSL2/Docker:** Use `host.docker.internal` instead of `localhost` in the MCP URL if Metronix runs on the Windows host.
+
 ## Recommendation
 
 Use one stable `X-Agent-Id` per long-lived Claude Code agent so memory history stays
-under a single identity.
+under a single identity. Prefer `--scope user` unless you specifically need to share the
+MCP registration with a team via git (`--scope project`).

--- a/docs/integrations/claude-code/prompt-1-install.md
+++ b/docs/integrations/claude-code/prompt-1-install.md
@@ -1,0 +1,83 @@
+# Metronix MCP — install as an MCP server
+You are a Claude Code instance with shell access. Run this ONCE per deployment.
+If `metronix` already exists in `claude mcp list` with the correct URL, just
+verify it and report — do not create a duplicate.
+
+## Parameters
+- METRONIX_URL = {{METRONIX_URL}}
+- METRONIX_MCP_API_KEY  = {{METRONIX_MCP_API_KEY}}
+- AGENT_UUID   = {{AGENT_UUID}}
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
+
+## 0. Check parameters first
+If any value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- METRONIX_URL — Metronix MCP endpoint URL: server URL + /mcp. If Claude Code runs in
+  WSL2/Docker and Metronix is on the Windows host, use host.docker.internal
+  instead of localhost. Example: http://host.docker.internal:8000/mcp
+- METRONIX_MCP_API_KEY — Bearer token for /mcp (server env var METRONIX_MCP_API_KEY; /mcp
+  returns HTTP 401 without it; ask the Metronix admin if you don't have it).
+  Example: the token from the Metronix deployment's .env
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can simply make one up, or create it via POST /api/v1/agents / the UI. You do NOT
+  create it. Example: a3c98413c3684a0992ac0e007b93f410
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Every metronix_* call (search/RAG and memory) needs it, which is why it is set
+  now. Example: MTRNIX
+Do NOT call POST /api/v1/agents (or otherwise hit the /api/v1/agents endpoint)
+yourself to create an agent or obtain AGENT_UUID — registering the agent and its id
+is the user's job, done out of band. If AGENT_UUID is missing, ask the user and
+wait; never self-register.
+Wait for the user's answers and fill them in before continuing.
+
+## 1. Register Metronix as an MCP server
+Run this yourself via your shell tool:
+
+    claude mcp add --transport http --scope user metronix {{METRONIX_URL}} \
+      --header "Authorization: Bearer {{METRONIX_MCP_API_KEY}}" \
+      --header "X-Agent-Id: {{AGENT_UUID}}"
+
+`--scope user` makes the server available in every project on this machine. If
+the user asks for project-only sharing instead, use `--scope project` (this
+writes `./.mcp.json`, which is typically committed to git — warn the user that
+this puts the Bearer token in version control before doing it) or
+`--scope local` (private, this project only).
+
+If the `claude` CLI is unavailable or the command fails, fall back to editing
+`~/.claude.json` directly: back it up first (copy to `~/.claude.json.bak-<timestamp>`),
+then ensure it contains:
+
+    {
+      "mcpServers": {
+        "metronix": {
+          "type": "http",
+          "url": "{{METRONIX_URL}}",
+          "headers": {
+            "Authorization": "Bearer {{METRONIX_MCP_API_KEY}}",
+            "X-Agent-Id": "{{AGENT_UUID}}"
+          }
+        }
+      }
+    }
+
+Merge this into the existing `mcpServers` object — do NOT overwrite unrelated
+keys elsewhere in the file (session history, project state, etc.). Validate the
+result is valid JSON before saving.
+
+The `Authorization: Bearer` header is REQUIRED — the /mcp endpoint validates
+METRONIX_MCP_API_KEY; without it every request is rejected with HTTP 401.
+The `X-Agent-Id` header is REQUIRED too — without it, server-side observability
+events for search and other no-agent_id-arg tools are dropped silently.
+
+## 2. Test, then restart
+Run `claude mcp list` from a shell to confirm `metronix` shows as connected. If
+it errors or shows disconnected, fix and retry before continuing.
+Then restart: Claude Code loads MCP servers only at startup, so the metronix_*
+tools become available only in the NEXT session. Exit and run `claude` again.
+
+## Report format
+- MCP registration: ok / changes made (method: CLI / manual JSON edit)
+- Scope used: user / project / local
+- claude mcp list: connected / disconnected (error)
+- Next step: restart the session, then run prompt 2 (memory source)

--- a/docs/integrations/claude-code/prompt-2-memory.md
+++ b/docs/integrations/claude-code/prompt-2-memory.md
@@ -1,0 +1,76 @@
+# Metronix MCP — primary & only memory source
+You are a Claude Code instance with the Metronix MCP server registered and
+active (run prompt 1 first, then restart). Run this ONCE.
+Prompt 1 left no memory-policy record; this prompt creates it with mandatory
+wording. If a `metronix-config` block already exists with the mandatory
+wording, just verify and report.
+
+## Parameters
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
+- AGENT_UUID   = {{AGENT_UUID}}
+
+## 0. Check parameters first
+If either value above is still a {{...}} placeholder or empty STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Example: MTRNIX
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
+Wait for the user's answers before continuing.
+
+## 1. Memory policy
+From now on, use Metronix memory as the durable knowledge store: all durable
+knowledge lives in Metronix, NOT in ad-hoc local notes.
+- The routing rule lives in `CLAUDE.md` (step 3 below writes it), which Claude
+  Code loads at the start of every session — so you go straight to Metronix
+  with no extra lookup hop.
+- Metronix memory is classified by `kind`:
+  - kind="fact" — durable factual statements ("user works at Acme")
+  - kind="preference" — user preferences ("respond in Russian"). Auto-injected
+    into prompts without retrieval — pin anything truly persistent here.
+  - kind="pinned" — explicit instructions the user marked must-not-vanish.
+
+## 2. Tools you have on Metronix
+Search/document (workspace_id only):
+`metronix_search_fast`, `metronix_get`, `metronix_store`,
+`metronix_status`, `metronix_sync`.
+Memory (workspace_id + agent_id BOTH required):
+`metronix_memory_store`, `metronix_memory_search`, `metronix_memory_get_context`,
+`metronix_memory_list`, `metronix_memory_update`, `metronix_memory_delete`,
+`metronix_memory_batch_store`, `metronix_memory_review_list`,
+`metronix_memory_review_resolve`. Run `/tools` for full schemas.
+ALWAYS pass workspace_id (and agent_id for memory tools) explicitly — defaults
+will not add them for you.
+
+## 3. Write the routing rule (CLAUDE.md)
+Pick the file that matches the scope prompt 1 registered the MCP server at:
+- `--scope user` → `~/.claude/CLAUDE.md` (create the file/dir if missing)
+- `--scope project` or `--scope local` → `./CLAUDE.md` in the project root
+
+Do NOT wipe or rewrite existing content in that file; just APPEND this block at
+the END, clearly delimited. If a `metronix-config` block is already there (e.g.
+from a previous run), update it in place instead of appending a second copy:
+
+    --- metronix-config ---
+    Durable memory lives in Metronix MCP. ALWAYS use the metronix_memory_*
+    tools for it, with workspace_id="{{DEFAULT_WORKSPACE_ID}}" and
+    agent_id="{{AGENT_UUID}}". Classify by kind:
+    fact (default) | preference (auto-injected) | pinned (must-not-vanish).
+    Do NOT use local scratch files or notes for new durable knowledge, and do
+    NOT silently fall back to them. If Metronix is unreachable, say so to the
+    user instead of storing durable knowledge locally.
+    --- end metronix-config ---
+
+## 4. Verify
+- `metronix_status(workspace_id="{{DEFAULT_WORKSPACE_ID}}")` — KB connectivity
+- `metronix_memory_list(workspace_id="{{DEFAULT_WORKSPACE_ID}}",
+  agent_id="{{AGENT_UUID}}", limit=5)` — memory channel reachable
+- confirm the `metronix-config` block in CLAUDE.md has the mandatory wording
+  AND that all pre-existing content in the file is still present and unchanged
+
+## Report format
+- CLAUDE.md: routing rule written/upgraded at <path>; existing content preserved
+- Verify: status ok, memory channel reachable
+- Next step: run prompt 3 if this agent has prior memory to migrate

--- a/docs/integrations/claude-code/prompt-3-migrate.md
+++ b/docs/integrations/claude-code/prompt-3-migrate.md
@@ -1,0 +1,91 @@
+# Memory consolidation into Metronix
+You are a Claude Code instance with the Metronix MCP server registered and
+active. Your task is to move ALL durable knowledge you currently hold into
+Metronix, so that Metronix becomes the single source of truth for long-lived
+memory. Run ONCE. Run this ONLY if you already hold durable memory (e.g. an
+auto-memory system, notes files, or a `MEMORY.md`).
+
+## Parameters
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
+- AGENT_UUID   = {{AGENT_UUID}}
+
+## 0. Check parameters first
+If either value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Example: MTRNIX
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
+Wait for the user's answers before continuing.
+
+## 1. Inventory every place you keep durable knowledge
+Before storing anything, build a complete list of where your durable memory
+currently lives. Do NOT stop at the first or most obvious location. Durable
+knowledge can be spread across many surfaces, in different forms. Consider, at
+minimum:
+  - any auto-memory system's files (e.g. `MEMORY.md` and its linked notes);
+  - any local notes, scratch files, or working documents you read from or write to;
+  - any external or shared knowledge store you have been treating as a source of
+    truth (a separate notes system, a shared knowledge base, a wiki, a document
+    collection, etc.);
+  - pinned or "always remember" instructions the user has given you;
+  - durable facts or preferences carried over from earlier sessions.
+
+The most common failure here is migrating only user-facing notes and leaving
+structured or external knowledge behind. Completeness of THIS inventory is the
+single most important step — err on the side of including a source rather than
+skipping it. List every source you found before moving on.
+
+Do NOT migrate or remove `CLAUDE.md` itself, or the durable-memory routing rule
+it contains — that is configuration, not knowledge, and must stay where it is.
+
+## 2. Classify each item by `kind`
+For every distinct piece of durable knowledge (skip empty entries, test/probe
+data, and anything tied to an already-finished task), decide its `kind`:
+  - kind="fact"       — a durable factual statement (default).
+  - kind="preference" — a user preference or behavioral rule (auto-injected into
+                        prompts; put anything that must always shape behavior here).
+  - kind="pinned"     — an explicit instruction the user marked must-not-vanish.
+
+## 3. Store everything into Metronix
+For each item, call:
+  metronix_memory_store(
+    workspace_id="{{DEFAULT_WORKSPACE_ID}}",
+    agent_id="{{AGENT_UUID}}",
+    content=<the knowledge, self-contained and readable on its own>,
+    scope="per_agent",
+    source_type="conversation",
+    kind=<fact|preference|pinned>,
+    importance_score=0.7,
+  )
+Use metronix_memory_batch_store when you have more than 5 items.
+Always pass BOTH workspace_id and agent_id — defaults will not add them for you.
+Do not create duplicates: if the same fact appears in more than one source,
+store it once.
+
+## 4. Retire the originals (carefully)
+After an item is confirmed stored in Metronix:
+  - For memory you own exclusively (your own auto-memory files, private
+    notes/scratch files): remove the migrated entry so there is one source of
+    truth and nothing drifts. (Do NOT remove `CLAUDE.md` or the routing rule
+    inside it — that is configuration, see step 1.)
+  - For shared or external sources you do NOT own exclusively (a shared
+    knowledge base, a team wiki): do NOT delete it. Leave it intact and just
+    note in your report that it has been mirrored into Metronix.
+From now on, write NEW durable knowledge to Metronix — not back into the old
+locations.
+
+## 5. Verify
+- metronix_memory_list(workspace_id="{{DEFAULT_WORKSPACE_ID}}",
+  agent_id="{{AGENT_UUID}}", limit=10) — your migrated entries are visible.
+Check that nothing you inventoried in step 1 was left un-migrated.
+
+## Report format
+  - Sources found: <list every memory surface you discovered in step 1>
+  - Migrated: N items (X fact / Y preference / Z pinned)
+  - Skipped: M items (and why — empty, test data, finished task, duplicate)
+  - Retired: which owned sources were cleared vs. which external/shared sources
+    were left intact and mirrored
+  - Verify: memory_list returned K entries — all inventoried sources accounted for

--- a/docs/integrations/claude-code/prompt-4-rollback.md
+++ b/docs/integrations/claude-code/prompt-4-rollback.md
@@ -1,0 +1,54 @@
+# Metronix MCP — roll back to the state after prompt 1
+You are a Claude Code instance with the Metronix MCP server registered and
+active. Run this to UNDO prompt 2: flip durable memory from mandatory back to
+optional, returning the agent to the state it was in right after prompt 1. The
+Metronix MCP server stays registered and nothing you stored in Metronix
+(including anything migrated in prompt 3) is touched — only the routing-rule
+wording is reverted (or removed). Run ONCE.
+
+## Parameters
+- DEFAULT_WORKSPACE_ID = {{DEFAULT_WORKSPACE_ID}}
+- AGENT_UUID           = {{AGENT_UUID}}
+
+## 0. Check parameters first
+If either value above is still a {{...}} placeholder or empty, STOP and try to find those values in .env
+If you couldn't find the values, ask the
+user for it before doing anything else — never guess. Show these hints:
+- DEFAULT_WORKSPACE_ID — workspace identifier (Workspaces UI, or GET /api/v1/workspaces).
+  Example: MTRNIX
+- AGENT_UUID — any stable unique id for this agent, provided by the user; the user
+  can make one up, or create it via POST /api/v1/agents / the UI. You do NOT create
+  it. Example: a3c98413c3684a0992ac0e007b93f410
+Wait for the user's answers before continuing.
+
+## 1. Downgrade or remove the routing rule (CLAUDE.md)
+Open the `CLAUDE.md` that prompt 2 edited (`~/.claude/CLAUDE.md` for a
+user-scope install, or `./CLAUDE.md` in the project root for project/local
+scope).
+
+Prompt 2 wrote a `metronix-config` block with the MANDATORY wording. Find that
+block and REPLACE its body with the OPTIONAL rule below, leaving everything
+else in the file intact. If the block isn't there, there is nothing to revert:
+
+    --- metronix-config ---
+    Metronix MCP is available. workspace_id="{{DEFAULT_WORKSPACE_ID}}",
+    agent_id="{{AGENT_UUID}}". You MAY use the metronix_* tools — knowledge search /
+    RAG and memory. Using Metronix for durable memory is OPTIONAL at this stage;
+    it is not yet your required store.
+    --- end metronix-config ---
+
+This reverts ONLY what prompt 2 changed (the routing-rule wording). It does NOT
+remove the Metronix MCP server (that was prompt 1) and does NOT delete or move any
+memory already stored in Metronix, including anything migrated in prompt 3 — that
+data stays exactly where it is.
+
+## 2. Verify
+- confirm the `metronix-config` block now has the OPTIONAL wording and that all
+  pre-existing content in CLAUDE.md is still present and unchanged
+- `metronix_status(workspace_id="{{DEFAULT_WORKSPACE_ID}}")` still works — the MCP
+  server is left in place
+
+## Report format
+- Routing rule: downgraded to optional (prompt 2 reverted)
+- Left intact: Metronix MCP server registration, all stored/migrated memory
+- Next step: re-run prompt 2 to make Metronix mandatory again, if desired

--- a/install.md
+++ b/install.md
@@ -22,7 +22,7 @@ Common flags (see `./install.sh --help` for the full list):
 | `--openwebui`                                  | Enable Open WebUI (`:3080`); only applies in **answers** mode                 |
 | `--kb`                                         | Install the KB Admin Console web UI (`:3000`); works in **any** mode          |
 | `--wire-hermes`                                | Connect Hermes after install (or `./install.sh --wire-hermes -y` alone)       |
-| `--wire-claude`                                | Connect Claude Code after install (or `./install.sh --wire-claude -y` alone)  |
+| `--connect-claude`                             | Connect Claude Code after install (or `./install.sh --connect-claude -y` alone) |
 | `--agent-id`, `--metronix-url`                 | Override agent id / MCP URL written into the agent config                     |
 | `--reconfigure`                                | Re-run `.env` setup even if `.env` already exists                             |
 | `--fresh-docker-reset`                         | Delete Metronix containers, images, volumes, and build cache before reinstall |
@@ -297,7 +297,7 @@ interactively, or force one with a flag:
   guide for any other client.
 - `./install.sh --wire-hermes -y` — apply Hermes MCP wiring without prompting (requires
   existing `.env`).
-- `./install.sh --wire-claude -y` — apply Claude Code MCP wiring without prompting, at
+- `./install.sh --connect-claude -y` — apply Claude Code MCP wiring without prompting, at
   **user** scope by default (requires existing `.env`).
 - Either way, filled prompts land in `metronix-hermes-setup/` or `metronix-claude-code-setup/`
   (`1-install-mcp.md`, `2-memory-source.md`, `3-migrate.md`; gitignored). Paste prompts 2 and 3

--- a/install.md
+++ b/install.md
@@ -22,7 +22,8 @@ Common flags (see `./install.sh --help` for the full list):
 | `--openwebui`                                  | Enable Open WebUI (`:3080`); only applies in **answers** mode                 |
 | `--kb`                                         | Install the KB Admin Console web UI (`:3000`); works in **any** mode          |
 | `--wire-hermes`                                | Connect Hermes after install (or `./install.sh --wire-hermes -y` alone)       |
-| `--agent-id`, `--metronix-url`                 | Override agent id / MCP URL written into Hermes config                        |
+| `--wire-claude`                                | Connect Claude Code after install (or `./install.sh --wire-claude -y` alone)  |
+| `--agent-id`, `--metronix-url`                 | Override agent id / MCP URL written into the agent config                     |
 | `--reconfigure`                                | Re-run `.env` setup even if `.env` already exists                             |
 | `--fresh-docker-reset`                         | Delete Metronix containers, images, volumes, and build cache before reinstall |
 
@@ -288,13 +289,20 @@ and offers a menu instead of blindly overwriting config:
 | Reconfigure               | `--reconfigure` — rewrite `.env` from scratch                           |
 
 
-After a successful install the script may **wire Hermes**:
+After a successful install the script may **wire an agent** — pick Hermes or Claude Code
+interactively, or force one with a flag:
 
-- Interactive prompt: edit `~/.hermes/config.yaml` + `SOUL.md`, or write a paste-ready guide.
-- `./install.sh --wire-hermes -y` — apply MCP wiring without prompting (requires existing `.env`).
-- Either way, filled prompts land in `**metronix-hermes-setup/`** (`1-install-mcp.md`,
-`2-memory-source.md`, `3-migrate.md`; gitignored). Paste prompts 2 and 3 after restarting
-Hermes — see `[docs/integrations/hermes.md](docs/integrations/hermes.md)`.
+- Interactive prompt: choose Hermes (edit `~/.hermes/config.yaml` + `SOUL.md`) or Claude Code
+  (`claude mcp add`, or edit `~/.claude.json` if the CLI is missing), or write a paste-ready
+  guide for any other client.
+- `./install.sh --wire-hermes -y` — apply Hermes MCP wiring without prompting (requires
+  existing `.env`).
+- `./install.sh --wire-claude -y` — apply Claude Code MCP wiring without prompting, at
+  **user** scope by default (requires existing `.env`).
+- Either way, filled prompts land in `metronix-hermes-setup/` or `metronix-claude-code-setup/`
+  (`1-install-mcp.md`, `2-memory-source.md`, `3-migrate.md`; gitignored). Paste prompts 2 and 3
+  after restarting the agent — see `[docs/integrations/hermes.md](docs/integrations/hermes.md)`
+  or `[docs/integrations/claude-code.md](docs/integrations/claude-code.md)`.
 
 Manual install: use `[connecting_to_agent.md](connecting_to_agent.md)` instead of the script
 for agent setup.

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,8 @@ ASSUME_YES=false
 RECONFIGURE=false
 FRESH_DOCKER_RESET=false
 WIRE_HERMES=false    # run the Hermes wiring step (and, with -y, apply without prompt)
-AGENT_ID=""          # override the generated X-Agent-Id (Hermes wiring)
+WIRE_CLAUDE=false    # run the Claude Code wiring step (and, with -y, apply without prompt)
+AGENT_ID=""          # override the generated X-Agent-Id (Hermes/Claude Code wiring)
 METRONIX_URL=""      # override the MCP URL written into the agent config
 COMPOSE=()
 
@@ -101,6 +102,11 @@ Options:
   --wire-hermes            Connect the Hermes agent to Metronix (edit ~/.hermes
                            config); with -y, apply without prompting. Also offered
                            interactively at the end of a normal install.
+  --wire-claude            Connect Claude Code to Metronix (claude mcp add, or
+                           edit ~/.claude.json if the CLI is unavailable); with
+                           -y, apply without prompting (defaults to user scope).
+                           Also offered interactively at the end of a normal
+                           install.
   --agent-id <id>          Override the generated agent id (X-Agent-Id)
   --metronix-url <url>     MCP URL written into the agent config
                            (default http://localhost:8000/mcp)
@@ -136,6 +142,7 @@ parse_args() {
       --chat-model)   [[ $# -ge 2 ]] || { err "--chat-model requires a value"; exit 2; }; CHAT_MODEL="$2"; shift 2 ;;
       --chat-api-key) [[ $# -ge 2 ]] || { err "--chat-api-key requires a value"; exit 2; }; CHAT_API_KEY="$2"; shift 2 ;;
       --wire-hermes)   WIRE_HERMES=true; shift ;;
+      --wire-claude)   WIRE_CLAUDE=true; shift ;;
       --agent-id)      [[ $# -ge 2 ]] || { err "--agent-id requires a value"; exit 2; }; AGENT_ID="$2"; shift 2 ;;
       --metronix-url)  [[ $# -ge 2 ]] || { err "--metronix-url requires a value"; exit 2; }; METRONIX_URL="$2"; shift 2 ;;
       --openwebui)   ENABLE_WEBUI=true; shift ;;
@@ -231,22 +238,44 @@ gen_agent_id() {
   fi
 }
 
+# Best-effort read of the X-Agent-Id already registered for metronix in a Claude
+# Code ~/.claude.json. Uses jq if available (host, else Docker); falls back to a
+# plain grep/sed scan of the raw JSON so a missing jq never blocks id resolution.
+claude_json_agent_id() {
+  local config="$1"
+  [[ -f "$config" ]] || return 0
+  if jq_available; then
+    jq_read "$config" '.mcpServers.metronix.headers["X-Agent-Id"] // ""' 2>/dev/null | tr -d '"'
+  else
+    grep -E '"X-Agent-Id"[[:space:]]*:' "$config" 2>/dev/null | head -1 \
+      | sed -E 's/.*"X-Agent-Id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/'
+  fi
+}
+
 # Resolve the agent id, in priority order:
 #   1. explicit --agent-id (operator override)
 #   2. the X-Agent-Id already in the live Hermes config (source of truth for the
 #      running agent — its memories are stored under this id)
-#   3. METRONIX_AGENT_ID persisted in .env (installer's durable record; survives a
-#      wiped/reset Hermes config so the agent keeps the same id, and thus the same
-#      memories, across re-runs)
-#   4. a freshly generated id
+#   3. the X-Agent-Id already in the live Claude Code config (~/.claude.json),
+#      same reasoning as step 2 for that runtime
+#   4. METRONIX_AGENT_ID persisted in .env (installer's durable record; survives a
+#      wiped/reset Hermes/Claude Code config so the agent keeps the same id, and
+#      thus the same memories, across re-runs)
+#   5. a freshly generated id
 # The backend never reads an agent id from env — it comes from the X-Agent-Id
 # request header — so METRONIX_AGENT_ID is purely the installer's own anchor.
-# wire_hermes() persists the resolved value back to .env.
+# Hermes and Claude Code share this one anchor by default (same human, same
+# memory), unless --agent-id is used to separate them explicitly.
+# wire_hermes() / wire_claude_code() persist the resolved value back to .env.
 resolve_agent_id() {
-  local config="$1" existing persisted
+  local config="$1" claude_config="$2" existing persisted
   if [[ -n "$AGENT_ID" ]]; then printf '%s' "$AGENT_ID"; return 0; fi
   if [[ -f "$config" ]]; then
     existing="$(grep -E '^[[:space:]]*X-Agent-Id:' "$config" 2>/dev/null | head -1 | sed -E 's/.*X-Agent-Id:[[:space:]]*//' | tr -d '"' | tr -d '[:space:]')"
+    if [[ -n "$existing" ]]; then printf '%s' "$existing"; return 0; fi
+  fi
+  if [[ -n "$claude_config" && -f "$claude_config" ]]; then
+    existing="$(claude_json_agent_id "$claude_config")"
     if [[ -n "$existing" ]]; then printf '%s' "$existing"; return 0; fi
   fi
   persisted="$(get_env METRONIX_AGENT_ID)"
@@ -317,6 +346,28 @@ write_hermes_prompt_dir() {
   fi
   ok "Wrote $found ready-to-paste Hermes prompt(s) to $dir/ (apply 1 -> 2 -> 3 in order; 4 is an optional rollback of 2)."
   info "Full Hermes setup guide: docs/integrations/hermes.md"
+}
+
+# Write the ready-to-paste Claude Code prompts (filled) into a directory. Same
+# shape as write_hermes_prompt_dir, sourced from docs/integrations/claude-code/.
+# Returns 0 (with a warning) if no templates were found (e.g. install.sh run
+# outside the repo) — never blocks the caller.
+write_claude_prompt_dir() {
+  local dir="$1" tdir="$REPO_ROOT/docs/integrations/claude-code" found=0 pair src out
+  mkdir -p "$dir"
+  for pair in "prompt-1-install.md:1-install-mcp.md" \
+              "prompt-2-memory.md:2-memory-source.md" \
+              "prompt-3-migrate.md:3-migrate.md" \
+              "prompt-4-rollback.md:4-rollback.md"; do
+    src="$tdir/${pair%%:*}"; out="$dir/${pair#*:}"
+    if [[ -f "$src" ]]; then fill_template "$src" "$out"; found=$((found + 1)); fi
+  done
+  if [[ "$found" -eq 0 ]]; then
+    warn "Prompt templates not found under $tdir — run the installer from the repo checkout."
+    return 0
+  fi
+  ok "Wrote $found ready-to-paste Claude Code prompt(s) to $dir/ (apply 1 -> 2 -> 3 in order; 4 is an optional rollback of 2)."
+  info "Claude Code setup guide: docs/integrations/claude-code.md"
 }
 
 # Write the ready-to-paste, runtime-agnostic setup prompts (filled with this
@@ -390,6 +441,40 @@ yq_read() {
   fi
 }
 
+# jq is the JSON equivalent of yq above, used ONLY for the Claude Code fallback
+# path (editing ~/.claude.json when the `claude` CLI is unavailable). Unlike the
+# Hermes YAML edit, JSON has no safe "insert a couple of lines" trick — the file
+# must be parsed and re-serialized — so jq (not a text patch) does the edit
+# itself in merge_claude_json below; it is still validated before being kept.
+# Same no-host-install guarantee as yq: fall back to a jq Docker image.
+jq_available()    { command -v jq >/dev/null 2>&1 || command -v docker >/dev/null 2>&1; }
+jq_needs_docker()  { ! command -v jq >/dev/null 2>&1; }
+
+# jq_read FILE EXPR — evaluate a read-only jq expression and print the result.
+jq_read() {
+  local file="$1" expr="$2"
+  if command -v jq >/dev/null 2>&1; then
+    jq -r "$expr" "$file"
+  else
+    local dir base; dir="$(cd "$(dirname "$file")" && pwd)"; base="$(basename "$file")"
+    docker run --rm --user "$(id -u):$(id -g)" -v "$dir:/work:ro" -w /work ghcr.io/jqlang/jq -r "$expr" "$base"
+  fi
+}
+
+# jq_write FILE EXPR [jq-args...] — evaluate a jq expression against FILE
+# (with any extra --arg/--argjson flags forwarded to jq) and print the
+# resulting JSON to stdout (caller redirects to a temp file). Never edits FILE
+# in place — same read-only-mount pattern as jq_read for the Docker path.
+jq_write() {
+  local file="$1" expr="$2"; shift 2
+  if command -v jq >/dev/null 2>&1; then
+    jq "$@" "$expr" "$file"
+  else
+    local dir base; dir="$(cd "$(dirname "$file")" && pwd)"; base="$(basename "$file")"
+    docker run --rm --user "$(id -u):$(id -g)" -v "$dir:/work:ro" -w /work ghcr.io/jqlang/jq "$@" "$expr" "$base"
+  fi
+}
+
 # Classify a config: "has_metronix" | "has_mcp" (mcp_servers but no metronix) | "none".
 # Uses mikefarah-yq-compatible boolean reads (no jq-style if/then/else).
 hermes_mcp_state() {
@@ -443,13 +528,13 @@ _backup_file() { [[ -f "$1" ]] && cp "$1" "$1.bak-$(date +%Y%m%d%H%M%S)"; }
 # wire_hermes path (--wire-hermes -y), which never goes through connect_agent.
 resolve_agent_connection() {
   [[ -n "${AGENT_CONN_RESOLVED:-}" ]] && return 0
-  local config="$HOME/.hermes/config.yaml"
+  local config="$HOME/.hermes/config.yaml" claude_config="$HOME/.claude.json"
   H_KEY="$(get_env METRONIX_MCP_API_KEY)"
   H_WS="$(get_env DEFAULT_WORKSPACE_ID)"; H_WS="${H_WS:-MTRNIX}"
   H_URL="${METRONIX_URL:-http://localhost:8000/mcp}"
-  H_AGENT="$(resolve_agent_id "$config")"
-  # Anchor the agent id in .env so re-runs reuse it even if the Hermes config is
-  # later reset — keeping the agent's memories under one stable id.
+  H_AGENT="$(resolve_agent_id "$config" "$claude_config")"
+  # Anchor the agent id in .env so re-runs reuse it even if the Hermes/Claude
+  # Code config is later reset — keeping the agent's memories under one stable id.
   [[ -f "$ENV_FILE" ]] && set_env METRONIX_AGENT_ID "$H_AGENT"
   AGENT_CONN_RESOLVED=1
 }
@@ -549,10 +634,150 @@ wire_hermes() {
   info "  $prompt_dir/ to make Metronix the mandatory memory store and migrate existing memory."
 }
 
-# Top-level agent-connection step. Picks the runtime, then routes: Hermes gets
-# the auto-edit/guide flow (wire_hermes); any other MCP client gets the filled,
-# runtime-agnostic setup prompts. The four connection values are identical for
-# every runtime, so print them up front.
+# --- Claude Code wiring -------------------------------------------------------
+# Claude Code, unlike Hermes, ships a first-party CLI (`claude mcp add`) that
+# manages ~/.claude.json for us — no hand-rolled minimal text edit needed in the
+# common case. We only fall back to editing ~/.claude.json ourselves (via jq)
+# when the CLI is missing or the add fails.
+
+# "Present" if the CLI is on PATH, or its config file/dir exists (a CLI-less
+# check covers an install whose binary isn't on this shell's PATH).
+claude_code_present() {
+  command -v claude >/dev/null 2>&1 && return 0
+  [[ -f "$HOME/.claude.json" || -d "$HOME/.claude" ]]
+}
+
+claude_cli_available() { command -v claude >/dev/null 2>&1; }
+
+# True (0) if a `metronix` MCP server is already registered, in either the CLI
+# view or (when the CLI is unavailable) the raw ~/.claude.json.
+claude_mcp_exists() {
+  if claude_cli_available; then
+    claude mcp get metronix >/dev/null 2>&1
+  elif [[ -f "$HOME/.claude.json" ]] && jq_available; then
+    [[ "$(jq_read "$HOME/.claude.json" '.mcpServers.metronix != null')" == "true" ]]
+  else
+    return 1
+  fi
+}
+
+# Register metronix via the official CLI. $1 = scope (user|project|local).
+register_via_cli() {
+  local scope="$1"
+  claude mcp add --transport http --scope "$scope" metronix "$H_URL" \
+    --header "Authorization: Bearer $H_KEY" \
+    --header "X-Agent-Id: $H_AGENT"
+}
+
+# Fallback used only when the CLI is absent or register_via_cli failed: add the
+# metronix entry to ~/.claude.json with jq (re-serializes the file; formatting
+# is not preserved, but the data is). Validates the result before committing,
+# and backs up the original first. Returns 1 if jq is unavailable or the
+# result doesn't validate — caller falls back to the prompt dir.
+register_via_json_edit() {
+  local config="$HOME/.claude.json" tmp
+  if ! jq_available; then
+    warn "Editing ~/.claude.json safely needs jq or Docker, and neither is available."
+    return 1
+  fi
+  if jq_needs_docker; then
+    info "Editing ~/.claude.json with jq via Docker (image ghcr.io/jqlang/jq, pulled once)."
+  fi
+  [[ -f "$config" ]] || printf '{}' > "$config"
+  tmp="$(mktemp "$HOME/.metronix-claude.XXXXXX")"
+  if ! jq_write "$config" \
+      '(.mcpServers = (.mcpServers // {})) | (.mcpServers.metronix = {type:"http", url:$u, headers:{"Authorization":("Bearer " + $k), "X-Agent-Id":$a}})' \
+      --arg u "$H_URL" --arg k "$H_KEY" --arg a "$H_AGENT" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"; return 1
+  fi
+  if [[ "$(jq_read "$tmp" '.mcpServers.metronix.url')" != "$H_URL" ]]; then
+    rm -f "$tmp"; return 1
+  fi
+  _backup_file "$config"
+  mv "$tmp" "$config"
+  return 0
+}
+
+wire_claude_code() {
+  local printed="${AGENT_CONN_RESOLVED:-}"
+  resolve_agent_connection
+
+  local prompt_dir="./metronix-claude-code-setup"
+
+  if [[ -z "$H_KEY" ]]; then
+    warn "No METRONIX_MCP_API_KEY in .env — cannot wire an agent without it."
+    write_claude_prompt_dir "$prompt_dir"; return 0
+  fi
+  if ! claude_code_present; then
+    info "Claude Code not found. Writing a setup guide to apply later."
+    write_claude_prompt_dir "$prompt_dir"; return 0
+  fi
+
+  info "Found Claude Code."
+  [[ -z "$printed" ]] && info "Metronix MCP URL: $H_URL   (use host.docker.internal if Claude Code runs in WSL2/Docker)"
+
+  if claude_mcp_exists; then
+    info "Metronix is already registered in Claude Code — leaving it unchanged."
+    write_claude_prompt_dir "$prompt_dir" || true
+    return 0
+  fi
+
+  # Which scope? Interactive: ask (default user). Non-interactive: always user,
+  # no override flag — --wire-claude just wires the common case unattended.
+  local scope=user
+  if [[ "$ASSUME_YES" == false ]]; then
+    info "Register Metronix at which Claude Code scope?"
+    info "  1) User    - available in every project on this machine   [default]"
+    info "  2) Project - written to ./.mcp.json, shared via git (put the API key in version control)"
+    info "  3) Local   - private to you, this project only"
+    read -rp "Choose 1, 2 or 3 [default: 1]: " ans || { err "Aborted (no input)."; exit 1; }
+    case "${ans:-1}" in
+      1|"") scope=user ;;
+      2)    scope=project; warn "Project scope writes the Bearer token into ./.mcp.json, which is typically committed to git." ;;
+      3)    scope=local ;;
+      *)    err "Invalid choice: $ans"; exit 1 ;;
+    esac
+  fi
+
+  local registered=false
+  if claude_cli_available; then
+    if register_via_cli "$scope"; then
+      registered=true
+    else
+      warn "claude mcp add failed — falling back to editing ~/.claude.json directly."
+    fi
+  fi
+  if [[ "$registered" == false ]]; then
+    if register_via_json_edit; then
+      registered=true
+    else
+      warn "Could not safely edit ~/.claude.json — writing a ready-to-paste guide instead so your file isn't touched."
+      write_claude_prompt_dir "$prompt_dir"; return 0
+    fi
+  fi
+
+  ok "Wired Metronix into Claude Code (agent_id=$H_AGENT, workspace=$H_WS, scope=$scope) — prompt 1 applied."
+
+  if claude_cli_available; then
+    info "Verifying with 'claude mcp list':"
+    if claude mcp list 2>/dev/null | grep -qi metronix; then
+      ok "metronix appears in 'claude mcp list'."
+    else
+      warn "metronix did not show up in 'claude mcp list' — restart Claude Code and check again."
+    fi
+  fi
+
+  # Always leave all filled prompts on disk so 2 (mandatory memory) and 3
+  # (migrate) are ready to paste; 1 is included for reference / re-runs.
+  write_claude_prompt_dir "$prompt_dir" || true
+  info "Restart Claude Code. Then paste prompts 2 and 3 from"
+  info "  $prompt_dir/ to make Metronix the mandatory memory store and migrate existing memory."
+}
+
+# Top-level agent-connection step. Picks the runtime, then routes: Hermes and
+# Claude Code get their auto-edit/guide flows; any other MCP client gets the
+# filled, runtime-agnostic setup prompts. The four connection values are
+# identical for every runtime, so print them up front.
 connect_agent() {
   resolve_agent_connection
 
@@ -566,18 +791,24 @@ connect_agent() {
   info "Setup walkthrough (auto and prompt-based paths): connecting_to_agent.md"
   info "Ready-to-paste prompts with the values above:    prompts.md"
 
-  # Non-interactive runs keep the existing behavior: go straight to the Hermes
-  # step (-y and --wire-hermes are handled inside wire_hermes).
-  if [[ "$ASSUME_YES" == true ]]; then wire_hermes; return 0; fi
+  # Non-interactive runs keep the existing behavior: --wire-claude picks Claude
+  # Code, otherwise go straight to the Hermes step (-y and --wire-hermes are
+  # handled inside wire_hermes; this preserves the historical default).
+  if [[ "$ASSUME_YES" == true ]]; then
+    if [[ "$WIRE_CLAUDE" == true ]]; then wire_claude_code; else wire_hermes; fi
+    return 0
+  fi
 
   info ""
   info "Which agent do you want to connect?"
   info "  1) Hermes - edit ~/.hermes for me, or generate paste-ready prompts   [default]"
-  info "  2) Another MCP client (Cursor, Claude Desktop/Code, Codex, ...) - generate paste-ready prompts"
-  read -rp "Choose 1 or 2 [default: 1]: " ans || { err "Aborted (no input)."; exit 1; }
+  info "  2) Claude Code - run 'claude mcp add' for me, or generate paste-ready prompts"
+  info "  3) Another MCP client (Cursor, Claude Desktop, Codex, ...) - generate paste-ready prompts"
+  read -rp "Choose 1, 2 or 3 [default: 1]: " ans || { err "Aborted (no input)."; exit 1; }
   case "${ans:-1}" in
     1|"") wire_hermes ;;
-    2)    write_generic_prompt_dir "./metronix-agent-setup" ;;
+    2)    wire_claude_code ;;
+    3)    write_generic_prompt_dir "./metronix-agent-setup" ;;
     *)    err "Invalid choice: $ans"; exit 1 ;;
   esac
 }
@@ -1182,6 +1413,11 @@ main() {
   if [[ "$WIRE_HERMES" == true && "$ASSUME_YES" == true ]]; then
     [[ -f "$ENV_FILE" ]] || { err "$ENV_FILE not found — run a full install first, or cd to the deployment dir."; exit 1; }
     wire_hermes
+    exit 0
+  fi
+  if [[ "$WIRE_CLAUDE" == true && "$ASSUME_YES" == true ]]; then
+    [[ -f "$ENV_FILE" ]] || { err "$ENV_FILE not found — run a full install first, or cd to the deployment dir."; exit 1; }
+    wire_claude_code
     exit 0
   fi
   check_prereqs

--- a/install.sh
+++ b/install.sh
@@ -685,6 +685,9 @@ register_via_json_edit() {
   fi
   [[ -f "$config" ]] || printf '{}' > "$config"
   tmp="$(mktemp "$HOME/.metronix-claude.XXXXXX")"
+  # $u/$k/$a below are jq variables (bound via --arg), not shell variables —
+  # the filter is deliberately single-quoted so the shell leaves them alone.
+  # shellcheck disable=SC2016
   if ! jq_write "$config" \
       '(.mcpServers = (.mcpServers // {})) | (.mcpServers.metronix = {type:"http", url:$u, headers:{"Authorization":("Bearer " + $k), "X-Agent-Id":$a}})' \
       --arg u "$H_URL" --arg k "$H_KEY" --arg a "$H_AGENT" > "$tmp" 2>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ ASSUME_YES=false
 RECONFIGURE=false
 FRESH_DOCKER_RESET=false
 WIRE_HERMES=false    # run the Hermes wiring step (and, with -y, apply without prompt)
-WIRE_CLAUDE=false    # run the Claude Code wiring step (and, with -y, apply without prompt)
+CONNECT_CLAUDE=false    # run the Claude Code connection step (and, with -y, apply without prompt)
 AGENT_ID=""          # override the generated X-Agent-Id (Hermes/Claude Code wiring)
 METRONIX_URL=""      # override the MCP URL written into the agent config
 COMPOSE=()
@@ -102,7 +102,7 @@ Options:
   --wire-hermes            Connect the Hermes agent to Metronix (edit ~/.hermes
                            config); with -y, apply without prompting. Also offered
                            interactively at the end of a normal install.
-  --wire-claude            Connect Claude Code to Metronix (claude mcp add, or
+  --connect-claude         Connect Claude Code to Metronix (claude mcp add, or
                            edit ~/.claude.json if the CLI is unavailable); with
                            -y, apply without prompting (defaults to user scope).
                            Also offered interactively at the end of a normal
@@ -142,7 +142,7 @@ parse_args() {
       --chat-model)   [[ $# -ge 2 ]] || { err "--chat-model requires a value"; exit 2; }; CHAT_MODEL="$2"; shift 2 ;;
       --chat-api-key) [[ $# -ge 2 ]] || { err "--chat-api-key requires a value"; exit 2; }; CHAT_API_KEY="$2"; shift 2 ;;
       --wire-hermes)   WIRE_HERMES=true; shift ;;
-      --wire-claude)   WIRE_CLAUDE=true; shift ;;
+      --connect-claude)   CONNECT_CLAUDE=true; shift ;;
       --agent-id)      [[ $# -ge 2 ]] || { err "--agent-id requires a value"; exit 2; }; AGENT_ID="$2"; shift 2 ;;
       --metronix-url)  [[ $# -ge 2 ]] || { err "--metronix-url requires a value"; exit 2; }; METRONIX_URL="$2"; shift 2 ;;
       --openwebui)   ENABLE_WEBUI=true; shift ;;
@@ -266,7 +266,7 @@ claude_json_agent_id() {
 # request header — so METRONIX_AGENT_ID is purely the installer's own anchor.
 # Hermes and Claude Code share this one anchor by default (same human, same
 # memory), unless --agent-id is used to separate them explicitly.
-# wire_hermes() / wire_claude_code() persist the resolved value back to .env.
+# wire_hermes() / connect_claude_code() persist the resolved value back to .env.
 resolve_agent_id() {
   local config="$1" claude_config="$2" existing persisted
   if [[ -n "$AGENT_ID" ]]; then printf '%s' "$AGENT_ID"; return 0; fi
@@ -701,7 +701,7 @@ register_via_json_edit() {
   return 0
 }
 
-wire_claude_code() {
+connect_claude_code() {
   local printed="${AGENT_CONN_RESOLVED:-}"
   resolve_agent_connection
 
@@ -726,7 +726,7 @@ wire_claude_code() {
   fi
 
   # Which scope? Interactive: ask (default user). Non-interactive: always user,
-  # no override flag — --wire-claude just wires the common case unattended.
+  # no override flag — --connect-claude just connects the common case unattended.
   local scope=user
   if [[ "$ASSUME_YES" == false ]]; then
     info "Register Metronix at which Claude Code scope?"
@@ -794,11 +794,11 @@ connect_agent() {
   info "Setup walkthrough (auto and prompt-based paths): connecting_to_agent.md"
   info "Ready-to-paste prompts with the values above:    prompts.md"
 
-  # Non-interactive runs keep the existing behavior: --wire-claude picks Claude
+  # Non-interactive runs keep the existing behavior: --connect-claude picks Claude
   # Code, otherwise go straight to the Hermes step (-y and --wire-hermes are
   # handled inside wire_hermes; this preserves the historical default).
   if [[ "$ASSUME_YES" == true ]]; then
-    if [[ "$WIRE_CLAUDE" == true ]]; then wire_claude_code; else wire_hermes; fi
+    if [[ "$CONNECT_CLAUDE" == true ]]; then connect_claude_code; else wire_hermes; fi
     return 0
   fi
 
@@ -810,7 +810,7 @@ connect_agent() {
   read -rp "Choose 1, 2 or 3 [default: 1]: " ans || { err "Aborted (no input)."; exit 1; }
   case "${ans:-1}" in
     1|"") wire_hermes ;;
-    2)    wire_claude_code ;;
+    2)    connect_claude_code ;;
     3)    write_generic_prompt_dir "./metronix-agent-setup" ;;
     *)    err "Invalid choice: $ans"; exit 1 ;;
   esac
@@ -1418,9 +1418,9 @@ main() {
     wire_hermes
     exit 0
   fi
-  if [[ "$WIRE_CLAUDE" == true && "$ASSUME_YES" == true ]]; then
+  if [[ "$CONNECT_CLAUDE" == true && "$ASSUME_YES" == true ]]; then
     [[ -f "$ENV_FILE" ]] || { err "$ENV_FILE not found — run a full install first, or cd to the deployment dir."; exit 1; }
-    wire_claude_code
+    connect_claude_code
     exit 0
   fi
   check_prereqs

--- a/prompts.md
+++ b/prompts.md
@@ -31,7 +31,7 @@ only at startup:
 
 > **Claude Code users:** Claude Code has shell access, so it can apply Prompt 1 itself —
 > it runs `claude mcp add` (or edits `~/.claude.json` as a fallback) instead of you doing it
-> by hand. `./install.sh --wire-claude` automates this same step outside the agent entirely.
+> by hand. `./install.sh --connect-claude` automates this same step outside the agent entirely.
 > See [`docs/integrations/claude-code.md`](docs/integrations/claude-code.md) and the
 > Claude-Code-specific prompt templates the installer fills into
 > `metronix-claude-code-setup/`.

--- a/prompts.md
+++ b/prompts.md
@@ -29,6 +29,13 @@ only at startup:
 - **Session 2:** run **Prompt 2**, then **Prompt 3** if the agent has prior memory to
   migrate. No restart needed between them.
 
+> **Claude Code users:** Claude Code has shell access, so it can apply Prompt 1 itself —
+> it runs `claude mcp add` (or edits `~/.claude.json` as a fallback) instead of you doing it
+> by hand. `./install.sh --wire-claude` automates this same step outside the agent entirely.
+> See [`docs/integrations/claude-code.md`](docs/integrations/claude-code.md) and the
+> Claude-Code-specific prompt templates the installer fills into
+> `metronix-claude-code-setup/`.
+
 ---
 
 ## Prompt 1 — Install Metronix as an MCP server


### PR DESCRIPTION
## Summary

Adds first-class **Claude Code** support to the Metronix installer and integration docs, mirroring the existing Hermes wiring flow.

**Installer (`install.sh`)**
- New `--connect-claude` flag (and interactive menu option 2) to register Metronix via `claude mcp add --transport http` at user/project/local scope
- Fallback when the CLI is missing or `mcp add` fails: safe `~/.claude.json` edit via `jq` (host or Docker), with backup and validation
- Writes filled, ready-to-paste prompts to `metronix-claude-code-setup/` when auto-wiring cannot run safely
- Extends `resolve_agent_id()` to reuse `X-Agent-Id` from `~/.claude.json` (shared anchor with Hermes via `METRONIX_AGENT_ID` in `.env`)
- Non-interactive `-y` behavior: `--connect-claude` selects Claude Code; otherwise Hermes remains the default

**Documentation**
- Expands `docs/integrations/claude-code.md` with automatic/manual setup, scope table, troubleshooting, and restart guidance
- Adds four Claude Code–specific prompt templates under `docs/integrations/claude-code/` (install, memory policy, migrate, rollback)
- Updates `connecting_to_agent.md`, `install.md`, and `prompts.md` to document the new path
- Gitignores `metronix-claude-code-setup/` (contains MCP API key)

No runtime/API behavior changes — docs and installer only.

## Related issue

https://github.com/mtrnix/metronix-memory/issues/186

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / internal change
- [x] Documentation
- [x] CI / tooling

## Checklist

- [x] `ruff format` and `ruff check` pass locally *(no Python files changed)*
- [x] Tests added/updated and `pytest` passes *(no test impact — shell/docs only)*
- [x] Docs updated if behavior or config changed
- [x] Changes are workspace-scoped where applicable (no cross-workspace data access)