### PR TITLE
fix: isolate Telegram chats and protect direct messages

### DIFF
--- a/src/metronix/agent/router.py
+++ b/src/metronix/agent/router.py
@@ -193,6 +193,8 @@ class AgentRouter:
         text: str,
         user_id: str,
         workspace_id: str | None = None,
+        history_enabled: bool = True,
+        conversation_id: str | None = None,
     ) -> str:
         """Route a message and return the response text.
 
@@ -200,6 +202,8 @@ class AgentRouter:
             text: User message text.
             user_id: Channel-specific user ID.
             workspace_id: Workspace scope (defaults to settings.default_workspace_id).
+            history_enabled: Whether to use and record conversation history.
+            conversation_id: Optional channel conversation scope for history.
 
         Returns:
             Response text string.
@@ -222,14 +226,22 @@ class AgentRouter:
 
         try:
             if intent == Intent.COMMAND:
-                return self._handle_command(text, user_id, ws)
+                return self._handle_command(
+                    text,
+                    user_id,
+                    ws,
+                    history_enabled=history_enabled,
+                    conversation_id=conversation_id,
+                )
             if intent == Intent.GREETING:
                 return self._handle_greeting(user_id, ws)
             if intent == Intent.SMALLTALK:
                 return self._handle_smalltalk(text, user_id, ws)
             if intent == Intent.ACTION:
                 return self._handle_action(text, user_id, ws)
-            return self._handle_search(text, user_id, ws)
+            return self._handle_search(
+                text, user_id, ws, history_enabled=history_enabled, conversation_id=conversation_id
+            )
         except LLMError as e:
             logger.error("router.error.llm", intent=intent, error=str(e), exc_info=True)
             return "AI service is temporarily unavailable. Please try again later."
@@ -271,15 +283,28 @@ class AgentRouter:
 
         return Intent.SEARCH
 
-    def _handle_search(self, text: str, user_id: str, workspace_id: str) -> str:
+    def _handle_search(
+        self,
+        text: str,
+        user_id: str,
+        workspace_id: str,
+        *,
+        history_enabled: bool = True,
+        conversation_id: str | None = None,
+    ) -> str:
         """Handle a search query via hybrid_search_and_answer."""
-        # Build composite query from conversation context
-        composite = self._sessions.build_composite_query(user_id, workspace_id, text)
+        composite = text
+        if history_enabled:
+            composite = self._sessions.build_composite_query(
+                user_id, workspace_id, text, conversation_id=conversation_id
+            )
 
         logger.info("router.search", user_id=user_id, composite_len=len(composite))
 
-        # Record user turn
-        self._sessions.add_turn(user_id, workspace_id, "user", text)
+        if history_enabled:
+            self._sessions.add_turn(
+                user_id, workspace_id, "user", text, conversation_id=conversation_id
+            )
 
         # Call existing search pipeline
         # query = composite (with history context for richer search)
@@ -291,8 +316,10 @@ class AgentRouter:
             intent_query=text,
         )
 
-        # Record assistant turn
-        self._sessions.add_turn(user_id, workspace_id, "assistant", answer)
+        if history_enabled:
+            self._sessions.add_turn(
+                user_id, workspace_id, "assistant", answer, conversation_id=conversation_id
+            )
 
         return answer
 
@@ -557,7 +584,15 @@ class AgentRouter:
             logger.warning("router.smalltalk.llm_failed", error=str(e))
             return "I'm Metronix, your team's knowledge assistant. How can I help?"
 
-    def _handle_command(self, text: str, user_id: str, workspace_id: str) -> str:
+    def _handle_command(
+        self,
+        text: str,
+        user_id: str,
+        workspace_id: str,
+        *,
+        history_enabled: bool = True,
+        conversation_id: str | None = None,
+    ) -> str:
         """Handle slash/bang commands (e.g. /help or !help)."""
         # Normalize: !command → /command
         normalized = text.strip()
@@ -573,13 +608,19 @@ class AgentRouter:
         if command == "/search":
             if not arg:
                 return "Usage: /search <query>"
-            return self._handle_search(arg, user_id, workspace_id)
+            return self._handle_search(
+                arg,
+                user_id,
+                workspace_id,
+                history_enabled=history_enabled,
+                conversation_id=conversation_id,
+            )
         if command == "/sync":
             return self._cmd_sync(arg or None, workspace_id)
         if command == "/status":
             return self._cmd_status(workspace_id)
         if command == "/clear":
-            self._sessions.clear(user_id, workspace_id)
+            self._sessions.clear(user_id, workspace_id, conversation_id=conversation_id)
             return "Conversation history cleared."
         if command == "/start":
             return self._handle_greeting(user_id, workspace_id)

--- a/src/metronix/agent/sessions.py
+++ b/src/metronix/agent/sessions.py
@@ -35,7 +35,7 @@ class ConversationTurn:
 class SessionManager:
     """Thread-safe in-memory conversation session store.
 
