### PR TITLE
feat(mcp): add JWT principals and workspace grants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,7 @@ SPLADE_SERVICE_URL=http://splade:8080                 # compose -> http://splade
 # compose; only an EXTERNAL Ollama (separate deployment) makes use of an override.
 
 # --- Auth (JWT) — off by default, not part of the basic install ---
-AUTH_ENABLED=false                    # when true, JWT required on /api/v1/*
+AUTH_ENABLED=false                    # false: local MCP key; true: JWT on /api/v1/* and /mcp
 AUTH_PASSWORD=metronix                # default admin login (admin@metronix.local) — seeded on first start; change in production
 
 # --- MCP standalone runner — only for `python -m metronix.mcp`, NOT the API mount ---
@@ -256,9 +256,10 @@ LLM_PROVIDER_MODEL=                   # required when LLM_PROVIDER=custom
 OLLAMA_HOST=http://ollama:11434    # bundled stack overrides this to http://ollama:11434
 
 # --- 2) MCP auth token ------------------------------------------------------
-# Bearer token for the /mcp endpoint (Hermes / Cursor / Claude Desktop / OpenClaw).
+# Legacy Bearer token for local /mcp clients when AUTH_ENABLED=false.
 # A token YOU create — any strong string. Generate one:  openssl rand -hex 32
 # Empty = MCP accepts connections with no auth.
+# This value is ignored when AUTH_ENABLED=true; hosted MCP clients must send a user JWT.
 METRONIX_MCP_API_KEY=
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 **Self-hosted memory infra for AI agents — MCP-native, local-model friendly: hybrid RAG + temporal knowledge graph & ontology layer, durable memory, freshness checks, agent-scoped context.**
 
+> **MCP authentication modes:** Local/self-hosted examples use the legacy
+> `METRONIX_MCP_API_KEY` bearer token with `AUTH_ENABLED=false`. Hosted deployments with
+> `AUTH_ENABLED=true` require a user JWT in the same `Authorization: Bearer ...` header;
+> the shared MCP API key is ignored in that mode.
+
 Metronix gives agents a memory backend they can actually call: ingest files and SaaS knowledge, retrieve with dense + sparse + graph context, store durable facts and preferences per agent, and keep long-lived knowledge fresh as projects change.
 
 <p align="center">
@@ -151,13 +156,15 @@ Flags: `--mode memory|answers`, `--chat-url`, `--chat-model`, `--chat-api-key`, 
 
 *Prefer manual setup? Continue with step 2 below.*
 
-### 2. Configure: set the MCP key in `.env`
+### 2. Configure: set the local MCP key in `.env`
 
 ```bash
 cp .env.example .env
 ```
 
-For **agent memory over MCP** (Hermes, Cursor, …) you only need the MCP auth key. Embeddings for ingest come from the bundled Ollama container (`nomic-embed-text`), and a small graph model (`qwen2.5:3b`) is pulled alongside it for knowledge-graph extraction — both on first
+For the default local `AUTH_ENABLED=false` setup, **agent memory over MCP** (Hermes,
+Cursor, …) uses the legacy MCP auth key below. Hosted `AUTH_ENABLED=true` deployments use
+a JWT obtained from the Metronix administrator instead. Embeddings for ingest come from the bundled Ollama container (`nomic-embed-text`), and a small graph model (`qwen2.5:3b`) is pulled alongside it for knowledge-graph extraction — both on first
 `docker compose up`. No external chat LLM is required in `.env`.
 
 ```bash
@@ -256,8 +263,9 @@ from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 async def main():
-    # If METRONIX_MCP_API_KEY is set in your .env, pass it as a Bearer token:
-    # headers = {"Authorization": "Bearer <your-mcp-key>"}
+    # Local AUTH_ENABLED=false: use METRONIX_MCP_API_KEY from .env.
+    # Hosted AUTH_ENABLED=true: use a user JWT instead; the shared key is ignored.
+    # headers = {"Authorization": "Bearer <local-key-or-user-jwt>"}
     headers = {}
 
     async with streamablehttp_client("http://localhost:8000/mcp", headers=headers) as (r, w, _):

--- a/connecting_to_agent.md
+++ b/connecting_to_agent.md
@@ -1,5 +1,9 @@
 # Connecting an Agent
 
+> **Authentication mode:** The local setup and generated examples below use
+> `METRONIX_MCP_API_KEY` with `AUTH_ENABLED=false`. For a hosted deployment with
+> `AUTH_ENABLED=true`, put a user JWT in the same Bearer header; the shared key is ignored.
+
 Metronix exposes an MCP server at `/mcp`. Connecting an agent does two things: it registers
 Metronix as an MCP server in the agent's runtime (giving it Metronix's knowledge search and
 memory tools), and it tells the agent to use Metronix as its durable-memory store.
@@ -13,8 +17,9 @@ There are two ways to do this:
   not agent-driven. To then make Metronix the agent's primary memory store and migrate
   existing memory, use the prompt-based setup.
 
-Both paths produce the same result. Do this **after** the backend is running and
-`METRONIX_MCP_API_KEY` is set in `.env` (see [`install.md`](install.md)).
+Both paths produce the same result. For the local mode shown below, do this **after** the
+backend is running and `METRONIX_MCP_API_KEY` is set in `.env` (see
+[`install.md`](install.md)). Hosted users need a JWT from their Metronix administrator.
 
 ## What you need
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,9 @@ For **MCP tools** (recommended for agent runtimes), see [`docs/MCP_API.md`](MCP_
 
 ## Authentication
 
-When `METRONIX_AUTH_ENABLED=true` (production default), pass a JWT or personal API key:
+When `AUTH_ENABLED=true`, pass a JWT or personal API key to REST endpoints. MCP accepts a
+user JWT in this mode. With `AUTH_ENABLED=false`, REST retains local trusted mode and MCP
+uses the legacy `METRONIX_MCP_API_KEY` when one is configured (or remains open when unset).
 
 ```bash
 export TOKEN="eyJ..."
@@ -22,7 +24,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/v1/auth/me
 | JWT (login) | `Authorization: Bearer <jwt>` | From `POST /api/v1/auth/login` |
 | Personal API key | `Authorization: Bearer mtk_...` | Created via `/api/v1/users/{id}/api-keys` |
 | OpenAI-compat key | `Authorization: Bearer mtk_...` or static `METRONIX_OPENAI_COMPAT_KEY` | `/v1/*` endpoints only |
-| MCP | `Authorization: Bearer <METRONIX_MCP_API_KEY>` | `/mcp` (see MCP doc) |
+| MCP | JWT when `AUTH_ENABLED=true`; `METRONIX_MCP_API_KEY` when `AUTH_ENABLED=false` | `/mcp`; the shared key is ignored in JWT mode (see MCP doc) |
 
 **RBAC hierarchy:** `viewer` < `editor` < `admin`. Endpoints below note the minimum role when auth is enabled.
 

