### PR TITLE
Keep channel pollers in sync with connections table, add reconciliation backstop

### DIFF
--- a/src/metronix/api/app.py
+++ b/src/metronix/api/app.py
@@ -209,8 +209,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.postgres = store
 
     # --- Channel manager (starts bots from DB config) ---
+    app.state.channel_reconcile_task = None
     if not getattr(app.state, "channel_manager", None):
         try:
+            import asyncio as _asyncio
+
             from metronix.agent.router import AgentRouter
             from metronix.channels.manager import ChannelManager
 
@@ -222,6 +225,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             )
             app.state.channel_manager = channel_manager
             logger.info("channel_manager.started", channels=started)
+
+            # Periodically stop any poller whose connection row was removed or
+            # disabled out-of-band (direct SQL, a script) — the normal delete/
+            # update endpoints already call stop_channel(), this is the
+            # backstop for anything that bypasses them.
+            app.state.channel_reconcile_task = _asyncio.create_task(
+                channel_manager.reconcile_loop(
+                    fernet_key=settings.fernet_key,
+                    default_workspace_id=settings.default_workspace_id,
+                ),
+                name="channel-reconcile",
+            )
         except Exception as exc:
             logger.warning("channel_manager.startup_failed", error=str(exc))
 
@@ -349,6 +364,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     if autosync_scheduler is not None:
         with suppress(Exception):
             await autosync_scheduler.cancel_inflight()
+    channel_reconcile_task = getattr(app.state, "channel_reconcile_task", None)
+    if channel_reconcile_task is not None and not channel_reconcile_task.done():
+        channel_reconcile_task.cancel()
+        await _asyncio.gather(channel_reconcile_task, return_exceptions=True)
     cm = getattr(app.state, "channel_manager", None)
     if cm is not None:
         await cm.stop_all()