-    Keyed by (channel_user_id, workspace_id). Stores the last N turns
+    Keyed by (channel_user_id, workspace_id, optional conversation_id). Stores the last N turns
     for LLM context. Provides composite query building from recent context.
 
     Not persistent across restarts — MVP design.
@@ -64,31 +64,55 @@ class SessionManager:
         with cls._init_lock:
             cls._instance = None
 
-    def _key(self, user_id: str, workspace_id: str) -> str:
-        return f"{user_id}:{workspace_id}"
+    def _key(
+        self,
+        user_id: str,
+        workspace_id: str,
+        conversation_id: str | None = None,
+    ) -> str:
+        return ":".join(
+            part for part in (user_id, workspace_id, conversation_id) if part is not None
+        )
 
-    def get_history(self, user_id: str, workspace_id: str) -> list[dict[str, str]]:
+    def get_history(
+        self,
+        user_id: str,
+        workspace_id: str,
+        conversation_id: str | None = None,
+    ) -> list[dict[str, str]]:
         """Get conversation history as list of role/content dicts.
 
         Thread-safe. Returns a copy.
         """
-        key = self._key(user_id, workspace_id)
+        key = self._key(user_id, workspace_id, conversation_id)
         with self._lock:
             turns = list(self._sessions[key])
         return [{"role": t.role, "content": t.content} for t in turns]
 
-    def add_turn(self, user_id: str, workspace_id: str, role: str, content: str) -> None:
+    def add_turn(
+        self,
+        user_id: str,
+        workspace_id: str,
+        role: str,
+        content: str,
+        conversation_id: str | None = None,
+    ) -> None:
         """Add a conversation turn. Trims to max_history (FIFO). Thread-safe."""
-        key = self._key(user_id, workspace_id)
+        key = self._key(user_id, workspace_id, conversation_id)
         turn = ConversationTurn(role=role, content=content)
         with self._lock:
             self._sessions[key].append(turn)
             if len(self._sessions[key]) > self._max_history:
                 self._sessions[key] = self._sessions[key][-self._max_history :]
 
-    def clear(self, user_id: str, workspace_id: str) -> None:
+    def clear(
+        self,
+        user_id: str,
+        workspace_id: str,
+        conversation_id: str | None = None,
+    ) -> None:
         """Clear conversation history for a user. Thread-safe."""
-        key = self._key(user_id, workspace_id)
+        key = self._key(user_id, workspace_id, conversation_id)
         with self._lock:
             self._sessions.pop(key, None)
 
@@ -145,6 +169,7 @@ class SessionManager:
         workspace_id: str,
         current_query: str,
         max_turns: int = DEFAULT_MAX_COMPOSITE_TURNS,