--- a/docs/MCP_API.md
+++ b/docs/MCP_API.md
@@ -7,7 +7,7 @@ For integration patterns and routing guidance see [integrations/hermes.md](integ
 
 **Endpoint:** `http://<host>:8000/mcp`  
 **Transport:** Streamable HTTP (MCP protocol)  
-**Auth:** Bearer token via `METRONIX_MCP_API_KEY` env var (optional in dev mode)
+**Hosted auth:** JWT bearer token (`Authorization: Bearer <jwt>`)
 
 ### Finding the MCP URL
 
@@ -36,6 +36,9 @@ The id must be **1–64 characters** from `A–Z a–z 0–9 . _ -` (UUIDs and s
 `my-agent-001` qualify; spaces and `/` do not). Invalid ids are dropped from the header and
 rejected by the memory tools with `INVALID_PARAMS`.
 
+`X-Agent-Id` does not grant workspace membership or delegation authority. It is request data
+used for attribution and memory partitioning; the server derives hosted access from the JWT.
+
 See [`docs/guides/agents-and-workspaces.md`](guides/agents-and-workspaces.md).
 
 ### Full HTTP Example
@@ -43,7 +46,7 @@ See [`docs/guides/agents-and-workspaces.md`](guides/agents-and-workspaces.md).
 ```bash
 # Initialize MCP session
 curl -X POST http://localhost:8000/mcp \
-  -H "Authorization: Bearer <your-api-key>" \
+  -H "Authorization: Bearer <jwt>" \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -67,7 +70,7 @@ from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
 async def main():
-    headers = {"Authorization": "Bearer <your-api-key>"}
+    headers = {"Authorization": "Bearer <jwt>"}
     async with streamablehttp_client("http://localhost:8000/mcp", headers=headers) as (r, w, _):
         async with ClientSession(r, w) as session:
             await session.initialize()
@@ -85,20 +88,22 @@ async def main():
 
 ## Authentication
 
-| Mode | Behavior |
-|------|----------|
-| `METRONIX_MCP_API_KEY` **not set** | All requests allowed (dev mode) |
-| `METRONIX_MCP_API_KEY` **set** | Requires `Authorization: Bearer <key>` header |
+When `AUTH_ENABLED=true`, `/mcp` requires `Authorization: Bearer <jwt>`. The server verifies
+the JWT and derives the user, role, and workspace grants from its claims. Absent, invalid, or
+expired credentials return **401** with `WWW-Authenticate: Bearer`.
 
-Auth uses timing-safe comparison (`hmac.compare_digest`). Invalid or missing keys
-return `PermissionError`.
+`METRONIX_MCP_API_KEY` is development/bootstrap-only and is not accepted as a hosted-user
+credential. It is not a substitute for a user JWT when `AUTH_ENABLED=true`. Auth-disabled local
+development and stdio retain their local configuration behavior.
 
 ---
 
 ## Workspace Isolation
 
-**Every tool accepts `workspace_id`.** If omitted, defaults to `"default"` — which
-typically has no data. Always pass the workspace explicitly.
+**Every tool accepts `workspace_id`.** In hosted mode, the requested workspace must be listed in
+the JWT's workspace grants. An ungranted workspace returns 403 before data access. If omitted,
+the server selects a granted workspace; a local auth-disabled or stdio client instead uses its
+configured default workspace. Always pass the intended workspace explicitly.
 
 ```json
 {

--- a/docs/examples/python-sdk.md
+++ b/docs/examples/python-sdk.md
@@ -1,5 +1,9 @@
 # Python SDK Example (MCP)
 
+> **Authentication mode:** The example uses `METRONIX_MCP_API_KEY` for local
+> `AUTH_ENABLED=false`. With hosted `AUTH_ENABLED=true`, supply a user JWT in the same
+> Bearer header; the shared key is ignored.
+
 Connect to Metronix Memory via MCP, store a memory record, and retrieve it.
 
 ## Prerequisites

--- a/docs/guides/agents-and-workspaces.md
+++ b/docs/guides/agents-and-workspaces.md
@@ -1,5 +1,9 @@
 # Agents And Workspaces
 
+> **MCP authentication mode:** Local `AUTH_ENABLED=false` clients may use
+> `METRONIX_MCP_API_KEY`. Hosted `AUTH_ENABLED=true` clients must use a user JWT in the
+> Bearer header; the shared key is ignored.
+
 Metronix scopes data by workspace and, for memory, by agent.
 
 ## Workspace

--- a/docs/integrations/atomic-chat.md
+++ b/docs/integrations/atomic-chat.md
@@ -1,5 +1,9 @@
 # Open WebUI + Ollama (local chat)
 
+> **MCP authentication mode:** Local `AUTH_ENABLED=false` MCP examples use
+> `METRONIX_MCP_API_KEY`. Hosted `AUTH_ENABLED=true` MCP clients use a user JWT instead;
+> the shared key is ignored.
+
 ## Recommended path
 
 If you want a local self-hosted chat UI quickly, use:

--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -1,5 +1,9 @@
 # Claude Code
 
+> **MCP authentication mode:** The installer and examples below target local
+> `AUTH_ENABLED=false` and use `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put
+> a user JWT in the same Bearer header; the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory through MCP, registered with the `claude` CLI's built-in

--- a/docs/integrations/claude-code/prompt-1-install.md
+++ b/docs/integrations/claude-code/prompt-1-install.md
@@ -1,4 +1,8 @@
 # Metronix MCP — install as an MCP server
+Authentication mode: this generated prompt targets local `AUTH_ENABLED=false` and uses
+`METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, use a user JWT in the Bearer header;
+the shared key is ignored.
+
 You are a Claude Code instance with shell access. Run this ONCE per deployment.
 If `metronix` already exists in `claude mcp list` with the correct URL, just
 verify it and report — do not create a duplicate.

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -2,6 +2,10 @@
 
 # Claude Desktop Integration
 
+> **MCP authentication mode:** The example targets local `AUTH_ENABLED=false` and uses
+> `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
+> header; the shared key is ignored.
+
 Configure Claude Desktop as an MCP client for Metronix.
 
 Required values:

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -1,5 +1,9 @@
 # Codex
 
+> **MCP authentication mode:** The installer and examples below target local
+> `AUTH_ENABLED=false` and use `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put
+> a user JWT in the same Bearer header; the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory through MCP, registered directly in `config.toml`. Unlike

--- a/docs/integrations/codex/prompt-1-install.md
+++ b/docs/integrations/codex/prompt-1-install.md
@@ -1,4 +1,8 @@
 # Metronix MCP — install as an MCP server
+Authentication mode: this generated prompt targets local `AUTH_ENABLED=false` and uses
+`METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, use a user JWT in the Bearer header;
+the shared key is ignored.
+
 You are a Codex instance with shell and file access. Run this ONCE per
 deployment. If a `[mcp_servers.metronix]` table already exists in your
 `config.toml` with the correct URL, just verify it and report — do not create

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,5 +1,9 @@
 # Cursor Integration
 
+> **MCP authentication mode:** The example targets local `AUTH_ENABLED=false` and uses
+> `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
+> header; the shared key is ignored.
+
 Use Metronix through Cursor's MCP support.
 
 1. Start Metronix and confirm `curl http://localhost:8000/health`.

--- a/docs/integrations/hermes-agent.md
+++ b/docs/integrations/hermes-agent.md
@@ -1,5 +1,9 @@
 # Hermes Agent
 
+> **MCP authentication mode:** The example targets local `AUTH_ENABLED=false` and uses
+> `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
+> header; the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory as an HTTP MCP server today.

--- a/docs/integrations/hermes.md
+++ b/docs/integrations/hermes.md
@@ -1,5 +1,9 @@
 # Hermes Integration
 
+> **MCP authentication mode:** The installer and examples below target local
+> `AUTH_ENABLED=false` and use `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put
+> a user JWT in the same Bearer header; the shared key is ignored.
+
 This is the full prompt-driven setup for **Hermes**. For any other MCP client, use the
 runtime-neutral guide in [`../../connecting_to_agent.md`](../../connecting_to_agent.md).
 

--- a/docs/integrations/hermes/prompt-1-install.md
+++ b/docs/integrations/hermes/prompt-1-install.md
@@ -1,4 +1,8 @@
 # Metronix MCP — install as an MCP server
+Authentication mode: this generated prompt targets local `AUTH_ENABLED=false` and uses
+`METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, use a user JWT in the Bearer header;
+the shared key is ignored.
+
 You are a Hermes Agent instance. Run this ONCE per deployment.
 If `mcp_servers.metronix` already exists in your config with the correct URL,
 just verify it and report — do not create a duplicate.

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,5 +1,9 @@
 # LangChain
 
+> **MCP authentication mode:** Local `AUTH_ENABLED=false` MCP examples use
+> `METRONIX_MCP_API_KEY`. Hosted `AUTH_ENABLED=true` MCP clients use a user JWT instead;
+> the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory's OpenAI-compatible API for chat, or call REST/MCP directly for advanced

--- a/docs/integrations/mcp-reference.md
+++ b/docs/integrations/mcp-reference.md
@@ -15,10 +15,18 @@ See [`../MCP_API.md`](../MCP_API.md#finding-the-mcp-url) for details.
 Required headers:
 
 ```text
-Authorization: Bearer <METRONIX_MCP_API_KEY>
+Authorization: Bearer <jwt>
 X-Agent-Id: <stable-agent-id>
 ```
 
+When `AUTH_ENABLED=true`, `/mcp` requires `Authorization: Bearer <jwt>`. Missing, invalid, or
+expired credentials return **401**. The server derives the caller's workspace grants from the
+JWT; an ungranted workspace returns 403 before data access.
+
+`METRONIX_MCP_API_KEY` is development/bootstrap-only and is not accepted as a hosted-user
+credential. It cannot authenticate a hosted MCP user when `AUTH_ENABLED=true`.
+
 `X-Agent-Id` scopes MCP and memory to one agent; use the same value as `agent_id` in memory
 tools and as the agent UUID in Metronix Console (corporate version) when linking a runtime.
+It does not grant workspace membership or delegation authority.
 See [`../guides/agents-and-workspaces.md`](../guides/agents-and-workspaces.md).

--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -1,5 +1,9 @@
 # n8n
 
+> **MCP authentication mode:** Local `AUTH_ENABLED=false` MCP examples use
+> `METRONIX_MCP_API_KEY`. Hosted `AUTH_ENABLED=true` MCP clients use a user JWT instead;
+> the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory through HTTP nodes first.

--- a/docs/integrations/nanobot.md
+++ b/docs/integrations/nanobot.md
@@ -1,5 +1,9 @@
 # NanoBot
 
+> **MCP authentication mode:** The example targets local `AUTH_ENABLED=false` and uses
+> `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
+> header; the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory through MCP if NanoBot supports external MCP servers. Otherwise use the

--- a/docs/integrations/nanoclaw.md
+++ b/docs/integrations/nanoclaw.md
@@ -1,5 +1,9 @@
 # NanoClaw
 
+> **MCP authentication mode:** The example targets local `AUTH_ENABLED=false` and uses
+> `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
+> header; the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory through MCP.

--- a/docs/integrations/openclaw.md
+++ b/docs/integrations/openclaw.md
@@ -1,5 +1,9 @@
 # OpenClaw
 
+> **MCP authentication mode:** The installer and examples below target local
+> `AUTH_ENABLED=false` and use `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put
+> a user JWT in the same Bearer header; the shared key is ignored.
+
 OpenClaw connects to Metronix through MCP.
 
 ## Recommended mode

--- a/docs/integrations/opencode.md
+++ b/docs/integrations/opencode.md
@@ -1,5 +1,9 @@
 # OpenCode
 
+> **MCP authentication mode:** The example targets local `AUTH_ENABLED=false` and uses
+> `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
+> header; the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory through MCP.

--- a/docs/integrations/pi.md
+++ b/docs/integrations/pi.md
@@ -1,5 +1,9 @@
 # Pi
 
+> **MCP authentication mode:** The example targets local `AUTH_ENABLED=false` and uses
+> `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
+> header; the shared key is ignored.
+
 ## Recommended mode
 
 Use Metronix Memory through MCP via Pi's MCP adapter.

--- a/docs/integrations/sdk-go.md
+++ b/docs/integrations/sdk-go.md
@@ -1,5 +1,9 @@
 # Go SDK
 
+> **MCP authentication mode:** Local `AUTH_ENABLED=false` MCP examples use
+> `METRONIX_MCP_API_KEY`. Hosted `AUTH_ENABLED=true` MCP clients use a user JWT instead;
+> the shared key is ignored.
+
 ## Recommended surfaces
 
 Use:

--- a/docs/integrations/sdk-python.md
+++ b/docs/integrations/sdk-python.md
@@ -1,5 +1,9 @@
 # Python SDK
 
+> **MCP authentication mode:** Local `AUTH_ENABLED=false` MCP examples use
+> `METRONIX_MCP_API_KEY`. Hosted `AUTH_ENABLED=true` MCP clients use a user JWT instead;
+> the shared key is ignored.
+
 ## Recommended surfaces
 
 Pick the simplest interface that matches the job:

--- a/docs/superpowers/specs/2026-07-20-mcp-jwt-principals-design.md
+++ b/docs/superpowers/specs/2026-07-20-mcp-jwt-principals-design.md
@@ -1,0 +1,74 @@
+# MCP JWT principals and workspace grants
+
+## Goal
+
+Implement issue #312 by making MCP authenticate the same concrete JWT user
+principal as REST. The result is trusted, server-derived identity and workspace
+grant context that issue #314 can later authorize against.
+
+## Scope
+
+The implementation accepts JWT bearer credentials for MCP in production and
+exposes a typed request-scoped principal containing the authenticated user ID,
+role, workspace grants, and `auth_method="jwt"`.
+
+It does not add service/API-key principals, resource policy decisions, agent
+delegation rules, or cross-transport authorization conformance. Those remain
+separate work for issues #314 and #310.
+
+## Authentication and context
+
+1. Define an immutable `MCPPrincipal` value with `user_id`, `role`,
+   `workspace_ids`, and `auth_method` fields.
+2. Define a context variable with bind/get/reset helpers so MCP dispatch and
+   tools can retrieve the current principal without accepting client-provided
+   identity fields.
+3. In production (`AUTH_ENABLED=true`), MCP HTTP middleware requires a bearer
+   JWT and validates it through the existing JWT verifier and configured secret.
+   Invalid, missing, or expired credentials receive a 401 response.
+4. Admin JWTs with an empty workspace list are normalized to `["*"]`, matching
+   REST. Every other empty list grants access to no workspaces.
+5. The deployment-wide `METRONIX_MCP_API_KEY` is not a hosted-user identity and
+   is rejected on production MCP requests. With authentication disabled, the
+   local development flow retains its existing trusted-admin behavior.
+
+## Workspace resolution
+
+MCP workspace resolution consumes the bound principal rather than treating a
+tool argument as authority.
+
+- A requested workspace must be syntactically valid and present in the
+  principal's grants, unless the principal carries `["*"]`.
+- An omitted workspace selects the principal's first concrete workspace. A
+  wildcard principal falls back to the configured default workspace.
+- A principal without a usable grant fails closed before any store or registry
+  lookup.
+- `X-Agent-Id` remains validated request context only. It neither grants
+  ownership nor delegation; the future shared evaluator receives it alongside
+  the principal.
+
+## Migration and documentation
+
+MCP clients in hosted deployments change from
+`Authorization: Bearer $METRONIX_MCP_API_KEY` to a user JWT bearer token.
+Documentation will describe that the shared MCP key is development-only, plus
+the expected 401 authentication and 403 workspace-grant failure behavior.
+
+## Verification
+
+Tests will prove:
+
+1. Valid and invalid JWTs resolve or reject an `MCPPrincipal` correctly.
+2. Empty-grant and admin-wildcard behavior matches REST.
+3. Production MCP rejects the shared deployment key and accepts a valid JWT.
+4. Granted workspaces resolve; ungranted or malformed values fail before store
+   construction.
+5. The same JWT produces equal effective workspace grants for REST and MCP.
+
+## Non-goals and follow-up boundaries
+
+This slice deliberately establishes authentication and authoritative request
+context only. Issue #314 will use the principal, resource, operation, and
+agent-context inputs to make auditable allow/deny decisions at discovery and
+execution boundaries. Issue #310 will verify the transport-neutral policy
+contract.

--- a/install.md
+++ b/install.md
@@ -1,5 +1,9 @@
 # Installing Metronix Memory
 
+> **MCP authentication mode:** This local installation guide uses
+> `METRONIX_MCP_API_KEY` with `AUTH_ENABLED=false`. If you enable hosted authentication with
+> `AUTH_ENABLED=true`, clients must send a user JWT instead; the shared key is ignored.
+
 This is the complete, by-hand installation guide for the Metronix Core backend. It takes
 you from an empty machine to a running stack you can verify with a health check.
 

--- a/prompts.md
+++ b/prompts.md
@@ -1,5 +1,9 @@
 # Agent Setup Prompts
 
+> **Authentication mode:** Installer-filled prompts target local `AUTH_ENABLED=false` and
+> use `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, replace that credential with
+> a user JWT in the Bearer header; the shared key is ignored.
+
 This page collects every prompt used to connect an agent to Metronix over MCP. Paste them
 into your agent or LLM client, in order. Each prompt is self-contained — it asks you for any
 missing parameter before doing anything.

--- a/src/metronix/api/middleware/__init__.py
+++ b/src/metronix/api/middleware/__init__.py
@@ -8,7 +8,8 @@ from starlette.responses import JSONResponse
 
 from metronix.auth.jwt import verify_token
 from metronix.core.config import Settings
-from metronix.mcp.auth import validate_api_key
+from metronix.mcp.auth import authenticate_jwt
+from metronix.mcp.principal import bind_principal, reset_principal
 
 PUBLIC_PATHS = {
     "/health",
@@ -23,16 +24,12 @@ PUBLIC_PATHS = {
     "/v1/openapi.json",
 }
 
-# Paths that use MCP API key auth instead of JWT
+# MCP routes authenticated separately from the REST API routes below.
 MCP_PATHS = {"/mcp"}
 
 
 class OptionalAuthMiddleware(BaseHTTPMiddleware):
-    """When AUTH_ENABLED=true, require JWT on /api/v1/ endpoints.
-
-    The /mcp endpoint uses its own API key auth (METRONIX_MCP_API_KEY)
-    independently of AUTH_ENABLED.
-    """
+    """When AUTH_ENABLED=true, require JWT on protected API and MCP endpoints."""
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         settings: Settings = request.app.state.settings
@@ -42,15 +39,33 @@ class OptionalAuthMiddleware(BaseHTTPMiddleware):
 
         path = request.url.path.rstrip("/")
 
-        # MCP endpoint: validate via METRONIX_MCP_API_KEY (independent of AUTH_ENABLED)
+        # MCP must receive the same server-derived principal as standalone HTTP.
+        # In development, retain the trusted request path used when auth is disabled.
         if path in MCP_PATHS:
-            auth_header = request.headers.get("authorization")
-            if not validate_api_key(auth_header):
+            if not settings.auth_enabled:
+                return await call_next(request)
+
+            try:
+                principal = authenticate_jwt(
+                    request.headers.get("authorization"), settings.secret_key
+                )
+            except PermissionError:
                 return JSONResponse(
                     status_code=401,
-                    content={"error": "Invalid or missing MCP API key"},
+                    content={"detail": "MCP JWT authentication required"},
+                    headers={"WWW-Authenticate": "Bearer"},
                 )
-            return await call_next(request)
+
+            request.state.user = {
+                "user_id": principal.user_id,
+                "role": principal.role,
+                "workspace_ids": list(principal.workspace_ids),
+            }
+            principal_token = bind_principal(principal)
+            try:
+                return await call_next(request)
+            finally:
+                reset_principal(principal_token)
 
         if not settings.auth_enabled:
             # AUTH off == dev mode == trusted admin. Without this, resolve_workspace_id

--- a/src/metronix/api/middleware/__init__.py
+++ b/src/metronix/api/middleware/__init__.py
@@ -8,7 +8,7 @@ from starlette.responses import JSONResponse
 
 from metronix.auth.jwt import verify_token
 from metronix.core.config import Settings
-from metronix.mcp.auth import authenticate_jwt
+from metronix.mcp.auth import authenticate_http_request
 from metronix.mcp.principal import bind_principal, reset_principal
 
 PUBLIC_PATHS = {
@@ -42,19 +42,26 @@ class OptionalAuthMiddleware(BaseHTTPMiddleware):
         # MCP must receive the same server-derived principal as standalone HTTP.
         # In development, retain the trusted request path used when auth is disabled.
         if path in MCP_PATHS:
-            if not settings.auth_enabled:
-                return await call_next(request)
-
             try:
-                principal = authenticate_jwt(
-                    request.headers.get("authorization"), settings.secret_key
+                principal = authenticate_http_request(
+                    request.headers.get("authorization"),
+                    auth_enabled=settings.auth_enabled,
+                    secret_key=settings.secret_key,
                 )
             except PermissionError:
+                detail = (
+                    "MCP JWT authentication required"
+                    if settings.auth_enabled
+                    else "Invalid or missing MCP API key"
+                )
                 return JSONResponse(
                     status_code=401,
-                    content={"detail": "MCP JWT authentication required"},
+                    content={"detail": detail},
                     headers={"WWW-Authenticate": "Bearer"},
                 )
+
+            if principal is None:
+                return await call_next(request)
 
             request.state.user = {
                 "user_id": principal.user_id,

--- a/src/metronix/mcp/auth.py
+++ b/src/metronix/mcp/auth.py
@@ -10,6 +10,10 @@ import os
 
 import structlog
 
+from metronix.auth.jwt import verify_token
+from metronix.core.exceptions import AuthenticationError
+from metronix.mcp.principal import MCPPrincipal
+
 logger = structlog.get_logger()
 
 
@@ -72,3 +76,42 @@ def require_api_key(authorization_header: str | None) -> None:
     """
     if not validate_api_key(authorization_header):
         raise PermissionError("Invalid or missing API key")
+
+
+def authenticate_jwt(authorization_header: str | None, secret_key: str) -> MCPPrincipal:
+    """Resolve an MCP principal from a bearer JWT.
+
+    JWT claims are verified server-side and only their expected, typed values are
+    used to construct the principal.
+    """
+    if not authorization_header or not authorization_header.startswith("Bearer "):
+        raise PermissionError("Invalid or missing JWT")
+
+    token = authorization_header.removeprefix("Bearer ")
+    if not token:
+        raise PermissionError("Invalid or missing JWT")
+
+    try:
+        payload = verify_token(token, secret_key)
+        user_id = payload["sub"]
+        role = payload["role"]
+        workspace_ids = payload["workspace_ids"]
+        if (
+            not isinstance(user_id, str)
+            or not isinstance(role, str)
+            or not isinstance(workspace_ids, list)
+            or not all(isinstance(workspace_id, str) for workspace_id in workspace_ids)
+        ):
+            raise ValueError("Invalid JWT payload")
+    except (AuthenticationError, KeyError, TypeError, ValueError) as exc:
+        raise PermissionError("Invalid or missing JWT") from exc
+
+    normalized_workspace_ids = tuple(workspace_ids)
+    if role == "admin" and not normalized_workspace_ids:
+        normalized_workspace_ids = ("*",)
+
+    return MCPPrincipal(
+        user_id=user_id,
+        role=role,
+        workspace_ids=normalized_workspace_ids,
+    )

--- a/src/metronix/mcp/auth.py
+++ b/src/metronix/mcp/auth.py
@@ -78,6 +78,25 @@ def require_api_key(authorization_header: str | None) -> None:
         raise PermissionError("Invalid or missing API key")
 
 
+def authenticate_http_request(
+    authorization_header: str | None,
+    *,
+    auth_enabled: bool,
+    secret_key: str,
+) -> MCPPrincipal | None:
+    """Authenticate one MCP HTTP request using the configured server mode.
+
+    Hosted deployments use JWT principals when application auth is enabled.
+    Authentication-disabled local deployments retain the legacy shared MCP key;
+    when no key is configured, ``require_api_key`` preserves the open dev mode.
+    """
+    if auth_enabled:
+        return authenticate_jwt(authorization_header, secret_key)
+
+    require_api_key(authorization_header)
+    return None
+
+
 def authenticate_jwt(authorization_header: str | None, secret_key: str) -> MCPPrincipal:
     """Resolve an MCP principal from a bearer JWT.
 

--- a/src/metronix/mcp/config.py
+++ b/src/metronix/mcp/config.py
@@ -112,13 +112,19 @@ def resolve_workspace_id(workspace_id: str | None) -> str:
         return requested or get_default_workspace_id()
 
     if not requested:
+
+        def settings_default_workspace_id() -> str:
+            from metronix.core.config import get_settings
+
+            return get_settings().default_workspace_id
+
         if principal.workspace_ids and principal.workspace_ids[0] == "*":
-            return get_default_workspace_id()
+            return settings_default_workspace_id()
         for granted_workspace_id in principal.workspace_ids:
             if granted_workspace_id != "*":
                 return granted_workspace_id
         if "*" in principal.workspace_ids:
-            return get_default_workspace_id()
+            return settings_default_workspace_id()
         raise PermissionError("MCP principal has no workspace grants")
 
     if requested in principal.workspace_ids or "*" in principal.workspace_ids:

--- a/src/metronix/mcp/config.py
+++ b/src/metronix/mcp/config.py
@@ -112,6 +112,8 @@ def resolve_workspace_id(workspace_id: str | None) -> str:
         return requested or get_default_workspace_id()
 
     if not requested:
+        if principal.workspace_ids and principal.workspace_ids[0] == "*":
+            return get_default_workspace_id()
         for granted_workspace_id in principal.workspace_ids:
             if granted_workspace_id != "*":
                 return granted_workspace_id

--- a/src/metronix/mcp/config.py
+++ b/src/metronix/mcp/config.py
@@ -7,6 +7,7 @@ stored per-workspace via MCPServerRegistry.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +50,7 @@ class MCPServerConfig(BaseModel):
 
 # Default path for stdio transport configuration
 CONFIG_PATH = Path.home() / ".metronix" / "config.json"
+WORKSPACE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 def load_stdio_config(config_path: Path = CONFIG_PATH) -> dict[str, Any]:
@@ -91,10 +93,32 @@ def get_default_workspace_id(config_path: Path = CONFIG_PATH) -> str:
 
 
 def resolve_workspace_id(workspace_id: str | None) -> str:
-    """Resolve an explicit ``workspace_id``, falling back to the configured default.
+    """Resolve and authorize an MCP tool workspace.
 
-    MCP tools call this so an omitted ``workspace_id`` routes to the server's
-    ``DEFAULT_WORKSPACE_ID`` rather than a literal ``"default"`` — keeping
-    MCP-driven ingestion/memory in the same workspace as the REST API and UI.
+    Explicit workspace IDs use the REST workspace syntax. When an authenticated
+    MCP principal is bound to the request, its grants are enforced before tools
+    can create stores or services for the requested workspace. Without a bound
+    principal, stdio and authentication-disabled MCP retain their existing
+    configured-default behavior.
     """
-    return workspace_id or get_default_workspace_id()
+    requested = workspace_id.strip() if workspace_id is not None else ""
+    if requested and not WORKSPACE_ID_PATTERN.fullmatch(requested):
+        raise ValueError("workspace_id must be 1-64 chars of A-Za-z0-9_-")
+
+    from metronix.mcp.principal import get_current_principal
+
+    principal = get_current_principal()
+    if principal is None:
+        return requested or get_default_workspace_id()
+
+    if not requested:
+        for granted_workspace_id in principal.workspace_ids:
+            if granted_workspace_id != "*":
+                return granted_workspace_id
+        if "*" in principal.workspace_ids:
+            return get_default_workspace_id()
+        raise PermissionError("MCP principal has no workspace grants")
+
+    if requested in principal.workspace_ids or "*" in principal.workspace_ids:
+        return requested
+    raise PermissionError(f"No access to workspace '{requested}'")

--- a/src/metronix/mcp/principal.py
+++ b/src/metronix/mcp/principal.py
@@ -1,0 +1,36 @@
+"""Request-scoped MCP authentication principal."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MCPPrincipal:
+    """Server-derived identity for an authenticated MCP request."""
+
+    user_id: str
+    role: str
+    workspace_ids: tuple[str, ...]
+    auth_method: str = "jwt"
+
+
+_current_principal: ContextVar[MCPPrincipal | None] = ContextVar(
+    "current_mcp_principal", default=None
+)
+
+
+def bind_principal(principal: MCPPrincipal) -> Token[MCPPrincipal | None]:
+    """Bind a principal to the current request context."""
+    return _current_principal.set(principal)
+
+
+def get_current_principal() -> MCPPrincipal | None:
+    """Return the principal bound to the current request context, if any."""
+    return _current_principal.get()
+
+
+def reset_principal(token: Token[MCPPrincipal | None]) -> None:
+    """Restore the principal context to its state before ``bind_principal``."""
+    _current_principal.reset(token)

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -304,7 +304,7 @@ async def run_http(
         port: Port to listen on
     """
     from metronix.core.config import get_settings
-    from metronix.mcp.auth import authenticate_jwt
+    from metronix.mcp.auth import authenticate_http_request
     from metronix.mcp.principal import bind_principal, reset_principal
 
     logger.info("mcp.server.http.starting", host=host, port=port)
@@ -332,19 +332,26 @@ async def run_http(
             if request.url.path in ("/health", "/ready"):
                 return await call_next(request)
 
-            if not settings.auth_enabled:
-                return await call_next(request)
-
             try:
-                principal = authenticate_jwt(
-                    request.headers.get("authorization"), settings.secret_key
+                principal = authenticate_http_request(
+                    request.headers.get("authorization"),
+                    auth_enabled=settings.auth_enabled,
+                    secret_key=settings.secret_key,
                 )
             except PermissionError:
+                detail = (
+                    "MCP JWT authentication required"
+                    if settings.auth_enabled
+                    else "Invalid or missing MCP API key"
+                )
                 return JSONResponse(
                     status_code=401,
-                    content={"detail": "MCP JWT authentication required"},
+                    content={"detail": detail},
                     headers={"WWW-Authenticate": "Bearer"},
                 )
+
+            if principal is None:
+                return await call_next(request)
 
             principal_token = bind_principal(principal)
             try:

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -70,6 +70,7 @@ mcp = FastMCP(
         "working with multi-tenant data."
     ),
     streamable_http_path="/mcp",
+    stateless_http=True,
     log_level="INFO",
     debug=False,
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
@@ -363,10 +364,7 @@ async def run_http(
     settings = get_settings()
 
     # Create HTTP app with stateless mode
-    app = mcp.streamable_http_app(
-        transport="streamable-http",
-        stateless_http=True,
-    )
+    app = mcp.streamable_http_app()
 
     # WS4 S6 — X-Agent-Id contextvar for standalone MCP transport
     from metronix.api.middleware.agent_id import AgentIdContextMiddleware

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -53,8 +53,8 @@ DEFAULT_PORT = 8080
 
 # Create FastMCP server instance
 # DNS rebinding protection is disabled because Metronix runs behind a reverse
-# proxy (nginx/caddy) that sets its own Host header.  Auth is handled by
-# METRONIX_MCP_API_KEY validation in the middleware instead.
+# proxy (nginx/caddy) that sets its own Host header. JWT authentication is
+# handled by the HTTP middleware instead.
 mcp = FastMCP(
     name="MetronixMCP",
     instructions=(
@@ -303,9 +303,12 @@ async def run_http(
         host: Host to bind to
         port: Port to listen on
     """
-    from metronix.mcp.auth import validate_api_key
+    from metronix.core.config import get_settings
+    from metronix.mcp.auth import authenticate_jwt
+    from metronix.mcp.principal import bind_principal, reset_principal
 
     logger.info("mcp.server.http.starting", host=host, port=port)
+    settings = get_settings()
 
     # Create HTTP app with stateless mode
     app = mcp.streamable_http_app(
@@ -329,17 +332,25 @@ async def run_http(
             if request.url.path in ("/health", "/ready"):
                 return await call_next(request)
 
-            # Get authorization header
-            auth_header = request.headers.get("authorization")
+            if not settings.auth_enabled:
+                return await call_next(request)
 
-            # Validate API key
-            if not validate_api_key(auth_header):
+            try:
+                principal = authenticate_jwt(
+                    request.headers.get("authorization"), settings.secret_key
+                )
+            except PermissionError:
                 return JSONResponse(
                     status_code=401,
-                    content={"error": "Invalid or missing API key"},
+                    content={"detail": "MCP JWT authentication required"},
+                    headers={"WWW-Authenticate": "Bearer"},
                 )
 
-            return await call_next(request)
+            principal_token = bind_principal(principal)
+            try:
+                return await call_next(request)
+            finally:
+                reset_principal(principal_token)
 
     app.add_middleware(AuthMiddleware)
 

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -155,12 +155,30 @@ def _wrap_tool_with_activity(
 
     @wraps(handler)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        from metronix.mcp.config import resolve_workspace_id
+        from metronix.mcp.principal import get_current_principal
+
         bus = bus_getter()
         start = time.monotonic()
-        agent_id = kwargs.get("agent_id") or current_agent_id.get()
-        workspace_id = kwargs.get("workspace_id") or ""
+        principal = get_current_principal()
+        transport_agent_id = current_agent_id.get()
+        handler_agent_id = transport_agent_id or kwargs.get("agent_id")
+        # In JWT mode, only transport middleware context is trusted for caller
+        # attribution. Authentication-disabled local/stdio mode retains the
+        # legacy tool-argument fallback.
+        activity_agent_id = transport_agent_id if principal is not None else handler_agent_id
         session_id = kwargs.get("session_id")
         arguments, truncated = _project_arguments(kwargs, tool_name=tool_name)
+
+        try:
+            effective_workspace_id = resolve_workspace_id(kwargs.get("workspace_id"))
+        except Exception as exc:  # fail closed for telemetry/activity persistence
+            effective_workspace_id = None
+            logger.warning(
+                "activity_log.context_unresolved",
+                tool_name=tool_name,
+                error_type=type(exc).__name__,
+            )
 
         # Bind agent_id into the contextvar so downstream calls (e.g.
         # `hybrid_search_and_answer`) that read it directly see the same
@@ -171,20 +189,41 @@ def _wrap_tool_with_activity(
         # so it will see the contextvar reset to its prior value (likely
         # `None`). No tools currently spawn fire-and-forget tasks; if that
         # changes, propagate `agent_id` explicitly into the spawned task.
-        token = bind_agent_id(agent_id) if agent_id is not None else None
+        token = (
+            bind_agent_id(handler_agent_id)
+            if transport_agent_id is None and handler_agent_id is not None
+            else None
+        )
 
         error: BaseException | None = None
+        result_error: tuple[str, str] | None = None
         try:
             # Telemetry context wraps the handler — `with` ensures correct
             # __exit__ semantics even if anyone later adds exception-aware
             # cleanup inside set_telemetry_context.
             with set_telemetry_context(
-                workspace_id=workspace_id or None,
-                agent_id=agent_id,
+                workspace_id=effective_workspace_id,
+                agent_id=activity_agent_id,
                 source="mcp",
                 correlation_id=uuid4(),
             ):
-                return await handler(*args, **kwargs)
+                result = await handler(*args, **kwargs)
+                if isinstance(result, dict) and result.get("error") is not None:
+                    result_error_payload = result["error"]
+                    if isinstance(result_error_payload, dict):
+                        error_type = str(
+                            result_error_payload.get("code")
+                            or result_error_payload.get("type")
+                            or "MCPToolError"
+                        )
+                        error_message = str(
+                            result_error_payload.get("message") or result_error_payload
+                        )
+                    else:
+                        error_type = "MCPToolError"
+                        error_message = str(result_error_payload)
+                    result_error = (error_type, error_message)
+                return result
         except BaseException as exc:  # noqa: BLE001 — emit then re-raise
             error = exc
             raise
@@ -192,31 +231,44 @@ def _wrap_tool_with_activity(
             if token is not None:
                 current_agent_id.reset(token)
             duration_ms = int((time.monotonic() - start) * 1000)
-            if bus is not None and agent_id is not None:
+            if (
+                bus is not None
+                and activity_agent_id is not None
+                and effective_workspace_id is not None
+            ):
+                error_message = (
+                    str(error)
+                    if error is not None
+                    else result_error[1]
+                    if result_error is not None
+                    else None
+                )
                 await bus.emit(
                     TOOL_CALLED,
                     {
-                        "workspace_id": workspace_id,
-                        "agent_id": agent_id,
+                        "workspace_id": effective_workspace_id,
+                        "agent_id": activity_agent_id,
                         "session_id": session_id,
                         "tool_name": tool_name,
                         "arguments": arguments,
                         "arguments_truncated": truncated,
                         "duration_ms": duration_ms,
-                        "success": error is None,
-                        "error_message": str(error) if error is not None else None,
+                        "success": error is None and result_error is None,
+                        "error_message": error_message,
                     },
                 )
-                if error is not None:
+                if error is not None or result_error is not None:
                     await bus.emit(
                         ERROR_OCCURRED,
                         {
-                            "workspace_id": workspace_id,
-                            "agent_id": agent_id,
+                            "workspace_id": effective_workspace_id,
+                            "agent_id": activity_agent_id,
                             "session_id": session_id,
                             "source": "tool",
-                            "error_type": type(error).__name__,
-                            "error_message": str(error),
+                            "error_type": (
+                                type(error).__name__ if error is not None else result_error[0]
+                            ),
+                            "error_message": error_message,
                             "context": {"tool_name": tool_name},
                         },
                     )

--- a/src/metronix/mcp/tools/export.py
+++ b/src/metronix/mcp/tools/export.py
@@ -6,7 +6,19 @@ from metronix.core.config import get_settings
 from metronix.export.deps import build_export_service
 from metronix.export.models import ExportScope
 from metronix.mcp.errors import ErrorCode, MCPError, handle_tool_error
+from metronix.mcp.principal import get_current_principal
 from metronix.mcp.server import mcp
+
+
+def _authorize_export_scope(
+    scope: ExportScope, *, denial_message: str = "no access to this export"
+) -> None:
+    """Fail closed when a bound principal cannot access an export scope."""
+    principal = get_current_principal()
+    if principal is None or "*" in principal.workspace_ids:
+        return
+    if scope.all_workspaces or scope.workspace_id not in principal.workspace_ids:
+        raise PermissionError(denial_message)
 
 
 @mcp.tool(
@@ -37,7 +49,16 @@ async def metronix_export_data(
                     hint="Pass an explicit workspace_id, or set all_workspaces=true",
                 ).to_dict(),
             }
-        scope = ExportScope(all_workspaces=all_workspaces, workspace_id=workspace_id)
+        if all_workspaces:
+            scope = ExportScope(all_workspaces=True)
+            _authorize_export_scope(scope, denial_message="all_workspaces requires admin access")
+        else:
+            from metronix.mcp.config import resolve_workspace_id
+
+            scope = ExportScope(
+                all_workspaces=False,
+                workspace_id=resolve_workspace_id(workspace_id),
+            )
         service = build_export_service(get_settings())
         job = await service.start(scope)
         return {"export_id": job.id, "status": str(job.status)}
@@ -64,6 +85,15 @@ async def metronix_export_status(export_id: str) -> dict[str, Any]:
                 ).to_dict(),
             }
         service = build_export_service(get_settings())
+        job = await service.get_job(export_id)
+        if job is None:
+            return {
+                "error": MCPError(
+                    code=ErrorCode.DOCUMENT_NOT_FOUND,
+                    message=f"metronix_export_status: no export with id '{export_id}'",
+                ).to_dict(),
+            }
+        _authorize_export_scope(job.scope)
         result = await service.status(export_id)
         if result is None:
             return {

--- a/src/metronix/mcp/tools/memory_context.py
+++ b/src/metronix/mcp/tools/memory_context.py
@@ -69,6 +69,10 @@ async def metronix_memory_get_context(
                 ).to_dict(),
             }
 
+        from metronix.mcp.config import resolve_workspace_id
+
+        ws_id = resolve_workspace_id(workspace_id)
+
         from metronix.core.config import get_settings
 
         settings = get_settings()
@@ -84,7 +88,7 @@ async def metronix_memory_get_context(
         # Import here to avoid circular imports at module level.
         from metronix.memory.assembler import AgentContextAssembler
 
-        service = await _memory_deps.build_memory_service_for_workspace(workspace_id)
+        service = await _memory_deps.build_memory_service_for_workspace(ws_id)
 
         assembler = AgentContextAssembler(
             memory_service=service,
@@ -95,7 +99,7 @@ async def metronix_memory_get_context(
         top_k = memory_top_k or settings.memory_injection_facts_top_k
         ctx = await assembler.assemble(
             agent_id=agent_id,
-            workspace_id=workspace_id,
+            workspace_id=ws_id,
             user_message=query,
             memory_top_k=top_k,
         )

--- a/tests/unit/test_auth_api.py
+++ b/tests/unit/test_auth_api.py
@@ -209,49 +209,31 @@ class TestMiddlewareEnabled:
 
 
 # ---------------------------------------------------------------------------
-# Middleware — MCP API key auth (independent of AUTH_ENABLED)
+# Middleware — MCP JWT auth
 # ---------------------------------------------------------------------------
 
 
 class TestMcpAuth:
-    """MCP endpoint uses METRONIX_MCP_API_KEY, not JWT, regardless of AUTH_ENABLED."""
+    """MCP endpoint uses JWT auth when AUTH_ENABLED is set."""
 
     def test_mcp_no_key_configured_allows_all(self, client: TestClient) -> None:
-        """When METRONIX_MCP_API_KEY is not set, /mcp is open (dev mode)."""
-        with patch("metronix.api.middleware.validate_api_key", return_value=True):
-            r = client.post("/mcp")
-            # MCP handler may return an error (no valid MCP request), but not 401
-            assert r.status_code != 401
+        """With auth disabled, development MCP requests remain open."""
+        response = client.post("/mcp")
+        # The MCP handler may reject the malformed transport request, but not auth.
+        assert response.status_code != 401
 
-    def test_mcp_rejects_without_key(self, client: TestClient) -> None:
-        """When METRONIX_MCP_API_KEY is set, /mcp rejects requests without key."""
-        with patch("metronix.api.middleware.validate_api_key", return_value=False):
-            r = client.post("/mcp")
-            assert r.status_code == 401
-            assert "MCP API key" in r.json()["error"]
+    def test_mcp_requires_jwt_when_auth_enabled(self, client_auth: TestClient) -> None:
+        response = client_auth.post("/mcp")
+        assert response.status_code == 401
+        assert response.json()["detail"] == "MCP JWT authentication required"
 
-    def test_mcp_rejects_wrong_key(self, client: TestClient) -> None:
-        """When METRONIX_MCP_API_KEY is set, /mcp rejects wrong key."""
-        with patch("metronix.api.middleware.validate_api_key", return_value=False):
-            r = client.post("/mcp", headers={"Authorization": "Bearer wrong"})
-            assert r.status_code == 401
+    def test_mcp_rejects_deployment_key_when_auth_enabled(self, client_auth: TestClient) -> None:
+        response = client_auth.post(
+            "/mcp", headers={"Authorization": "Bearer shared-deployment-key"}
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "MCP JWT authentication required"
 
-    def test_mcp_accepts_correct_key(self, client: TestClient) -> None:
-        """When correct key is provided, /mcp passes through."""
-        with patch("metronix.api.middleware.validate_api_key", return_value=True):
-            r = client.post("/mcp")
-            assert r.status_code != 401
-
-    def test_mcp_auth_works_with_auth_enabled(self, client_auth: TestClient) -> None:
-        """MCP uses API key auth even when AUTH_ENABLED=true (not JWT)."""
-        with patch("metronix.api.middleware.validate_api_key", return_value=True):
-            r = client_auth.post("/mcp")
-            # Should not get JWT 401
-            assert r.status_code != 401
-
-    def test_mcp_rejects_with_auth_enabled(self, client_auth: TestClient) -> None:
-        """MCP rejects bad key even when AUTH_ENABLED=true."""
-        with patch("metronix.api.middleware.validate_api_key", return_value=False):
-            r = client_auth.post("/mcp")
-            assert r.status_code == 401
-            assert "MCP API key" in r.json()["error"]
+    def test_mcp_accepts_valid_jwt_when_auth_enabled(self, client_auth: TestClient) -> None:
+        response = client_auth.post("/mcp", headers={"Authorization": f"Bearer {_make_token()}"})
+        assert response.status_code != 401

--- a/tests/unit/test_auth_api.py
+++ b/tests/unit/test_auth_api.py
@@ -216,11 +216,38 @@ class TestMiddlewareEnabled:
 class TestMcpAuth:
     """MCP endpoint uses JWT auth when AUTH_ENABLED is set."""
 
+    @patch.dict("os.environ", {}, clear=True)
     def test_mcp_no_key_configured_allows_all(self, client: TestClient) -> None:
         """With auth disabled, development MCP requests remain open."""
         response = client.post("/mcp")
         # The MCP handler may reject the malformed transport request, but not auth.
         assert response.status_code != 401
+
+    @pytest.mark.parametrize(
+        ("authorization", "expected_status"),
+        [
+            (None, 401),
+            ("Bearer wrong-key", 401),
+            ("Bearer legacy-key", 200),
+        ],
+    )
+    @patch.dict("os.environ", {"METRONIX_MCP_API_KEY": "legacy-key"})
+    def test_mcp_uses_legacy_api_key_when_auth_disabled(
+        self,
+        client: TestClient,
+        authorization: str | None,
+        expected_status: int,
+    ) -> None:
+        headers = {"Authorization": authorization} if authorization else {}
+
+        response = client.post("/mcp", headers=headers)
+
+        if expected_status == 401:
+            assert response.status_code == 401
+            assert response.json()["detail"] == "Invalid or missing MCP API key"
+        else:
+            # The malformed MCP request may fail downstream, but authentication passed.
+            assert response.status_code != 401
 
     def test_mcp_requires_jwt_when_auth_enabled(self, client_auth: TestClient) -> None:
         response = client_auth.post("/mcp")

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -7,7 +7,14 @@ from unittest.mock import patch
 
 import pytest
 
-from metronix.mcp.auth import get_api_key, require_api_key, validate_api_key
+from metronix.auth.jwt import create_token
+from metronix.mcp.auth import (
+    authenticate_jwt,
+    get_api_key,
+    require_api_key,
+    validate_api_key,
+)
+from metronix.mcp.principal import get_current_principal
 
 
 class TestGetApiKey:
@@ -54,3 +61,31 @@ class TestRequireApiKey:
     def test_passes_on_valid(self) -> None:
         with patch("metronix.mcp.auth.get_api_key", return_value="secret"):
             require_api_key("Bearer secret")  # Should not raise
+
+
+def test_authenticate_jwt_returns_server_derived_principal() -> None:
+    token = create_token(
+        user_id="user-1", role="editor", workspace_ids=["ws-a", "ws-b"], secret_key="test-secret"
+    )
+
+    principal = authenticate_jwt(f"Bearer {token}", "test-secret")
+
+    assert principal.user_id == "user-1"
+    assert principal.role == "editor"
+    assert principal.workspace_ids == ("ws-a", "ws-b")
+    assert principal.auth_method == "jwt"
+    assert get_current_principal() is None
+
+
+def test_authenticate_jwt_normalizes_empty_admin_grants() -> None:
+    token = create_token(
+        user_id="admin-1", role="admin", workspace_ids=[], secret_key="test-secret"
+    )
+
+    assert authenticate_jwt(f"Bearer {token}", "test-secret").workspace_ids == ("*",)
+
+
+@pytest.mark.parametrize("header", [None, "Basic token", "Bearer invalid"])
+def test_authenticate_jwt_rejects_invalid_bearer_credentials(header: str | None) -> None:
+    with pytest.raises(PermissionError, match="Invalid or missing JWT"):
+        authenticate_jwt(header, "test-secret")

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -6,8 +6,14 @@ import os
 from unittest.mock import patch
 
 import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
 
 from metronix.auth.jwt import create_token
+from metronix.core.config import Settings
 from metronix.mcp.auth import (
     authenticate_jwt,
     get_api_key,
@@ -15,6 +21,7 @@ from metronix.mcp.auth import (
     validate_api_key,
 )
 from metronix.mcp.principal import get_current_principal
+from metronix.mcp.server import run_http
 
 
 class TestGetApiKey:
@@ -89,3 +96,44 @@ def test_authenticate_jwt_normalizes_empty_admin_grants() -> None:
 def test_authenticate_jwt_rejects_invalid_bearer_credentials(header: str | None) -> None:
     with pytest.raises(PermissionError, match="Invalid or missing JWT"):
         authenticate_jwt(header, "test-secret")
+
+
+async def test_standalone_http_uses_legacy_api_key_when_auth_disabled() -> None:
+    async def endpoint(request: Request) -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    app = Starlette(routes=[Route("/mcp", endpoint, methods=["POST"])])
+    observed: list[int] = []
+
+    class FakeServer:
+        def __init__(self, config) -> None:
+            self.config = config
+
+        async def serve(self) -> None:
+            with TestClient(self.config.app) as client:
+                observed.extend(
+                    [
+                        client.post("/mcp").status_code,
+                        client.post(
+                            "/mcp", headers={"Authorization": "Bearer wrong-key"}
+                        ).status_code,
+                        client.post(
+                            "/mcp", headers={"Authorization": "Bearer legacy-key"}
+                        ).status_code,
+                    ]
+                )
+
+    settings = Settings(AUTH_ENABLED=False, METRONIX_SECRET_KEY="test-secret")
+
+    def app_factory(**_kwargs) -> Starlette:
+        return app
+
+    with (
+        patch.dict(os.environ, {"METRONIX_MCP_API_KEY": "legacy-key"}),
+        patch("metronix.core.config.get_settings", return_value=settings),
+        patch("metronix.mcp.server.mcp.streamable_http_app", side_effect=app_factory),
+        patch("uvicorn.Server", FakeServer),
+    ):
+        await run_http()
+
+    assert observed == [401, 401, 200]

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -21,7 +21,7 @@ from metronix.mcp.auth import (
     validate_api_key,
 )
 from metronix.mcp.principal import get_current_principal
-from metronix.mcp.server import run_http
+from metronix.mcp.server import mcp, run_http
 
 
 class TestGetApiKey:
@@ -104,6 +104,7 @@ async def test_standalone_http_uses_legacy_api_key_when_auth_disabled() -> None:
 
     app = Starlette(routes=[Route("/mcp", endpoint, methods=["POST"])])
     observed: list[int] = []
+    factory_kwargs: list[dict[str, object]] = []
 
     class FakeServer:
         def __init__(self, config) -> None:
@@ -125,7 +126,8 @@ async def test_standalone_http_uses_legacy_api_key_when_auth_disabled() -> None:
 
     settings = Settings(AUTH_ENABLED=False, METRONIX_SECRET_KEY="test-secret")
 
-    def app_factory(**_kwargs) -> Starlette:
+    def app_factory(**kwargs: object) -> Starlette:
+        factory_kwargs.append(kwargs)
         return app
 
     with (
@@ -137,3 +139,5 @@ async def test_standalone_http_uses_legacy_api_key_when_auth_disabled() -> None:
         await run_http()
 
     assert observed == [401, 401, 200]
+    assert factory_kwargs == [{}]
+    assert mcp.settings.stateless_http is True

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -14,6 +14,7 @@ from metronix.mcp.config import (
     load_stdio_config,
     resolve_workspace_id,
 )
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 
 
 class TestMCPServerConfig:
@@ -85,3 +86,52 @@ class TestResolveWorkspaceId:
         # None/empty must resolve to the configured default, never literal "default".
         assert resolve_workspace_id(None) == get_default_workspace_id()
         assert resolve_workspace_id("") == get_default_workspace_id()
+
+    def test_whitespace_only_defers_to_default(self) -> None:
+        assert resolve_workspace_id("  \t\n") == get_default_workspace_id()
+
+    def test_granted_principal_may_select_listed_workspace(self) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a", "ws-b")))
+        try:
+            assert resolve_workspace_id("ws-b") == "ws-b"
+        finally:
+            reset_principal(token)
+
+    def test_ungranted_workspace_is_rejected_before_resolution(self) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+        try:
+            with pytest.raises(PermissionError, match="No access to workspace 'ws-b'"):
+                resolve_workspace_id("ws-b")
+        finally:
+            reset_principal(token)
+
+    def test_empty_grants_fail_closed_when_workspace_is_omitted(self) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", ()))
+        try:
+            with pytest.raises(PermissionError, match="no workspace grants"):
+                resolve_workspace_id(None)
+        finally:
+            reset_principal(token)
+
+    def test_omitted_workspace_selects_first_concrete_grant(self) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-b", "ws-a")))
+        try:
+            assert resolve_workspace_id(None) == "ws-b"
+        finally:
+            reset_principal(token)
+
+    def test_wildcard_grant_uses_default_workspace_when_omitted(self) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", ("*",)))
+        try:
+            assert resolve_workspace_id(None) == get_default_workspace_id()
+        finally:
+            reset_principal(token)
+
+    @pytest.mark.parametrize("workspace_id", ["*", "ws/a", "x" * 65])
+    def test_malformed_workspace_is_rejected_before_grant_checks(self, workspace_id: str) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", ()))
+        try:
+            with pytest.raises(ValueError):
+                resolve_workspace_id(workspace_id)
+        finally:
+            reset_principal(token)

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -127,6 +127,26 @@ class TestResolveWorkspaceId:
         finally:
             reset_principal(token)
 
+    @pytest.mark.parametrize(
+        ("workspace_ids", "expected_workspace_id"),
+        [
+            (("*", "ws-a"), None),
+            (("ws-a", "*"), "ws-a"),
+        ],
+    )
+    def test_omitted_workspace_honors_wildcard_grant_precedence(
+        self,
+        workspace_ids: tuple[str, ...],
+        expected_workspace_id: str | None,
+    ) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", workspace_ids))
+        try:
+            assert resolve_workspace_id(None) == (
+                expected_workspace_id or get_default_workspace_id()
+            )
+        finally:
+            reset_principal(token)
+
     @pytest.mark.parametrize("workspace_id", ["*", "ws/a", "x" * 65])
     def test_malformed_workspace_is_rejected_before_grant_checks(self, workspace_id: str) -> None:
         token = bind_principal(MCPPrincipal("u1", "viewer", ()))

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -124,6 +125,21 @@ class TestResolveWorkspaceId:
         token = bind_principal(MCPPrincipal("u1", "viewer", ("*",)))
         try:
             assert resolve_workspace_id(None) == get_default_workspace_id()
+        finally:
+            reset_principal(token)
+
+    def test_bound_wildcard_uses_settings_default_not_stdio_default(self) -> None:
+        settings = get_settings().model_copy(update={"default_workspace_id": "settings-ws"})
+        token = bind_principal(MCPPrincipal("u1", "viewer", ("*",)))
+        try:
+            with (
+                patch("metronix.core.config.get_settings", return_value=settings),
+                patch(
+                    "metronix.mcp.config.get_default_workspace_id",
+                    return_value="stdio-ws",
+                ),
+            ):
+                assert resolve_workspace_id(None) == "settings-ws"
         finally:
             reset_principal(token)
 

--- a/tests/unit/test_mcp_docs.py
+++ b/tests/unit/test_mcp_docs.py
@@ -1,0 +1,43 @@
+"""Regression checks for the public hosted MCP authentication contract."""
+
+from pathlib import Path
+
+import pytest
+
+DOCS = (
+    Path("docs/MCP_API.md"),
+    Path("docs/integrations/mcp-reference.md"),
+)
+
+
+def _normalized(content: str) -> str:
+    """Make line wrapping in Markdown irrelevant to contract assertions."""
+    return " ".join(content.split())
+
+
+@pytest.mark.parametrize("path", DOCS)
+def test_hosted_mcp_docs_describe_jwt_authentication(path: Path) -> None:
+    content = _normalized(path.read_text())
+
+    assert "Authorization: Bearer <jwt>" in content
+    assert "AUTH_ENABLED=true" in content
+    assert "401" in content
+
+
+@pytest.mark.parametrize("path", DOCS)
+def test_hosted_mcp_docs_describe_grants_and_deployment_key_limits(path: Path) -> None:
+    content = _normalized(path.read_text())
+
+    assert "ungranted workspace returns 403 before data access" in content
+    assert "METRONIX_MCP_API_KEY" in content
+    assert "development/bootstrap-only" in content
+    assert "not accepted as a hosted-user credential" in content
+    assert "does not grant workspace membership or delegation authority" in content
+
+
+@pytest.mark.parametrize("path", DOCS)
+def test_hosted_mcp_docs_do_not_present_deployment_key_as_bearer_credential(path: Path) -> None:
+    content = _normalized(path.read_text())
+
+    assert "Authorization: Bearer <METRONIX_MCP_API_KEY>" not in content
+    assert "Authorization: Bearer <your-api-key>" not in content

--- a/tests/unit/test_mcp_docs.py
+++ b/tests/unit/test_mcp_docs.py
@@ -9,6 +9,36 @@ DOCS = (
     Path("docs/integrations/mcp-reference.md"),
 )
 
+PUBLIC_MCP_MODE_DOCS = (
+    Path("README.md"),
+    Path(".env.example"),
+    Path("docs/API.md"),
+    Path("connecting_to_agent.md"),
+    Path("install.md"),
+    Path("prompts.md"),
+    Path("docs/examples/python-sdk.md"),
+    Path("docs/guides/agents-and-workspaces.md"),
+    Path("docs/integrations/atomic-chat.md"),
+    Path("docs/integrations/claude-code.md"),
+    Path("docs/integrations/claude-code/prompt-1-install.md"),
+    Path("docs/integrations/claude-desktop.md"),
+    Path("docs/integrations/codex.md"),
+    Path("docs/integrations/codex/prompt-1-install.md"),
+    Path("docs/integrations/cursor.md"),
+    Path("docs/integrations/hermes-agent.md"),
+    Path("docs/integrations/hermes.md"),
+    Path("docs/integrations/hermes/prompt-1-install.md"),
+    Path("docs/integrations/langchain.md"),
+    Path("docs/integrations/n8n.md"),
+    Path("docs/integrations/nanobot.md"),
+    Path("docs/integrations/nanoclaw.md"),
+    Path("docs/integrations/openclaw.md"),
+    Path("docs/integrations/opencode.md"),
+    Path("docs/integrations/pi.md"),
+    Path("docs/integrations/sdk-go.md"),
+    Path("docs/integrations/sdk-python.md"),
+)
+
 
 def _normalized(content: str) -> str:
     """Make line wrapping in Markdown irrelevant to contract assertions."""
@@ -41,3 +71,25 @@ def test_hosted_mcp_docs_do_not_present_deployment_key_as_bearer_credential(path
 
     assert "Authorization: Bearer <METRONIX_MCP_API_KEY>" not in content
     assert "Authorization: Bearer <your-api-key>" not in content
+
+
+@pytest.mark.parametrize("path", PUBLIC_MCP_MODE_DOCS)
+def test_public_mcp_guidance_distinguishes_both_authentication_modes(path: Path) -> None:
+    content = _normalized(path.read_text())
+
+    assert "AUTH_ENABLED=false" in content
+    assert "AUTH_ENABLED=true" in content
+    assert "JWT" in content
+
+
+def test_api_reference_mcp_auth_row_describes_mode_specific_bearer_credentials() -> None:
+    content = _normalized(Path("docs/API.md").read_text())
+
+    assert "JWT when `AUTH_ENABLED=true`" in content
+    assert "`METRONIX_MCP_API_KEY` when `AUTH_ENABLED=false`" in content
+
+
+def test_env_example_documents_legacy_key_is_ignored_in_jwt_mode() -> None:
+    content = _normalized(Path(".env.example").read_text())
+
+    assert "ignored when AUTH_ENABLED=true" in content

--- a/tests/unit/test_mcp_export_tools.py
+++ b/tests/unit/test_mcp_export_tools.py
@@ -1,6 +1,10 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 import metronix.mcp.tools.export as export_tool
+from metronix.export.models import ExportScope
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 
 
 @pytest.mark.asyncio
@@ -27,3 +31,56 @@ async def test_export_data_starts_job(monkeypatch):
     monkeypatch.setattr(export_tool, "build_export_service", lambda s: FakeSvc())
     res = await export_tool.metronix_export_data(workspace_id="ws1")
     assert res["export_id"] == "exp9" and res["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_export_data_rejects_ungranted_workspace_before_creating_service(monkeypatch):
+    build_service = MagicMock()
+    monkeypatch.setattr(export_tool, "build_export_service", build_service)
+    token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    try:
+        res = await export_tool.metronix_export_data(workspace_id="ws-b")
+    finally:
+        reset_principal(token)
+
+    assert "No access to workspace 'ws-b'" in res["error"]["message"]
+    build_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_export_data_rejects_all_workspaces_without_wildcard_before_creating_service(
+    monkeypatch,
+):
+    build_service = MagicMock()
+    monkeypatch.setattr(export_tool, "build_export_service", build_service)
+    token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    try:
+        res = await export_tool.metronix_export_data(all_workspaces=True)
+    finally:
+        reset_principal(token)
+
+    assert "all_workspaces requires admin access" in res["error"]["message"]
+    build_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope",
+    [ExportScope(workspace_id="ws-b"), ExportScope(all_workspaces=True)],
+)
+async def test_export_status_rejects_ungranted_scope_before_returning_download_url(
+    monkeypatch,
+    scope,
+):
+    service = AsyncMock()
+    service.get_job = AsyncMock(return_value=MagicMock(scope=scope))
+    service.status = AsyncMock(return_value={"download_url": "https://example.test/secret.zip"})
+    monkeypatch.setattr(export_tool, "build_export_service", lambda s: service)
+    token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    try:
+        res = await export_tool.metronix_export_status("export-foreign")
+    finally:
+        reset_principal(token)
+
+    assert "no access to this export" in res["error"]["message"]
+    service.status.assert_not_awaited()

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 from metronix.core.models import MemoryRecord, MemoryScope, MemorySearchResult
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 
 if TYPE_CHECKING:
     from contextlib import AbstractContextManager
@@ -109,6 +110,24 @@ class TestMemorySearch:
 
         assert "error" in out
         assert out["error"]["code"] in {"INTERNAL_ERROR", "QDRANT_UNAVAILABLE"}
+
+    async def test_ungranted_workspace_does_not_build_memory_service(self) -> None:
+        service = AsyncMock()
+        token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+        try:
+            with _patch_service(service) as build_service:
+                from metronix.mcp.tools.memory_search import metronix_memory_search
+
+                out = await metronix_memory_search(
+                    query="what did we learn",
+                    agent_id="agent-a",
+                    workspace_id="ws-b",
+                )
+        finally:
+            reset_principal(token)
+
+        assert "No access to workspace 'ws-b'" in out["error"]["message"]
+        build_service.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_tool_wrapper.py
+++ b/tests/unit/test_mcp_tool_wrapper.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 import pytest
 
+from metronix.activity.context import bind_agent_id, current_agent_id
 from metronix.core import events as evt
 from metronix.core.events import EventBus
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 from metronix.mcp.server import _wrap_tool_with_activity
 
 
@@ -171,3 +175,86 @@ async def test_wrapper_binds_agent_id_to_contextvar(
     await wrapped(agent_id="ag_42")
     assert captured == ["ag_42"]  # contextvar visible inside handler
     assert current_agent_id.get() is None  # reset on exit
+
+
+async def test_activity_uses_server_resolved_context_not_raw_tool_arguments(
+    bus_spy: tuple[EventBus, list[tuple[str, dict[str, object]]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from metronix.mcp import server as mcp_server
+
+    bus, calls = bus_spy
+    telemetry_contexts: list[dict[str, object]] = []
+
+    @contextmanager
+    def capture_telemetry(**context):
+        telemetry_contexts.append(context)
+        yield
+
+    monkeypatch.setattr(mcp_server, "set_telemetry_context", capture_telemetry)
+
+    async def my_tool(*, agent_id: str, workspace_id: str) -> str:
+        assert current_agent_id.get() == "transport-agent"
+        return "ok"
+
+    wrapped = _wrap_tool_with_activity("my_tool", my_tool, bus_getter=lambda: bus)
+    principal_token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    agent_token = bind_agent_id("transport-agent")
+    try:
+        await wrapped(agent_id="raw-target-agent", workspace_id="  ws-a  ")
+    finally:
+        current_agent_id.reset(agent_token)
+        reset_principal(principal_token)
+
+    payload = next(p for n, p in calls if n == evt.TOOL_CALLED)
+    assert payload["workspace_id"] == "ws-a"
+    assert payload["agent_id"] == "transport-agent"
+    assert telemetry_contexts[0]["workspace_id"] == "ws-a"
+    assert telemetry_contexts[0]["agent_id"] == "transport-agent"
+
+
+async def test_denied_workspace_does_not_emit_tenant_scoped_activity(
+    bus_spy: tuple[EventBus, list[tuple[str, dict[str, object]]]],
+) -> None:
+    bus, calls = bus_spy
+
+    async def denied_tool(*, agent_id: str, workspace_id: str) -> dict[str, object]:
+        return {"error": {"code": "FORBIDDEN", "message": "workspace denied"}}
+
+    wrapped = _wrap_tool_with_activity("denied", denied_tool, bus_getter=lambda: bus)
+    principal_token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    agent_token = bind_agent_id("transport-agent")
+    try:
+        result = await wrapped(agent_id="raw-target-agent", workspace_id="ws-denied")
+    finally:
+        current_agent_id.reset(agent_token)
+        reset_principal(principal_token)
+
+    assert "error" in result
+    assert calls == []
+
+
+async def test_tool_error_result_emits_failed_activity(
+    bus_spy: tuple[EventBus, list[tuple[str, dict[str, object]]]],
+) -> None:
+    bus, calls = bus_spy
+
+    async def failing_tool(*, workspace_id: str) -> dict[str, object]:
+        return {"error": {"code": "BACKEND_ERROR", "message": "database unavailable"}}
+
+    wrapped = _wrap_tool_with_activity("failing", failing_tool, bus_getter=lambda: bus)
+    principal_token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    agent_token = bind_agent_id("transport-agent")
+    try:
+        result = await wrapped(workspace_id="ws-a")
+    finally:
+        current_agent_id.reset(agent_token)
+        reset_principal(principal_token)
+
+    assert "error" in result
+    tool_event = next(p for n, p in calls if n == evt.TOOL_CALLED)
+    assert tool_event["success"] is False
+    assert tool_event["error_message"] == "database unavailable"
+    error_event = next(p for n, p in calls if n == evt.ERROR_OCCURRED)
+    assert error_event["error_type"] == "BACKEND_ERROR"
+    assert error_event["error_message"] == "database unavailable"

--- a/tests/unit/test_mcp_transport.py
+++ b/tests/unit/test_mcp_transport.py
@@ -1,0 +1,70 @@
+"""Regression coverage for hosted MCP transport session isolation."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from fastapi.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+from metronix.api.app import create_app, mcp_server
+from metronix.auth.jwt import create_token
+from metronix.core.config import Settings
+
+_SECRET = "stateless-mcp-test-secret-at-least-32-bytes"
+_INITIALIZE_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "metronix-test", "version": "1"},
+    },
+}
+_MCP_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+
+def test_mounted_mcp_does_not_issue_sessions_reusable_across_principals() -> None:
+    app = create_app(
+        Settings(
+            AUTH_ENABLED=True,
+            METRONIX_ENV="development",
+            METRONIX_SECRET_KEY=_SECRET,
+        )
+    )
+
+    @asynccontextmanager
+    async def mcp_lifespan(_app: Starlette):
+        async with mcp_server.session_manager.run():
+            yield
+
+    # Run the real FastAPI middleware and mounted /mcp route while limiting
+    # lifespan startup to the MCP manager (the full app also starts databases).
+    transport_app = Starlette(routes=[Mount("/", app=app)], lifespan=mcp_lifespan)
+    principals = [
+        create_token(
+            user_id=user_id,
+            role="viewer",
+            workspace_ids=["ws-a"],
+            secret_key=_SECRET,
+        )
+        for user_id in ("user-a", "user-b")
+    ]
+
+    with TestClient(transport_app) as client:
+        responses = [
+            client.post(
+                "/mcp",
+                json=_INITIALIZE_REQUEST,
+                headers={**_MCP_HEADERS, "Authorization": f"Bearer {token}"},
+            )
+            for token in principals
+        ]
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert [response.headers.get("mcp-session-id") for response in responses] == [None, None]

--- a/tests/unit/test_mcp_transport.py
+++ b/tests/unit/test_mcp_transport.py
@@ -2,23 +2,30 @@
 
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi.testclient import TestClient
+from httpx import Response
 from starlette.applications import Starlette
 from starlette.routing import Mount
 
 from metronix.api.app import create_app, mcp_server
 from metronix.auth.jwt import create_token
 from metronix.core.config import Settings
+from metronix.mcp.config import resolve_workspace_id
+from metronix.mcp.principal import get_current_principal
 
 _SECRET = "stateless-mcp-test-secret-at-least-32-bytes"
+_PROTOCOL_VERSION = "2025-03-26"
+_TEST_TOOL_NAME = "test_authenticated_principal"
 _INITIALIZE_REQUEST = {
     "jsonrpc": "2.0",
     "id": 1,
     "method": "initialize",
     "params": {
-        "protocolVersion": "2025-03-26",
+        "protocolVersion": _PROTOCOL_VERSION,
         "capabilities": {},
         "clientInfo": {"name": "metronix-test", "version": "1"},
     },
@@ -29,7 +36,44 @@ _MCP_HEADERS = {
 }
 
 
-def test_mounted_mcp_does_not_issue_sessions_reusable_across_principals() -> None:
+def _post_rpc(
+    client: TestClient,
+    token: str,
+    request: dict[str, Any],
+) -> Response:
+    return client.post(
+        "/mcp",
+        json=request,
+        headers={
+            **_MCP_HEADERS,
+            "Authorization": f"Bearer {token}",
+            "MCP-Protocol-Version": _PROTOCOL_VERSION,
+        },
+    )
+
+
+def _sse_payload(response: Response) -> dict[str, Any]:
+    data = next(
+        line.removeprefix("data: ")
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    )
+    payload: dict[str, Any] = json.loads(data)
+    return payload
+
+
+def test_mounted_stateless_mcp_authorizes_each_tool_call_with_its_request_principal() -> None:
+    @mcp_server.tool(name=_TEST_TOOL_NAME)
+    async def authenticated_principal(workspace_id: str) -> dict[str, str]:
+        """Expose the principal observed by an authorization-sensitive test tool."""
+        principal = get_current_principal()
+        if principal is None:
+            raise PermissionError("JWT principal required")
+        return {
+            "user_id": principal.user_id,
+            "workspace_id": resolve_workspace_id(workspace_id),
+        }
+
     app = create_app(
         Settings(
             AUTH_ENABLED=True,
@@ -46,25 +90,87 @@ def test_mounted_mcp_does_not_issue_sessions_reusable_across_principals() -> Non
     # Run the real FastAPI middleware and mounted /mcp route while limiting
     # lifespan startup to the MCP manager (the full app also starts databases).
     transport_app = Starlette(routes=[Mount("/", app=app)], lifespan=mcp_lifespan)
-    principals = [
-        create_token(
+    principals = {
+        user_id: create_token(
             user_id=user_id,
             role="viewer",
-            workspace_ids=["ws-a"],
+            workspace_ids=[workspace_id],
             secret_key=_SECRET,
         )
-        for user_id in ("user-a", "user-b")
+        for user_id, workspace_id in (("user-a", "ws-a"), ("user-b", "ws-b"))
+    }
+
+    try:
+        with TestClient(transport_app) as client:
+            initialize_responses = [
+                _post_rpc(client, principals[user_id], _INITIALIZE_REQUEST)
+                for user_id in ("user-a", "user-b")
+            ]
+            initialized_responses = [
+                _post_rpc(
+                    client,
+                    principals[user_id],
+                    {"jsonrpc": "2.0", "method": "notifications/initialized"},
+                )
+                for user_id in ("user-a", "user-b")
+            ]
+
+            def call_tool(user_id: str, workspace_id: str, request_id: int) -> Response:
+                return _post_rpc(
+                    client,
+                    principals[user_id],
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "method": "tools/call",
+                        "params": {
+                            "name": _TEST_TOOL_NAME,
+                            "arguments": {"workspace_id": workspace_id},
+                        },
+                    },
+                )
+
+            user_a_call = call_tool("user-a", "ws-a", 2)
+            user_b_reusing_a_context = call_tool("user-b", "ws-a", 3)
+            user_b_call = call_tool("user-b", "ws-b", 4)
+    finally:
+        mcp_server._tool_manager.remove_tool(_TEST_TOOL_NAME)
+
+    assert [response.status_code for response in initialize_responses] == [200, 200]
+    assert [response.status_code for response in initialized_responses] == [202, 202]
+    assert _sse_payload(initialize_responses[0])["result"]["protocolVersion"] == _PROTOCOL_VERSION
+
+    all_responses = [
+        *initialize_responses,
+        *initialized_responses,
+        user_a_call,
+        user_b_reusing_a_context,
+        user_b_call,
     ]
+    assert all(response.headers.get("mcp-session-id") is None for response in all_responses)
 
-    with TestClient(transport_app) as client:
-        responses = [
-            client.post(
-                "/mcp",
-                json=_INITIALIZE_REQUEST,
-                headers={**_MCP_HEADERS, "Authorization": f"Bearer {token}"},
-            )
-            for token in principals
-        ]
-
-    assert [response.status_code for response in responses] == [200, 200]
-    assert [response.headers.get("mcp-session-id") for response in responses] == [None, None]
+    assert _sse_payload(user_a_call)["result"] == {
+        "content": [
+            {
+                "type": "text",
+                "text": '{\n  "user_id": "user-a",\n  "workspace_id": "ws-a"\n}',
+            }
+        ],
+        "structuredContent": {"user_id": "user-a", "workspace_id": "ws-a"},
+        "isError": False,
+    }
+    assert _sse_payload(user_b_reusing_a_context)["result"]["isError"] is True
+    assert (
+        "No access to workspace 'ws-a'"
+        in (_sse_payload(user_b_reusing_a_context)["result"]["content"][0]["text"])
+    )
+    assert _sse_payload(user_b_call)["result"] == {
+        "content": [
+            {
+                "type": "text",
+                "text": '{\n  "user_id": "user-b",\n  "workspace_id": "ws-b"\n}',
+            }
+        ],
+        "structuredContent": {"user_id": "user-b", "workspace_id": "ws-b"},
+        "isError": False,
+    }

--- a/tests/unit/test_memory_context_mcp.py
+++ b/tests/unit/test_memory_context_mcp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from metronix.core.models import AssembledContext
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 from metronix.mcp.tools.memory_context import metronix_memory_get_context
 
 
@@ -59,6 +60,24 @@ class TestMemoryGetContextValidation:
             query="   ",
         )
         assert "error" in result
+
+    async def test_ungranted_workspace_does_not_build_memory_service(self) -> None:
+        token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+        try:
+            with patch(
+                "metronix.mcp.tools.memory_context._memory_deps.build_memory_service_for_workspace",
+                new=AsyncMock(),
+            ) as build_service:
+                result = await metronix_memory_get_context(
+                    agent_id="agent-1",
+                    workspace_id="ws-b",
+                    query="test",
+                )
+        finally:
+            reset_principal(token)
+
+        assert "No access to workspace 'ws-b'" in result["error"]["message"]
+        build_service.assert_not_awaited()
 
 
 class TestMemoryGetContextWithAssembler:


### PR DESCRIPTION
Closes #312

## Summary

- authenticate hosted MCP calls as verified JWT principals and preserve API-key protection for auth-disabled local deployments
- enforce principal workspace grants across MCP tools, export creation/status, and activity logging
- make MCP HTTP transport stateless to prevent cross-principal session reuse
- document hosted JWT versus local legacy-key configuration and add regression coverage

## Why

The previous shared MCP key could not represent a concrete principal or workspace grant. This adds the trusted principal/context layer needed before #314's shared authorization evaluator.

## Validation

- `123 passed, 1 skipped` targeted MCP/auth suite
- Ruff lint and format checks
- Hermes installer: 57 passed
- OpenClaw installer: 38 passed

## Follow-up

Native OAuth resource-server integration via the MCP SDK remains a future hardening step; this PR keeps the existing JWT contract and uses stateless HTTP to make per-request authorization safe.