### PR TITLE
fix: disable telemetry by default for self-hosted installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,8 +107,8 @@ METRONIX_FRESHNESS_KB_SEARCH_FILTER_ENABLED=false
 METRONIX_FRESHNESS_WEIGHT=0.0
 METRONIX_FRESHNESS_KB_STALE_AFTER_DAYS=90
 
-# --- LLM generation telemetry (internal; fine-tuning bootstrap, PROJ-336) ---
-METRONIX_LLM_TELEMETRY_ENABLED=true   # master kill-switch; false -> no-op
+# --- LLM generation telemetry (opt-in; internal fine-tuning bootstrap, PROJ-336) ---
+METRONIX_LLM_TELEMETRY_ENABLED=false  # master kill-switch; false -> no-op
 METRONIX_LLM_TELEMETRY_RETENTION_DAYS=0
 METRONIX_LLM_TELEMETRY_OPT_OUT_CACHE_TTL_SECONDS=60
 

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -400,7 +400,7 @@ class Settings(BaseSettings):
 
     # --- LLM generation telemetry (MTRNIX-336) ---
     llm_telemetry_enabled: bool = Field(
-        default=True,
+        default=False,
         alias="METRONIX_LLM_TELEMETRY_ENABLED",
         description="Master kill-switch. false → all telemetry is a no-op.",
     )

--- a/tests/unit/core/test_default_ollama_model.py
+++ b/tests/unit/core/test_default_ollama_model.py
@@ -15,6 +15,12 @@ def test_default_freshness_model_is_qwen() -> None:
     assert Settings.model_fields["freshness_llm_model"].default == "qwen2.5:3b"
 
 
+def test_public_install_defaults_match_self_hosted_expectations() -> None:
+    assert Settings.model_fields["freshness_enabled"].default is False
+    assert Settings.model_fields["llm_telemetry_enabled"].default is False
+    assert Settings.model_fields["cors_origins"].default == "*"
+
+
 def test_ollama_chat_model_field_removed() -> None:
     # The redundant pull-only variable is gone.
     assert "ollama_chat_model" not in Settings.model_fields


### PR DESCRIPTION
## Summary
- disable LLM telemetry by default in shipped settings and `.env.example`
- keep freshness disabled by default and lock that public-install contract in tests
- preserve wildcard CORS behavior while making the self-hosted telemetry default explicit

## Verification
- `.venv/bin/python -m pytest -q tests/unit/core/test_default_ollama_model.py tests/unit/test_llm_telemetry.py`