### PR TITLE
feat: add unified memory evaluation harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev test lint migrate docker-up docker-down clean test-installer prepare-release eval eval-all eval-save eval-compare eval-history grid-search graph-rebuild graph-rebuild-dry graph-process bench-lme-setup bench-lme-smoke bench-lme bench-watch
+.PHONY: setup dev test lint migrate docker-up docker-down clean test-installer prepare-release eval eval-all eval-save eval-compare eval-history memory-eval grid-search graph-rebuild graph-rebuild-dry graph-process bench-lme-setup bench-lme-smoke bench-lme bench-watch
 
 setup:
 	python -m venv .venv
@@ -63,6 +63,9 @@ eval-compare:
 
 eval-history:
 	.venv/bin/python scripts/run_eval.py --history
+
+memory-eval:
+	.venv/bin/python scripts/run_memory_eval.py $(MEMORY_EVAL_ARGS)
 
 grid-search:
 	.venv/bin/python scripts/grid_search_weights.py --workspace $(or $(WORKSPACE),MTRNIX) --step 0.10

--- a/benchmarks/longmemeval/run.sh
+++ b/benchmarks/longmemeval/run.sh
@@ -5,21 +5,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ROOT"
 
-VENV="$ROOT/.venv"
-if [[ -x "$VENV/Scripts/python.exe" ]]; then
-  PYTHON="$VENV/Scripts/python.exe"
-elif [[ -x "$VENV/bin/python" ]]; then
-  PYTHON="$VENV/bin/python"
-else
-  echo "Virtual environment not found. Run ./setup.sh or .\\setup.ps1 first."
-  exit 1
-fi
-
 SMOKE=0
 RUN_ONLY=0
 MAX_QUESTIONS=""
 VARIANT="s"
 FORCE=0
+OUTPUT=""
 
 usage() {
   cat <<'EOF'
@@ -30,6 +21,7 @@ Options:
   --run-only         Skip LLM judge evaluation
   --max-questions N  Limit number of questions
   --variant oracle|s Dataset variant (default: s)
+  --output PATH      Write hypotheses to this path
   --force            Delete output file before run
   -h, --help         Show this help
 EOF
@@ -41,11 +33,22 @@ while [[ $# -gt 0 ]]; do
     --run-only) RUN_ONLY=1; shift ;;
     --max-questions) MAX_QUESTIONS="$2"; shift 2 ;;
     --variant) VARIANT="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
     --force) FORCE=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
 done
+
+VENV="$ROOT/.venv"
+if [[ -x "$VENV/Scripts/python.exe" ]]; then
+  PYTHON="$VENV/Scripts/python.exe"
+elif [[ -x "$VENV/bin/python" ]]; then
+  PYTHON="$VENV/bin/python"
+else
+  echo "Virtual environment not found. Run ./setup.sh or .\\setup.ps1 first."
+  exit 1
+fi
 
 if [[ -z "${BASH_VERSION:-}" ]]; then
   echo "run.sh requires bash."
@@ -62,8 +65,10 @@ echo "==> Preflight"
 "$PYTHON" scripts/preflight.py --ensure-workspace
 
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
-OUTPUT="$ROOT/results/${TIMESTAMP}_${VARIANT}.jsonl"
-mkdir -p "$ROOT/results"
+if [[ -z "$OUTPUT" ]]; then
+  OUTPUT="$ROOT/results/${TIMESTAMP}_${VARIANT}.jsonl"
+fi
+mkdir -p "$(dirname "$OUTPUT")"
 
 RUN_ARGS=(run --variant "$VARIANT" --output "$OUTPUT")
 if [[ -n "$MAX_QUESTIONS" ]]; then

--- a/docs/memory-eval-harness.md
+++ b/docs/memory-eval-harness.md
@@ -104,19 +104,21 @@ path, and a small native summary.
 Search quality summaries include retrieval metrics such as `mrr` and
 `ndcg_at_k`. RAG-397 summaries are bucket and error counters, not a universal
 quality score. LongMemEval records answer count and, when the judge prints it,
-accuracy. A nonzero RAG-397 case error count or any LongMemEval hypothesis that
-begins with `Error:` fails its suite even when the child process exits zero. A
-judged LongMemEval run also fails unless the judge emits a finite accuracy.
-Keep these metrics separate: the harness deliberately does not blend them into
-one score.
+accuracy. Any RAG-397 case carrying an `error` key, regardless of its value, or
+any LongMemEval hypothesis that begins with `Error:` fails its suite even when
+the child process exits zero. A judged LongMemEval run also fails unless the
+judge emits a finite accuracy. Keep these metrics separate: the harness
+deliberately does not blend them into one score.
 
 The command exits:
 
 - `0` when all selected suites pass and no configured quality gate is breached.
-- `1` when a selected suite fails or an explicit regression threshold is
-  breached; the completed report is still written.
+- `1` when a selected suite fails, an explicit regression threshold is
+  breached, or a configured gate cannot be evaluated; the completed report is
+  still written.
 - `2` for invalid arguments or configuration, including an unknown suite,
-  invalid threshold, malformed baseline, or missing RAG-397 credential
+  invalid threshold, `--max-regression` without `--baseline`, a gate for an
+  unselected suite, malformed baseline, or missing RAG-397 credential
   environment variables. No suite starts in this case.
 
 The command continues selected suites after a runtime failure so the report
@@ -130,6 +132,10 @@ configuration is identical after normalization. Compatible same-key numeric
 metrics are included as informational deltas. Incompatible suites are listed
 in `incompatible_suites`; their deltas and gates are not evaluated. A
 configured gate for an incompatible suite fails closed with exit code `1`.
+For LongMemEval, compatibility includes the workspace, retrieval `top_k`, chat
+and judge model/base URLs, and dataset filename/source/content SHA-256 in
+addition to the variant, question limit, and judge mode. Secret values are
+never recorded.
 Compatible metrics only become CI gates when you provide one or more
 `--max-regression suite.metric=decline` values.
 Thresholds are accepted only for the higher-is-better quality metrics:
@@ -152,7 +158,9 @@ LongMemEval accuracy drops by more than 0.03:
   --output results/memory-eval/ci.json
 ```
 
-An omitted or non-numeric metric has no delta. An unjudged LongMemEval run is
-valid only with `--longmemeval-run-only`; a judged run without a parsed accuracy
-fails. RAG-397 counters are useful for inspection but intentionally cannot be
-configured as generic quality gates.
+An omitted or non-numeric metric has no informational delta; if a threshold is
+configured for that metric, the gate fails closed and the incompatibility is
+recorded. An unjudged LongMemEval run is valid only with
+`--longmemeval-run-only`; a judged run without a parsed accuracy fails. RAG-397
+counters are useful for inspection but intentionally cannot be configured as
+generic quality gates.

--- a/docs/memory-eval-harness.md
+++ b/docs/memory-eval-harness.md
@@ -1,0 +1,144 @@
+# Unified memory evaluation harness
+
+`scripts/run_memory_eval.py` is the single run-level entry point for the
+repository's existing memory and retrieval evaluations. It orchestrates the
+native runners without changing their datasets, scoring, or artifact formats:
+
+- `search` runs `scripts/run_eval.py` against a live Metronix workspace.
+- `rag-397` runs `scripts/rag_eval_397.py` against a live authenticated REST
+  API with RAG trace capture enabled.
+- `longmemeval` runs the existing LongMemEval pipeline and, unless disabled,
+  its external LLM judge.
+
+The harness is not a substitute for any suite's setup. It does not start
+services, provide credentials, or turn the LLM-judged suite into a deterministic
+or free benchmark.
+
+## Run a suite
+
+Create the project virtual environment first (`make setup`), then select only
+the suites whose prerequisites are available. For example, run labelled search
+quality against a local stack:
+
+```bash
+make memory-eval MEMORY_EVAL_ARGS='--suites search --search-workspace MTRNIX'
+```
+
+Use an explicit report path when the report will be retained or consumed by CI:
+
+```bash
+.venv/bin/python scripts/run_memory_eval.py \
+  --suites search,longmemeval \
+  --search-workspace MTRNIX \
+  --longmemeval-variant s \
+  --longmemeval-max-questions 25 \
+  --output results/memory-eval/release-candidate.json
+```
+
+Without `--output`, the report is written to
+`results/memory-eval/<UTC timestamp>.json`. Native outputs are placed alongside
+it in `<report stem>.artifacts/`; the unified report links to these files but
+does not embed query traces, model answers, credentials, tokens, or passwords.
+
+## Per-suite setup and cost
+
+### Search
+
+`search` needs a running Metronix service stack and an indexed workspace. The
+default workspace is `MTRNIX`; select another with `--search-workspace`. The
+default test set is the one used by `scripts/run_eval.py`; use
+`--search-testset PATH` for a labelled alternative, `--search-k N` to change
+the retrieval cut-off, and `--include-unstable` to include unstable queries.
+
+This suite's runtime depends on the size of the test set and on the live
+retrieval stack. It has the same model and infrastructure usage as the existing
+search evaluator.
+
+### RAG-397
+
+`rag-397` needs a live API with RAG trace capture enabled, a populated
+workspace, and credentials exported in the shell running the command:
+
+```bash
+export METRONIX_ADMIN_EMAIL='operator@example.com'
+export METRONIX_ADMIN_PASSWORD='...'
+make memory-eval MEMORY_EVAL_ARGS='--suites rag-397 \
+  --rag-397-base-url http://localhost:8000 \
+  --rag-397-workspace MTRNIX'
+```
+
+The credentials are passed to the child runner only and are not printed or
+written into the unified report. RAG-397 sends its fixed regression, positive,
+and adversarial prompts to the live API, so it has the same latency and any
+provider/model cost as a real RAG interaction. Do not use production accounts
+or data unless that traffic is explicitly approved.
+
+### LongMemEval
+
+Prepare its dedicated environment and dataset as described in
+[`docs/benchmarks/longmemeval.md`](benchmarks/longmemeval.md):
+
+```bash
+make bench-lme-setup
+make memory-eval MEMORY_EVAL_ARGS='--suites longmemeval \
+  --longmemeval-variant s --longmemeval-max-questions 25'
+```
+
+LongMemEval can take substantial time and invokes the configured external LLM
+judge by default, which can incur provider charges. Use
+`--longmemeval-run-only` to generate hypotheses without the judge; the report
+will still record answer count, but no judged `accuracy` is available.
+
+## Read the report and select exit behavior
+
+The JSON report has `schema_version`, timestamps, `requested_suites`, a
+per-suite `suites` map, and optional `deltas` and `regressions` when a baseline
+is supplied. Each suite records its status, timing, exit code, sanitized
+effective configuration, native artifact path, and a small native summary.
+
+Search quality summaries include retrieval metrics such as `mrr` and
+`ndcg_at_k`. RAG-397 summaries are bucket and error counters, not a universal
+quality score. LongMemEval records answer count and, when the judge prints it,
+accuracy. Keep these metrics separate: the harness deliberately does not blend
+them into one score.
+
+The command exits:
+
+- `0` when all selected suites pass and no configured quality gate is breached.
+- `1` when a selected suite fails or an explicit regression threshold is
+  breached; the completed report is still written.
+- `2` for invalid arguments or configuration, including an unknown suite,
+  invalid threshold, malformed baseline, or missing RAG-397 credential
+  environment variables. No suite starts in this case.
+
+The command continues selected suites after a runtime failure so the report
+captures the whole requested run.
+
+## Baselines and CI gates
+
+Pass a prior harness report with `--baseline`. Compatible same-key numeric
+metrics are included as informational deltas. They only become CI gates when
+you provide one or more `--max-regression suite.metric=decline` values.
+Thresholds are accepted only for the higher-is-better quality metrics:
+
+- `search.precision_at_k`
+- `search.mrr`
+- `search.ndcg_at_k`
+- `search.negative_accuracy`
+- `longmemeval.accuracy`
+
+For example, fail CI if search MRR drops by more than 0.02 or judged
+LongMemEval accuracy drops by more than 0.03:
+
+```bash
+.venv/bin/python scripts/run_memory_eval.py \
+  --suites search,longmemeval \
+  --baseline artifacts/main-memory-eval.json \
+  --max-regression search.mrr=0.02 \
+  --max-regression longmemeval.accuracy=0.03 \
+  --output results/memory-eval/ci.json
+```
+
+An omitted, incompatible, non-numeric, or unjudged metric remains
+informational and does not breach a threshold. RAG-397 counters are useful for
+inspection but intentionally cannot be configured as generic quality gates.

--- a/docs/memory-eval-harness.md
+++ b/docs/memory-eval-harness.md
@@ -39,6 +39,8 @@ Without `--output`, the report is written to
 `results/memory-eval/<UTC timestamp>.json`. Native outputs are placed alongside
 it in `<report stem>.artifacts/`; the unified report links to these files but
 does not embed query traces, model answers, credentials, tokens, or passwords.
+Child stdout and stderr are never retained in the unified report, including on
+failure; failure entries contain only generic diagnostics.
 
 ## Per-suite setup and cost
 
@@ -87,20 +89,26 @@ make memory-eval MEMORY_EVAL_ARGS='--suites longmemeval \
 LongMemEval can take substantial time and invokes the configured external LLM
 judge by default, which can incur provider charges. Use
 `--longmemeval-run-only` to generate hypotheses without the judge; the report
-will still record answer count, but no judged `accuracy` is available.
+will still record answer count, but no judged `accuracy` is available. Each
+harness invocation forces its explicit LongMemEval artifact to start fresh, so
+rerunning the same report path never resumes stale hypotheses.
 
 ## Read the report and select exit behavior
 
 The JSON report has `schema_version`, timestamps, `requested_suites`, a
-per-suite `suites` map, and optional `deltas` and `regressions` when a baseline
-is supplied. Each suite records its status, timing, exit code, sanitized
-effective configuration, native artifact path, and a small native summary.
+per-suite `suites` map, and optional `deltas`, `regressions`, and
+`incompatible_suites` when a baseline is supplied. Each suite records its
+status, timing, exit code, sanitized effective configuration, native artifact
+path, and a small native summary.
 
 Search quality summaries include retrieval metrics such as `mrr` and
 `ndcg_at_k`. RAG-397 summaries are bucket and error counters, not a universal
 quality score. LongMemEval records answer count and, when the judge prints it,
-accuracy. Keep these metrics separate: the harness deliberately does not blend
-them into one score.
+accuracy. A nonzero RAG-397 case error count or any LongMemEval hypothesis that
+begins with `Error:` fails its suite even when the child process exits zero. A
+judged LongMemEval run also fails unless the judge emits a finite accuracy.
+Keep these metrics separate: the harness deliberately does not blend them into
+one score.
 
 The command exits:
 
@@ -116,9 +124,14 @@ captures the whole requested run.
 
 ## Baselines and CI gates
 
-Pass a prior harness report with `--baseline`. Compatible same-key numeric
-metrics are included as informational deltas. They only become CI gates when
-you provide one or more `--max-regression suite.metric=decline` values.
+Pass a prior harness report with `--baseline`. A suite is comparable only when
+both its current and baseline status are `passed` and its recorded relevant
+configuration is identical after normalization. Compatible same-key numeric
+metrics are included as informational deltas. Incompatible suites are listed
+in `incompatible_suites`; their deltas and gates are not evaluated. A
+configured gate for an incompatible suite fails closed with exit code `1`.
+Compatible metrics only become CI gates when you provide one or more
+`--max-regression suite.metric=decline` values.
 Thresholds are accepted only for the higher-is-better quality metrics:
 
 - `search.precision_at_k`
@@ -139,6 +152,7 @@ LongMemEval accuracy drops by more than 0.03:
   --output results/memory-eval/ci.json
 ```
 