+        conversation_id: str | None = None,
     ) -> str:
         """Build a composite query from recent conversation context.
 
@@ -165,7 +190,7 @@ class SessionManager:
         if not self._is_follow_up(current_query):
             return current_query
 
-        key = self._key(user_id, workspace_id)
+        key = self._key(user_id, workspace_id, conversation_id)
         with self._lock:
             turns = list(self._sessions[key])
 

--- a/src/metronix/channels/manager.py
+++ b/src/metronix/channels/manager.py
@@ -379,7 +379,7 @@ def _create_channel(
             workspace_id=workspace_id,
             mapper=mapper,
             event_bus=event_bus,
-            store_direct_messages=bool(config.get("store_direct_messages", False)),
+            store_direct_messages=config.get("store_direct_messages") is True,
         )
 
     if connector_type == "discord":

--- a/src/metronix/channels/manager.py
+++ b/src/metronix/channels/manager.py
@@ -192,7 +192,7 @@ class ChannelManager:
         self._running[connection_id] = channel
 
         task = asyncio.create_task(
-            _run_channel_safe(connection_id, connector_type, channel),
+            self._run_channel(connection_id, connector_type, channel),
         )
         self._tasks[connection_id] = task
         logger.info(
@@ -253,6 +253,57 @@ class ChannelManager:
             config,
             workspace_id=workspace_id,
         )
+
+    async def _run_channel(
+        self,
+        connection_id: str,
+        connector_type: str,
+        channel: Any,
+    ) -> None:
+        """Run a poller and release its ownership if it crashes unexpectedly."""
+        try:
+            await channel.start()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error(
+                "channel_manager.channel_crashed",
+                connection_id=connection_id,
+                connector_type=connector_type,
+                error=_sanitize_error(str(exc)),
+                exc_info=True,
+            )
+            await self._handle_channel_crash(connection_id, connector_type, exc)
+
+    async def _handle_channel_crash(
+        self,
+        connection_id: str,
+        connector_type: str,
+        exc: Exception,
+    ) -> None:
+        """Persist a crash and free local state even if persistence fails."""
+        error_message = _sanitize_error(str(exc))
+        try:
+            await self._store.update_connection_status(
+                connection_id,
+                status="error",
+                error_message=error_message,
+            )
+        except Exception:
+            logger.warning(
+                "channel_manager.crash_status_update_failed",
+                connection_id=connection_id,
+                connector_type=connector_type,
+                exc_info=True,
+            )
+        finally:
+            self._running.pop(connection_id, None)
+            self._tasks.pop(connection_id, None)
+            self._active_tokens = {
+                key: owner
+                for key, owner in self._active_tokens.items()
+                if owner != connection_id
+            }
 
     @property
     def running_count(self) -> int:
@@ -365,23 +416,3 @@ def _create_channel(
 
     msg = f"Unknown channel type: {connector_type}"
     raise ValueError(msg)
-
-
-async def _run_channel_safe(
-    connection_id: str,
-    connector_type: str,
-    channel: Any,
-) -> None:
-    """Run a channel with crash isolation."""
-    try:
-        await channel.start()
-    except asyncio.CancelledError:
-        pass
-    except Exception as exc:
-        logger.error(
-            "channel_manager.channel_crashed",
-            connection_id=connection_id,
-            connector_type=connector_type,
-            error=_sanitize_error(str(exc)),
-            exc_info=True,
-        )

--- a/src/metronix/channels/manager.py
+++ b/src/metronix/channels/manager.py
@@ -300,9 +300,7 @@ class ChannelManager:
             self._running.pop(connection_id, None)
             self._tasks.pop(connection_id, None)
             self._active_tokens = {
-                key: owner
-                for key, owner in self._active_tokens.items()
-                if owner != connection_id
+                key: owner for key, owner in self._active_tokens.items() if owner != connection_id
             }
 
     @property

--- a/src/metronix/channels/manager.py
+++ b/src/metronix/channels/manager.py
@@ -328,6 +328,7 @@ def _create_channel(
             workspace_id=workspace_id,
             mapper=mapper,
             event_bus=event_bus,
+            store_direct_messages=bool(config.get("store_direct_messages", False)),
         )
 
     if connector_type == "discord":

--- a/src/metronix/channels/telegram.py
+++ b/src/metronix/channels/telegram.py
@@ -24,6 +24,11 @@ logger = structlog.get_logger()
 _TG_MAX_LENGTH = 4096
 
 
+def _is_private_chat(message: types.Message) -> bool:
+    """Return whether a Telegram message belongs to a direct-message chat."""
+    return message.chat.type == "private"
+
+
 class TelegramChannel:
     """Telegram bot channel using aiogram 3.x with long-polling.
 
