### PR TITLE
docs: preserve Claude workspace memory context

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -77,20 +77,44 @@ If the `claude` CLI is unavailable, add the entry to `~/.claude.json` directly
 Merge this into the existing `mcpServers` object — don't overwrite unrelated
 keys (session history, project state, etc.) elsewhere in the file.
 
+### Required persistent context after registration
+
+This step is required after every registration path: the installer, `claude mcp
+add`, and a direct `~/.claude.json` edit only register the MCP connection.
+X-Agent-Id does not select or resolve a workspace; it identifies the agent for
+activity and agent-scoped memory. The MCP server therefore cannot recover a
+non-default workspace from that header in a new Claude Code session.
+
+After restarting Claude Code, add the following rule to the `CLAUDE.md` that
+applies to the project where you will use Metronix (or to your equivalent
+always-loaded Claude Code instruction file):
+
+```text
+Metronix memory is available. For every metronix_memory_* call, pass
+workspace_id="<workspace-id>" and
+agent_id="<stable-claude-code-agent-id>". Keep both values unchanged across
+sessions.
+```
+
+Replace both placeholders with the values used when registering the server.
+Without this persistent context, Claude Code may omit `workspace_id` in a later
+session and the MCP tools will use the server's default workspace instead.
+
 ### Agent-assisted setup
 
 Claude Code has shell access, so it can run the setup itself. Use the prompts
 in [`../../connecting_to_agent.md`](../../connecting_to_agent.md), or the
 filled versions the installer writes to `metronix-claude-code-setup/`. Prompt 1
-has Claude Code run `claude mcp add` (or edit `~/.claude.json` as a fallback);
-prompt 2 records the memory policy in `CLAUDE.md`.
+has Claude Code run `claude mcp add` (or edit `~/.claude.json` as a fallback).
+After restarting, Prompt 2 records the required memory policy in `CLAUDE.md`.
+Run both prompts in order; Prompt 2 is not an alternative to registration.
 
 **Restart Claude Code** after registering the MCP server — it loads MCP
 servers only at startup.
 
 ## Verify
 
-Run:
+In a fresh Claude Code session after saving the persistent context, run:
 
 ```text
 metronix_status(workspace_id="MTRNIX")

--- a/tests/unit/test_mcp_docs.py
+++ b/tests/unit/test_mcp_docs.py
@@ -93,3 +93,12 @@ def test_env_example_documents_legacy_key_is_ignored_in_jwt_mode() -> None:
     content = _normalized(Path(".env.example").read_text())
 
     assert "ignored when AUTH_ENABLED=true" in content
+
+
+def test_claude_code_docs_require_persistent_workspace_and_agent_context() -> None:
+    content = _normalized(Path("docs/integrations/claude-code.md").read_text())
+
+    assert "X-Agent-Id does not select or resolve a workspace" in content
+    assert "required after every registration path" in content
+    assert 'workspace_id="<workspace-id>"' in content
+    assert 'agent_id="<stable-claude-code-agent-id>"' in content


### PR DESCRIPTION
## Summary

- make Claude Code's persistent workspace and agent context mandatory after every MCP registration path
- explain that `X-Agent-Id` identifies the agent but cannot resolve a workspace
- add a documentation contract test and fresh-session verification guidance

## Root cause

Claude Code retains the MCP connection header across sessions but does not automatically supply `workspace_id` to MCP tools. The server correctly uses its configured default when the argument is omitted; deriving a workspace from an unregistered, caller-controlled agent header would weaken workspace isolation.

## Validation

- `uv run --no-project --with ruff ruff format --check tests/unit/test_mcp_docs.py`
- `uv run --no-project --with ruff ruff check tests/unit/test_mcp_docs.py`
- focused `test_claude_code_docs_require_persistent_workspace_and_agent_context` assertion
- `git diff origin/main...HEAD --check`

Full pytest collection was not run because this clean worktree lacks the project test environment required by shared fixtures.

Closes #366