-An omitted, incompatible, non-numeric, or unjudged metric remains
-informational and does not breach a threshold. RAG-397 counters are useful for
-inspection but intentionally cannot be configured as generic quality gates.
+An omitted or non-numeric metric has no delta. An unjudged LongMemEval run is
+valid only with `--longmemeval-run-only`; a judged run without a parsed accuracy
+fails. RAG-397 counters are useful for inspection but intentionally cannot be
+configured as generic quality gates.

--- a/docs/superpowers/specs/2026-07-20-mcp-jwt-principals-design.md
+++ b/docs/superpowers/specs/2026-07-20-mcp-jwt-principals-design.md
@@ -1,0 +1,74 @@
+# MCP JWT principals and workspace grants
+
+## Goal
+
+Implement issue #312 by making MCP authenticate the same concrete JWT user
+principal as REST. The result is trusted, server-derived identity and workspace
+grant context that issue #314 can later authorize against.
+
+## Scope
+
+The implementation accepts JWT bearer credentials for MCP in production and
+exposes a typed request-scoped principal containing the authenticated user ID,
+role, workspace grants, and `auth_method="jwt"`.
+
+It does not add service/API-key principals, resource policy decisions, agent
+delegation rules, or cross-transport authorization conformance. Those remain
+separate work for issues #314 and #310.
+
+## Authentication and context
+
+1. Define an immutable `MCPPrincipal` value with `user_id`, `role`,
+   `workspace_ids`, and `auth_method` fields.
+2. Define a context variable with bind/get/reset helpers so MCP dispatch and
+   tools can retrieve the current principal without accepting client-provided
+   identity fields.
+3. In production (`AUTH_ENABLED=true`), MCP HTTP middleware requires a bearer
+   JWT and validates it through the existing JWT verifier and configured secret.
+   Invalid, missing, or expired credentials receive a 401 response.
+4. Admin JWTs with an empty workspace list are normalized to `["*"]`, matching
+   REST. Every other empty list grants access to no workspaces.
+5. The deployment-wide `METRONIX_MCP_API_KEY` is not a hosted-user identity and
+   is rejected on production MCP requests. With authentication disabled, the
+   local development flow retains its existing trusted-admin behavior.
+
+## Workspace resolution
+
+MCP workspace resolution consumes the bound principal rather than treating a
+tool argument as authority.
+
+- A requested workspace must be syntactically valid and present in the
+  principal's grants, unless the principal carries `["*"]`.
+- An omitted workspace selects the principal's first concrete workspace. A
+  wildcard principal falls back to the configured default workspace.
+- A principal without a usable grant fails closed before any store or registry
+  lookup.
+- `X-Agent-Id` remains validated request context only. It neither grants
+  ownership nor delegation; the future shared evaluator receives it alongside
+  the principal.
+
+## Migration and documentation
+
+MCP clients in hosted deployments change from
+`Authorization: Bearer $METRONIX_MCP_API_KEY` to a user JWT bearer token.
+Documentation will describe that the shared MCP key is development-only, plus
+the expected 401 authentication and 403 workspace-grant failure behavior.
+
+## Verification
+
+Tests will prove:
+
+1. Valid and invalid JWTs resolve or reject an `MCPPrincipal` correctly.
+2. Empty-grant and admin-wildcard behavior matches REST.
+3. Production MCP rejects the shared deployment key and accepts a valid JWT.
+4. Granted workspaces resolve; ungranted or malformed values fail before store
+   construction.
+5. The same JWT produces equal effective workspace grants for REST and MCP.
+
+## Non-goals and follow-up boundaries
+
+This slice deliberately establishes authentication and authoritative request
+context only. Issue #314 will use the principal, resource, operation, and
+agent-context inputs to make auditable allow/deny decisions at discovery and
+execution boundaries. Issue #310 will verify the transport-neutral policy
+contract.

--- a/docs/superpowers/specs/2026-07-20-unified-memory-eval-harness-design.md
+++ b/docs/superpowers/specs/2026-07-20-unified-memory-eval-harness-design.md
@@ -1,0 +1,104 @@
+# Unified Memory Evaluation Harness
+
+## Purpose
+
+Issue #309 needs one repeatable entry point for the repository's existing
+memory and retrieval evaluations. Version one wraps their current behavior;
+it does not replace their domain-specific runners or change their scoring.
+
+## Scope
+
+The new root-level CLI, `scripts/run_memory_eval.py`, runs any selected subset
+of these suites:
+
+1. `search`: `scripts/run_eval.py`, which measures labelled retrieval quality
+   for a live workspace.
+2. `rag-397`: `scripts/rag_eval_397.py`, which exercises authenticated REST
+   chat and RAG traces with its regression, positive, and adversarial buckets.
+3. `longmemeval`: the existing LongMemEval runner and judge under
+   `benchmarks/longmemeval/`.
+
+Each suite retains its existing prerequisites, configuration, native artifact
+format, and scoring semantics. The harness only orchestrates it and exposes a
+consistent run-level contract.
+
+## Command-line interface
+
+`python scripts/run_memory_eval.py` accepts a comma-separated `--suites` list
+and defaults to all three suites. It writes a versioned report to an explicit
+`--output` path or to a timestamped file under `results/memory-eval/`.
+
+The CLI defines explicit, non-secret configuration for the selected suite:
+
+- search: workspace, test-set path, top-K, and whether unstable queries are
+  included;
+- rag-397: base URL, workspace, and the paths or environment-variable names
+  used for credentials (never their values);
+- LongMemEval: variant, maximum questions, output path, and whether the judge
+  runs.
+
+Credentials remain in environment variables or the existing benchmark env
+file. They are supplied to child processes without being printed or persisted
+in the unified report.
+
+## Report contract
+
+The report is JSON with a schema version and run metadata (`started_at`,
+`finished_at`, duration, harness version, requested suites). `suites` is a
+mapping keyed by suite name. Every suite entry contains:
+
+- `status`: `passed`, `failed`, or `skipped`;
+- timing and child-process exit code;
+- sanitized effective configuration and native artifact paths;
+- a suite-specific `summary` containing parsed metrics or counters;
+- a diagnostic error message when execution or result parsing failed.
+
+The raw native outputs stay in their current paths. The report links to them
+rather than embedding secrets, full model answers, or high-volume traces.
+
+## Baselines and CI behavior
+
+`--baseline <report.json>` adds deltas for compatible metrics from a previous
+harness report. The harness does not infer a universal quality score: search
+retrieval metrics, RAG trace checks, and LLM-judged LongMemEval scores remain
+separate.
+
+`--max-regression suite.metric=value` supplies explicit acceptance thresholds.
+Without thresholds, baseline comparisons are informational. A selected suite
+failure or a threshold breach returns a non-zero exit code, making the command
+suitable for CI; otherwise it exits zero.
+
+Argument validation fails before a child process starts. Once a run begins,
+the harness continues after a suite failure and records each selected suite in
+the same report. Missing optional prerequisites produce a clear failed or
+skipped suite record according to whether the user selected that suite.
+
+## Implementation boundaries
+
+The orchestrator is deliberately small and uses subprocess boundaries around
+the existing scripts. It owns selection, argument validation, environment
+passing, artifact discovery, result normalization, baseline comparison, and
+exit status. Existing evaluators continue to own retrieval behavior, RAG
+requests, dataset ingestion, judge invocation, and their native output.
+
+To keep the code testable, the CLI will delegate report construction,
+subprocess execution, parsing, and comparison to focused functions or a small
+support module. No new third-party dependency is required.
+
+## Tests and documentation
+
+Unit tests will mock child-process execution and cover command construction,
+sanitization, successful mixed-suite reports, partial failures, malformed
+artifacts, baseline compatibility, regression thresholds, and exit codes.
+
+Documentation will list per-suite setup, expected runtime and external cost,
+report locations, metric interpretation, threshold examples, and a CI command.
+It will explicitly state that a live Metronix stack and relevant credentials
+are still required for real runs.
+
+## Non-goals
+
+- Rewriting the three evaluators into a common scoring framework.
+- Making LongMemEval deterministic or free of external LLM costs.
+- Treating RAG-397's project-specific queries as a generic benchmark.
+- Running live benchmark services in the unit-test suite.

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -150,9 +150,9 @@ def compare_baseline(
 ) -> list[Regression]:
     """Return quality-gate breaches for comparable, higher-is-better metrics."""
     _validate_thresholds(thresholds)
-    deltas = baseline_deltas(current, baseline)
+    deltas = _raw_baseline_deltas(current, baseline)
     return [
-        Regression(metric=metric, delta=deltas[metric], threshold=limit)
+        Regression(metric=metric, delta=round(deltas[metric], 12), threshold=limit)
         for metric, limit in thresholds.items()
         if metric in deltas and deltas[metric] < -limit
     ]