@@ -38,12 +43,14 @@ class TelegramChannel:
         workspace_id: str | None = None,
         mapper: Any | None = None,
         event_bus: Any | None = None,
+        store_direct_messages: bool = False,
     ) -> None:
         self._token = bot_token
         self._router = router
         self._workspace_id = workspace_id or router._settings.default_workspace_id
         self._mapper = mapper
         self._event_bus = event_bus
+        self._store_direct_messages = store_direct_messages
         self._bot = Bot(
             token=bot_token,
             default=DefaultBotProperties(parse_mode=ParseMode.MARKDOWN),
@@ -94,6 +101,14 @@ class TelegramChannel:
         """Handle a file upload from Telegram."""
         doc = message.document
         if not doc:
+            return
+
+        if _is_private_chat(message) and not self._store_direct_messages:
+            await self._send_response(
+                message.chat.id,
+                "Direct-message file uploads are disabled for privacy.",
+                reply_to=message.message_id,
+            )
             return
 
         chat_id = message.chat.id
@@ -204,6 +219,10 @@ class TelegramChannel:
                 text=text,
                 user_id=user_id,
                 workspace_id=self._workspace_id,
+                conversation_id=str(chat_id),
+                history_enabled=not (
+                    _is_private_chat(message) and not self._store_direct_messages
+                ),
             )
         except Exception as e:
             logger.error("telegram.route.error", error=str(e), exc_info=True)

--- a/src/metronix/connectors/schemas.py
+++ b/src/metronix/connectors/schemas.py
@@ -179,6 +179,12 @@ CONNECTOR_SCHEMAS: dict[str, ConnectorSchema] = {
                 type="secret",
                 placeholder="123456:ABC-DEF...",
             ),