--- a/src/metronix/api/routes/connections.py
+++ b/src/metronix/api/routes/connections.py
@@ -513,9 +513,7 @@ async def update_connection(
     if schema and schema.category == "channel":
         if body.enabled is False:
             await _try_stop_channel(request, connection_id)
-        elif (body.config is not None or body.enabled is not None) and result.get(
-            "enabled", True
-        ):
+        elif (body.config is not None or body.enabled is not None) and result.get("enabled", True):
             decrypted = await store.get_connection_decrypted(connection_id, fernet_key)
             if decrypted:
                 await _try_restart_channel(

--- a/src/metronix/api/routes/connections.py
+++ b/src/metronix/api/routes/connections.py
@@ -173,6 +173,60 @@ async def _try_start_channel(
         )
 
 
+async def _try_stop_channel(request: Request, connection_id: str) -> None:
+    """Stop a channel bot if ChannelManager is available on app.state.
+
+    Non-fatal — logs warning on failure but never raises.
+    """
+    channel_manager = getattr(request.app.state, "channel_manager", None)
+    if channel_manager is None:
+        return
+    try:
+        await channel_manager.stop_channel(connection_id)
+        logger.info("api.connections.channel_stopped", connection_id=connection_id)
+    except Exception as exc:
+        logger.warning(
+            "api.connections.channel_stop.failed",
+            connection_id=connection_id,
+            error=sanitize_error(str(exc)),
+        )
+
+
+async def _try_restart_channel(
+    request: Request,
+    connection_id: str,
+    connector_type: str,
+    config: dict[str, Any],
+    workspace_id: str,
+) -> None:
+    """Restart a channel bot (stop + start) if ChannelManager is available.
+
+    Non-fatal — logs warning on failure but never raises. Used when a
+    channel's config changes (e.g. bot_token rotation) or it is re-enabled,
+    so the running poller always reflects the latest DB state — previously
+    ``update_connection`` never touched ``channel_manager`` at all, so
+    disabling/rotating a channel via this endpoint left the old poller
+    running untouched.
+    """
+    channel_manager = getattr(request.app.state, "channel_manager", None)
+    if channel_manager is None:
+        return
+    try:
+        await channel_manager.restart_channel(
+            connection_id,
+            connector_type,
+            config,
+            workspace_id=workspace_id,
+        )
+        logger.info("api.connections.channel_restarted", connection_id=connection_id)
+    except Exception as exc:
+        logger.warning(
+            "api.connections.channel_restart.failed",
+            connection_id=connection_id,
+            error=sanitize_error(str(exc)),
+        )
+
+
 # ---------------------------------------------------------------------------
 # New CRUD endpoints
 # ---------------------------------------------------------------------------
@@ -449,6 +503,28 @@ async def update_connection(
         await store.set_connection_schedule(connection_id, new_sync_cron, new_next_run_at)
         result["sync_cron"] = new_sync_cron
         result["next_run_at"] = new_next_run_at.isoformat() if new_next_run_at else None
+
+    # Keep the running poller in sync with the DB: a channel connection that
+    # gets disabled must stop, and one that gets re-enabled or has its config
+    # changed (e.g. bot_token rotation) must restart with the fresh decrypted
+    # config — otherwise the old poller keeps running against stale/no-longer
+    # authoritative state.
+    schema = CONNECTOR_SCHEMAS.get(existing["connector_type"])
+    if schema and schema.category == "channel":
+        if body.enabled is False:
+            await _try_stop_channel(request, connection_id)
+        elif (body.config is not None or body.enabled is not None) and result.get(
+            "enabled", True
+        ):
+            decrypted = await store.get_connection_decrypted(connection_id, fernet_key)
+            if decrypted:
+                await _try_restart_channel(
+                    request,
+                    connection_id,
+                    existing["connector_type"],
+                    decrypted["config"],
+                    ws_id,
+                )
 
     return ConnectionResponse(**result)
 

--- a/src/metronix/channels/manager.py
+++ b/src/metronix/channels/manager.py
@@ -262,6 +262,49 @@ class ChannelManager:
     def running_ids(self) -> list[str]:
         return list(self._running.keys())
 
+    async def reconcile_once(
+        self,
+        fernet_key: str,
+        default_workspace_id: str,
+    ) -> list[str]:
+        """Stop any running poller whose connection row is gone or disabled.
+
+        Defends against a poller staying alive forever after its row is
+        removed out-of-band — a direct SQL delete, a script, or any other
+        path that bypasses ``DELETE /connections/{id}``/``update_connection``
+        (which already call :meth:`stop_channel` themselves on the normal
+        path). Returns the list of connection_ids that were stopped.
+        """
+        if not self._running:
+            return []
+        connections = await self._store.list_connections(default_workspace_id, fernet_key)
+        live_ids = {c["id"] for c in connections if c.get("enabled", True)}
+        orphans = [cid for cid in self.running_ids if cid not in live_ids]
+        for connection_id in orphans:
+            logger.warning("channel_manager.orphan_detected", connection_id=connection_id)
+            await self.stop_channel(connection_id)
+        return orphans
+
+    async def reconcile_loop(
+        self,
+        fernet_key: str,
+        default_workspace_id: str,
+        interval_seconds: float = 300,
+    ) -> None:
+        """Run :meth:`reconcile_once` on a fixed interval until cancelled."""
+        while True:
+            await asyncio.sleep(interval_seconds)
+            try:
+                await self.reconcile_once(fernet_key, default_workspace_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error(
+                    "channel_manager.reconcile_failed",
+                    error=_sanitize_error(str(exc)),
+                    exc_info=True,
+                )
+
 
 def _create_channel(
     connector_type: str,

--- a/tests/unit/test_channel_manager.py
+++ b/tests/unit/test_channel_manager.py
@@ -1,0 +1,96 @@
+"""Tests for ChannelManager.reconcile_once/reconcile_loop.
+
+A poller whose connection row was removed or disabled out-of-band (direct
+SQL, a script — anything that bypasses DELETE/PUT /connections/{id}, which
+already call stop_channel themselves) must not run forever. reconcile_once
+is the backstop that catches that case.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from metronix.channels.manager import ChannelManager
+
+
+class _FakeChannel:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+def _add_running(manager: ChannelManager, connection_id: str) -> _FakeChannel:
+    """Simulate a live poller without actually starting a real bot."""
+    channel = _FakeChannel()
+    manager._running[connection_id] = channel
+    manager._tasks[connection_id] = asyncio.create_task(asyncio.sleep(1000))
+    return channel
+
+
+@pytest.fixture
+def manager() -> ChannelManager:
+    router = AsyncMock()
+    store = AsyncMock()
+    return ChannelManager(router=router, store=store)
+
+
+async def test_reconcile_once_stops_orphan_when_row_missing(manager: ChannelManager) -> None:
+    """Row no longer exists in the DB at all -> the poller is stopped."""
+    channel = _add_running(manager, "c1")
+    manager._store.list_connections.return_value = []
+
+    stopped = await manager.reconcile_once("fernet", "ws_default")
+
+    assert stopped == ["c1"]
+    assert "c1" not in manager.running_ids
+    assert channel.stopped is True
+
+
+async def test_reconcile_once_stops_orphan_when_disabled(manager: ChannelManager) -> None:
+    """Row still exists but was disabled out-of-band -> the poller is stopped."""
+    _add_running(manager, "c1")
+    manager._store.list_connections.return_value = [{"id": "c1", "enabled": False}]
+
+    stopped = await manager.reconcile_once("fernet", "ws_default")
+
+    assert stopped == ["c1"]
+    assert "c1" not in manager.running_ids
+
+
+async def test_reconcile_once_leaves_healthy_channel_running(manager: ChannelManager) -> None:
+    """Row exists and is enabled -> nothing is stopped."""
+    _add_running(manager, "c1")
+    manager._store.list_connections.return_value = [{"id": "c1", "enabled": True}]
+
+    stopped = await manager.reconcile_once("fernet", "ws_default")
+
+    assert stopped == []
+    assert "c1" in manager.running_ids
+
+
+async def test_reconcile_once_noop_when_nothing_running(manager: ChannelManager) -> None:
+    """No pollers running -> never even queries the DB."""
+    stopped = await manager.reconcile_once("fernet", "ws_default")
+
+    assert stopped == []
+    manager._store.list_connections.assert_not_awaited()
+
+
+async def test_reconcile_loop_survives_transient_failure(manager: ChannelManager) -> None:
+    """A transient DB error during reconciliation is logged, not raised."""
+    _add_running(manager, "c1")
+    manager._store.list_connections.side_effect = ConnectionRefusedError("db down")
+
+    task = asyncio.create_task(manager.reconcile_loop("fernet", "ws_default", interval_seconds=0))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The failed reconcile must not have torn down the (still-healthy-looking) poller.
+    assert "c1" in manager.running_ids

--- a/tests/unit/test_connections_update.py
+++ b/tests/unit/test_connections_update.py
@@ -200,3 +200,161 @@ class TestUpdateConnection:
 
         assert r.status_code == 422
         assert "No fields to update" in r.json()["detail"]
+
+
+_EXISTING_TELEGRAM = {
+    "id": "conn_tg_001",
+    "workspace_id": "ws_test",
+    "connector_type": "telegram",
+    "name": "Support bot",
+    "config": {"bot_token": "***"},
+    "status": "active",
+    "enabled": True,
+    "error_message": None,
+    "last_synced_at": None,
+    "created_at": "2026-01-01T00:00:00+00:00",
+    "updated_at": None,
+}
+
+
+def _updated_telegram_row(**overrides) -> dict:
+    row = dict(_EXISTING_TELEGRAM)
+    row["updated_at"] = "2026-04-16T12:00:00+00:00"
+    row.update(overrides)
+    return row
+
+
+class TestUpdateConnectionChannelSync:
+    """PUT /api/v1/connections/{id}/ keeps the running channel poller in sync.
+
+    Previously update_connection never touched channel_manager at all, so
+    disabling/rotating a channel connection left the old poller running
+    against stale state indefinitely.
+    """
+
+    @patch("metronix.api.routes.connections._get_store")
+    def test_disabling_channel_stops_poller(self, mock_store, app, client: TestClient) -> None:
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_TELEGRAM)
+        store.update_connection = AsyncMock(
+            return_value=_updated_telegram_row(enabled=False),
+        )
+        channel_manager = AsyncMock()
+        app.state.channel_manager = channel_manager
+
+        token = _make_token(role="admin")
+        r = client.put(
+            "/api/v1/connections/conn_tg_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"enabled": False},
+        )
+
+        assert r.status_code == 200, r.text
+        channel_manager.stop_channel.assert_awaited_once_with("conn_tg_001")
+        channel_manager.restart_channel.assert_not_awaited()
+
+    @patch("metronix.api.routes.connections._get_store")
+    def test_reenabling_channel_restarts_poller_with_decrypted_config(
+        self, mock_store, app, client: TestClient
+    ) -> None:
+        """Re-enabling a previously-disabled channel restarts it with fresh
+        decrypted config (never the masked '***' value)."""
+        store = mock_store.return_value
+        disabled = dict(_EXISTING_TELEGRAM, enabled=False)
+        store.get_connection = AsyncMock(return_value=disabled)
+        store.update_connection = AsyncMock(
+            return_value=_updated_telegram_row(enabled=True),
+        )
+        store.get_connection_decrypted = AsyncMock(
+            return_value=dict(_EXISTING_TELEGRAM, config={"bot_token": "real-token-xyz"}),
+        )
+        channel_manager = AsyncMock()
+        app.state.channel_manager = channel_manager
+
+        token = _make_token(role="admin")
+        r = client.put(
+            "/api/v1/connections/conn_tg_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"enabled": True},
+        )
+
+        assert r.status_code == 200, r.text
+        channel_manager.restart_channel.assert_awaited_once_with(
+            "conn_tg_001",
+            "telegram",
+            {"bot_token": "real-token-xyz"},
+            workspace_id="ws_test",
+        )
+        channel_manager.stop_channel.assert_not_awaited()
+
+    @patch("metronix.api.routes.connections._get_store")
+    def test_config_change_restarts_channel(self, mock_store, app, client: TestClient) -> None:
+        """Rotating bot_token on an already-enabled channel restarts the poller."""
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_TELEGRAM)
+        store.update_connection = AsyncMock(return_value=_updated_telegram_row())
+        store.get_connection_decrypted = AsyncMock(
+            return_value=dict(_EXISTING_TELEGRAM, config={"bot_token": "rotated-token"}),
+        )
+        channel_manager = AsyncMock()
+        app.state.channel_manager = channel_manager
+
+        token = _make_token(role="admin")
+        r = client.put(
+            "/api/v1/connections/conn_tg_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"config": {"bot_token": "rotated-token"}},
+        )
+
+        assert r.status_code == 200, r.text
+        channel_manager.restart_channel.assert_awaited_once_with(
+            "conn_tg_001",
+            "telegram",
+            {"bot_token": "rotated-token"},
+            workspace_id="ws_test",
+        )
+
+    @patch("metronix.api.routes.connections._get_store")
+    def test_rename_only_does_not_touch_channel_poller(
+        self, mock_store, app, client: TestClient
+    ) -> None:
+        """A name-only update must not bounce a healthy, unrelated poller."""
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_TELEGRAM)
+        store.update_connection = AsyncMock(
+            return_value=_updated_telegram_row(name="Renamed bot"),
+        )
+        channel_manager = AsyncMock()
+        app.state.channel_manager = channel_manager
+
+        token = _make_token(role="admin")
+        r = client.put(
+            "/api/v1/connections/conn_tg_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "Renamed bot"},
+        )
+
+        assert r.status_code == 200, r.text
+        channel_manager.stop_channel.assert_not_awaited()
+        channel_manager.restart_channel.assert_not_awaited()
+
+    @patch("metronix.api.routes.connections._get_store")
+    def test_missing_channel_manager_is_non_fatal(
+        self, mock_store, app, client: TestClient
+    ) -> None:
+        """No channel_manager on app.state (e.g. startup failed) must not break the update."""
+        store = mock_store.return_value
+        store.get_connection = AsyncMock(return_value=_EXISTING_TELEGRAM)
+        store.update_connection = AsyncMock(
+            return_value=_updated_telegram_row(enabled=False),
+        )
+        app.state.channel_manager = None
+
+        token = _make_token(role="admin")
+        r = client.put(
+            "/api/v1/connections/conn_tg_001/?workspace_id=ws_test",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"enabled": False},
+        )
+
+        assert r.status_code == 200, r.text


### PR DESCRIPTION
## Summary

Closes #329. A Telegram channel connection row disappeared from the DB out-of-band (not via the API), but its in-process poller kept running against the stale token — logs showed continuous `telegram.message.received` events plus repeated `TelegramConflictError: Conflict: terminated by other getUpdates request`. Restarting the API container cleared the in-memory state, confirming the poller was orphaned in-process state, not an external duplicate bot.

## Root cause

Two gaps in `ChannelManager` lifecycle management:

1. **`update_connection` (`PUT /connections/{id}`) never touched `channel_manager` at all** — unlike `create_connection` (auto-starts) and `delete_connection` (stops), disabling a channel or rotating its `bot_token` left the old poller running against stale config.
2. **Nothing ever reconciled `ChannelManager`'s in-memory running pollers against the DB after startup.** Any out-of-band row removal (direct SQL, a script, a migration) orphans the poller forever, since the only DB reads happen once at `start_channels_from_db()`.

## What changed

### `src/metronix/api/routes/connections.py`
- New `_try_stop_channel`/`_try_restart_channel` helpers, mirroring the existing `_try_start_channel` pattern (non-fatal — logged, never raises).
- `update_connection` now:
  - `enabled: false` → stops the poller.
  - `enabled: true` (re-enable) or a `config` change while enabled → restarts the poller with freshly-decrypted config (never the masked `***` value).
  - A name-only rename leaves the poller untouched.

### `src/metronix/channels/manager.py`
- `ChannelManager.reconcile_once(fernet_key, default_workspace_id)`: diffs running pollers against the DB's currently-enabled connections, stops any orphan, returns the stopped ids.
- `ChannelManager.reconcile_loop(...)`: runs `reconcile_once` on a fixed interval (default 5 min) until cancelled; a transient failure is logged, not raised, and never tears down a still-healthy poller.

### `src/metronix/api/app.py`
- Spawns `reconcile_loop` as a background task alongside `channel_manager` startup, stored on `app.state.channel_reconcile_task`.
- Cancelled on shutdown alongside the other background tasks (autosync, graph-sweep, export-sweep).

## Tests

- `tests/unit/test_connections_update.py` — 5 new cases: disable stops poller, re-enable restarts with decrypted config, config change restarts, rename-only leaves poller untouched, missing `channel_manager` is non-fatal.
- `tests/unit/test_channel_manager.py` (new) — 5 cases: stops orphan when row missing, stops orphan when disabled, leaves healthy channel running, no-ops when nothing running (never queries DB), survives a transient DB error without tearing down a healthy poller.

## Verification

- `pytest tests/unit/test_connections_update.py tests/unit/test_channel_manager.py` — 15/15 pass.
- `ruff format --check .` / `ruff check .` — clean across the whole repo.
- Deployed to the local dev stack; `channel_manager.started channels=0` confirmed on restart with the reconciliation task running.