@@ -160,10 +160,17 @@ def compare_baseline(
 
 def baseline_deltas(current: HarnessReport, baseline: HarnessReport) -> dict[str, float]:
     """Return informational deltas for numeric summary metrics shared by both reports."""
+    return {
+        metric: round(delta, 12)
+        for metric, delta in _raw_baseline_deltas(current, baseline).items()
+    }
+
+
+def _raw_baseline_deltas(current: HarnessReport, baseline: HarnessReport) -> dict[str, float]:
     current_metrics = _summary_metrics(current)
     baseline_metrics = _summary_metrics(baseline)
     return {
-        metric: round(current_metrics[metric] - baseline_metrics[metric], 12)
+        metric: current_metrics[metric] - baseline_metrics[metric]
         for metric in sorted(current_metrics.keys() & baseline_metrics.keys())
     }
 

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -1,0 +1,445 @@
+"""Pure orchestration and sanitized reporting for existing memory evaluations.
+
+This module deliberately does not provide a command-line interface.  It runs
+the repository's existing evaluators as child processes and links their native
+artifacts from a small, versioned report.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+SuiteName = Literal["search", "rag-397", "longmemeval"]
+SuiteStatus = Literal["passed", "failed", "skipped"]
+SummaryValue = float | int | str | bool | None
+
+_RAG_EMAIL_ENV = "METRONIX_ADMIN_EMAIL"
+_RAG_PASSWORD_ENV = "METRONIX_ADMIN_PASSWORD"
+_ACCURACY_RE = re.compile(r"Accuracy:\s*([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+_SECRET_ENV_MARKERS = ("API_KEY", "APIKEY", "CREDENTIAL", "PASS", "SECRET", "TOKEN")
+
+
+@dataclass(frozen=True)
+class SearchConfig:
+    workspace: str
+    k: int
+    testset: Path | None
+    include_unstable: bool
+
+
+@dataclass(frozen=True)
+class Rag397Config:
+    base_url: str
+    workspace: str
+    admin_email: str
+    admin_password: str
+
+
+@dataclass(frozen=True)
+class LongMemEvalConfig:
+    variant: str
+    max_questions: int | None
+    run_judge: bool
+
+
+@dataclass(frozen=True)
+class HarnessRequest:
+    suites: tuple[SuiteName, ...]
+    artifact_dir: Path
+    search: SearchConfig | None
+    rag_397: Rag397Config | None
+    longmemeval: LongMemEvalConfig | None
+
+
+@dataclass(frozen=True)
+class SuiteResult:
+    status: SuiteStatus
+    started_at: str
+    finished_at: str
+    duration_seconds: float
+    exit_code: int | None
+    configuration: dict[str, object]
+    artifacts: dict[str, str]
+    summary: dict[str, SummaryValue]
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class HarnessReport:
+    schema_version: int
+    started_at: str
+    finished_at: str
+    requested_suites: list[SuiteName]
+    suites: dict[SuiteName, SuiteResult]
+    regressions: list[object]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe representation that omits all secret values."""
+        return asdict(self)
+
+
+class CommandRunner:
+    """Run one evaluator command while capturing its native terminal output."""
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        child_env: Mapping[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=dict(child_env),
+        )
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def build_search_command(config: SearchConfig, output: Path) -> list[str]:
+    command = [
+        sys.executable,
+        "scripts/run_eval.py",
+        "--workspace",
+        config.workspace,
+        "--k",
+        str(config.k),
+    ]
+    if config.testset is not None:
+        command.extend(("--testset", str(config.testset)))
+    if config.include_unstable:
+        command.append("--all")
+    command.extend(("--output", str(output)))
+    return command
+
+
+def build_rag_397_command() -> list[str]:
+    """Build a static command that expands RAG credentials only in the child."""
+    return [
+        "bash",
+        "-c",
+        (
+            'exec "$0" scripts/rag_eval_397.py '
+            '--base-url "$METRONIX_EVAL_RAG_BASE_URL" '
+            f'--email "${_RAG_EMAIL_ENV}" '
+            f'--password "${_RAG_PASSWORD_ENV}" '
+            '--workspace "$METRONIX_EVAL_RAG_WORKSPACE" '
+            '--out "$METRONIX_EVAL_RAG_ARTIFACT"'
+        ),
+        sys.executable,
+    ]
+
+
+def build_longmemeval_command(config: LongMemEvalConfig, output: Path) -> list[str]:
+    command = [
+        "bash",
+        "benchmarks/longmemeval/run.sh",
+        "--variant",
+        config.variant,
+        "--output",
+        str(output),
+    ]
+    if config.max_questions is not None:
+        command.extend(("--max-questions", str(config.max_questions)))
+    if not config.run_judge:
+        command.append("--run-only")
+    return command
+
+
+def run_suites(request: HarnessRequest, runner: CommandRunner) -> HarnessReport:
+    """Run every requested suite, preserving results after a prior failure."""
+    started_at = utc_now()
+    request.artifact_dir.mkdir(parents=True, exist_ok=True)
+    results = {name: run_one_suite(name, request, runner) for name in request.suites}
+    return HarnessReport(
+        schema_version=1,
+        started_at=started_at,
+        finished_at=utc_now(),
+        requested_suites=list(request.suites),
+        suites=results,
+        regressions=[],
+    )
+
+
+def run_one_suite(name: SuiteName, request: HarnessRequest, runner: CommandRunner) -> SuiteResult:
+    started_at = utc_now()
+    started = time.monotonic()
+    try:
+        command, child_env, configuration, artifact_path, secrets = _suite_invocation(
+            name, request
+        )
+    except ValueError as exc:
+        return _skipped_result(started_at, started, str(exc))
+
+    try:
+        completed = runner.run(command, child_env=child_env)
+    except Exception as exc:  # noqa: BLE001 - runner errors must be reported per suite.
+        return _failed_result(
+            started_at,
+            started,
+            configuration,
+            artifact_path,
+            None,
+            {},
+            _redact_text(f"Could not start suite: {exc}", secrets),
+        )
+
+    errors: list[str] = []
+    if completed.returncode != 0:
+        errors.append(
+            _redact_text(
+                _command_failure_message(completed.returncode, completed.stdout, completed.stderr),
+                secrets,
+            )
+        )
+
+    try:
+        summary = _parse_summary(name, artifact_path, completed.stdout, completed.stderr)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        summary = {}
+        errors.append(
+            _redact_text(f"Could not read expected artifact {artifact_path}: {exc}", secrets)
+        )
+
+    if errors:
+        return _failed_result(
+            started_at,
+            started,
+            configuration,
+            artifact_path,
+            completed.returncode,
+            summary,
+            " ".join(errors),
+        )
+
+    return SuiteResult(
+        status="passed",
+        started_at=started_at,
+        finished_at=utc_now(),
+        duration_seconds=round(time.monotonic() - started, 6),
+        exit_code=completed.returncode,
+        configuration=configuration,
+        artifacts={"native_result": str(artifact_path)},
+        summary=summary,
+    )
+
+
+def write_report(report: HarnessReport, path: Path) -> None:
+    """Write a report without embedding raw evaluator output or credentials."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _suite_invocation(
+    name: SuiteName, request: HarnessRequest
+) -> tuple[list[str], dict[str, str], dict[str, object], Path, tuple[str, ...]]:
+    artifact_path = request.artifact_dir / _artifact_name(name)
+    child_env = dict(os.environ)
+    child_env["METRONIX_EVAL_SUITE"] = name
+    child_env["METRONIX_EVAL_ARTIFACT"] = str(artifact_path)
+
+    if name == "search":
+        if request.search is None:
+            raise ValueError("Search configuration was not provided")
+        config = request.search
+        return (
+            build_search_command(config, artifact_path),
+            child_env,
+            {
+                "workspace": config.workspace,
+                "k": config.k,
+                "testset": str(config.testset) if config.testset is not None else None,
+                "include_unstable": config.include_unstable,
+            },
+            artifact_path,
+            _redaction_values(child_env),
+        )
+
+    if name == "rag-397":
+        if request.rag_397 is None:
+            raise ValueError("RAG-397 configuration was not provided")
+        config = request.rag_397
+        child_env.update(
+            {
+                "METRONIX_EVAL_RAG_BASE_URL": config.base_url,
+                "METRONIX_EVAL_RAG_WORKSPACE": config.workspace,
+                "METRONIX_EVAL_RAG_ARTIFACT": str(artifact_path),
+                _RAG_EMAIL_ENV: config.admin_email,
+                _RAG_PASSWORD_ENV: config.admin_password,
+            }
+        )
+        return (
+            build_rag_397_command(),
+            child_env,
+            {
+                "base_url": config.base_url,
+                "workspace": config.workspace,
+                "credential_environment_variables": [_RAG_EMAIL_ENV, _RAG_PASSWORD_ENV],
+            },
+            artifact_path,
+            _redaction_values(child_env, config.admin_email),
+        )
+
+    if request.longmemeval is None:
+        raise ValueError("LongMemEval configuration was not provided")
+    config = request.longmemeval
+    return (
+        build_longmemeval_command(config, artifact_path),
+        child_env,
+        {
+            "variant": config.variant,
+            "max_questions": config.max_questions,
+            "run_judge": config.run_judge,
+        },
+        artifact_path,
+        _redaction_values(child_env),
+    )
+
+
+def _artifact_name(name: SuiteName) -> str:
+    if name == "longmemeval":
+        return "longmemeval.jsonl"
+    return f"{name}.json"
+
+
+def _parse_summary(
+    name: SuiteName,
+    artifact_path: Path,
+    stdout: str,
+    stderr: str,
+) -> dict[str, SummaryValue]:
+    if name == "search":
+        return _parse_search_summary(artifact_path)
+    if name == "rag-397":
+        return _parse_rag_397_summary(artifact_path)
+    return _parse_longmemeval_summary(artifact_path, stdout, stderr)
+
+
+def _parse_search_summary(path: Path) -> dict[str, SummaryValue]:
+    data = _load_json_object(path)
+    averages = data.get("averages")
+    if not isinstance(averages, dict):
+        raise ValueError("search artifact has no averages object")
+    summary: dict[str, SummaryValue] = {}
+    for key, value in averages.items():
+        if not isinstance(key, str) or not isinstance(value, (float, int, str, bool, type(None))):
+            raise ValueError("search averages contain a non-scalar value")
+        summary[key] = value
+    return summary
+
+
+def _parse_rag_397_summary(path: Path) -> dict[str, SummaryValue]:
+    data = _load_json_object(path)
+    buckets = ("regression", "positive", "adversarial")
+    rows: dict[str, list[object]] = {}
+    for bucket in buckets:
+        value = data.get(bucket)
+        if not isinstance(value, list):
+            raise ValueError(f"RAG-397 artifact has no {bucket} list")
+        rows[bucket] = value
+    return {
+        **{f"{bucket}_count": len(rows[bucket]) for bucket in buckets},
+        "error_count": sum(
+            1
+            for bucket_rows in rows.values()
+            for row in bucket_rows
+            if isinstance(row, dict) and row.get("error")
+        ),
+    }
+
+
+def _parse_longmemeval_summary(path: Path, stdout: str, stderr: str) -> dict[str, SummaryValue]:
+    answer_count = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        if not isinstance(json.loads(line), dict):
+            raise ValueError("LongMemEval artifact contains a non-object JSON line")
+        answer_count += 1
+    match = _ACCURACY_RE.search(f"{stdout}\n{stderr}")
+    return {
+        "answer_count": answer_count,
+        "accuracy": float(match.group(1)) if match else None,
+    }
+
+
+def _load_json_object(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("artifact root must be a JSON object")
+    return data
+
+
+def _command_failure_message(exit_code: int, stdout: str, stderr: str) -> str:
+    output = (stderr or stdout).strip()
+    if not output:
+        return f"Suite command exited with code {exit_code}"
+    return f"Suite command exited with code {exit_code}: {output[:1000]}"
+
+
+def _redact_text(text: str, secrets: Sequence[str]) -> str:
+    redacted = text
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "[REDACTED]")
+    return redacted
+
+
+def _redaction_values(child_env: Mapping[str, str], *additional_values: str) -> tuple[str, ...]:
+    values = [
+        value
+        for name, value in child_env.items()
+        if value and any(marker in name.upper() for marker in _SECRET_ENV_MARKERS)
+    ]
+    values.extend(value for value in additional_values if value)
+    return tuple(dict.fromkeys(values))
+
+
+def _failed_result(
+    started_at: str,
+    started: float,
+    configuration: dict[str, object],
+    artifact_path: Path,
+    exit_code: int | None,
+    summary: dict[str, SummaryValue],
+    error: str,
+) -> SuiteResult:
+    return SuiteResult(
+        status="failed",
+        started_at=started_at,
+        finished_at=utc_now(),
+        duration_seconds=round(time.monotonic() - started, 6),
+        exit_code=exit_code,
+        configuration=configuration,
+        artifacts={"native_result": str(artifact_path)},
+        summary=summary,
+        error=error,
+    )
+
+
+def _skipped_result(started_at: str, started: float, error: str) -> SuiteResult:
+    return SuiteResult(
+        status="skipped",
+        started_at=started_at,
+        finished_at=utc_now(),
+        duration_seconds=round(time.monotonic() - started, 6),
+        exit_code=None,
+        configuration={},
+        artifacts={},
+        summary={},
+        error=error,
+    )

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -7,6 +7,7 @@ artifacts from a small, versioned report.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import os
@@ -32,6 +33,26 @@ _ACCURACY_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _SECRET_ENV_MARKERS = ("API_KEY", "APIKEY", "CREDENTIAL", "PASS", "SECRET", "TOKEN")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LONGMEMEVAL_ROOT = _REPO_ROOT / "benchmarks" / "longmemeval"
+_LONGMEMEVAL_ENV = _LONGMEMEVAL_ROOT / ".env.benchmark"
+_LONGMEMEVAL_LEGACY_ENV = _LONGMEMEVAL_ROOT / ".env"
+_LONGMEMEVAL_DATASETS = {
+    "oracle": {
+        "filename": "longmemeval_oracle.json",
+        "source": (
+            "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+            "resolve/main/longmemeval_oracle.json"
+        ),
+    },
+    "s": {
+        "filename": "longmemeval_s_cleaned.json",
+        "source": (
+            "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+            "resolve/main/longmemeval_s_cleaned.json"
+        ),
+    },
+}
 
 HIGHER_IS_BETTER = frozenset(
     {
@@ -46,7 +67,18 @@ HIGHER_IS_BETTER = frozenset(
 _COMPARISON_CONFIGURATION_KEYS: dict[SuiteName, tuple[str, ...]] = {
     "search": ("workspace", "k", "testset", "include_unstable"),
     "rag-397": ("base_url", "workspace", "credential_environment_variables"),
-    "longmemeval": ("variant", "max_questions", "run_judge"),
+    "longmemeval": (
+        "variant",
+        "max_questions",
+        "run_judge",
+        "workspace",
+        "top_k",
+        "chat_model",
+        "chat_base_url",
+        "judge_model",
+        "judge_base_url",
+        "dataset",
+    ),
 }
 
 
@@ -178,9 +210,7 @@ def baseline_deltas(current: HarnessReport, baseline: HarnessReport) -> dict[str
 
 
 def _raw_baseline_deltas(current: HarnessReport, baseline: HarnessReport) -> dict[str, float]:
-    compatible_suites = set(current.suites) - set(
-        _comparison_incompatibilities(current, baseline)
-    )
+    compatible_suites = set(current.suites) - set(_comparison_incompatibilities(current, baseline))
     current_metrics = _summary_metrics(current, compatible_suites)
     baseline_metrics = _summary_metrics(baseline, compatible_suites)
     return {
@@ -196,6 +226,20 @@ def attach_baseline_comparison(
 ) -> HarnessReport:
     """Return a report enriched with baseline deltas and threshold breaches."""
     incompatibilities = _comparison_incompatibilities(current, baseline)
+    current_metrics = _summary_metrics(current)
+    baseline_metrics = _summary_metrics(baseline)
+    missing_gate_metrics: dict[str, list[str]] = {}
+    for metric in thresholds:
+        suite, _, _ = metric.partition(".")
+        if suite not in incompatibilities and (
+            metric not in current_metrics or metric not in baseline_metrics
+        ):
+            missing_gate_metrics.setdefault(suite, []).append(metric)
+    for suite, metrics in missing_gate_metrics.items():
+        incompatibilities[suite] = (
+            "configured threshold metrics must be finite numbers in current and "
+            f"baseline reports: {', '.join(sorted(metrics))}"
+        )
     return replace(
         current,
         deltas=baseline_deltas(current, baseline),
@@ -273,6 +317,21 @@ def run_suites(request: HarnessRequest, runner: CommandRunner) -> HarnessReport:
 def run_one_suite(name: SuiteName, request: HarnessRequest, runner: CommandRunner) -> SuiteResult:
     started_at = utc_now()
     started = time.monotonic()
+    artifact_path = (request.artifact_dir / _artifact_name(name)).resolve()
+    if name == "longmemeval":
+        try:
+            artifact_path.unlink(missing_ok=True)
+        except OSError:
+            return _failed_result(
+                started_at,
+                started,
+                {},
+                artifact_path,
+                None,
+                {},
+                "Could not remove existing LongMemEval artifact",
+                include_artifact=False,
+            )
     try:
         command, child_env, configuration, artifact_path, secrets = _suite_invocation(
             name, request
@@ -346,9 +405,7 @@ def _validate_thresholds(thresholds: Mapping[str, float]) -> None:
             raise ValueError(f"threshold for {metric} must be a non-negative number")
 
 
-def _summary_metrics(
-    report: HarnessReport, suites: set[str] | None = None
-) -> dict[str, float]:
+def _summary_metrics(report: HarnessReport, suites: set[str] | None = None) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for suite, result in report.suites.items():
         if suites is not None and suite not in suites:
@@ -373,9 +430,7 @@ def _comparison_incompatibilities(
         current_result = current.suites[suite]
         baseline_result = baseline.suites[suite]
         if current_result.status != "passed" or baseline_result.status != "passed":
-            incompatibilities[suite] = (
-                "current and baseline suite status must both be passed"
-            )
+            incompatibilities[suite] = "current and baseline suite status must both be passed"
             continue
         current_configuration = _normalized_suite_configuration(
             suite, current_result.configuration
@@ -388,9 +443,7 @@ def _comparison_incompatibilities(
             or baseline_configuration is None
             or current_configuration != baseline_configuration
         ):
-            incompatibilities[suite] = (
-                "current and baseline suite configuration must be identical"
-            )
+            incompatibilities[suite] = "current and baseline suite configuration must be identical"
     return incompatibilities
 
 
@@ -460,6 +513,7 @@ def _suite_invocation(
     if request.longmemeval is None:
         raise ValueError("LongMemEval configuration was not provided")
     config = request.longmemeval
+    effective_configuration = _longmemeval_effective_configuration(config)
     return (
         build_longmemeval_command(config, artifact_path),
         child_env,
@@ -467,6 +521,7 @@ def _suite_invocation(
             "variant": config.variant,
             "max_questions": config.max_questions,
             "run_judge": config.run_judge,
+            **effective_configuration,
         },
         artifact_path,
         _redaction_values(child_env),
@@ -477,6 +532,68 @@ def _artifact_name(name: SuiteName) -> str:
     if name == "longmemeval":
         return "longmemeval.jsonl"
     return f"{name}.json"
+
+
+def _longmemeval_effective_configuration(
+    config: LongMemEvalConfig,
+) -> dict[str, object]:
+    environment = dict(os.environ)
+    for key, value in _parse_env_file(_REPO_ROOT / ".env").items():
+        environment.setdefault(key, value)
+
+    benchmark_env = _LONGMEMEVAL_ENV
+    if not benchmark_env.exists() and _LONGMEMEVAL_LEGACY_ENV.exists():
+        benchmark_env = _LONGMEMEVAL_LEGACY_ENV
+    for key, value in _parse_env_file(benchmark_env).items():
+        if value:
+            environment[key] = value
+        else:
+            environment.setdefault(key, value)
+
+    dataset = _LONGMEMEVAL_DATASETS[config.variant]
+    dataset_path = _LONGMEMEVAL_ROOT / "data" / dataset["filename"]
+    return {
+        "workspace": environment.get("LME_WORKSPACE_ID", "MABENCH"),
+        "top_k": _integer_if_valid(environment.get("LME_RETRIEVE_TOP_K", "10")),
+        "chat_model": environment.get("LME_CHAT_MODEL", "gpt-4o-mini"),
+        "chat_base_url": environment.get("LME_CHAT_BASE_URL", "https://api.openai.com/v1"),
+        "judge_model": environment.get("LME_JUDGE_MODEL", "gpt-4o"),
+        "judge_base_url": environment.get("LME_JUDGE_BASE_URL", "https://api.openai.com/v1"),
+        "dataset": {
+            **dataset,
+            "sha256": _sha256_if_present(dataset_path),
+        },
+    }
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def _integer_if_valid(value: str) -> int | str:
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def _sha256_if_present(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _parse_summary(
@@ -520,7 +637,7 @@ def _parse_rag_397_summary(path: Path) -> dict[str, SummaryValue]:
             1
             for bucket_rows in rows.values()
             for row in bucket_rows
-            if isinstance(row, dict) and row.get("error")
+            if isinstance(row, dict) and "error" in row
         ),
     }
 
@@ -606,6 +723,8 @@ def _failed_result(
     exit_code: int | None,
     summary: dict[str, SummaryValue],
     error: str,
+    *,
+    include_artifact: bool = True,
 ) -> SuiteResult:
     return SuiteResult(
         status="failed",
@@ -614,7 +733,7 @@ def _failed_result(
         duration_seconds=round(time.monotonic() - started, 6),
         exit_code=exit_code,
         configuration=configuration,
-        artifacts={"native_result": str(artifact_path)},
+        artifacts={"native_result": str(artifact_path)} if include_artifact else {},
         summary=summary,
         error=error,
     )

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -20,6 +20,7 @@ from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlsplit, urlunsplit
 
 SuiteName = Literal["search", "rag-397", "longmemeval"]
 SuiteStatus = Literal["passed", "failed", "skipped"]
@@ -71,6 +72,7 @@ _COMPARISON_CONFIGURATION_KEYS: dict[SuiteName, tuple[str, ...]] = {
         "variant",
         "max_questions",
         "run_judge",
+        "metronix_mcp_endpoint",
         "workspace",
         "top_k",
         "chat_model",
@@ -336,8 +338,17 @@ def run_one_suite(name: SuiteName, request: HarnessRequest, runner: CommandRunne
         command, child_env, configuration, artifact_path, secrets = _suite_invocation(
             name, request
         )
-    except ValueError as exc:
-        return _skipped_result(started_at, started, str(exc))
+    except Exception:  # noqa: BLE001 - preparation errors must remain suite-local.
+        return _failed_result(
+            started_at,
+            started,
+            {},
+            artifact_path,
+            None,
+            {},
+            "Could not prepare suite configuration",
+            include_artifact=False,
+        )
 
     try:
         completed = runner.run(command, child_env=child_env)
@@ -553,8 +564,11 @@ def _longmemeval_effective_configuration(
     dataset = _LONGMEMEVAL_DATASETS[config.variant]
     dataset_path = _LONGMEMEVAL_ROOT / "data" / dataset["filename"]
     return {
+        "metronix_mcp_endpoint": _sanitized_endpoint_identity(
+            environment.get("METRONIX_MCP_URL", "http://localhost:8000/mcp")
+        ),
         "workspace": environment.get("LME_WORKSPACE_ID", "MABENCH"),
-        "top_k": _integer_if_valid(environment.get("LME_RETRIEVE_TOP_K", "10")),
+        "top_k": int(environment.get("LME_RETRIEVE_TOP_K", "10")),
         "chat_model": environment.get("LME_CHAT_MODEL", "gpt-4o-mini"),
         "chat_base_url": environment.get("LME_CHAT_BASE_URL", "https://api.openai.com/v1"),
         "judge_model": environment.get("LME_JUDGE_MODEL", "gpt-4o"),
@@ -579,11 +593,22 @@ def _parse_env_file(path: Path) -> dict[str, str]:
     return values
 
 
-def _integer_if_valid(value: str) -> int | str:
-    try:
-        return int(value)
-    except ValueError:
-        return value
+def _sanitized_endpoint_identity(value: str) -> str:
+    """Return a normalized endpoint identity without URL credentials or parameters."""
+    parsed = urlsplit(value)
+    scheme = parsed.scheme.lower()
+    hostname = parsed.hostname
+    if not scheme or hostname is None:
+        raise ValueError("METRONIX_MCP_URL must be an absolute URL")
+
+    hostname = hostname.lower()
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    port = parsed.port
+    default_port = (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    netloc = hostname if port is None or default_port else f"{hostname}:{port}"
+    path = parsed.path.rstrip("/")
+    return urlunsplit((scheme, netloc, path, "", ""))
 
 
 def _sha256_if_present(path: Path) -> str | None:

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -247,7 +247,7 @@ def write_report(report: HarnessReport, path: Path) -> None:
 def _suite_invocation(
     name: SuiteName, request: HarnessRequest
 ) -> tuple[list[str], dict[str, str], dict[str, object], Path, tuple[str, ...]]:
-    artifact_path = request.artifact_dir / _artifact_name(name)
+    artifact_path = (request.artifact_dir / _artifact_name(name)).resolve()
     child_env = dict(os.environ)
     child_env["METRONIX_EVAL_SUITE"] = name
     child_env["METRONIX_EVAL_ARTIFACT"] = str(artifact_path)

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -8,13 +8,14 @@ artifacts from a small, versioned report.
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import subprocess
 import sys
 import time
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
@@ -27,6 +28,16 @@ _RAG_EMAIL_ENV = "METRONIX_ADMIN_EMAIL"
 _RAG_PASSWORD_ENV = "METRONIX_ADMIN_PASSWORD"
 _ACCURACY_RE = re.compile(r"Accuracy:\s*([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
 _SECRET_ENV_MARKERS = ("API_KEY", "APIKEY", "CREDENTIAL", "PASS", "SECRET", "TOKEN")
+
+HIGHER_IS_BETTER = frozenset(
+    {
+        "search.precision_at_k",
+        "search.mrr",
+        "search.ndcg_at_k",
+        "search.negative_accuracy",
+        "longmemeval.accuracy",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -75,13 +86,21 @@ class SuiteResult:
 
 
 @dataclass(frozen=True)
+class Regression:
+    metric: str
+    delta: float
+    threshold: float
+
+
+@dataclass(frozen=True)
 class HarnessReport:
     schema_version: int
     started_at: str
     finished_at: str
     requested_suites: list[SuiteName]
     suites: dict[SuiteName, SuiteResult]
-    regressions: list[object]
+    regressions: list[Regression] = field(default_factory=list)
+    deltas: dict[str, float] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-safe representation that omits all secret values."""
@@ -108,6 +127,58 @@ class CommandRunner:
 
 def utc_now() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def parse_threshold(value: str) -> tuple[str, float]:
+    """Parse one ``suite.metric=maximum-decline`` CLI value."""
+    key, separator, raw_limit = value.partition("=")
+    try:
+        limit = float(raw_limit)
+    except ValueError as exc:
+        raise ValueError("threshold must be suite.metric=non-negative-number") from exc
+    if not separator or not key or not math.isfinite(limit) or limit < 0:
+        raise ValueError("threshold must be suite.metric=non-negative-number")
+    if key not in HIGHER_IS_BETTER:
+        raise ValueError(f"unknown threshold metric: {key}")
+    return key, limit
+
+
+def compare_baseline(
+    current: HarnessReport,
+    baseline: HarnessReport,
+    thresholds: Mapping[str, float],
+) -> list[Regression]:
+    """Return quality-gate breaches for comparable, higher-is-better metrics."""
+    _validate_thresholds(thresholds)
+    deltas = baseline_deltas(current, baseline)
+    return [
+        Regression(metric=metric, delta=deltas[metric], threshold=limit)
+        for metric, limit in thresholds.items()
+        if metric in deltas and deltas[metric] < -limit
+    ]
+
+
+def baseline_deltas(current: HarnessReport, baseline: HarnessReport) -> dict[str, float]:
+    """Return informational deltas for numeric summary metrics shared by both reports."""
+    current_metrics = _summary_metrics(current)
+    baseline_metrics = _summary_metrics(baseline)
+    return {
+        metric: round(current_metrics[metric] - baseline_metrics[metric], 12)
+        for metric in sorted(current_metrics.keys() & baseline_metrics.keys())
+    }
+
+
+def attach_baseline_comparison(
+    current: HarnessReport,
+    baseline: HarnessReport,
+    thresholds: Mapping[str, float],
+) -> HarnessReport:
+    """Return a report enriched with baseline deltas and threshold breaches."""
+    return replace(
+        current,
+        deltas=baseline_deltas(current, baseline),
+        regressions=compare_baseline(current, baseline, thresholds),
+    )
 
 
 def build_search_command(config: SearchConfig, output: Path) -> list[str]:
@@ -242,6 +313,28 @@ def write_report(report: HarnessReport, path: Path) -> None:
     """Write a report without embedding raw evaluator output or credentials."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _validate_thresholds(thresholds: Mapping[str, float]) -> None:
+    for metric, limit in thresholds.items():
+        if metric not in HIGHER_IS_BETTER:
+            raise ValueError(f"unknown threshold metric: {metric}")
+        if isinstance(limit, bool) or not isinstance(limit, (float, int)):
+            raise ValueError(f"threshold for {metric} must be a non-negative number")
+        if not math.isfinite(float(limit)) or limit < 0:
+            raise ValueError(f"threshold for {metric} must be a non-negative number")
+
+
+def _summary_metrics(report: HarnessReport) -> dict[str, float]:
+    metrics: dict[str, float] = {}
+    for suite, result in report.suites.items():
+        for metric, value in result.summary.items():
+            if isinstance(value, bool) or not isinstance(value, (float, int)):
+                continue
+            numeric_value = float(value)
+            if math.isfinite(numeric_value):
+                metrics[f"{suite}.{metric}"] = numeric_value
+    return metrics
 
 
 def _suite_invocation(

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -26,7 +26,11 @@ SummaryValue = float | int | str | bool | None
 
 _RAG_EMAIL_ENV = "METRONIX_ADMIN_EMAIL"
 _RAG_PASSWORD_ENV = "METRONIX_ADMIN_PASSWORD"
-_ACCURACY_RE = re.compile(r"Accuracy:\s*([0-9]+(?:\.[0-9]+)?)", re.IGNORECASE)
+_ACCURACY_RE = re.compile(
+    r"^\s*Accuracy:\s*"
+    r"([+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 _SECRET_ENV_MARKERS = ("API_KEY", "APIKEY", "CREDENTIAL", "PASS", "SECRET", "TOKEN")
 
 HIGHER_IS_BETTER = frozenset(
@@ -38,6 +42,12 @@ HIGHER_IS_BETTER = frozenset(
         "longmemeval.accuracy",
     }
 )
+
+_COMPARISON_CONFIGURATION_KEYS: dict[SuiteName, tuple[str, ...]] = {
+    "search": ("workspace", "k", "testset", "include_unstable"),
+    "rag-397": ("base_url", "workspace", "credential_environment_variables"),
+    "longmemeval": ("variant", "max_questions", "run_judge"),
+}
 
 
 @dataclass(frozen=True)
@@ -101,6 +111,7 @@ class HarnessReport:
     suites: dict[SuiteName, SuiteResult]
     regressions: list[Regression] = field(default_factory=list)
     deltas: dict[str, float] = field(default_factory=dict)
+    incompatible_suites: dict[SuiteName, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-safe representation that omits all secret values."""
@@ -167,8 +178,11 @@ def baseline_deltas(current: HarnessReport, baseline: HarnessReport) -> dict[str
 
 
 def _raw_baseline_deltas(current: HarnessReport, baseline: HarnessReport) -> dict[str, float]:
-    current_metrics = _summary_metrics(current)
-    baseline_metrics = _summary_metrics(baseline)
+    compatible_suites = set(current.suites) - set(
+        _comparison_incompatibilities(current, baseline)
+    )
+    current_metrics = _summary_metrics(current, compatible_suites)
+    baseline_metrics = _summary_metrics(baseline, compatible_suites)
     return {
         metric: current_metrics[metric] - baseline_metrics[metric]
         for metric in sorted(current_metrics.keys() & baseline_metrics.keys())
@@ -181,10 +195,12 @@ def attach_baseline_comparison(
     thresholds: Mapping[str, float],
 ) -> HarnessReport:
     """Return a report enriched with baseline deltas and threshold breaches."""
+    incompatibilities = _comparison_incompatibilities(current, baseline)
     return replace(
         current,
         deltas=baseline_deltas(current, baseline),
         regressions=compare_baseline(current, baseline, thresholds),
+        incompatible_suites=incompatibilities,
     )
 
 
@@ -230,6 +246,7 @@ def build_longmemeval_command(config: LongMemEvalConfig, output: Path) -> list[s
         config.variant,
         "--output",
         str(output),
+        "--force",
     ]
     if config.max_questions is not None:
         command.extend(("--max-questions", str(config.max_questions)))
@@ -265,7 +282,7 @@ def run_one_suite(name: SuiteName, request: HarnessRequest, runner: CommandRunne
 
     try:
         completed = runner.run(command, child_env=child_env)
-    except Exception as exc:  # noqa: BLE001 - runner errors must be reported per suite.
+    except Exception:  # noqa: BLE001 - runner errors must be reported per suite.
         return _failed_result(
             started_at,
             started,
@@ -273,17 +290,12 @@ def run_one_suite(name: SuiteName, request: HarnessRequest, runner: CommandRunne
             artifact_path,
             None,
             {},
-            _redact_text(f"Could not start suite: {exc}", secrets),
+            "Could not start suite process",
         )
 
     errors: list[str] = []
     if completed.returncode != 0:
-        errors.append(
-            _redact_text(
-                _command_failure_message(completed.returncode, completed.stdout, completed.stderr),
-                secrets,
-            )
-        )
+        errors.append(_command_failure_message(completed.returncode))
 
     try:
         summary = _parse_summary(name, artifact_path, completed.stdout, completed.stderr)
@@ -292,6 +304,8 @@ def run_one_suite(name: SuiteName, request: HarnessRequest, runner: CommandRunne
         errors.append(
             _redact_text(f"Could not read expected artifact {artifact_path}: {exc}", secrets)
         )
+
+    errors.extend(_summary_failure_messages(name, summary, configuration))
 
     if errors:
         return _failed_result(
@@ -332,9 +346,13 @@ def _validate_thresholds(thresholds: Mapping[str, float]) -> None:
             raise ValueError(f"threshold for {metric} must be a non-negative number")
 
 
-def _summary_metrics(report: HarnessReport) -> dict[str, float]:
+def _summary_metrics(
+    report: HarnessReport, suites: set[str] | None = None
+) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for suite, result in report.suites.items():
+        if suites is not None and suite not in suites:
+            continue
         for metric, value in result.summary.items():
             if isinstance(value, bool) or not isinstance(value, (float, int)):
                 continue
@@ -342,6 +360,51 @@ def _summary_metrics(report: HarnessReport) -> dict[str, float]:
             if math.isfinite(numeric_value):
                 metrics[f"{suite}.{metric}"] = numeric_value
     return metrics
+
+
+def _comparison_incompatibilities(
+    current: HarnessReport, baseline: HarnessReport
+) -> dict[SuiteName, str]:
+    incompatibilities: dict[SuiteName, str] = {}
+    for suite in current.suites:
+        if suite not in baseline.suites:
+            incompatibilities[suite] = "suite must be present in current and baseline reports"
+            continue
+        current_result = current.suites[suite]
+        baseline_result = baseline.suites[suite]
+        if current_result.status != "passed" or baseline_result.status != "passed":
+            incompatibilities[suite] = (
+                "current and baseline suite status must both be passed"
+            )
+            continue
+        current_configuration = _normalized_suite_configuration(
+            suite, current_result.configuration
+        )
+        baseline_configuration = _normalized_suite_configuration(
+            suite, baseline_result.configuration
+        )
+        if (
+            current_configuration is None
+            or baseline_configuration is None
+            or current_configuration != baseline_configuration
+        ):
+            incompatibilities[suite] = (
+                "current and baseline suite configuration must be identical"
+            )
+    return incompatibilities
+
+
+def _normalized_suite_configuration(
+    suite: SuiteName, configuration: Mapping[str, object]
+) -> str | None:
+    keys = _COMPARISON_CONFIGURATION_KEYS.get(suite)
+    if keys is None or any(key not in configuration for key in keys):
+        return None
+    relevant = {key: configuration[key] for key in keys}
+    try:
+        return json.dumps(relevant, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return None
 
 
 def _suite_invocation(
@@ -464,17 +527,46 @@ def _parse_rag_397_summary(path: Path) -> dict[str, SummaryValue]:
 
 def _parse_longmemeval_summary(path: Path, stdout: str, stderr: str) -> dict[str, SummaryValue]:
     answer_count = 0
+    error_count = 0
     for line in path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
             continue
-        if not isinstance(json.loads(line), dict):
+        row = json.loads(line)
+        if not isinstance(row, dict):
             raise ValueError("LongMemEval artifact contains a non-object JSON line")
         answer_count += 1
+        hypothesis = row.get("hypothesis")
+        if isinstance(hypothesis, str) and hypothesis.startswith("Error:"):
+            error_count += 1
     match = _ACCURACY_RE.search(f"{stdout}\n{stderr}")
+    accuracy = float(match.group(1)) if match else None
+    if accuracy is not None and not math.isfinite(accuracy):
+        accuracy = None
     return {
         "answer_count": answer_count,
-        "accuracy": float(match.group(1)) if match else None,
+        "error_count": error_count,
+        "accuracy": accuracy,
     }
+
+
+def _summary_failure_messages(
+    name: SuiteName,
+    summary: Mapping[str, SummaryValue],
+    configuration: Mapping[str, object],
+) -> list[str]:
+    if name == "rag-397" and summary.get("error_count", 0) != 0:
+        return ["RAG-397 artifact contains one or more case errors"]
+    if name == "longmemeval":
+        if summary.get("error_count", 0) != 0:
+            return ["LongMemEval artifact contains one or more error hypotheses"]
+        accuracy = summary.get("accuracy")
+        if configuration.get("run_judge") is True and (
+            isinstance(accuracy, bool)
+            or not isinstance(accuracy, (float, int))
+            or not math.isfinite(float(accuracy))
+        ):
+            return ["LongMemEval judge did not produce a finite accuracy"]
+    return []
 
 
 def _load_json_object(path: Path) -> dict[str, object]:
@@ -484,11 +576,8 @@ def _load_json_object(path: Path) -> dict[str, object]:
     return data
 
 
-def _command_failure_message(exit_code: int, stdout: str, stderr: str) -> str:
-    output = (stderr or stdout).strip()
-    if not output:
-        return f"Suite command exited with code {exit_code}"
-    return f"Suite command exited with code {exit_code}: {output[:1000]}"
+def _command_failure_message(exit_code: int) -> str:
+    return f"Suite command exited with code {exit_code}"
 
 
 def _redact_text(text: str, secrets: Sequence[str]) -> str:

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -424,6 +424,11 @@ def main() -> None:
         help="Save results to eval_results/",
     )
     parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write result JSON to this path",
+    )
+    parser.add_argument(
         "--compare",
         nargs="?",
         const="latest",
@@ -463,7 +468,10 @@ def main() -> None:
     )
 
     # Save if requested
-    if args.save:
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8")
+    elif args.save:
         save_results(results)
 
     # Compare if requested

--- a/scripts/run_memory_eval.py
+++ b/scripts/run_memory_eval.py
@@ -322,12 +322,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         report = attach_baseline_comparison(report, baseline, thresholds)
     write_report(report, output)
 
-    suite_failed = any(result.status == "failed" for result in report.suites.values())
+    all_suites_passed = all(
+        suite in report.suites and report.suites[suite].status == "passed" for suite in suites
+    )
     incompatible_gate = any(
         metric.partition(".")[0] in report.incompatible_suites for metric in thresholds
     )
     unverifiable_gate = any(metric not in report.deltas for metric in thresholds)
-    return 1 if suite_failed or report.regressions or incompatible_gate or unverifiable_gate else 0
+    return (
+        1
+        if not all_suites_passed or report.regressions or incompatible_gate or unverifiable_gate
+        else 0
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/run_memory_eval.py
+++ b/scripts/run_memory_eval.py
@@ -157,6 +157,7 @@ def _load_baseline(path: Path) -> HarnessReport:
         suites_data = data["suites"]
         if (
             isinstance(data["schema_version"], bool)
+            or not isinstance(data["schema_version"], int)
             or data["schema_version"] != _SCHEMA_VERSION
             or not isinstance(data["started_at"], str)
             or not isinstance(data["finished_at"], str)

--- a/scripts/run_memory_eval.py
+++ b/scripts/run_memory_eval.py
@@ -314,7 +314,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     write_report(report, output)
 
     suite_failed = any(result.status == "failed" for result in report.suites.values())
-    return 1 if suite_failed or report.regressions else 0
+    incompatible_gate = any(
+        metric.partition(".")[0] in report.incompatible_suites for metric in thresholds
+    )
+    return 1 if suite_failed or report.regressions or incompatible_gate else 0
 
 
 if __name__ == "__main__":

--- a/scripts/run_memory_eval.py
+++ b/scripts/run_memory_eval.py
@@ -1,0 +1,320 @@
+"""Run selected Metronix memory evaluations and write one sanitized report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+if __package__:
+    from scripts.memory_eval_harness import (
+        CommandRunner,
+        HarnessReport,
+        HarnessRequest,
+        LongMemEvalConfig,
+        Rag397Config,
+        SearchConfig,
+        SuiteResult,
+        attach_baseline_comparison,
+        parse_threshold,
+        run_suites,
+        write_report,
+    )
+else:
+    from memory_eval_harness import (
+        CommandRunner,
+        HarnessReport,
+        HarnessRequest,
+        LongMemEvalConfig,
+        Rag397Config,
+        SearchConfig,
+        SuiteResult,
+        attach_baseline_comparison,
+        parse_threshold,
+        run_suites,
+        write_report,
+    )
+
+
+_SUITES = ("search", "rag-397", "longmemeval")
+_SCHEMA_VERSION = 1
+_RAG_EMAIL_ENV = "METRONIX_ADMIN_EMAIL"
+_RAG_PASSWORD_ENV = "METRONIX_ADMIN_PASSWORD"
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run selected Metronix memory evaluations and write one sanitized report."
+    )
+    parser.add_argument(
+        "--suites",
+        default=",".join(_SUITES),
+        help="Comma-separated suite names: search,rag-397,longmemeval (default: all)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write the unified JSON report here (default: results/memory-eval/<timestamp>.json)",
+    )
+    parser.add_argument(
+        "--baseline", type=Path, help="Previous unified JSON report for comparison"
+    )
+    parser.add_argument(
+        "--max-regression",
+        action="append",
+        default=[],
+        metavar="SUITE.METRIC=VALUE",
+        help="Maximum permitted decline; repeat for each quality gate",
+    )
+
+    search = parser.add_argument_group("search configuration")
+    search.add_argument("--search-workspace", default="MTRNIX")
+    search.add_argument("--search-k", type=_positive_int, default=10)
+    search.add_argument("--search-testset", type=Path)
+    search.add_argument("--include-unstable", action="store_true")
+
+    rag = parser.add_argument_group("RAG-397 configuration")
+    rag.add_argument("--rag-397-base-url", default="http://localhost:8000")
+    rag.add_argument("--rag-397-workspace", default="MTRNIX")
+
+    longmemeval = parser.add_argument_group("LongMemEval configuration")
+    longmemeval.add_argument("--longmemeval-variant", choices=("oracle", "s"), default="s")
+    longmemeval.add_argument("--longmemeval-max-questions", type=_positive_int)
+    longmemeval.add_argument(
+        "--longmemeval-run-only",
+        action="store_true",
+        help="Skip the external LLM judge after generating hypotheses",
+    )
+    return parser
+
+
+def _selected_suites(value: str) -> tuple[str, ...]:
+    suites = tuple(item.strip() for item in value.split(","))
+    if not suites or any(not suite for suite in suites):
+        raise ValueError("--suites must be a non-empty comma-separated list")
+    invalid = sorted(set(suites) - set(_SUITES))
+    if invalid:
+        raise ValueError(f"unknown suite: {', '.join(invalid)}")
+    if len(set(suites)) != len(suites):
+        raise ValueError("--suites must not contain duplicates")
+    return suites
+
+
+def _thresholds(values: Sequence[str]) -> dict[str, float]:
+    thresholds: dict[str, float] = {}
+    for value in values:
+        metric, limit = parse_threshold(value)
+        if metric in thresholds:
+            raise ValueError(f"duplicate threshold metric: {metric}")
+        thresholds[metric] = limit
+    return thresholds
+
+
+def _report_path(path: Path | None) -> Path:
+    if path is not None:
+        return path
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    return Path("results") / "memory-eval" / f"{timestamp}.json"
+
+
+def _prepare_output(path: Path) -> Path:
+    artifact_dir = path.parent / f"{path.stem}.artifacts"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists() and path.is_dir():
+            raise ValueError(f"output path is a directory: {path}")
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ValueError(f"could not prepare output path {path}: {exc}") from exc
+    return artifact_dir
+
+
+def _load_baseline(path: Path) -> HarnessReport:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read baseline report {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("baseline report must be a JSON object")
+
+    try:
+        requested_suites = data["requested_suites"]
+        suites_data = data["suites"]
+        if (
+            isinstance(data["schema_version"], bool)
+            or data["schema_version"] != _SCHEMA_VERSION
+            or not isinstance(data["started_at"], str)
+            or not isinstance(data["finished_at"], str)
+            or not isinstance(requested_suites, list)
+            or not all(isinstance(suite, str) for suite in requested_suites)
+            or not isinstance(suites_data, dict)
+        ):
+            raise TypeError
+        suites = {
+            name: _suite_result(value)
+            for name, value in suites_data.items()
+            if isinstance(name, str)
+        }
+        if (
+            len(suites) != len(suites_data)
+            or len(set(requested_suites)) != len(requested_suites)
+            or not set(requested_suites).issubset(_SUITES)
+            or not set(suites).issubset(_SUITES)
+            or set(requested_suites) != set(suites)
+        ):
+            raise TypeError
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("baseline report does not match the memory-eval report schema") from exc
+
+    return HarnessReport(
+        schema_version=_SCHEMA_VERSION,
+        started_at=data["started_at"],
+        finished_at=data["finished_at"],
+        requested_suites=requested_suites,
+        suites=suites,
+    )
+
+
+def _suite_result(value: object) -> SuiteResult:
+    if not isinstance(value, dict):
+        raise TypeError
+    status = value["status"]
+    exit_code = value["exit_code"]
+    duration = value["duration_seconds"]
+    configuration = value["configuration"]
+    artifacts = value["artifacts"]
+    summary = value["summary"]
+    error = value.get("error")
+    if (
+        status not in {"passed", "failed", "skipped"}
+        or not isinstance(value["started_at"], str)
+        or not isinstance(value["finished_at"], str)
+        or isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or (
+            exit_code is not None
+            and (isinstance(exit_code, bool) or not isinstance(exit_code, int))
+        )
+        or not isinstance(configuration, dict)
+        or not all(isinstance(key, str) for key in configuration)
+        or not isinstance(artifacts, dict)
+        or not all(
+            isinstance(key, str) and isinstance(path, str) for key, path in artifacts.items()
+        )
+        or not _summary_is_valid(summary)
+        or (error is not None and not isinstance(error, str))
+    ):
+        raise TypeError
+    return SuiteResult(
+        status=status,
+        started_at=value["started_at"],
+        finished_at=value["finished_at"],
+        duration_seconds=float(duration),
+        exit_code=exit_code,
+        configuration=configuration,
+        artifacts=artifacts,
+        summary=summary,
+        error=error,
+    )
+
+
+def _summary_is_valid(summary: object) -> bool:
+    if not isinstance(summary, dict) or not all(isinstance(key, str) for key in summary):
+        return False
+    for value in summary.values():
+        if isinstance(value, bool) or value is None or isinstance(value, str):
+            continue
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+            return False
+    return True
+
+
+def _request(
+    args: argparse.Namespace, suites: tuple[str, ...], artifact_dir: Path
+) -> HarnessRequest:
+    rag_config = None
+    if "rag-397" in suites:
+        admin_email = os.environ.get(_RAG_EMAIL_ENV)
+        admin_password = os.environ.get(_RAG_PASSWORD_ENV)
+        if not admin_email or not admin_password:
+            raise ValueError(
+                f"rag-397 requires {_RAG_EMAIL_ENV} and {_RAG_PASSWORD_ENV} environment variables"
+            )
+        rag_config = Rag397Config(
+            base_url=args.rag_397_base_url,
+            workspace=args.rag_397_workspace,
+            admin_email=admin_email,
+            admin_password=admin_password,
+        )
+
+    return HarnessRequest(
+        suites=suites,  # type: ignore[arg-type]
+        artifact_dir=artifact_dir,
+        search=(
+            SearchConfig(
+                workspace=args.search_workspace,
+                k=args.search_k,
+                testset=args.search_testset,
+                include_unstable=args.include_unstable,
+            )
+            if "search" in suites
+            else None
+        ),
+        rag_397=rag_config,
+        longmemeval=(
+            LongMemEvalConfig(
+                variant=args.longmemeval_variant,
+                max_questions=args.longmemeval_max_questions,
+                run_judge=not args.longmemeval_run_only,
+            )
+            if "longmemeval" in suites
+            else None
+        ),
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        return int(exc.code)
+
+    try:
+        suites = _selected_suites(args.suites)
+        thresholds = _thresholds(args.max_regression)
+        output = _report_path(args.output)
+        baseline = _load_baseline(args.baseline) if args.baseline is not None else None
+        artifact_dir = _prepare_output(output)
+        request = _request(args, suites, artifact_dir)
+    except ValueError as exc:
+        parser.print_usage(sys.stderr)
+        print(f"{parser.prog}: error: {exc}", file=sys.stderr)
+        return 2
+
+    report = run_suites(request, CommandRunner())
+    if baseline is not None:
+        report = attach_baseline_comparison(report, baseline, thresholds)
+    write_report(report, output)
+
+    suite_failed = any(result.status == "failed" for result in report.suites.values())
+    return 1 if suite_failed or report.regressions else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_memory_eval.py
+++ b/scripts/run_memory_eval.py
@@ -299,6 +299,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         suites = _selected_suites(args.suites)
         thresholds = _thresholds(args.max_regression)
+        if thresholds and args.baseline is None:
+            raise ValueError("--max-regression requires --baseline")
+        unselected_gate_suites = sorted(
+            {metric.partition(".")[0] for metric in thresholds} - set(suites)
+        )
+        if unselected_gate_suites:
+            raise ValueError(
+                "--max-regression suite must be selected: " + ", ".join(unselected_gate_suites)
+            )
         output = _report_path(args.output)
         baseline = _load_baseline(args.baseline) if args.baseline is not None else None
         artifact_dir = _prepare_output(output)
@@ -317,7 +326,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     incompatible_gate = any(
         metric.partition(".")[0] in report.incompatible_suites for metric in thresholds
     )
-    return 1 if suite_failed or report.regressions or incompatible_gate else 0
+    unverifiable_gate = any(metric not in report.deltas for metric in thresholds)
+    return 1 if suite_failed or report.regressions or incompatible_gate or unverifiable_gate else 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_eval_runner_cli.py
+++ b/tests/unit/test_eval_runner_cli.py
@@ -1,0 +1,30 @@
+"""CLI contracts for evaluation runners that require no live services."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_search_eval_help_lists_output_flag() -> None:
+    completed = subprocess.run(
+        [sys.executable, "scripts/run_eval.py", "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "--output" in completed.stdout
+
+
+def test_longmemeval_help_lists_output_flag() -> None:
+    completed = subprocess.run(
+        ["bash", "benchmarks/longmemeval/run.sh", "--help"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "--output" in completed.stdout

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+from scripts.memory_eval_harness import (
+    HarnessRequest,
+    LongMemEvalConfig,
+    Rag397Config,
+    SearchConfig,
+    build_search_command,
+    run_suites,
+    write_report,
+)
+
+
+class FakeRunner:
+    def __init__(self, exit_codes: dict[str, int] | None = None) -> None:
+        self.exit_codes = exit_codes or {}
+        self.calls: list[tuple[Sequence[str], dict[str, str]]] = []
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        child_env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append((command, child_env))
+        suite = child_env["METRONIX_EVAL_SUITE"]
+        output = Path(child_env["METRONIX_EVAL_ARTIFACT"])
+        if suite == "search":
+            output.write_text(
+                json.dumps({"averages": {"mrr": 0.75, "ndcg_at_k": 0.8}}),
+                encoding="utf-8",
+            )
+        elif suite == "rag-397":
+            output.write_text(
+                json.dumps(
+                    {
+                        "regression": [{"query": "one"}],
+                        "positive": [{"query": "two", "error": "not found"}],
+                        "adversarial": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+        else:
+            output.write_text(
+                '{"question_id": "one", "hypothesis": "answer"}\n', encoding="utf-8"
+            )
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=self.exit_codes.get(suite, 0),
+            stdout="Accuracy: 0.8\n",
+            stderr="",
+        )
+
+
+def request_for_all_suites(tmp_path: Path) -> HarnessRequest:
+    return HarnessRequest(
+        suites=("search", "rag-397", "longmemeval"),
+        artifact_dir=tmp_path,
+        search=SearchConfig(workspace="MTRNIX", k=10, testset=None, include_unstable=False),
+        rag_397=Rag397Config(
+            base_url="http://localhost:8000",
+            workspace="MTRNIX",
+            admin_email="admin@example.com",
+            admin_password="not-a-real-password",
+        ),
+        longmemeval=LongMemEvalConfig(variant="s", max_questions=3, run_judge=True),
+    )
+
+
+def request_with_rag_password(password: str, tmp_path: Path) -> HarnessRequest:
+    request = request_for_all_suites(tmp_path)
+    return HarnessRequest(
+        suites=("rag-397",),
+        artifact_dir=request.artifact_dir,
+        search=None,
+        rag_397=Rag397Config(
+            base_url="http://localhost:8000",
+            workspace="MTRNIX",
+            admin_email="admin@example.com",
+            admin_password=password,
+        ),
+        longmemeval=None,
+    )
+
+
+def test_run_suites_keeps_running_after_a_failure(tmp_path: Path) -> None:
+    runner = FakeRunner(exit_codes={"search": 1, "rag-397": 0, "longmemeval": 0})
+
+    report = run_suites(request_for_all_suites(tmp_path), runner)
+
+    assert report.suites["search"].status == "failed"
+    assert report.suites["rag-397"].status == "passed"
+    assert report.suites["longmemeval"].status == "passed"
+
+
+def test_build_search_command_uses_explicit_output(tmp_path: Path) -> None:
+    config = SearchConfig(workspace="MTRNIX", k=10, testset=None, include_unstable=False)
+
+    assert build_search_command(config, tmp_path / "search.json")[-2:] == [
+        "--output",
+        str(tmp_path / "search.json"),
+    ]
+
+
+def test_report_never_serializes_secret_values(tmp_path: Path) -> None:
+    report = run_suites(request_with_rag_password("super-secret", tmp_path), FakeRunner())
+
+    serialized = json.dumps(report.to_dict())
+    assert "super-secret" not in serialized
+    assert "METRONIX_ADMIN_PASSWORD" in serialized
+
+
+def test_report_redacts_inherited_api_keys_from_failure_diagnostics(
+    tmp_path: Path, monkeypatch
+) -> None:
+    class ApiKeyErrorRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=1,
+                stdout="authentication failed for api-key-value",
+                stderr="",
+    )
+
+    monkeypatch.setenv("EXAMPLE_API_KEY", "api-key-value")
+    report = run_suites(
+        request_with_rag_password("different-password", tmp_path), ApiKeyErrorRunner()
+    )
+
+    assert "api-key-value" not in json.dumps(report.to_dict())
+
+
+def test_report_summarizes_native_artifacts_without_embedding_them(tmp_path: Path) -> None:
+    report = run_suites(request_for_all_suites(tmp_path), FakeRunner())
+
+    assert report.suites["search"].summary == {"mrr": 0.75, "ndcg_at_k": 0.8}
+    assert report.suites["rag-397"].summary == {
+        "regression_count": 1,
+        "positive_count": 1,
+        "adversarial_count": 0,
+        "error_count": 1,
+    }
+    assert report.suites["longmemeval"].summary == {"answer_count": 1, "accuracy": 0.8}
+
+
+def test_unreadable_expected_artifact_fails_the_suite(tmp_path: Path) -> None:
+    class MissingArtifactRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+
+    report = run_suites(
+        request_with_rag_password("super-secret", tmp_path), MissingArtifactRunner()
+    )
+
+    assert report.suites["rag-397"].status == "failed"
+    assert "artifact" in (report.suites["rag-397"].error or "").lower()
+
+
+def test_write_report_writes_sanitized_json(tmp_path: Path) -> None:
+    report = run_suites(request_with_rag_password("super-secret", tmp_path), FakeRunner())
+    path = tmp_path / "report.json"
+
+    write_report(report, path)
+
+    assert "super-secret" not in path.read_text(encoding="utf-8")

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -9,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts import memory_eval_harness as harness
 from scripts.memory_eval_harness import (
     HarnessReport,
     HarnessRequest,
@@ -58,9 +60,7 @@ class FakeRunner:
                 encoding="utf-8",
             )
         else:
-            output.write_text(
-                '{"question_id": "one", "hypothesis": "answer"}\n', encoding="utf-8"
-            )
+            output.write_text('{"question_id": "one", "hypothesis": "answer"}\n', encoding="utf-8")
         return subprocess.CompletedProcess(
             args=command,
             returncode=self.exit_codes.get(suite, 0),
@@ -117,7 +117,25 @@ def suite_configuration(suite: str) -> dict[str, object]:
                 "METRONIX_ADMIN_PASSWORD",
             ],
         }
-    return {"variant": "s", "max_questions": 3, "run_judge": True}
+    return {
+        "variant": "s",
+        "max_questions": 3,
+        "run_judge": True,
+        "workspace": "MABENCH",
+        "top_k": 10,
+        "chat_model": "gpt-4o-mini",
+        "chat_base_url": "https://api.openai.com/v1",
+        "judge_model": "gpt-4o",
+        "judge_base_url": "https://api.openai.com/v1",
+        "dataset": {
+            "filename": "longmemeval_s_cleaned.json",
+            "source": (
+                "https://huggingface.co/datasets/xiaowu0162/"
+                "longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json"
+            ),
+            "sha256": None,
+        },
+    }
 
 
 def report_with_summary(
@@ -193,15 +211,14 @@ def test_threshold_breach_is_not_lost_to_report_display_rounding() -> None:
         {"search.mrr": 0.05},
     )
 
-    assert regressions == [
-        Regression(metric="search.mrr", delta=-0.05, threshold=0.05)
-    ]
+    assert regressions == [Regression(metric="search.mrr", delta=-0.05, threshold=0.05)]
 
 
 def test_incompatible_or_missing_metric_is_informational() -> None:
-    assert compare_baseline(
-        current_without("longmemeval.accuracy"), baseline_with_accuracy(), {}
-    ) == []
+    assert (
+        compare_baseline(current_without("longmemeval.accuracy"), baseline_with_accuracy(), {})
+        == []
+    )
 
 
 def test_comparison_attaches_same_key_deltas_to_report() -> None:
@@ -216,9 +233,7 @@ def test_comparison_attaches_same_key_deltas_to_report() -> None:
 def test_comparison_is_incompatible_when_suite_status_is_not_passed() -> None:
     baseline = report_with_summary("search", {"mrr": 0.8}, status="failed")
 
-    report = attach_baseline_comparison(
-        current_search_mrr(0.7), baseline, {"search.mrr": 0.05}
-    )
+    report = attach_baseline_comparison(current_search_mrr(0.7), baseline, {"search.mrr": 0.05})
 
     assert report.deltas == {}
     assert report.regressions == []
@@ -239,14 +254,50 @@ def test_comparison_is_incompatible_when_normalized_configuration_differs() -> N
         },
     )
 
-    report = attach_baseline_comparison(
-        current_search_mrr(0.7), baseline, {"search.mrr": 0.05}
-    )
+    report = attach_baseline_comparison(current_search_mrr(0.7), baseline, {"search.mrr": 0.05})
 
     assert report.deltas == {}
     assert report.regressions == []
     assert report.incompatible_suites == {
         "search": "current and baseline suite configuration must be identical"
+    }
+
+
+@pytest.mark.parametrize(
+    ("key", "different_value"),
+    [
+        ("workspace", "OTHER"),
+        ("top_k", 20),
+        ("chat_model", "different-chat"),
+        ("chat_base_url", "https://chat.example/v1"),
+        ("judge_model", "different-judge"),
+        ("judge_base_url", "https://judge.example/v1"),
+        (
+            "dataset",
+            {
+                "filename": "longmemeval_s_cleaned.json",
+                "source": "https://example.invalid/different-dataset.json",
+                "sha256": "abc123",
+            },
+        ),
+    ],
+)
+def test_longmemeval_comparison_includes_effective_result_configuration(
+    key: str, different_value: object
+) -> None:
+    current = report_with_summary("longmemeval", {"accuracy": 0.7})
+    baseline_configuration = suite_configuration("longmemeval")
+    baseline_configuration[key] = different_value
+    baseline = report_with_summary(
+        "longmemeval", {"accuracy": 0.8}, configuration=baseline_configuration
+    )
+
+    report = attach_baseline_comparison(current, baseline, {"longmemeval.accuracy": 0.05})
+
+    assert report.deltas == {}
+    assert report.regressions == []
+    assert report.incompatible_suites == {
+        "longmemeval": "current and baseline suite configuration must be identical"
     }
 
 
@@ -319,6 +370,118 @@ def test_longmemeval_command_forces_fresh_explicit_artifact(tmp_path: Path) -> N
     assert command.count("--force") == 1
 
 
+def test_longmemeval_records_effective_non_secret_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LME_WORKSPACE_ID", "ENV-WORKSPACE")
+    monkeypatch.setenv("LME_RETRIEVE_TOP_K", "17")
+    monkeypatch.setenv("LME_CHAT_MODEL", "chat-model")
+    monkeypatch.setenv("LME_CHAT_BASE_URL", "https://chat.example/v1")
+    monkeypatch.setenv("LME_JUDGE_MODEL", "judge-model")
+    monkeypatch.setenv("LME_JUDGE_BASE_URL", "https://judge.example/v1")
+    monkeypatch.setenv("LME_CHAT_API_KEY", "must-not-be-reported")
+    request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
+
+    report = run_suites(request, FakeRunner())
+
+    configuration = report.suites["longmemeval"].configuration
+    assert configuration["workspace"] == "ENV-WORKSPACE"
+    assert configuration["top_k"] == 17
+    assert configuration["chat_model"] == "chat-model"
+    assert configuration["chat_base_url"] == "https://chat.example/v1"
+    assert configuration["judge_model"] == "judge-model"
+    assert configuration["judge_base_url"] == "https://judge.example/v1"
+    assert configuration["dataset"] == {
+        "filename": "longmemeval_s_cleaned.json",
+        "source": (
+            "https://huggingface.co/datasets/xiaowu0162/"
+            "longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json"
+        ),
+        "sha256": None,
+    }
+    assert "must-not-be-reported" not in json.dumps(configuration)
+
+
+def test_longmemeval_effective_configuration_honors_benchmark_env_precedence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    benchmark_root = tmp_path / "benchmarks" / "longmemeval"
+    benchmark_root.mkdir(parents=True)
+    benchmark_env = benchmark_root / ".env.benchmark"
+    benchmark_env.write_text(
+        "\n".join(
+            [
+                "LME_WORKSPACE_ID=FILE-WORKSPACE",
+                "LME_RETRIEVE_TOP_K=23",
+                "LME_CHAT_MODEL=file-chat",
+                "LME_CHAT_BASE_URL=https://file-chat.example/v1",
+                "LME_JUDGE_MODEL=file-judge",
+                "LME_JUDGE_BASE_URL=https://file-judge.example/v1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LME_WORKSPACE_ID", "PROCESS-WORKSPACE")
+    monkeypatch.setenv("LME_RETRIEVE_TOP_K", "5")
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_ROOT", benchmark_root)
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_ENV", benchmark_env)
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_LEGACY_ENV", benchmark_root / ".env")
+    request = replace(request_for_all_suites(tmp_path / "artifacts"), suites=("longmemeval",))
+
+    report = run_suites(request, FakeRunner())
+
+    configuration = report.suites["longmemeval"].configuration
+    assert configuration["workspace"] == "FILE-WORKSPACE"
+    assert configuration["top_k"] == 23
+    assert configuration["chat_model"] == "file-chat"
+    assert configuration["chat_base_url"] == "https://file-chat.example/v1"
+    assert configuration["judge_model"] == "file-judge"
+    assert configuration["judge_base_url"] == "https://file-judge.example/v1"
+
+
+def test_longmemeval_records_local_dataset_content_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    benchmark_root = tmp_path / "benchmarks" / "longmemeval"
+    dataset = benchmark_root / "data" / "longmemeval_s_cleaned.json"
+    dataset.parent.mkdir(parents=True)
+    dataset_bytes = b"dataset-version"
+    dataset.write_bytes(dataset_bytes)
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_ROOT", benchmark_root)
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_ENV", benchmark_root / ".env.benchmark")
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_LEGACY_ENV", benchmark_root / ".env")
+    request = replace(request_for_all_suites(tmp_path / "artifacts"), suites=("longmemeval",))
+
+    report = run_suites(request, FakeRunner())
+
+    dataset_configuration = report.suites["longmemeval"].configuration["dataset"]
+    assert isinstance(dataset_configuration, dict)
+    assert dataset_configuration["sha256"] == hashlib.sha256(dataset_bytes).hexdigest()
+
+
+def test_longmemeval_removes_stale_artifact_before_process_launch(tmp_path: Path) -> None:
+    artifact = tmp_path / "longmemeval.jsonl"
+    artifact.write_text('{"question_id":"stale"}\n', encoding="utf-8")
+
+    class PreflightFailureRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            assert not artifact.exists()
+            return subprocess.CompletedProcess(
+                args=command, returncode=1, stdout="preflight failed", stderr=""
+            )
+
+    request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
+    report = run_suites(request, PreflightFailureRunner())
+
+    assert report.suites["longmemeval"].status == "failed"
+    assert not artifact.exists()
+
+
 def test_report_never_serializes_secret_values(tmp_path: Path) -> None:
     report = run_suites(request_with_rag_password("super-secret", tmp_path), FakeRunner())
 
@@ -342,7 +505,7 @@ def test_report_redacts_inherited_api_keys_from_failure_diagnostics(
                 returncode=1,
                 stdout="authentication failed for api-key-value",
                 stderr="",
-    )
+            )
 
     monkeypatch.setenv("EXAMPLE_API_KEY", "api-key-value")
     report = run_suites(
@@ -374,9 +537,7 @@ def test_report_does_not_persist_any_raw_child_output(tmp_path: Path) -> None:
 
     assert "raw model answer" not in serialized
     assert "secret loaded by child dotenv" not in serialized
-    assert (report.suites["rag-397"].error or "").startswith(
-        "Suite command exited with code 23"
-    )
+    assert (report.suites["rag-397"].error or "").startswith("Suite command exited with code 23")
 
 
 def test_report_summarizes_native_artifacts_without_embedding_them(tmp_path: Path) -> None:
@@ -417,11 +578,38 @@ def test_rag_case_error_fails_suite_even_when_runner_exits_zero(tmp_path: Path) 
                 ),
                 encoding="utf-8",
             )
-            return subprocess.CompletedProcess(
-                args=command, returncode=0, stdout="", stderr=""
-            )
+            return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
 
     report = run_suites(request_for_all_suites(tmp_path), RagCaseErrorRunner())
+
+    assert report.suites["rag-397"].status == "failed"
+    assert report.suites["rag-397"].summary["error_count"] == 1
+
+
+@pytest.mark.parametrize("error_value", ["", None, False])
+def test_rag_case_error_counts_key_presence(tmp_path: Path, error_value: object) -> None:
+    class RagCaseErrorRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            output = Path(child_env["METRONIX_EVAL_ARTIFACT"])
+            output.write_text(
+                json.dumps(
+                    {
+                        "regression": [{"query": "one", "error": error_value}],
+                        "positive": [],
+                        "adversarial": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(args=command, returncode=0, stdout="", stderr="")
+
+    request = replace(request_for_all_suites(tmp_path), suites=("rag-397",))
+    report = run_suites(request, RagCaseErrorRunner())
 
     assert report.suites["rag-397"].status == "failed"
     assert report.suites["rag-397"].summary["error_count"] == 1
@@ -465,9 +653,7 @@ def test_judged_longmemeval_requires_finite_parsed_accuracy(
             child_env: dict[str, str],
         ) -> subprocess.CompletedProcess[str]:
             output = Path(child_env["METRONIX_EVAL_ARTIFACT"])
-            output.write_text(
-                '{"question_id": "one", "hypothesis": "answer"}\n', encoding="utf-8"
-            )
+            output.write_text('{"question_id": "one", "hypothesis": "answer"}\n', encoding="utf-8")
             return subprocess.CompletedProcess(
                 args=command, returncode=0, stdout=judge_output, stderr=""
             )

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -8,11 +8,17 @@ from dataclasses import replace
 from pathlib import Path
 
 from scripts.memory_eval_harness import (
+    HarnessReport,
     HarnessRequest,
     LongMemEvalConfig,
     Rag397Config,
+    Regression,
     SearchConfig,
+    SuiteResult,
+    attach_baseline_comparison,
     build_search_command,
+    compare_baseline,
+    parse_threshold,
     run_suites,
     write_report,
 )
@@ -89,6 +95,89 @@ def request_with_rag_password(password: str, tmp_path: Path) -> HarnessRequest:
         ),
         longmemeval=None,
     )
+
+
+def report_with_summary(suite: str, summary: dict[str, float | None]) -> HarnessReport:
+    return HarnessReport(
+        schema_version=1,
+        started_at="2026-07-20T00:00:00+00:00",
+        finished_at="2026-07-20T00:00:01+00:00",
+        requested_suites=[suite],
+        suites={
+            suite: SuiteResult(
+                status="passed",
+                started_at="2026-07-20T00:00:00+00:00",
+                finished_at="2026-07-20T00:00:01+00:00",
+                duration_seconds=1.0,
+                exit_code=0,
+                configuration={},
+                artifacts={},
+                summary=summary,
+            )
+        },
+        regressions=[],
+    )
+
+
+def current_search_mrr(mrr: float) -> HarnessReport:
+    return report_with_summary("search", {"mrr": mrr})
+
+
+def baseline_search_mrr(mrr: float) -> HarnessReport:
+    return report_with_summary("search", {"mrr": mrr})
+
+
+def baseline_with_accuracy() -> HarnessReport:
+    return report_with_summary("longmemeval", {"accuracy": 0.8})
+
+
+def current_without(metric: str) -> HarnessReport:
+    suite, _ = metric.split(".", maxsplit=1)
+    return report_with_summary(suite, {})
+
+
+def test_threshold_breach_marks_run_failed() -> None:
+    regressions = compare_baseline(
+        current_search_mrr(0.70), baseline_search_mrr(0.80), {"search.mrr": 0.05}
+    )
+
+    assert regressions == [Regression(metric="search.mrr", delta=-0.10, threshold=0.05)]
+
+
+def test_incompatible_or_missing_metric_is_informational() -> None:
+    assert compare_baseline(
+        current_without("longmemeval.accuracy"), baseline_with_accuracy(), {}
+    ) == []
+
+
+def test_comparison_attaches_same_key_deltas_to_report() -> None:
+    report = attach_baseline_comparison(
+        current_search_mrr(0.75), baseline_search_mrr(0.80), {"search.mrr": 0.10}
+    )
+
+    assert report.deltas == {"search.mrr": -0.05}
+    assert report.regressions == []
+
+
+def test_parse_threshold_rejects_unknown_or_invalid_quality_gates() -> None:
+    assert parse_threshold("search.mrr=0.05") == ("search.mrr", 0.05)
+
+    for value in ("search.mrr", "search.mrr=-0.01", "search.mrr=not-a-number"):
+        try:
+            parse_threshold(value)
+        except ValueError as exc:
+            assert str(exc) == "threshold must be suite.metric=non-negative-number"
+        else:
+            raise AssertionError(f"expected {value!r} to be rejected")
+
+
+def test_parse_threshold_rejects_unknown_metric_before_evaluation() -> None:
+    try:
+        parse_threshold("rag-397.error_count=1.0")
+    except ValueError as exc:
+        assert str(exc) == "unknown threshold metric: rag-397.error_count"
+    else:
+        raise AssertionError("expected RAG-397 trace counter threshold to be rejected")
 
 
 def test_run_suites_keeps_running_after_a_failure(tmp_path: Path) -> None:

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -144,6 +144,31 @@ def test_threshold_breach_marks_run_failed() -> None:
     assert regressions == [Regression(metric="search.mrr", delta=-0.10, threshold=0.05)]
 
 
+def test_threshold_breach_uses_unrounded_delta() -> None:
+    regressions = compare_baseline(
+        current_search_mrr(0.749999999999),
+        baseline_search_mrr(0.80),
+        {"search.mrr": 0.05},
+    )
+
+    assert len(regressions) == 1
+    assert regressions[0].metric == "search.mrr"
+    assert regressions[0].delta < -0.05
+    assert regressions[0].threshold == 0.05
+
+
+def test_threshold_breach_is_not_lost_to_report_display_rounding() -> None:
+    regressions = compare_baseline(
+        current_search_mrr(0.7499999999999),
+        baseline_search_mrr(0.80),
+        {"search.mrr": 0.05},
+    )
+
+    assert regressions == [
+        Regression(metric="search.mrr", delta=-0.05, threshold=0.05)
+    ]
+
+
 def test_incompatible_or_missing_metric_is_informational() -> None:
     assert compare_baseline(
         current_without("longmemeval.accuracy"), baseline_with_accuracy(), {}

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 
 from scripts.memory_eval_harness import (
@@ -106,6 +108,25 @@ def test_build_search_command_uses_explicit_output(tmp_path: Path) -> None:
         "--output",
         str(tmp_path / "search.json"),
     ]
+
+
+def test_run_suites_uses_real_runner_output_flags_with_absolute_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    request = replace(request_for_all_suites(tmp_path), artifact_dir=Path("artifacts"))
+    runner = FakeRunner()
+
+    run_suites(request, runner)
+
+    search_command, longmemeval_command = runner.calls[0][0], runner.calls[2][0]
+    expected_search_output = str(tmp_path / "artifacts" / "search.json")
+    expected_longmemeval_output = str(tmp_path / "artifacts" / "longmemeval.jsonl")
+    assert search_command[:2] == [sys.executable, "scripts/run_eval.py"]
+    assert search_command[-2:] == ["--output", expected_search_output]
+    assert longmemeval_command[:2] == ["bash", "benchmarks/longmemeval/run.sh"]
+    longmemeval_output_index = longmemeval_command.index("--output") + 1
+    assert longmemeval_command[longmemeval_output_index] == expected_longmemeval_output
 
 
 def test_report_never_serializes_secret_values(tmp_path: Path) -> None:

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
 
+import pytest
+
 from scripts.memory_eval_harness import (
     HarnessReport,
     HarnessRequest,
@@ -16,6 +18,7 @@ from scripts.memory_eval_harness import (
     SearchConfig,
     SuiteResult,
     attach_baseline_comparison,
+    build_longmemeval_command,
     build_search_command,
     compare_baseline,
     parse_threshold,
@@ -48,7 +51,7 @@ class FakeRunner:
                 json.dumps(
                     {
                         "regression": [{"query": "one"}],
-                        "positive": [{"query": "two", "error": "not found"}],
+                        "positive": [{"query": "two"}],
                         "adversarial": [],
                     }
                 ),
@@ -97,7 +100,33 @@ def request_with_rag_password(password: str, tmp_path: Path) -> HarnessRequest:
     )
 
 
-def report_with_summary(suite: str, summary: dict[str, float | None]) -> HarnessReport:
+def suite_configuration(suite: str) -> dict[str, object]:
+    if suite == "search":
+        return {
+            "workspace": "MTRNIX",
+            "k": 10,
+            "testset": None,
+            "include_unstable": False,
+        }
+    if suite == "rag-397":
+        return {
+            "base_url": "http://localhost:8000",
+            "workspace": "MTRNIX",
+            "credential_environment_variables": [
+                "METRONIX_ADMIN_EMAIL",
+                "METRONIX_ADMIN_PASSWORD",
+            ],
+        }
+    return {"variant": "s", "max_questions": 3, "run_judge": True}
+
+
+def report_with_summary(
+    suite: str,
+    summary: dict[str, float | None],
+    *,
+    status: str = "passed",
+    configuration: dict[str, object] | None = None,
+) -> HarnessReport:
     return HarnessReport(
         schema_version=1,
         started_at="2026-07-20T00:00:00+00:00",
@@ -105,12 +134,12 @@ def report_with_summary(suite: str, summary: dict[str, float | None]) -> Harness
         requested_suites=[suite],
         suites={
             suite: SuiteResult(
-                status="passed",
+                status=status,  # type: ignore[arg-type]
                 started_at="2026-07-20T00:00:00+00:00",
                 finished_at="2026-07-20T00:00:01+00:00",
                 duration_seconds=1.0,
                 exit_code=0,
-                configuration={},
+                configuration=configuration or suite_configuration(suite),
                 artifacts={},
                 summary=summary,
             )
@@ -184,6 +213,43 @@ def test_comparison_attaches_same_key_deltas_to_report() -> None:
     assert report.regressions == []
 
 
+def test_comparison_is_incompatible_when_suite_status_is_not_passed() -> None:
+    baseline = report_with_summary("search", {"mrr": 0.8}, status="failed")
+
+    report = attach_baseline_comparison(
+        current_search_mrr(0.7), baseline, {"search.mrr": 0.05}
+    )
+
+    assert report.deltas == {}
+    assert report.regressions == []
+    assert report.incompatible_suites == {
+        "search": "current and baseline suite status must both be passed"
+    }
+
+
+def test_comparison_is_incompatible_when_normalized_configuration_differs() -> None:
+    baseline = report_with_summary(
+        "search",
+        {"mrr": 0.8},
+        configuration={
+            "include_unstable": False,
+            "testset": None,
+            "k": 20,
+            "workspace": "MTRNIX",
+        },
+    )
+
+    report = attach_baseline_comparison(
+        current_search_mrr(0.7), baseline, {"search.mrr": 0.05}
+    )
+
+    assert report.deltas == {}
+    assert report.regressions == []
+    assert report.incompatible_suites == {
+        "search": "current and baseline suite configuration must be identical"
+    }
+
+
 def test_parse_threshold_rejects_unknown_or_invalid_quality_gates() -> None:
     assert parse_threshold("search.mrr=0.05") == ("search.mrr", 0.05)
 
@@ -241,6 +307,16 @@ def test_run_suites_uses_real_runner_output_flags_with_absolute_paths(
     assert longmemeval_command[:2] == ["bash", "benchmarks/longmemeval/run.sh"]
     longmemeval_output_index = longmemeval_command.index("--output") + 1
     assert longmemeval_command[longmemeval_output_index] == expected_longmemeval_output
+    assert "--force" in longmemeval_command
+
+
+def test_longmemeval_command_forces_fresh_explicit_artifact(tmp_path: Path) -> None:
+    command = build_longmemeval_command(
+        LongMemEvalConfig(variant="s", max_questions=None, run_judge=False),
+        tmp_path / "longmemeval.jsonl",
+    )
+
+    assert command.count("--force") == 1
 
 
 def test_report_never_serializes_secret_values(tmp_path: Path) -> None:
@@ -276,6 +352,33 @@ def test_report_redacts_inherited_api_keys_from_failure_diagnostics(
     assert "api-key-value" not in json.dumps(report.to_dict())
 
 
+def test_report_does_not_persist_any_raw_child_output(tmp_path: Path) -> None:
+    class SensitiveOutputRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=23,
+                stdout="raw model answer that must not be retained",
+                stderr="secret loaded by child dotenv",
+            )
+
+    report = run_suites(
+        request_with_rag_password("different-password", tmp_path), SensitiveOutputRunner()
+    )
+    serialized = json.dumps(report.to_dict())
+
+    assert "raw model answer" not in serialized
+    assert "secret loaded by child dotenv" not in serialized
+    assert (report.suites["rag-397"].error or "").startswith(
+        "Suite command exited with code 23"
+    )
+
+
 def test_report_summarizes_native_artifacts_without_embedding_them(tmp_path: Path) -> None:
     report = run_suites(request_for_all_suites(tmp_path), FakeRunner())
 
@@ -284,9 +387,96 @@ def test_report_summarizes_native_artifacts_without_embedding_them(tmp_path: Pat
         "regression_count": 1,
         "positive_count": 1,
         "adversarial_count": 0,
-        "error_count": 1,
+        "error_count": 0,
     }
-    assert report.suites["longmemeval"].summary == {"answer_count": 1, "accuracy": 0.8}
+    assert report.suites["longmemeval"].summary == {
+        "answer_count": 1,
+        "error_count": 0,
+        "accuracy": 0.8,
+    }
+
+
+def test_rag_case_error_fails_suite_even_when_runner_exits_zero(tmp_path: Path) -> None:
+    class RagCaseErrorRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            if child_env["METRONIX_EVAL_SUITE"] != "rag-397":
+                return super().run(command, child_env=child_env)
+            output = Path(child_env["METRONIX_EVAL_ARTIFACT"])
+            output.write_text(
+                json.dumps(
+                    {
+                        "regression": [{"query": "one", "error": "request failed"}],
+                        "positive": [],
+                        "adversarial": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(
+                args=command, returncode=0, stdout="", stderr=""
+            )
+
+    report = run_suites(request_for_all_suites(tmp_path), RagCaseErrorRunner())
+
+    assert report.suites["rag-397"].status == "failed"
+    assert report.suites["rag-397"].summary["error_count"] == 1
+
+
+def test_longmemeval_error_hypothesis_fails_suite_even_when_runner_exits_zero(
+    tmp_path: Path,
+) -> None:
+    class ErrorHypothesisRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            output = Path(child_env["METRONIX_EVAL_ARTIFACT"])
+            output.write_text(
+                '{"question_id": "one", "hypothesis": "Error: provider unavailable"}\n',
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(
+                args=command, returncode=0, stdout="Accuracy: 0.8", stderr=""
+            )
+
+    request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
+    report = run_suites(request, ErrorHypothesisRunner())
+
+    assert report.suites["longmemeval"].status == "failed"
+    assert report.suites["longmemeval"].summary["error_count"] == 1
+
+
+@pytest.mark.parametrize("judge_output", ["Accuracy: not-a-number", "Accuracy: 1e309"])
+def test_judged_longmemeval_requires_finite_parsed_accuracy(
+    tmp_path: Path, judge_output: str
+) -> None:
+    class MissingAccuracyRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            output = Path(child_env["METRONIX_EVAL_ARTIFACT"])
+            output.write_text(
+                '{"question_id": "one", "hypothesis": "answer"}\n', encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(
+                args=command, returncode=0, stdout=judge_output, stderr=""
+            )
+
+    request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
+    report = run_suites(request, MissingAccuracyRunner())
+
+    assert report.suites["longmemeval"].status == "failed"
+    assert report.suites["longmemeval"].summary["accuracy"] is None
 
 
 def test_unreadable_expected_artifact_fails_the_suite(tmp_path: Path) -> None:

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -121,6 +121,7 @@ def suite_configuration(suite: str) -> dict[str, object]:
         "variant": "s",
         "max_questions": 3,
         "run_judge": True,
+        "metronix_mcp_endpoint": "http://localhost:8000/mcp",
         "workspace": "MABENCH",
         "top_k": 10,
         "chat_model": "gpt-4o-mini",
@@ -267,6 +268,7 @@ def test_comparison_is_incompatible_when_normalized_configuration_differs() -> N
     ("key", "different_value"),
     [
         ("workspace", "OTHER"),
+        ("metronix_mcp_endpoint", "https://other.example/mcp"),
         ("top_k", 20),
         ("chat_model", "different-chat"),
         ("chat_base_url", "https://chat.example/v1"),
@@ -379,12 +381,17 @@ def test_longmemeval_records_effective_non_secret_environment(
     monkeypatch.setenv("LME_CHAT_BASE_URL", "https://chat.example/v1")
     monkeypatch.setenv("LME_JUDGE_MODEL", "judge-model")
     monkeypatch.setenv("LME_JUDGE_BASE_URL", "https://judge.example/v1")
+    monkeypatch.setenv(
+        "METRONIX_MCP_URL",
+        "HTTPS://user:password@Metronix.Example:443/mcp/?token=secret#credentials",
+    )
     monkeypatch.setenv("LME_CHAT_API_KEY", "must-not-be-reported")
     request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
 
     report = run_suites(request, FakeRunner())
 
     configuration = report.suites["longmemeval"].configuration
+    assert configuration["metronix_mcp_endpoint"] == "https://metronix.example/mcp"
     assert configuration["workspace"] == "ENV-WORKSPACE"
     assert configuration["top_k"] == 17
     assert configuration["chat_model"] == "chat-model"
@@ -400,6 +407,43 @@ def test_longmemeval_records_effective_non_secret_environment(
         "sha256": None,
     }
     assert "must-not-be-reported" not in json.dumps(configuration)
+    assert "password" not in json.dumps(configuration)
+    assert "secret" not in json.dumps(configuration)
+
+
+def test_longmemeval_malformed_effective_environment_fails_without_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LME_RETRIEVE_TOP_K", "not-an-integer")
+    request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
+    runner = FakeRunner()
+
+    report = run_suites(request, runner)
+
+    assert report.suites["longmemeval"].status == "failed"
+    assert report.suites["longmemeval"].error == "Could not prepare suite configuration"
+    assert runner.calls == []
+
+
+def test_longmemeval_dataset_preparation_failure_does_not_abort_later_suite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_hash(_: Path) -> str | None:
+        raise OSError("offline dataset read failed")
+
+    monkeypatch.setattr(harness, "_sha256_if_present", fail_hash)
+    request = replace(
+        request_for_all_suites(tmp_path),
+        suites=("longmemeval", "search"),
+        rag_397=None,
+    )
+    runner = FakeRunner()
+
+    report = run_suites(request, runner)
+
+    assert report.suites["longmemeval"].status == "failed"
+    assert report.suites["search"].status == "passed"
+    assert [call[1]["METRONIX_EVAL_SUITE"] for call in runner.calls] == ["search"]
 
 
 def test_longmemeval_effective_configuration_honors_benchmark_env_precedence(

--- a/tests/unit/test_run_memory_eval.py
+++ b/tests/unit/test_run_memory_eval.py
@@ -141,6 +141,15 @@ def test_cli_returns_one_for_suite_failure(
     assert json.loads(output.read_text(encoding="utf-8"))["suites"]["search"]["status"] == "failed"
 
 
+def test_cli_returns_one_for_selected_suite_skip(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(cli, "run_suites", lambda *_: report_with_search(status="skipped"))
+
+    output = tmp_path / "report.json"
+    assert cli.main(["--suites", "search", "--output", str(output)]) == 1
+
+
 def test_cli_returns_one_for_regression_breach(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/test_run_memory_eval.py
+++ b/tests/unit/test_run_memory_eval.py
@@ -9,7 +9,12 @@ from scripts import run_memory_eval as cli
 from scripts.memory_eval_harness import HarnessReport, SuiteResult
 
 
-def report_with_search(*, status: str = "passed", mrr: float = 0.8) -> HarnessReport:
+def report_with_search(
+    *,
+    status: str = "passed",
+    mrr: float = 0.8,
+    k: int = 10,
+) -> HarnessReport:
     return HarnessReport(
         schema_version=1,
         started_at="2026-07-20T00:00:00+00:00",
@@ -22,7 +27,12 @@ def report_with_search(*, status: str = "passed", mrr: float = 0.8) -> HarnessRe
                 finished_at="2026-07-20T00:00:01+00:00",
                 duration_seconds=1.0,
                 exit_code=0 if status == "passed" else 1,
-                configuration={},
+                configuration={
+                    "workspace": "MTRNIX",
+                    "k": k,
+                    "testset": None,
+                    "include_unstable": False,
+                },
                 artifacts={},
                 summary={"mrr": mrr},
                 error="failed" if status == "failed" else None,
@@ -127,6 +137,40 @@ def test_cli_returns_one_for_regression_breach(
     assert json.loads(output.read_text(encoding="utf-8"))["regressions"] == [
         {"delta": -0.1, "metric": "search.mrr", "threshold": 0.05}
     ]
+
+
+@pytest.mark.parametrize(
+    "baseline_report",
+    [report_with_search(status="failed"), report_with_search(k=20)],
+)
+def test_cli_fails_closed_when_configured_gate_is_incompatible(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    baseline_report: HarnessReport,
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(baseline_report.to_dict()), encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: report_with_search(mrr=0.8))
+
+    output = tmp_path / "report.json"
+    assert (
+        cli.main(
+            [
+                "--suites",
+                "search",
+                "--baseline",
+                str(baseline),
+                "--max-regression",
+                "search.mrr=0.05",
+                "--output",
+                str(output),
+            ]
+        )
+        == 1
+    )
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["regressions"] == []
+    assert report["incompatible_suites"]["search"]
 
 
 def test_cli_uses_selected_suite_configuration(

--- a/tests/unit/test_run_memory_eval.py
+++ b/tests/unit/test_run_memory_eval.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import run_memory_eval as cli
+from scripts.memory_eval_harness import HarnessReport, SuiteResult
+
+
+def report_with_search(*, status: str = "passed", mrr: float = 0.8) -> HarnessReport:
+    return HarnessReport(
+        schema_version=1,
+        started_at="2026-07-20T00:00:00+00:00",
+        finished_at="2026-07-20T00:00:01+00:00",
+        requested_suites=["search"],
+        suites={
+            "search": SuiteResult(
+                status=status,  # type: ignore[arg-type]
+                started_at="2026-07-20T00:00:00+00:00",
+                finished_at="2026-07-20T00:00:01+00:00",
+                duration_seconds=1.0,
+                exit_code=0 if status == "passed" else 1,
+                configuration={},
+                artifacts={},
+                summary={"mrr": mrr},
+                error="failed" if status == "failed" else None,
+            )
+        },
+    )
+
+
+def test_cli_rejects_unknown_suite_before_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli, "run_suites", lambda *_: pytest.fail("must not run suites"))
+
+    assert cli.main(["--suites", "search,unknown"]) == 2
+
+
+def test_cli_validates_threshold_before_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "run_suites", lambda *_: pytest.fail("must not run suites"))
+
+    assert cli.main(["--suites", "search", "--max-regression", "rag-397.error_count=1"]) == 2
+
+
+def test_cli_rejects_unwritable_output_parent_before_running(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    output_parent = tmp_path / "not-a-directory"
+    output_parent.write_text("file", encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: pytest.fail("must not run suites"))
+
+    assert cli.main(["--suites", "search", "--output", str(output_parent / "report.json")]) == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", 999),
+        ("schema_version", True),
+        ("requested_suites", ["unexpected"]),
+    ],
+)
+def test_cli_rejects_incompatible_baseline_before_running(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    baseline_data = report_with_search().to_dict()
+    baseline_data[field] = value
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(baseline_data), encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: pytest.fail("must not run suites"))
+
+    assert cli.main(["--suites", "search", "--baseline", str(baseline)]) == 2
+
+
+def test_cli_rejects_non_scalar_baseline_summary_before_running(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    baseline_data = report_with_search().to_dict()
+    baseline_data["suites"]["search"]["summary"] = {"mrr": []}
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(baseline_data), encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: pytest.fail("must not run suites"))
+
+    assert cli.main(["--suites", "search", "--baseline", str(baseline)]) == 2
+
+
+def test_cli_returns_one_for_suite_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(cli, "run_suites", lambda *_: report_with_search(status="failed"))
+
+    output = tmp_path / "report.json"
+    assert cli.main(["--suites", "search", "--output", str(output)]) == 1
+    assert json.loads(output.read_text(encoding="utf-8"))["suites"]["search"]["status"] == "failed"
+
+
+def test_cli_returns_one_for_regression_breach(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(report_with_search(mrr=0.9).to_dict()), encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: report_with_search(mrr=0.8))
+
+    output = tmp_path / "report.json"
+    assert (
+        cli.main(
+            [
+                "--suites",
+                "search",
+                "--baseline",
+                str(baseline),
+                "--max-regression",
+                "search.mrr=0.05",
+                "--output",
+                str(output),
+            ]
+        )
+        == 1
+    )
+    assert json.loads(output.read_text(encoding="utf-8"))["regressions"] == [
+        {"delta": -0.1, "metric": "search.mrr", "threshold": 0.05}
+    ]
+
+
+def test_cli_uses_selected_suite_configuration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    requests = []
+    monkeypatch.setattr(
+        cli,
+        "run_suites",
+        lambda request, _: requests.append(request) or report_with_search(),
+    )
+
+    assert (
+        cli.main(
+            [
+                "--suites",
+                "search",
+                "--search-workspace",
+                "CUSTOM",
+                "--search-k",
+                "7",
+                "--search-testset",
+                "fixtures/eval.json",
+                "--include-unstable",
+                "--output",
+                str(tmp_path / "report.json"),
+            ]
+        )
+        == 0
+    )
+
+    request = requests[0]
+    assert request.suites == ("search",)
+    assert request.search is not None
+    assert request.search.workspace == "CUSTOM"
+    assert request.search.k == 7
+    assert request.search.testset == Path("fixtures/eval.json")
+    assert request.search.include_unstable is True
+    assert request.rag_397 is None
+    assert request.longmemeval is None

--- a/tests/unit/test_run_memory_eval.py
+++ b/tests/unit/test_run_memory_eval.py
@@ -60,6 +60,7 @@ def test_cli_rejects_unwritable_output_parent_before_running(
     [
         ("schema_version", 999),
         ("schema_version", True),
+        ("schema_version", 1.0),
         ("requested_suites", ["unexpected"]),
     ],
 )

--- a/tests/unit/test_run_memory_eval.py
+++ b/tests/unit/test_run_memory_eval.py
@@ -55,6 +55,36 @@ def test_cli_validates_threshold_before_running(monkeypatch: pytest.MonkeyPatch)
     assert cli.main(["--suites", "search", "--max-regression", "rag-397.error_count=1"]) == 2
 
 
+def test_cli_requires_baseline_for_regression_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli, "run_suites", lambda *_: pytest.fail("must not run suites"))
+
+    assert cli.main(["--suites", "search", "--max-regression", "search.mrr=0.05"]) == 2
+
+
+def test_cli_requires_gated_suite_to_be_selected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(report_with_search().to_dict()), encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: pytest.fail("must not run suites"))
+
+    assert (
+        cli.main(
+            [
+                "--suites",
+                "longmemeval",
+                "--baseline",
+                str(baseline),
+                "--max-regression",
+                "search.mrr=0.05",
+            ]
+        )
+        == 2
+    )
+
+
 def test_cli_rejects_unwritable_output_parent_before_running(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -171,6 +201,83 @@ def test_cli_fails_closed_when_configured_gate_is_incompatible(
     report = json.loads(output.read_text(encoding="utf-8"))
     assert report["regressions"] == []
     assert report["incompatible_suites"]["search"]
+
+
+@pytest.mark.parametrize("missing_from", ["current", "baseline"])
+def test_cli_fails_closed_when_configured_metric_is_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, missing_from: str
+) -> None:
+    baseline_report = report_with_search(mrr=0.9)
+    current_report = report_with_search(mrr=0.8)
+    if missing_from == "baseline":
+        baseline_report.suites["search"].summary.pop("mrr")
+    else:
+        current_report.suites["search"].summary.pop("mrr")
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(baseline_report.to_dict()), encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: current_report)
+
+    output = tmp_path / "report.json"
+    assert (
+        cli.main(
+            [
+                "--suites",
+                "search",
+                "--baseline",
+                str(baseline),
+                "--max-regression",
+                "search.mrr=0.05",
+                "--output",
+                str(output),
+            ]
+        )
+        == 1
+    )
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["incompatible_suites"] == {
+        "search": (
+            "configured threshold metrics must be finite numbers in current and "
+            "baseline reports: search.mrr"
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    ("non_numeric_in", "value"),
+    [("current", None), ("baseline", "not-available"), ("current", True)],
+)
+def test_cli_fails_closed_when_configured_metric_is_not_numeric(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    non_numeric_in: str,
+    value: object,
+) -> None:
+    baseline_report = report_with_search(mrr=0.9)
+    current_report = report_with_search(mrr=0.8)
+    target = baseline_report if non_numeric_in == "baseline" else current_report
+    target.suites["search"].summary["mrr"] = value  # type: ignore[assignment]
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(baseline_report.to_dict()), encoding="utf-8")
+    monkeypatch.setattr(cli, "run_suites", lambda *_: current_report)
+
+    output = tmp_path / "report.json"
+    assert (
+        cli.main(
+            [
+                "--suites",
+                "search",
+                "--baseline",
+                str(baseline),
+                "--max-regression",
+                "search.mrr=0.05",
+                "--output",
+                str(output),
+            ]
+        )
+        == 1
+    )
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert "search.mrr" in report["incompatible_suites"]["search"]
 
 
 def test_cli_uses_selected_suite_configuration(


### PR DESCRIPTION
## Summary

- add a unified memory-evaluation CLI that orchestrates search-quality, RAG-397, and LongMemEval runs into a versioned, sanitized JSON report
- add explicit native artifact paths, per-suite failure detection, baseline compatibility checks, and fail-closed regression gates
- document environment setup, runtime/cost expectations, artifacts, and CI usage

## Validation

- 116 focused harness/CLI tests passed during remediation; final core verification recorded 104 relevant tests plus 7 report/baseline/failure checks
- Ruff, formatting, shell syntax, CLI help, Make expansion, and diff checks passed
- LongMemEval's existing test module was not collected locally because its optional `openai` dependency is absent; no dependency was added and no live service or LLM calls were made

Closes #309