+            _F(
+                name="store_direct_messages",
+                label="Store direct-message context",
+                type="boolean",
+                required=False,
+            ),
         ],
     ),
     "discord": ConnectorSchema(

--- a/tests/unit/test_agent_router.py
+++ b/tests/unit/test_agent_router.py
@@ -90,6 +90,17 @@ class TestRouteClear:
         assert "cleared" in result.lower()
         assert router._sessions.get_history("u1", "TEST_WS") == []
 
+    def test_clear_command_only_clears_conversation(self, router: AgentRouter) -> None:
+        router._sessions.add_turn("u1", "TEST_WS", "user", "dm message", conversation_id="10")
+        router._sessions.add_turn("u1", "TEST_WS", "user", "group message", conversation_id="20")
+
+        router.route("/clear", user_id="u1", conversation_id="10")
+
+        assert router._sessions.get_history("u1", "TEST_WS", conversation_id="10") == []
+        assert router._sessions.get_history("u1", "TEST_WS", conversation_id="20") == [
+            {"role": "user", "content": "group message"}
+        ]
+
 
 class TestRouteGreeting:
     def test_greeting_response(self, router: AgentRouter) -> None:
@@ -137,6 +148,16 @@ class TestRouteSearch:
         assert history[0]["role"] == "user"
         assert history[0]["content"] == "query1"
         assert history[1]["role"] == "assistant"
+
+    @patch("metronix.agent.router.hybrid_search_and_answer_sync")
+    def test_search_with_history_disabled_does_not_record_turns(
+        self, mock_search, router: AgentRouter
+    ) -> None:
+        mock_search.return_value = "answer"
+
+        router.route("query1", user_id="u1", history_enabled=False)
+
+        assert router._sessions.get_history("u1", "TEST_WS") == []
 
     @patch("metronix.agent.router.hybrid_search_and_answer_sync")
     def test_search_command_dispatches(self, mock_search, router: AgentRouter) -> None:

--- a/tests/unit/test_channel_manager.py
+++ b/tests/unit/test_channel_manager.py
@@ -24,6 +24,14 @@ class _FakeChannel:
         self.stopped = True
 
 
+class _CrashingChannel:
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def start(self) -> None:
+        raise self._exc
+
+
 def _add_running(manager: ChannelManager, connection_id: str) -> _FakeChannel:
     """Simulate a live poller without actually starting a real bot."""
     channel = _FakeChannel()
@@ -37,6 +45,44 @@ def manager() -> ChannelManager:
     router = AsyncMock()
     store = AsyncMock()
     return ChannelManager(router=router, store=store)
+
+
+async def test_crashed_channel_is_marked_error_and_released(manager: ChannelManager) -> None:
+    """Unexpected poller failures release local ownership and persist a safe error."""
+    manager._running["c1"] = _FakeChannel()
+    manager._active_tokens[("telegram", "token-1")] = "c1"
+
+    await manager._handle_channel_crash("c1", "telegram", RuntimeError("token=secret failed"))
+
+    manager._store.update_connection_status.assert_awaited_once_with(
+        "c1", status="error", error_message="token=*** failed"
+    )
+    assert "c1" not in manager._running
+    assert "c1" not in manager._tasks
+    assert ("telegram", "token-1") not in manager._active_tokens
+
+
+async def test_crashed_channel_cleanup_survives_status_persistence_failure(
+    manager: ChannelManager,
+) -> None:
+    """A database failure cannot leave a dead poller claiming its token."""
+    manager._running["c1"] = _FakeChannel()
+    manager._active_tokens[("telegram", "token-1")] = "c1"
+    manager._store.update_connection_status.side_effect = ConnectionRefusedError("db down")
+
+    await manager._handle_channel_crash("c1", "telegram", RuntimeError("poller failed"))
+
+    assert "c1" not in manager._running
+    assert "c1" not in manager._tasks
+    assert ("telegram", "token-1") not in manager._active_tokens
+
+
+async def test_cancelled_channel_is_not_marked_as_crashed(manager: ChannelManager) -> None:
+    """Normal shutdown cancellation remains owned by stop_channel."""
+    with pytest.raises(asyncio.CancelledError):
+        await manager._run_channel("c1", "telegram", _CrashingChannel(asyncio.CancelledError()))
+
+    manager._store.update_connection_status.assert_not_awaited()
 
 
 async def test_reconcile_once_stops_orphan_when_row_missing(manager: ChannelManager) -> None:

--- a/tests/unit/test_channel_manager.py
+++ b/tests/unit/test_channel_manager.py
@@ -9,11 +9,11 @@ is the backstop that catches that case.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from metronix.channels.manager import ChannelManager
+from metronix.channels.manager import ChannelManager, _create_channel
 
 
 class _FakeChannel:
@@ -45,6 +45,27 @@ def manager() -> ChannelManager:
     router = AsyncMock()
     store = AsyncMock()
     return ChannelManager(router=router, store=store)
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected_storage"),
+    [("false", False), (True, True)],
+)
+def test_telegram_factory_only_enables_direct_message_storage_for_true_boolean(
+    configured_value: object,
+    expected_storage: bool,
+) -> None:
+    """The persisted config must not treat truthy strings as privacy opt-ins."""
+    router = MagicMock()
+    router._settings.default_workspace_id = "ws_test"
+
+    channel = _create_channel(
+        "telegram",
+        {"bot_token": "123456:TEST", "store_direct_messages": configured_value},
+        router,
+    )
+
+    assert channel._store_direct_messages is expected_storage
 
 
 async def test_crashed_channel_is_marked_error_and_released(manager: ChannelManager) -> None:

--- a/tests/unit/test_connections_update.py
+++ b/tests/unit/test_connections_update.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from metronix.api.app import create_app
+from metronix.connectors.schemas import get_schema
 from metronix.core.config import Settings
 
 _FERNET_KEY = "dGVzdC1mZXJuZXQta2V5LTMyLWJ5dGVzLWxvbmc="  # 32-byte base64
@@ -200,6 +201,15 @@ class TestUpdateConnection:
 
         assert r.status_code == 422
         assert "No fields to update" in r.json()["detail"]
