### PR TITLE
Memory Inspector: surface fetch errors and no-workspace state instead of blank screen

### DIFF
--- a/frontend/src/components/memory/MemoryInspectorPage.tsx
+++ b/frontend/src/components/memory/MemoryInspectorPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { ConfirmDialog, useAuthStore } from '@/shared';
+import { ConfirmDialog, ErrorMessage, useAuthStore, useWorkspaceStore } from '@/shared';
 import {
   useMemoryRecords,
   useMemoryFacets,
@@ -22,9 +22,11 @@ export default function MemoryInspectorPage() {
   const role = useAuthStore((s) => s.role);
   const canDelete = role !== 'viewer';
 
-  const { data: facets } = useMemoryFacets();
-  const kindOptions = facets?.kinds ?? [];
-  const sourceTypeOptions = facets?.source_types ?? [];
+  const workspaceId = useWorkspaceStore((s) => s.active?.workspace_id);
+
+  const facetsQuery = useMemoryFacets();
+  const kindOptions = facetsQuery.data?.kinds ?? [];
+  const sourceTypeOptions = facetsQuery.data?.source_types ?? [];
 
   // Filter options only ever reflect records that currently exist in the
   // workspace — if the selected value's last matching record was deleted,
@@ -41,9 +43,12 @@ export default function MemoryInspectorPage() {
   const {
     data,
     isLoading,
+    isError,
+    error,
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    refetch,
   } = useMemoryRecords({
     kindFilter: effectiveKindFilter === 'all' ? [] : [effectiveKindFilter],
     sourceTypeFilter:
@@ -128,21 +133,42 @@ export default function MemoryInspectorPage() {
           onSourceTypeChange={resetSelectionAndFilter(setSourceTypeFilter)}
           sourceTypeOptions={sourceTypeOptions}
         />
+        {facetsQuery.isError && (
+          <ErrorMessage
+            className="mt-3"
+            message="Failed to load filter options for this workspace."
+            onRetry={() => facetsQuery.refetch()}
+          />
+        )}
       </div>
 
       <div className="flex flex-1 overflow-hidden">
         <div className="flex w-96 shrink-0 flex-col border-r border-border">
-          <MemoryList
-            records={records}
-            selectedIds={selectedIds}
-            activeId={activeId}
-            onToggleSelect={toggleSelect}
-            onSelect={setActiveId}
-            hasNextPage={!!hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            onLoadMore={fetchNextPage}
-            isLoading={isLoading}
-          />
+          {!workspaceId ? (
+            <div className="flex flex-1 items-center justify-center px-4 text-center text-sm text-text-muted">
+              Select a workspace to inspect its memory records.
+            </div>
+          ) : isError ? (
+            <ErrorMessage
+              className="m-4"
+              message={
+                error instanceof Error ? error.message : 'Failed to load memory records.'
+              }
+              onRetry={() => refetch()}
+            />
+          ) : (
+            <MemoryList
+              records={records}
+              selectedIds={selectedIds}
+              activeId={activeId}
+              onToggleSelect={toggleSelect}
+              onSelect={setActiveId}
+              hasNextPage={!!hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              onLoadMore={fetchNextPage}
+              isLoading={isLoading}
+            />
+          )}
         </div>
         <MemoryDetailPanel recordId={activeId} />
       </div>

--- a/src/metronix/api/routes/memory.py
+++ b/src/metronix/api/routes/memory.py
@@ -360,26 +360,38 @@ async def list_records(
             has_more=False,
         )
 
-    records, total = await asyncio.gather(
-        service.list_records(
-            workspace_id,
-            agent_id=agent_id,
-            scope=scope,
-            kind_filter=kind_filter,
-            source_type_filter=source_type_filter,
-            status=status_filter,
-            limit=limit,
-            offset=offset,
-        ),
-        service.count_records(
-            workspace_id,
-            agent_id=agent_id,
-            scope=scope,
-            kind_filter=kind_filter,
-            source_type_filter=source_type_filter,
-            status=status_filter,
-        ),
-    )
+    try:
+        records, total = await asyncio.gather(
+            service.list_records(
+                workspace_id,
+                agent_id=agent_id,
+                scope=scope,
+                kind_filter=kind_filter,
+                source_type_filter=source_type_filter,
+                status=status_filter,
+                limit=limit,
+                offset=offset,
+            ),
+            service.count_records(
+                workspace_id,
+                agent_id=agent_id,
+                scope=scope,
+                kind_filter=kind_filter,
+                source_type_filter=source_type_filter,
+                status=status_filter,
+            ),
+        )
+    except Exception as exc:
+        # #325: an unreachable/misconfigured Postgres or Qdrant backend for this
+        # workspace must surface as a clean 503, not an unhandled 500 that the
+        # Memory Inspector UI has no way to distinguish from "zero records".
+        logger.error(
+            "memory.list_records.backend_error", workspace_id=workspace_id, error=str(exc)
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Memory backend is temporarily unavailable for this workspace.",
+        ) from exc
     return MemoryRecordListResponse(
         records=[_record_to_response(r) for r in records],
         count=len(records),
@@ -402,7 +414,16 @@ async def get_memory_facets(
     matching records right now.
     """
     workspace_id = resolve_workspace_id(request)
-    kinds, source_types = await service.get_facets(workspace_id)
+    try:
+        kinds, source_types = await service.get_facets(workspace_id)
+    except Exception as exc:
+        # #325: same rationale as list_records — surface backend connectivity
+        # failures as a clean 503 instead of an unhandled 500.
+        logger.error("memory.get_facets.backend_error", workspace_id=workspace_id, error=str(exc))
+        raise HTTPException(
+            status_code=503,
+            detail="Memory backend is temporarily unavailable for this workspace.",
+        ) from exc
     return MemoryFacetsResponse(kinds=kinds, source_types=source_types)
 
 

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -387,6 +387,21 @@ class TestListRecords:
         _, kwargs = service.list_records.call_args
         assert kwargs["source_type_filter"] == ["confluence", "jira"]
 
+    def test_list_records_backend_error_503(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """#325: an unhandled backend exception (e.g. Postgres/Qdrant unreachable
+        for this workspace) surfaces as a clean 503, not an opaque 500 — the
+        Memory Inspector UI has no way to distinguish a 500 from "zero records"."""
+        service.list_records.side_effect = ConnectionRefusedError("connection refused")
+
+        response = client.get("/api/v1/memory/records")
+
+        assert response.status_code == 503
+        assert "unavailable" in response.json()["detail"].lower()
+
 
 # ---------------------------------------------------------------------------
 # GET /facets
@@ -430,6 +445,20 @@ class TestGetFacets:
         response = viewer_client.get("/api/v1/memory/facets")
 
         assert response.status_code == 200
+
+    def test_get_facets_backend_error_503(
+        self,
+        client: TestClient,
+        service: AsyncMock,
+    ) -> None:
+        """#325: same rationale as list_records — backend connectivity failures
+        surface as a clean 503 instead of an unhandled 500."""
+        service.get_facets.side_effect = ConnectionRefusedError("connection refused")
+
+        response = client.get("/api/v1/memory/facets")
+
+        assert response.status_code == 503
+        assert "unavailable" in response.json()["detail"].lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #325. `MemoryInspectorPage` discarded `isError`/`error` from `useMemoryRecords`/`useMemoryFacets`, so a failed request (e.g. an unreachable Postgres/Qdrant backend for the workspace) or no active workspace collapsed to the exact same "No memory records match the current filters." copy as a genuinely empty workspace — no visible indication anything had failed.

## What changed

### Frontend (`frontend/src/components/memory/MemoryInspectorPage.tsx`)
- Reads `isError`/`error`/`refetch` from `useMemoryRecords` and renders an `ErrorMessage` banner with a **Retry** button on failure, instead of silently falling through to the empty-list copy.
- Same treatment for `useMemoryFacets` — a failed facets fetch now shows its own inline error banner near the filter bar (filter dropdowns still degrade gracefully to empty options).
- Added an explicit "Select a workspace to inspect its memory records." state when no workspace is active, previously indistinguishable from a failed fetch or a genuinely empty workspace.

### Backend (`src/metronix/api/routes/memory.py`)
- `GET /records` and `GET /facets` now wrap their backend calls (`service.list_records`/`count_records`/`get_facets`) in `try/except`, converting any unhandled exception into a clean `503` with an actionable message instead of leaking a generic 500 with no detail.

### Tests (`tests/unit/api/test_memory_routes.py`)
- `test_list_records_backend_error_503` and `test_get_facets_backend_error_503` pin the new 503 behavior.

## Acceptance criteria (#325)

- [x] A failed `/records` or `/facets` request shows a visible error banner/message, not an indistinguishable empty state.
- [x] No active workspace selected shows a distinct "select a workspace" state.
- [x] Backend misconfiguration surfaces as a clean 503 with a message, not an unhandled exception.
- [x] Genuinely zero records still shows the existing "No memory records match the current filters." copy, now distinguishable from the failure/no-workspace states.

## Verification

- `pytest tests/unit/api/test_memory_routes.py` — 59/59 pass (57 existing + 2 new)
- `ruff format --check .` / `ruff check .` — clean across the whole repo
- Frontend: `tsc -b`, `eslint .`, and `npm run build` all pass clean