+
+
+def test_telegram_schema_exposes_optional_direct_message_storage_setting() -> None:
+    schema = get_schema("telegram")
+
+    assert schema is not None
+    field = next(field for field in schema.fields if field.name == "store_direct_messages")
+    assert field.type == "boolean"
+    assert field.required is False
 
 
 _EXISTING_TELEGRAM = {

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -49,6 +49,28 @@ class TestSessionManager:
         assert len(self.sm.get_history("u1", "ws1")) == 1
         assert len(self.sm.get_history("u2", "ws1")) == 1
 
+    def test_conversation_isolation_for_same_user_and_workspace(self) -> None:
+        self.sm.add_turn("u1", "ws1", "user", "dm message", conversation_id="10")
+        self.sm.add_turn("u1", "ws1", "user", "group message", conversation_id="20")
+
+        assert self.sm.get_history("u1", "ws1", conversation_id="10") == [
+            {"role": "user", "content": "dm message"}
+        ]
+        assert self.sm.get_history("u1", "ws1", conversation_id="20") == [
+            {"role": "user", "content": "group message"}
+        ]
+
+    def test_clear_only_scoped_conversation(self) -> None:
+        self.sm.add_turn("u1", "ws1", "user", "dm message", conversation_id="10")
+        self.sm.add_turn("u1", "ws1", "user", "group message", conversation_id="20")
+
+        self.sm.clear("u1", "ws1", conversation_id="10")
+
+        assert self.sm.get_history("u1", "ws1", conversation_id="10") == []
+        assert self.sm.get_history("u1", "ws1", conversation_id="20") == [
+            {"role": "user", "content": "group message"}
+        ]
+
     def test_max_history_trim(self) -> None:
         for i in range(10):
             self.sm.add_turn("u1", "ws1", "user", f"msg{i}")

--- a/tests/unit/test_telegram.py
+++ b/tests/unit/test_telegram.py
@@ -105,6 +105,26 @@ def group_document(group_message: SimpleNamespace) -> SimpleNamespace:
     )
 
 
+@pytest.fixture
+def supergroup_message() -> SimpleNamespace:
+    return SimpleNamespace(
+        text="supergroup hello",
+        chat=SimpleNamespace(id=-102, type="supergroup"),
+        from_user=SimpleNamespace(id=203, first_name="Supergroup", last_name="User"),
+        message_id=3,
+    )
+
+
+@pytest.fixture
+def supergroup_document(supergroup_message: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        **supergroup_message.__dict__,
+        document=SimpleNamespace(
+            file_name="supergroup.txt", file_size=5, file_id="file-supergroup"
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_private_message_does_not_store_history_when_disabled(
     channel: telegram.TelegramChannel, private_message: SimpleNamespace
@@ -136,6 +156,38 @@ async def test_group_message_stores_history(
 
 
 @pytest.mark.asyncio
+async def test_private_message_stores_history_when_enabled(
+    channel: telegram.TelegramChannel, private_message: SimpleNamespace
+) -> None:
+    channel._store_direct_messages = True
+
+    await channel._handle_message(private_message)
+
+    channel._router.route.assert_called_once_with(
+        text=private_message.text,
+        user_id=str(private_message.from_user.id),
+        workspace_id=channel._workspace_id,
+        conversation_id=str(private_message.chat.id),
+        history_enabled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_supergroup_message_stores_history(
+    channel: telegram.TelegramChannel, supergroup_message: SimpleNamespace
+) -> None:
+    await channel._handle_message(supergroup_message)
+
+    channel._router.route.assert_called_once_with(
+        text=supergroup_message.text,
+        user_id=str(supergroup_message.from_user.id),
+        workspace_id=channel._workspace_id,
+        conversation_id=str(supergroup_message.chat.id),
+        history_enabled=True,
+    )
+
+
+@pytest.mark.asyncio
 async def test_private_document_is_rejected_before_download(
     channel: telegram.TelegramChannel, private_document: SimpleNamespace
 ) -> None:
@@ -161,6 +213,47 @@ async def test_group_document_is_uploaded(
         content=b"hello",
         filename="group.txt",
         user_id=str(group_document.from_user.id),
+        workspace_id=channel._workspace_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_private_document_is_uploaded_when_enabled(
+    channel: telegram.TelegramChannel, private_document: SimpleNamespace
+) -> None:
+    file_bytes = MagicMock()
+    file_bytes.read.return_value = b"hello"
+    channel._store_direct_messages = True
+    channel._bot.get_file.return_value = SimpleNamespace(file_path="file/path")
+    channel._bot.download_file.return_value = file_bytes
+
+    await channel._handle_document(private_document)
+
+    channel._bot.get_file.assert_awaited_once_with(private_document.document.file_id)
+    channel._router.handle_file_upload.assert_called_once_with(
+        content=b"hello",
+        filename="private.txt",
+        user_id=str(private_document.from_user.id),
+        workspace_id=channel._workspace_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_supergroup_document_is_uploaded(
+    channel: telegram.TelegramChannel, supergroup_document: SimpleNamespace
+) -> None:
+    file_bytes = MagicMock()
+    file_bytes.read.return_value = b"hello"
+    channel._bot.get_file.return_value = SimpleNamespace(file_path="file/path")
+    channel._bot.download_file.return_value = file_bytes
+
+    await channel._handle_document(supergroup_document)
+
+    channel._bot.get_file.assert_awaited_once_with(supergroup_document.document.file_id)
+    channel._router.handle_file_upload.assert_called_once_with(
+        content=b"hello",
+        filename="supergroup.txt",
+        user_id=str(supergroup_document.from_user.id),
         workspace_id=channel._workspace_id,
     )
 

--- a/tests/unit/test_telegram.py
+++ b/tests/unit/test_telegram.py
@@ -1,8 +1,168 @@
-"""Tests for channels/telegram.py — message splitting and markdown conversion."""
+"""Tests for channels/telegram.py — message handling and formatting helpers."""
 
 from __future__ import annotations
 
-from metronix.channels.telegram import _markdown_to_html, _split_message
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+if importlib.util.find_spec("aiogram") is None:
+    aiogram = ModuleType("aiogram")
+    aiogram.Bot = object
+    aiogram.Dispatcher = object
+    aiogram.F = SimpleNamespace(document=object())
+    aiogram.types = SimpleNamespace(Message=object, ErrorEvent=object)
+    aiogram_default = ModuleType("aiogram.client.default")
+    aiogram_default.DefaultBotProperties = lambda **kwargs: kwargs
+    aiogram_enums = ModuleType("aiogram.enums")
+    aiogram_enums.ChatAction = SimpleNamespace(TYPING="typing")
+    aiogram_enums.ParseMode = SimpleNamespace(MARKDOWN="markdown", HTML="html")
+    sys.modules.update(
+        {
+            "aiogram": aiogram,
+            "aiogram.client": ModuleType("aiogram.client"),
+            "aiogram.client.default": aiogram_default,
+            "aiogram.enums": aiogram_enums,
+        }
+    )
+
+_MODULE_PATH = Path(__file__).parents[2] / "src/metronix/channels/telegram.py"
+_SPEC = importlib.util.spec_from_file_location("telegram_channel_under_test", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+telegram = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(telegram)
+_markdown_to_html = telegram._markdown_to_html
+_split_message = telegram._split_message
+
+
+class _FakeDispatcher:
+    """Avoid registering handlers with a live aiogram dispatcher in unit tests."""
+
+    def errors(self):
+        return lambda handler: handler
+
+    def message(self, *args, **kwargs):
+        return lambda handler: handler
+
+
+@pytest.fixture
+def channel(monkeypatch: pytest.MonkeyPatch) -> telegram.TelegramChannel:
+    bot = SimpleNamespace(
+        send_chat_action=AsyncMock(),
+        send_message=AsyncMock(),
+        get_file=AsyncMock(),
+        download_file=AsyncMock(),
+    )
+    router = MagicMock()
+    router._settings.default_workspace_id = "ws_test"
+    router.route.return_value = "response"
+    router.handle_file_upload.return_value = "indexed"
+
+    monkeypatch.setattr(telegram, "Bot", lambda **kwargs: bot)
+    monkeypatch.setattr(telegram, "Dispatcher", _FakeDispatcher)
+    result = telegram.TelegramChannel(bot_token="test-token", router=router)
+    result._send_response = AsyncMock()
+    return result
+
+
+@pytest.fixture
+def private_message() -> SimpleNamespace:
+    return SimpleNamespace(
+        text="private hello",
+        chat=SimpleNamespace(id=101, type="private"),
+        from_user=SimpleNamespace(id=202, first_name="Private", last_name="User"),
+        message_id=1,
+    )
+
+
+@pytest.fixture
+def group_message() -> SimpleNamespace:
+    return SimpleNamespace(
+        text="group hello",
+        chat=SimpleNamespace(id=-101, type="group"),
+        from_user=SimpleNamespace(id=202, first_name="Group", last_name="User"),
+        message_id=2,
+    )
+
+
+@pytest.fixture
+def private_document(private_message: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        **private_message.__dict__,
+        document=SimpleNamespace(file_name="private.txt", file_size=5, file_id="file-private"),
+    )
+
+
+@pytest.fixture
+def group_document(group_message: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        **group_message.__dict__,
+        document=SimpleNamespace(file_name="group.txt", file_size=5, file_id="file-group"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_private_message_does_not_store_history_when_disabled(
+    channel: telegram.TelegramChannel, private_message: SimpleNamespace
+) -> None:
+    await channel._handle_message(private_message)
+
+    channel._router.route.assert_called_once_with(
+        text=private_message.text,
+        user_id=str(private_message.from_user.id),
+        workspace_id=channel._workspace_id,
+        conversation_id=str(private_message.chat.id),
+        history_enabled=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_group_message_stores_history(
+    channel: telegram.TelegramChannel, group_message: SimpleNamespace
+) -> None:
+    await channel._handle_message(group_message)
+
+    channel._router.route.assert_called_once_with(
+        text=group_message.text,
+        user_id=str(group_message.from_user.id),
+        workspace_id=channel._workspace_id,
+        conversation_id=str(group_message.chat.id),
+        history_enabled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_private_document_is_rejected_before_download(
+    channel: telegram.TelegramChannel, private_document: SimpleNamespace
+) -> None:
+    await channel._handle_document(private_document)
+
+    channel._bot.get_file.assert_not_awaited()
+    channel._router.handle_file_upload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_group_document_is_uploaded(
+    channel: telegram.TelegramChannel, group_document: SimpleNamespace
+) -> None:
+    file_bytes = MagicMock()
+    file_bytes.read.return_value = b"hello"
+    channel._bot.get_file.return_value = SimpleNamespace(file_path="file/path")
+    channel._bot.download_file.return_value = file_bytes
+
+    await channel._handle_document(group_document)
+
+    channel._bot.get_file.assert_awaited_once_with(group_document.document.file_id)
+    channel._router.handle_file_upload.assert_called_once_with(
+        content=b"hello",
+        filename="group.txt",
+        user_id=str(group_document.from_user.id),
+        workspace_id=channel._workspace_id,
+    )
 
 
 class TestSplitMessage:


### PR DESCRIPTION
Fixes #328.

## What changed
- Scope Telegram session history by chat ID, isolating DMs, groups, and supergroups for the same user.
- Add the privacy-first Telegram setting `store_direct_messages`, defaulting to `false`.
- When DM storage is disabled, answer DMs without retained history and reject DM document uploads before mapping, download, or ingestion.
- Mark unexpected channel poller failures as `error` and release runtime/task/token ownership without deleting the connection.
- Treat malformed DM-storage config values as disabled; only a real boolean `true` opts in.

## Why
Telegram history was keyed only by user and workspace, allowing context to cross between a user’s DM and group conversations. Channel task failures also left stale runtime state while the connection could silently stop responding.

## Validation
- 93 passed across the focused session, router, Telegram, channel-manager, and connection-update tests.
- Ruff check passed.
- Independent task reviews and final branch review completed.

Automatic recovery with bounded backoff remains tracked in #337.