### PR TITLE
feat: enforce agent memory ownership

### DIFF
--- a/docs/MCP_API.md
+++ b/docs/MCP_API.md
@@ -113,6 +113,19 @@ configured default workspace. Always pass the intended workspace explicitly.
 ```
 
 Data (documents, memory records, graph entities) is strictly isolated per workspace.
+
+### Agent-memory ownership and delegation
+
+Agent-memory tools are additionally authorized against server-side grants for the exact
+`workspace_id` and `agent_id`. The caller-supplied identifiers select a target; they never
+confer access. An owner grant permits its agent's read/write operations, an explicit delegated
+grant permits only its assigned capability, and a workspace administrator may override either.
+An unowned legacy agent is denied to non-administrators. Protected calls are denied before a
+memory service or record lookup is performed.
+
+Hosted agent-memory access requires a verified JWT or personal API-key principal. The shared
+`METRONIX_MCP_API_KEY` does not authorize agent-memory operations. Audit events retain the
+policy decision ID, policy version, and outcome without storing memory content.
 A search in workspace A never returns results from workspace B.
 
 ---
@@ -328,6 +341,7 @@ Delete a persistent memory record from all stores (PG + Qdrant + Neo4j).
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `record_id` | string | yes | — | Record ID to delete |
+| `agent_id` | string | yes | — | Agent owning the record |
 | `workspace_id` | string | no | `"default"` | Target workspace |
 
 **Response:**
@@ -432,12 +446,13 @@ Update an existing memory record in place. Preserves Neo4j relationships.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `record_id` | string | yes | — | Record ID to update |
+| `agent_id` | string | yes | — | Agent owning the record |
 | `workspace_id` | string | no | `"default"` | Target workspace |
 | `content` | string | no | `null` | New content (triggers re-embedding) |
 | `tags` | list[string] | no | `null` | Replace tags |
 | `importance_score` | float | no | `null` | New importance (0.0–1.0) |
 
-All fields except `record_id` and `workspace_id` are optional. Only provided
+All fields except `record_id`, `agent_id`, and `workspace_id` are optional. Only provided
 fields are updated. If `content` changes, Qdrant re-embeds; if only
 `tags`/`importance_score` change, only the payload is updated (no re-embedding).
 
@@ -463,6 +478,7 @@ or the DecisionEngine falls below the confidence threshold.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `workspace_id` | string | no | `"default"` | Target workspace |
+| `agent_id` | string | yes | — | Agent whose reviews to list |
 | `reason` | string | no | `null` | Filter: `possible_duplicate` / `possible_contradiction` / `low_confidence_decision` |
 | `record_id` | string | no | `null` | Filter to review entries for a specific memory record |
 | `limit` | integer | no | `20` | Page size (1–100) |
@@ -504,6 +520,7 @@ only — no hard DELETE at the MCP layer.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `review_id` | string | yes | — | Review entry id |
+| `agent_id` | string | yes | — | Agent owning the reviewed record |
 | `workspace_id` | string | no | `"default"` | Target workspace |
 | `action` | string | yes | — | `keep` / `archive` / `merge_into:<record_id>` / `discard` |
 | `notes` | string | no | `null` | Free-form audit note (capped at 1024 chars, stored in MachineEvent) |

--- a/docs/guides/agents-and-workspaces.md
+++ b/docs/guides/agents-and-workspaces.md
@@ -45,3 +45,8 @@ Authorization: Bearer <METRONIX_MCP_API_KEY>
 ```
 
 Memory tool calls should also pass `agent_id` explicitly in their arguments.
+
+In hosted mode this identifier is only a target selector. The server checks the verified
+principal against an explicit owner or delegated grant for that exact workspace and agent;
+there is no same-id or implicit-sharing fallback. A delegated read grant cannot mutate memory,
+and a workspace administrator is the only override for an otherwise unowned agent.

--- a/migrations/versions/032_agent_access_grants.py
+++ b/migrations/versions/032_agent_access_grants.py
@@ -1,0 +1,72 @@
+"""Add explicit server-side grants for workspace-scoped agents.
+
+Revision ID: 032
+Revises: 031
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "032"
+down_revision: str | None = "031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_access_grants",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("workspace_id", sa.String(64), nullable=False),
+        sa.Column("agent_id", sa.String(64), nullable=False),
+        sa.Column("principal_user_id", sa.String(128), nullable=False),
+        sa.Column("capability", sa.String(16), nullable=False),
+        sa.Column("grant_type", sa.String(16), nullable=False),
+        sa.Column("granted_by_user_id", sa.String(128), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "capability IN ('read', 'write', 'admin')", name="ck_agent_access_capability"
+        ),
+        sa.CheckConstraint(
+            "grant_type IN ('owner', 'delegate')", name="ck_agent_access_grant_type"
+        ),
+    )
+    op.create_index(
+        "ix_agent_access_grants_lookup",
+        "agent_access_grants",
+        ["workspace_id", "agent_id", "principal_user_id"],
+    )
+    op.create_index(
+        "uq_agent_access_grants_active",
+        "agent_access_grants",
+        ["workspace_id", "agent_id", "principal_user_id", "capability", "grant_type"],
+        unique=True,
+        postgresql_where=sa.text("revoked_at IS NULL"),
+    )
+    op.execute(
+        """
+        INSERT INTO agent_access_grants (
+            id, workspace_id, agent_id, principal_user_id, capability,
+            grant_type, granted_by_user_id
+        )
+        SELECT
+            'owner_' || md5(workspace_id || ':' || id || ':' || created_by),
+            workspace_id, id, created_by, 'admin', 'owner', created_by
+        FROM agents
+        WHERE created_by <> '' AND created_by <> 'system'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_agent_access_grants_active", table_name="agent_access_grants")
+    op.drop_index("ix_agent_access_grants_lookup", table_name="agent_access_grants")
+    op.drop_table("agent_access_grants")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,10 @@ packages = ["src/metronix"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-markers = ["integration: integration tests (require running services)"]
+markers = [
+    "integration: integration tests (require running services)",
+    "no_agent_principal: run an agent-memory tool test without the authenticated grant fixture",
+]
 
 [tool.ruff]
 target-version = "py312"

--- a/src/metronix/api/middleware/__init__.py
+++ b/src/metronix/api/middleware/__init__.py
@@ -9,7 +9,7 @@ from starlette.responses import JSONResponse
 from metronix.auth.jwt import verify_token
 from metronix.core.config import Settings
 from metronix.mcp.auth import authenticate_http_request
-from metronix.mcp.principal import bind_principal, reset_principal
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 
 PUBLIC_PATHS = {
     "/health",
@@ -57,6 +57,19 @@ async def _authenticate_personal_api_key(request: Request, token: str) -> dict[s
     }
 
 
+async def _resolve_mcp_personal_principal(request: Request, token: str) -> MCPPrincipal | None:
+    """Convert a valid stored personal key into a request-bound MCP principal."""
+    user = await _authenticate_personal_api_key(request, token)
+    if user is None:
+        return None
+    return MCPPrincipal(
+        user_id=str(user["user_id"]),
+        role=str(user["role"]),
+        workspace_ids=tuple(str(workspace_id) for workspace_id in user["workspace_ids"]),
+        auth_method="personal_api_key",
+    )
+
+
 class OptionalAuthMiddleware(BaseHTTPMiddleware):
     """When AUTH_ENABLED=true, require JWT on protected API and MCP endpoints."""
 
@@ -72,10 +85,13 @@ class OptionalAuthMiddleware(BaseHTTPMiddleware):
         # In development, retain the trusted request path used when auth is disabled.
         if path in MCP_PATHS:
             try:
-                principal = authenticate_http_request(
+                principal = await authenticate_http_request(
                     request.headers.get("authorization"),
                     auth_enabled=settings.auth_enabled,
                     secret_key=settings.secret_key,
+                    principal_resolver=lambda token: _resolve_mcp_personal_principal(
+                        request, token
+                    ),
                 )
             except PermissionError:
                 detail = (

--- a/src/metronix/auth/agent_access.py
+++ b/src/metronix/auth/agent_access.py
@@ -7,6 +7,9 @@ from enum import StrEnum
 from typing import Protocol
 from uuid import uuid4
 
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
 from metronix.mcp.principal import MCPPrincipal
 
 
@@ -32,6 +35,44 @@ class AgentAccessStore(Protocol):
         self, workspace_id: str, agent_id: str, principal_user_id: str
     ) -> list[AgentAccessGrantLike]:
         """Return active grants for an exact principal and agent target."""
+
+
+@dataclass(frozen=True)
+class AgentAccessGrant:
+    """Persisted active grant projection."""
+
+    capability: str
+    grant_type: str
+
+
+class PostgresAgentAccessStore:
+    """PostgreSQL implementation of the active-grant lookup boundary."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    async def list_active_grants(
+        self, workspace_id: str, agent_id: str, principal_user_id: str
+    ) -> list[AgentAccessGrant]:
+        async with self._engine.connect() as connection:
+            rows = await connection.execute(
+                text(
+                    """
+                    SELECT capability, grant_type
+                    FROM agent_access_grants
+                    WHERE workspace_id = :workspace_id
+                      AND agent_id = :agent_id
+                      AND principal_user_id = :principal_user_id
+                      AND revoked_at IS NULL
+                    """
+                ),
+                {
+                    "workspace_id": workspace_id,
+                    "agent_id": agent_id,
+                    "principal_user_id": principal_user_id,
+                },
+            )
+            return [AgentAccessGrant(capability=row[0], grant_type=row[1]) for row in rows]
 
 
 @dataclass(frozen=True)

--- a/src/metronix/auth/agent_access.py
+++ b/src/metronix/auth/agent_access.py
@@ -1,0 +1,90 @@
+"""Fail-closed authorization decisions for workspace-scoped agent access."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+from uuid import uuid4
+
+from metronix.mcp.principal import MCPPrincipal
+
+
+class AgentCapability(StrEnum):
+    """Capabilities available for an agent within one workspace."""
+
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"
+
+
+class AgentAccessGrantLike(Protocol):
+    """Read-only active-grant shape consumed by the authorizer."""
+
+    capability: str
+    grant_type: str
+
+
+class AgentAccessStore(Protocol):
+    """Persistence boundary for active grants."""
+
+    async def list_active_grants(
+        self, workspace_id: str, agent_id: str, principal_user_id: str
+    ) -> list[AgentAccessGrantLike]:
+        """Return active grants for an exact principal and agent target."""
+
+
+@dataclass(frozen=True)
+class AgentAccessDecision:
+    """Content-free result of an agent-access evaluation."""
+
+    decision_id: str
+    allowed: bool
+    reason: str
+    policy_version: str = "agent-access-v1"
+
+
+class AgentAccessAuthorizer:
+    """Authorize verified MCP principals using explicit server-side grants."""
+
+    def __init__(self, store: AgentAccessStore) -> None:
+        self._store = store
+
+    async def authorize(
+        self,
+        principal: MCPPrincipal | None,
+        workspace_id: str,
+        agent_id: str,
+        capability: AgentCapability,
+    ) -> AgentAccessDecision:
+        if principal is None:
+            return self._decision(False, "principal_required")
+        if workspace_id not in principal.workspace_ids and "*" not in principal.workspace_ids:
+            return self._decision(False, "workspace_not_granted")
+        if principal.role == "admin":
+            return self._decision(True, "admin_override")
+
+        grants = await self._store.list_active_grants(workspace_id, agent_id, principal.user_id)
+        allowed_grants = [grant for grant in grants if self._covers(grant.capability, capability)]
+        if not allowed_grants:
+            reason = "no_active_grant" if not grants else "capability_not_granted"
+            return self._decision(False, reason)
+        if any(grant.grant_type == "owner" for grant in allowed_grants):
+            return self._decision(True, "owner_grant")
+        return self._decision(True, "delegated_grant")
+
+    @staticmethod
+    def _covers(granted: str, requested: AgentCapability) -> bool:
+        levels = {
+            AgentCapability.READ: 1,
+            AgentCapability.WRITE: 2,
+            AgentCapability.ADMIN: 3,
+        }
+        try:
+            return levels[AgentCapability(granted)] >= levels[requested]
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _decision(allowed: bool, reason: str) -> AgentAccessDecision:
+        return AgentAccessDecision(decision_id=uuid4().hex, allowed=allowed, reason=reason)

--- a/src/metronix/mcp/auth.py
+++ b/src/metronix/mcp/auth.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hmac
 import os
+from collections.abc import Awaitable, Callable
 
 import structlog
 
@@ -78,11 +79,12 @@ def require_api_key(authorization_header: str | None) -> None:
         raise PermissionError("Invalid or missing API key")
 
 
-def authenticate_http_request(
+async def authenticate_http_request(
     authorization_header: str | None,
     *,
     auth_enabled: bool,
     secret_key: str,
+    principal_resolver: Callable[[str], Awaitable[MCPPrincipal | None]] | None = None,
 ) -> MCPPrincipal | None:
     """Authenticate one MCP HTTP request using the configured server mode.
 
@@ -90,8 +92,25 @@ def authenticate_http_request(
     Authentication-disabled local deployments retain the legacy shared MCP key;
     when no key is configured, ``require_api_key`` preserves the open dev mode.
     """
+    token = (
+        authorization_header.removeprefix("Bearer ")
+        if authorization_header and authorization_header.startswith("Bearer ")
+        else ""
+    )
     if auth_enabled:
-        return authenticate_jwt(authorization_header, secret_key)
+        try:
+            return authenticate_jwt(authorization_header, secret_key)
+        except PermissionError:
+            if principal_resolver and token:
+                principal = await principal_resolver(token)
+                if principal is not None:
+                    return principal
+            raise
+
+    if token and principal_resolver:
+        principal = await principal_resolver(token)
+        if principal is not None:
+            return principal
 
     require_api_key(authorization_header)
     return None

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 import time
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -49,6 +49,42 @@ TRANSPORT_HTTP = "streamable-http"
 # Default values
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8080
+
+
+@lru_cache(maxsize=1)
+def _get_standalone_personal_key_stores() -> tuple[Any, Any]:
+    """Create the persistent stores used by standalone HTTP MCP auth."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from metronix.auth.api_key_store import ApiKeyStore
+    from metronix.auth.user_store import UserStore
+    from metronix.core.config import get_settings
+
+    engine = create_async_engine(get_settings().postgres_dsn)
+    return ApiKeyStore(engine), UserStore(engine)
+
+
+async def _resolve_standalone_mcp_personal_principal(token: str) -> Any:
+    """Resolve an active personal key without trusting a shared MCP key."""
+    from metronix.mcp.principal import MCPPrincipal
+
+    api_key_store, user_store = _get_standalone_personal_key_stores()
+    resolved = await api_key_store.resolve_key(token, static_key="")
+    if resolved is None or resolved.get("source") != "personal":
+        return None
+    user = await user_store.get_user_by_id(str(resolved["user_id"]))
+    if user is None or not user.get("is_active", True):
+        return None
+    workspace_ids = list(user.get("workspace_ids", []) or [])
+    role = str(user.get("role", "viewer"))
+    if role == "admin" and not workspace_ids:
+        workspace_ids = ["*"]
+    return MCPPrincipal(
+        user_id=str(user["id"]),
+        role=role,
+        workspace_ids=tuple(str(workspace_id) for workspace_id in workspace_ids),
+        auth_method="personal_api_key",
+    )
 
 
 # Create FastMCP server instance
@@ -387,6 +423,7 @@ async def run_http(
                     request.headers.get("authorization"),
                     auth_enabled=settings.auth_enabled,
                     secret_key=settings.secret_key,
+                    principal_resolver=_resolve_standalone_mcp_personal_principal,
                 )
             except PermissionError:
                 detail = (

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -383,7 +383,7 @@ async def run_http(
                 return await call_next(request)
 
             try:
-                principal = authenticate_http_request(
+                principal = await authenticate_http_request(
                     request.headers.get("authorization"),
                     auth_enabled=settings.auth_enabled,
                     secret_key=settings.secret_key,

--- a/src/metronix/mcp/tools/_agent_access.py
+++ b/src/metronix/mcp/tools/_agent_access.py
@@ -1,0 +1,124 @@
+"""Authorization guard shared by MCP agent-memory tools."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from uuid import uuid4
+
+import structlog
+
+from metronix.auth.agent_access import (
+    AgentAccessAuthorizer,
+    AgentAccessDecision,
+    AgentCapability,
+    PostgresAgentAccessStore,
+)
+from metronix.mcp.principal import get_current_principal
+from metronix.storage.activity_pg import ActivityRow, ActivityStore
+
+logger = structlog.get_logger(__name__)
+
+
+@lru_cache(maxsize=1)
+def get_agent_access_authorizer() -> AgentAccessAuthorizer:
+    """Return the configured grant authorizer for MCP tool dispatch."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from metronix.core.config import get_settings
+
+    engine = create_async_engine(get_settings().postgres_dsn)
+    return AgentAccessAuthorizer(PostgresAgentAccessStore(engine))
+
+
+@lru_cache(maxsize=1)
+def get_agent_access_audit_store() -> ActivityStore:
+    """Return the append-only audit store for authorization decisions."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from metronix.core.config import get_settings
+
+    return ActivityStore(create_async_engine(get_settings().postgres_dsn))
+
+
+async def _record_decision(
+    *,
+    principal_id: str | None,
+    workspace_id: str,
+    agent_id: str,
+    capability: AgentCapability | str,
+    decision: AgentAccessDecision,
+) -> None:
+    """Persist a content-free, append-only authorization decision."""
+    await get_agent_access_audit_store().insert(
+        ActivityRow(
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            event_type="agent.access_decision",
+            event_data={
+                "principal_id": principal_id,
+                "capability": str(capability),
+                "decision_id": decision.decision_id,
+                "policy_version": decision.policy_version,
+                "outcome": decision.allowed,
+                "reason": decision.reason,
+            },
+        )
+    )
+
+
+async def _best_effort_denial_audit(**kwargs: object) -> None:
+    """Record a denial without ever weakening the fail-closed response."""
+    try:
+        await _record_decision(**kwargs)  # type: ignore[arg-type]
+    except Exception:  # noqa: BLE001 - denial must stay an authorization denial
+        logger.error("agent_access.audit_failed", exc_info=True)
+
+
+async def require_agent_access(
+    workspace_id: str, agent_id: str, capability: AgentCapability | str
+) -> AgentAccessDecision:
+    """Require an authenticated principal before an agent-memory operation."""
+    principal = get_current_principal()
+    if principal is None:
+        decision = AgentAccessDecision(uuid4().hex, False, "principal_required")
+        await _best_effort_denial_audit(
+            principal_id=None,
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            capability=capability,
+            decision=decision,
+        )
+        raise PermissionError("unauthorized agent memory access")
+
+    decision = await get_agent_access_authorizer().authorize(
+        principal, workspace_id, agent_id, AgentCapability(capability)
+    )
+    if not decision.allowed:
+        await _best_effort_denial_audit(
+            principal_id=principal.user_id,
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            capability=capability,
+            decision=decision,
+        )
+        raise PermissionError("unauthorized agent memory access")
+
+    await _record_decision(
+        principal_id=principal.user_id,
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        capability=capability,
+        decision=decision,
+    )
+    logger.info(
+        "agent_access.decision",
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        capability=str(capability),
+        principal_id=principal.user_id,
+        decision_id=decision.decision_id,
+        policy_version=decision.policy_version,
+        outcome=True,
+        reason=decision.reason,
+    )
+    return decision

--- a/src/metronix/mcp/tools/memory_batch_store.py
+++ b/src/metronix/mcp/tools/memory_batch_store.py
@@ -101,8 +101,10 @@ async def metronix_memory_batch_store(
             }
 
         from metronix.mcp.config import resolve_workspace_id
+        from metronix.mcp.tools._agent_access import require_agent_access
 
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, agent_id, "write")
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)
 
         results: list[MemoryBatchStoreResult] = []

--- a/src/metronix/mcp/tools/memory_context.py
+++ b/src/metronix/mcp/tools/memory_context.py
@@ -70,8 +70,10 @@ async def metronix_memory_get_context(
             }
 
         from metronix.mcp.config import resolve_workspace_id
+        from metronix.mcp.tools._agent_access import require_agent_access
 
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, agent_id, "read")
 
         from metronix.core.config import get_settings
 

--- a/src/metronix/mcp/tools/memory_delete.py
+++ b/src/metronix/mcp/tools/memory_delete.py
@@ -9,6 +9,7 @@ import structlog
 from metronix.mcp.errors import ErrorCode, MCPError, handle_tool_error
 from metronix.mcp.server import mcp
 from metronix.mcp.tools import _memory_deps
+from metronix.mcp.tools._agent_access import require_agent_access
 from metronix.mcp.tools.models import MemoryDeleteResponse
 
 logger = structlog.get_logger(__name__)
@@ -26,6 +27,7 @@ logger = structlog.get_logger(__name__)
 )
 async def metronix_memory_delete(
     record_id: str,
+    agent_id: str,
     workspace_id: str | None = None,
 ) -> dict[str, Any]:
     """Delete a persistent memory record by id."""
@@ -38,11 +40,22 @@ async def metronix_memory_delete(
                 ).to_dict(),
             }
 
+        from metronix.core.utils import is_valid_agent_id
+
+        if not agent_id or not is_valid_agent_id(agent_id):
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message="metronix_memory_delete: agent_id must be 1-64 chars of A-Za-z0-9._-",
+                ).to_dict(),
+            }
+
         from metronix.mcp.config import resolve_workspace_id
 
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, agent_id, "write")
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)
-        deleted = await service.delete(ws_id, record_id)
+        deleted = await service.delete(ws_id, record_id, agent_id=agent_id)
 
         if not deleted:
             return {

--- a/src/metronix/mcp/tools/memory_list.py
+++ b/src/metronix/mcp/tools/memory_list.py
@@ -98,8 +98,10 @@ async def metronix_memory_list(
             }
 
         from metronix.mcp.config import resolve_workspace_id
+        from metronix.mcp.tools._agent_access import require_agent_access
 
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, agent_id, "read")
         limit = min(max(1, int(limit)), 100)
         offset = max(0, int(offset))
 

--- a/src/metronix/mcp/tools/memory_review_list.py
+++ b/src/metronix/mcp/tools/memory_review_list.py
@@ -10,9 +10,12 @@ from typing import Any
 
 import structlog
 
-from metronix.mcp.errors import handle_tool_error
+from metronix.activity.context import current_agent_id
+from metronix.core.utils import is_valid_agent_id
+from metronix.mcp.errors import ErrorCode, MCPError, handle_tool_error
 from metronix.mcp.server import mcp
 from metronix.mcp.tools import _memory_deps
+from metronix.mcp.tools._agent_access import require_agent_access
 from metronix.mcp.tools.models import MemoryReviewListResponse, ReviewEntryDTO
 
 logger = structlog.get_logger(__name__)
@@ -36,6 +39,7 @@ logger = structlog.get_logger(__name__)
 )
 async def metronix_memory_review_list(
     workspace_id: str | None = None,
+    agent_id: str | None = None,
     reason: str | None = None,
     record_id: str | None = None,
     limit: int = 20,
@@ -45,7 +49,16 @@ async def metronix_memory_review_list(
     try:
         from metronix.mcp.config import resolve_workspace_id
 
+        resolved_agent_id = agent_id or current_agent_id.get()
+        if not resolved_agent_id or not is_valid_agent_id(resolved_agent_id):
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message="metronix_memory_review_list: agent_id is required",
+                ).to_dict()
+            }
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, resolved_agent_id, "read")
         limit = min(max(1, int(limit)), 100)
         offset = max(0, int(offset))
 
@@ -54,6 +67,7 @@ async def metronix_memory_review_list(
             ws_id,
             record_id=record_id,
             reason=reason,
+            agent_id=resolved_agent_id,
             limit=limit,
             offset=offset,
         )

--- a/src/metronix/mcp/tools/memory_review_resolve.py
+++ b/src/metronix/mcp/tools/memory_review_resolve.py
@@ -17,9 +17,12 @@ from typing import Any
 
 import structlog
 
+from metronix.activity.context import current_agent_id
+from metronix.core.utils import is_valid_agent_id
 from metronix.mcp.errors import ErrorCode, MCPError, handle_tool_error
 from metronix.mcp.server import mcp
 from metronix.mcp.tools import _memory_deps
+from metronix.mcp.tools._agent_access import require_agent_access
 from metronix.mcp.tools.models import MemoryReviewResolveResponse
 
 logger = structlog.get_logger(__name__)
@@ -53,6 +56,7 @@ async def metronix_memory_review_resolve(
     review_id: str,
     action: str,
     workspace_id: str | None = None,
+    agent_id: str | None = None,
     notes: str | None = None,
 ) -> dict[str, Any]:
     """Resolve a memory review entry via soft status transition."""
@@ -75,7 +79,16 @@ async def metronix_memory_review_resolve(
 
         from metronix.mcp.config import resolve_workspace_id
 
+        resolved_agent_id = agent_id or current_agent_id.get()
+        if not resolved_agent_id or not is_valid_agent_id(resolved_agent_id):
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message="metronix_memory_review_resolve: agent_id is required",
+                ).to_dict()
+            }
         ws_id = resolve_workspace_id(workspace_id)
+        decision = await require_agent_access(ws_id, resolved_agent_id, "write")
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)
 
         try:
@@ -84,6 +97,13 @@ async def metronix_memory_review_resolve(
                 review_id=review_id,
                 action=action,
                 notes=notes,
+                actor=f"mcp:{decision.policy_version}",
+                agent_id=resolved_agent_id,
+                access_policy={
+                    "decision_id": decision.decision_id,
+                    "policy_version": decision.policy_version,
+                    "outcome": decision.allowed,
+                },
             )
         except ValueError as exc:
             # Malformed action / unknown action / missing merge target -> 400.

--- a/src/metronix/mcp/tools/memory_search.py
+++ b/src/metronix/mcp/tools/memory_search.py
@@ -99,8 +99,10 @@ async def metronix_memory_search(
             }
 
         from metronix.mcp.config import resolve_workspace_id
+        from metronix.mcp.tools._agent_access import require_agent_access
 
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, agent_id, "read")
         top_k = min(max(1, int(top_k)), 50)
 
         service = await _memory_deps.build_memory_service_for_workspace(ws_id)

--- a/src/metronix/mcp/tools/memory_store.py
+++ b/src/metronix/mcp/tools/memory_store.py
@@ -97,8 +97,10 @@ async def metronix_memory_store(
             }
 
         from metronix.mcp.config import resolve_workspace_id
+        from metronix.mcp.tools._agent_access import require_agent_access
 
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, agent_id, "write")
         record = MemoryRecord(
             workspace_id=ws_id,
             agent_id=agent_id,

--- a/src/metronix/mcp/tools/memory_update.py
+++ b/src/metronix/mcp/tools/memory_update.py
@@ -10,6 +10,7 @@ import structlog
 from metronix.mcp.errors import ErrorCode, MCPError, handle_tool_error
 from metronix.mcp.server import mcp
 from metronix.mcp.tools import _memory_deps
+from metronix.mcp.tools._agent_access import require_agent_access
 from metronix.mcp.tools._memory_utils import validate_kind
 from metronix.mcp.tools.models import MemoryUpdateResponse
 from metronix.memory.freshness.producer import enqueue_if_enabled
@@ -37,6 +38,7 @@ logger = structlog.get_logger(__name__)
 )
 async def metronix_memory_update(
     record_id: str,
+    agent_id: str,
     workspace_id: str | None = None,
     content: str | None = None,
     tags: list[str] | None = None,
@@ -50,6 +52,16 @@ async def metronix_memory_update(
                 "error": MCPError(
                     code=ErrorCode.INVALID_PARAMS,
                     message="metronix_memory_update: record_id is required",
+                ).to_dict(),
+            }
+
+        from metronix.core.utils import is_valid_agent_id
+
+        if not agent_id or not is_valid_agent_id(agent_id):
+            return {
+                "error": MCPError(
+                    code=ErrorCode.INVALID_PARAMS,
+                    message="metronix_memory_update: agent_id must be 1-64 chars of A-Za-z0-9._-",
                 ).to_dict(),
             }
 
@@ -67,6 +79,7 @@ async def metronix_memory_update(
         from metronix.mcp.config import resolve_workspace_id
 
         ws_id = resolve_workspace_id(workspace_id)
+        await require_agent_access(ws_id, agent_id, "write")
 
         validated_kind: MemoryKind | None = None
         if kind is not None:
@@ -85,6 +98,7 @@ async def metronix_memory_update(
         updated = await service.pg_store.update(
             ws_id,
             record_id,
+            agent_id=agent_id,
             content=content,
             tags=tags,
             importance_score=importance_score,

--- a/src/metronix/memory/service.py
+++ b/src/metronix/memory/service.py
@@ -400,13 +400,16 @@ class MemoryService:
         self,
         workspace_id: str,
         record_id: str,
+        *,
+        agent_id: str | None = None,
     ) -> bool:
         """Delete a record from all stores. Returns True if PG had it."""
         self._check_workspace(workspace_id)
         # Pre-fetch to learn agent_id / session_id for the event payload
         # before the record is removed.
-        existing = await self._pg.get(workspace_id, record_id)
-        deleted = await self._pg.delete(workspace_id, record_id)
+        agent_filter = {"agent_id": agent_id} if agent_id is not None else {}
+        existing = await self._pg.get(workspace_id, record_id, **agent_filter)
+        deleted = await self._pg.delete(workspace_id, record_id, **agent_filter)
         if not deleted:
             return False
 
@@ -792,6 +795,7 @@ class MemoryService:
         *,
         record_id: str | None = None,
         reason: str | None = None,
+        agent_id: str | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> tuple[list[ReviewEntry], int]:
@@ -805,6 +809,7 @@ class MemoryService:
         self._check_workspace(workspace_id)
         if self._freshness_store is None:
             raise RuntimeError("freshness_store not configured")
+        agent_filter = {"agent_id": agent_id} if agent_id is not None else {}
         entries = await self._freshness_store.list_review_entries(
             workspace_id,
             target_kind="memory_record",
@@ -812,12 +817,14 @@ class MemoryService:
             reason=reason,
             limit=limit,
             offset=offset,
+            **agent_filter,
         )
         total = await self._freshness_store.count_review_entries(
             workspace_id,
             target_kind="memory_record",
             record_id=record_id,
             reason=reason,
+            **agent_filter,
         )
         return entries, total
 
@@ -829,6 +836,8 @@ class MemoryService:
         action: str,
         notes: str | None = None,
         actor: str = "mcp_caller",
+        agent_id: str | None = None,
+        access_policy: dict[str, str | bool] | None = None,
     ) -> ReviewResolution:
         """Apply a resolution (``keep``/``archive``/``merge_into:<id>``/``discard``).
 
@@ -859,7 +868,7 @@ class MemoryService:
         # ``find_review_entry`` doesn't support lookup-by-id, so we paginate
         # with a reasonable cap. Review tables are expected to be small.
         entries = await self._freshness_store.list_review_entries(
-            workspace_id, target_kind="memory_record", limit=1000
+            workspace_id, target_kind="memory_record", agent_id=agent_id, limit=1000
         )
         entry = next((e for e in entries if e.id == review_id), None)
         if entry is None:
@@ -867,7 +876,7 @@ class MemoryService:
             raise MemoryNotFoundError(msg)
 
         # 2. Load the target record.
-        record = await self._pg.get(workspace_id, entry.target_id)
+        record = await self._pg.get(workspace_id, entry.target_id, agent_id=agent_id)
         if record is None:
             msg = f"Record {entry.target_id} not found"
             raise MemoryNotFoundError(msg)
@@ -882,22 +891,24 @@ class MemoryService:
         mirror_id: str | None = None
         mirror_target_id: str = ""  # partner record (B) — set iff mirror found
         if entry.related_record_id:
-            mirror = await self._freshness_store.find_review_entry(
-                workspace_id,
-                target_id=entry.related_record_id,
-                target_kind="memory_record",
-                reason=entry.reason,
-                related_record_id=entry.target_id,
-            )
-            if mirror is not None and mirror.id != review_id:
-                mirror_id = mirror.id
-                mirror_target_id = mirror.target_id
+            partner = await self._pg.get(workspace_id, entry.related_record_id, agent_id=agent_id)
+            if partner is not None:
+                mirror = await self._freshness_store.find_review_entry(
+                    workspace_id,
+                    target_id=entry.related_record_id,
+                    target_kind="memory_record",
+                    reason=entry.reason,
+                    related_record_id=entry.target_id,
+                )
+                if mirror is not None and mirror.id != review_id:
+                    mirror_id = mirror.id
+                    mirror_target_id = mirror.target_id
 
         # 3. Resolve the new status / verification_state / superseded_by.
         new_status: LifecycleStatus
         if action_kind == "merge_into":
             assert merge_target is not None  # parse_action guarantees
-            target_rec = await self._pg.get(workspace_id, merge_target)
+            target_rec = await self._pg.get(workspace_id, merge_target, agent_id=agent_id)
             if target_rec is None:
                 msg = f"merge_into target {merge_target} not found"
                 raise ValueError(msg)
@@ -929,6 +940,7 @@ class MemoryService:
         # same AsyncEngine (wired in ``_memory_deps.py``), so a single
         # transaction can span all of them.
         truncated_notes = (notes or "")[:1024]
+        agent_filter = {"agent_id": agent_id} if agent_id is not None else {}
         evt = MachineEvent(
             workspace_id=workspace_id,
             event_type="freshness_review_resolved",
@@ -944,6 +956,7 @@ class MemoryService:
                 "new_status": new_status.value,
                 "superseded_by": superseded_by,
                 "notes": truncated_notes,
+                "access_policy": access_policy or {},
             },
         )
         async with self._pg.begin() as conn:
@@ -960,8 +973,11 @@ class MemoryService:
                 superseded_by=superseded_by,
                 bump_updated_at=True,
                 conn=conn,
+                **agent_filter,
             )
-            await self._freshness_store.delete_review_entry(workspace_id, review_id, conn=conn)
+            await self._freshness_store.delete_review_entry(
+                workspace_id, review_id, conn=conn, **agent_filter
+            )
             if mirror_id is not None:
                 # Cascade-delete the mirror entry (MTRNIX-395) so the pair
                 # leaves the queue as a unit. This is intentional for ALL
@@ -970,7 +986,9 @@ class MemoryService:
                 # the B->A mirror is moot even when A merges into some C. If B
                 # is genuinely similar to the survivor, the Reconciler re-flags
                 # it on B's next pipeline pass.
-                await self._freshness_store.delete_review_entry(workspace_id, mirror_id, conn=conn)
+                await self._freshness_store.delete_review_entry(
+                    workspace_id, mirror_id, conn=conn, **agent_filter
+                )
                 # Give the partner record (B) its own audit row so a per-record
                 # review-history view explains why its queue entry vanished —
                 # otherwise the only trace is the ``mirror_review_entry_id`` on
@@ -988,6 +1006,7 @@ class MemoryService:
                         "resolved_via_review_entry_id": review_id,
                         "resolved_via_target_id": entry.target_id,
                         "reason": entry.reason,
+                        "access_policy": access_policy or {},
                     },
                 )
                 await self._freshness_store.save_machine_event(mirror_evt, conn=conn)

--- a/src/metronix/storage/freshness_pg.py
+++ b/src/metronix/storage/freshness_pg.py
@@ -150,6 +150,7 @@ class FreshnessStore:
         target_id: str | None = None,
         target_kind: str | None = None,
         reason: str | None = None,
+        agent_id: str | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[ReviewEntry]:
@@ -178,6 +179,14 @@ class FreshnessStore:
         if reason is not None:
             where_parts.append("reason = :reason")
             params["reason"] = reason
+        if agent_id is not None:
+            where_parts.append(
+                "EXISTS (SELECT 1 FROM memory_records m "
+                "WHERE m.id = review_entries.target_id "
+                "AND m.workspace_id = review_entries.workspace_id "
+                "AND m.agent_id = :agent_id)"
+            )
+            params["agent_id"] = agent_id
         where_clause = " AND ".join(where_parts)
         async with self._engine.begin() as conn:
             result = await conn.execute(
@@ -205,6 +214,7 @@ class FreshnessStore:
         target_id: str | None = None,
         target_kind: str | None = None,
         reason: str | None = None,
+        agent_id: str | None = None,
     ) -> int:
         """Count review entries matching the same filters as ``list_review_entries``.
 
@@ -222,6 +232,14 @@ class FreshnessStore:
         if reason is not None:
             where_parts.append("reason = :reason")
             params["reason"] = reason
+        if agent_id is not None:
+            where_parts.append(
+                "EXISTS (SELECT 1 FROM memory_records m "
+                "WHERE m.id = review_entries.target_id "
+                "AND m.workspace_id = review_entries.workspace_id "
+                "AND m.agent_id = :agent_id)"
+            )
+            params["agent_id"] = agent_id
         where_clause = " AND ".join(where_parts)
         async with self._engine.begin() as conn:
             result = await conn.execute(
@@ -241,6 +259,7 @@ class FreshnessStore:
         workspace_id: str,
         review_id: str,
         *,
+        agent_id: str | None = None,
         conn: AsyncConnection | None = None,
     ) -> bool:
         """Delete a review entry by id, scoped to workspace.
@@ -252,8 +271,17 @@ class FreshnessStore:
         connection — used by ``MemoryService.resolve_review`` to group the
         update + delete + event-write into one transaction (MTRNIX-319 fix).
         """
-        sql = text("DELETE FROM review_entries WHERE id = :id AND workspace_id = :ws")
+        where = "id = :id AND workspace_id = :ws"
         params = {"id": review_id, "ws": workspace_id}
+        if agent_id is not None:
+            where += (
+                " AND EXISTS (SELECT 1 FROM memory_records m "
+                "WHERE m.id = review_entries.target_id "
+                "AND m.workspace_id = review_entries.workspace_id "
+                "AND m.agent_id = :agent_id)"
+            )
+            params["agent_id"] = agent_id
+        sql = text(f"DELETE FROM review_entries WHERE {where}")
         if conn is not None:
             result = await conn.execute(sql, params)
             return bool(result.rowcount and result.rowcount > 0)

--- a/src/metronix/storage/memory_postgres.py
+++ b/src/metronix/storage/memory_postgres.py
@@ -235,7 +235,9 @@ class MemoryPostgresStore:
         logger.debug("memory_pg.saved", record_id=record.id)
         return record
 
-    async def get(self, workspace_id: str, record_id: str) -> MemoryRecord | None:
+    async def get(
+        self, workspace_id: str, record_id: str, *, agent_id: str | None = None
+    ) -> MemoryRecord | None:
         """Fetch a single record by id within the workspace."""
         async with self._engine.begin() as conn:
             result = await conn.execute(
@@ -243,21 +245,30 @@ class MemoryPostgresStore:
                     SELECT {_RECORD_COLUMNS}
                     FROM memory_records
                     WHERE id = :id AND workspace_id = :ws
+                    {"AND agent_id = :agent_id" if agent_id is not None else ""}
                 """),
-                {"id": record_id, "ws": workspace_id},
+                {
+                    "id": record_id,
+                    "ws": workspace_id,
+                    **({"agent_id": agent_id} if agent_id is not None else {}),
+                },
             )
             row = result.first()
         if row is None:
             return None
         return _row_to_record(row._mapping)
 
-    async def delete(self, workspace_id: str, record_id: str) -> bool:
+    async def delete(
+        self, workspace_id: str, record_id: str, *, agent_id: str | None = None
+    ) -> bool:
         """Delete a record. Returns True if it existed."""
         async with self._engine.begin() as conn:
-            result = await conn.execute(
-                text("DELETE FROM memory_records WHERE id = :id AND workspace_id = :ws"),
-                {"id": record_id, "ws": workspace_id},
-            )
+            where = "id = :id AND workspace_id = :ws"
+            params: dict[str, str] = {"id": record_id, "ws": workspace_id}
+            if agent_id is not None:
+                where += " AND agent_id = :agent_id"
+                params["agent_id"] = agent_id
+            result = await conn.execute(text(f"DELETE FROM memory_records WHERE {where}"), params)
             deleted = result.rowcount > 0
         if deleted:
             logger.debug("memory_pg.deleted", record_id=record_id)
@@ -551,6 +562,7 @@ class MemoryPostgresStore:
         workspace_id: str,
         record_id: str,
         *,
+        agent_id: str | None = None,
         content: str | None = None,
         tags: list[str] | None = None,
         importance_score: float | None = None,
@@ -562,6 +574,10 @@ class MemoryPostgresStore:
         """
         set_parts: list[str] = []
         params: dict[str, Any] = {"id": record_id, "ws": workspace_id}
+        agent_predicate = ""
+        if agent_id is not None:
+            agent_predicate = " AND agent_id = :agent_id"
+            params["agent_id"] = agent_id
 
         if content is not None:
             set_parts.append("content = :content")
@@ -590,7 +606,7 @@ class MemoryPostgresStore:
             result = await conn.execute(
                 text(
                     f"UPDATE memory_records SET {set_clause} "
-                    f"WHERE id = :id AND workspace_id = :ws "
+                    f"WHERE id = :id AND workspace_id = :ws{agent_predicate} "
                     f"RETURNING {_RECORD_COLUMNS}"
                 ),
                 params,
@@ -607,6 +623,7 @@ class MemoryPostgresStore:
         workspace_id: str,
         record_id: str,
         *,
+        agent_id: str | None = None,
         status: MemoryStatus | None = None,
         freshness_score: float | None = None,
         superseded_by: str | None = None,
@@ -647,6 +664,10 @@ class MemoryPostgresStore:
         """
         set_parts: list[str] = []
         params: dict[str, Any] = {"id": record_id, "ws": workspace_id}
+        agent_predicate = ""
+        if agent_id is not None:
+            agent_predicate = " AND agent_id = :agent_id"
+            params["agent_id"] = agent_id
 
         if status is not None:
             set_parts.append("status = :status")
@@ -714,7 +735,7 @@ class MemoryPostgresStore:
 
         sql = text(
             f"UPDATE memory_records SET {set_clause} "
-            f"WHERE id = :id AND workspace_id = :ws "
+            f"WHERE id = :id AND workspace_id = :ws{agent_predicate} "
             f"RETURNING {_RECORD_COLUMNS}"
         )
 

--- a/tests/integration/mcp/test_agent_access_conformance.py
+++ b/tests/integration/mcp/test_agent_access_conformance.py
@@ -1,0 +1,152 @@
+"""Direct MCP conformance checks for explicit agent ownership and delegation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from metronix.auth.agent_access import AgentAccessAuthorizer
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
+
+
+@dataclass(frozen=True)
+class _Grant:
+    workspace_id: str
+    agent_id: str
+    principal_user_id: str
+    capability: str
+    grant_type: str
+
+
+class _GrantStore:
+    def __init__(self, grants: list[_Grant]) -> None:
+        self._grants = grants
+
+    async def list_active_grants(
+        self, workspace_id: str, agent_id: str, principal_user_id: str
+    ) -> list[_Grant]:
+        return [
+            grant
+            for grant in self._grants
+            if (grant.workspace_id, grant.agent_id, grant.principal_user_id)
+            == (workspace_id, agent_id, principal_user_id)
+        ]
+
+
+class _AuditStore:
+    async def insert(self, row: object) -> None:
+        return None
+
+
+@pytest.fixture
+def evaluator(monkeypatch: pytest.MonkeyPatch) -> AgentAccessAuthorizer:
+    from metronix.mcp.tools import _agent_access
+
+    authorizer = AgentAccessAuthorizer(
+        _GrantStore(
+            [
+                _Grant("ws-a", "owner-agent", "owner", "admin", "owner"),
+                _Grant("ws-a", "shared-agent", "delegate", "read", "delegate"),
+            ]
+        )
+    )
+    monkeypatch.setattr(_agent_access, "get_agent_access_authorizer", lambda: authorizer)
+    monkeypatch.setattr(_agent_access, "get_agent_access_audit_store", lambda: _AuditStore())
+    return authorizer
+
+
+@pytest.mark.asyncio
+async def test_delegated_read_can_call_search_for_the_explicitly_shared_agent(
+    evaluator: AgentAccessAuthorizer,
+) -> None:
+    from metronix.mcp.tools.memory_search import metronix_memory_search
+
+    service = AsyncMock()
+    service.search = AsyncMock(return_value=[])
+    token = bind_principal(MCPPrincipal("delegate", "editor", ("ws-a",)))
+    try:
+        with patch(
+            "metronix.mcp.tools.memory_search._memory_deps.build_memory_service_for_workspace",
+            new=AsyncMock(return_value=service),
+        ):
+            out = await metronix_memory_search(
+                query="recall", workspace_id="ws-a", agent_id="shared-agent"
+            )
+    finally:
+        reset_principal(token)
+
+    assert out["count"] == 0
+    service.search.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delegated_read_cannot_write_or_swap_to_another_agent(
+    evaluator: AgentAccessAuthorizer,
+) -> None:
+    from metronix.mcp.tools.memory_search import metronix_memory_search
+    from metronix.mcp.tools.memory_store import metronix_memory_store
+
+    search_service = AsyncMock()
+    store_service = AsyncMock()
+    token = bind_principal(MCPPrincipal("delegate", "editor", ("ws-a",)))
+    try:
+        with (
+            patch(
+                "metronix.mcp.tools.memory_search._memory_deps.build_memory_service_for_workspace",
+                new=AsyncMock(return_value=search_service),
+            ) as build_search,
+            patch(
+                "metronix.mcp.tools.memory_store._memory_deps.build_memory_service_for_workspace",
+                new=AsyncMock(return_value=store_service),
+            ) as build_store,
+        ):
+            swapped = await metronix_memory_search(
+                query="recall", workspace_id="ws-a", agent_id="owner-agent"
+            )
+            write = await metronix_memory_store(
+                content="attempted mutation", workspace_id="ws-a", agent_id="shared-agent"
+            )
+    finally:
+        reset_principal(token)
+
+    assert swapped["error"]["code"] == "AUTH_REQUIRED"
+    assert write["error"]["code"] == "AUTH_REQUIRED"
+    build_search.assert_not_awaited()
+    build_store.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_review_actions_use_the_same_agent_capability_decision(
+    evaluator: AgentAccessAuthorizer,
+) -> None:
+    from metronix.mcp.tools.memory_review_list import metronix_memory_review_list
+    from metronix.mcp.tools.memory_review_resolve import metronix_memory_review_resolve
+
+    service = AsyncMock()
+    token = bind_principal(MCPPrincipal("delegate", "editor", ("ws-a",)))
+    try:
+        with (
+            patch(
+                "metronix.mcp.tools.memory_review_list._memory_deps.build_memory_service_for_workspace",
+                new=AsyncMock(return_value=service),
+            ) as build_list,
+            patch(
+                "metronix.mcp.tools.memory_review_resolve._memory_deps.build_memory_service_for_workspace",
+                new=AsyncMock(return_value=service),
+            ) as build_resolve,
+        ):
+            list_out = await metronix_memory_review_list(
+                workspace_id="ws-a", agent_id="owner-agent"
+            )
+            resolve_out = await metronix_memory_review_resolve(
+                review_id="review-1", action="keep", workspace_id="ws-a", agent_id="shared-agent"
+            )
+    finally:
+        reset_principal(token)
+
+    assert list_out["error"]["code"] == "AUTH_REQUIRED"
+    assert resolve_out["error"]["code"] == "AUTH_REQUIRED"
+    build_list.assert_not_awaited()
+    build_resolve.assert_not_awaited()

--- a/tests/integration/mcp/test_memory_review_end_to_end.py
+++ b/tests/integration/mcp/test_memory_review_end_to_end.py
@@ -27,11 +27,18 @@ from metronix.core.models import (
     MemoryScope,
     ReviewEntry,
 )
-from metronix.mcp.tools import _memory_deps
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
+from metronix.mcp.tools import _agent_access, _memory_deps
 from metronix.storage.freshness_pg import FreshnessStore
 from metronix.storage.memory_postgres import MemoryPostgresStore
 
 pytestmark = pytest.mark.integration
+
+
+def _reset_mcp_caches() -> None:
+    _memory_deps._reset_cache_for_tests()
+    _agent_access.get_agent_access_authorizer.cache_clear()
+    _agent_access.get_agent_access_audit_store.cache_clear()
 
 
 async def _cleanup(engine, workspace_id: str) -> None:
@@ -48,24 +55,49 @@ async def _cleanup(engine, workspace_id: str) -> None:
             sa_text("DELETE FROM memory_records WHERE workspace_id = :ws"),
             {"ws": workspace_id},
         )
+        await conn.execute(
+            sa_text("DELETE FROM agent_access_grants WHERE workspace_id = :ws"),
+            {"ws": workspace_id},
+        )
 
 
 async def test_memory_review_resolve_keep_end_to_end() -> None:
     settings = get_settings()
     workspace_id = f"review-it-{uuid4().hex[:8]}"
+    agent_id = "agent-it"
+    principal_user_id = f"review-user-{uuid4().hex[:8]}"
     record_id = uuid4().hex
     review_id = uuid4().hex
 
     engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
     pg_store = MemoryPostgresStore(engine)
     freshness_store = FreshnessStore(engine)
+    principal_token = bind_principal(MCPPrincipal(principal_user_id, "editor", (workspace_id,)))
 
     try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                sa_text("""
+                    INSERT INTO agent_access_grants (
+                        id, workspace_id, agent_id, principal_user_id, capability,
+                        grant_type, granted_by_user_id
+                    ) VALUES (
+                        :id, :workspace_id, :agent_id, :principal_user_id, 'admin',
+                        'owner', :principal_user_id
+                    )
+                """),
+                {
+                    "id": f"owner-{uuid4().hex}",
+                    "workspace_id": workspace_id,
+                    "agent_id": agent_id,
+                    "principal_user_id": principal_user_id,
+                },
+            )
         # --- Seed memory_records row with REVIEW_NEEDED status ---
         record = MemoryRecord(
             id=record_id,
             workspace_id=workspace_id,
-            agent_id="agent-it",
+            agent_id=agent_id,
             scope=MemoryScope.PER_AGENT,
             source_type="integration_test",
             content="review-it content snippet",
@@ -94,14 +126,14 @@ async def test_memory_review_resolve_keep_end_to_end() -> None:
 
         # --- Reset MCP service cache so our tool uses a fresh MemoryService
         # that picks up the same PG engine. ---
-        _memory_deps._reset_cache_for_tests()
+        _reset_mcp_caches()
 
         # --- Drive memory_review_list ---
         from metronix.mcp.tools.memory_review_list import (
             metronix_memory_review_list,
         )
 
-        out = await metronix_memory_review_list(workspace_id=workspace_id)
+        out = await metronix_memory_review_list(workspace_id=workspace_id, agent_id=agent_id)
         assert "error" not in out
         assert out["total"] >= 1
         seeded_ids = [e["id"] for e in out["entries"]]
@@ -116,6 +148,7 @@ async def test_memory_review_resolve_keep_end_to_end() -> None:
             review_id=review_id,
             action="keep",
             workspace_id=workspace_id,
+            agent_id=agent_id,
             notes="integration test",
         )
         assert "error" not in resolve_out
@@ -140,9 +173,11 @@ async def test_memory_review_resolve_keep_end_to_end() -> None:
             workspace_id, "memory_record", record_id
         )
         assert any(
-            e.event_type == "freshness_review_resolved" and e.actor == "mcp_caller" for e in events
+            e.event_type == "freshness_review_resolved" and e.actor == "mcp:agent-access-v1"
+            for e in events
         )
     finally:
-        _memory_deps._reset_cache_for_tests()
+        reset_principal(principal_token)
+        _reset_mcp_caches()
         await _cleanup(engine, workspace_id)
         await engine.dispose()

--- a/tests/integration/mcp/test_memory_search_status_live.py
+++ b/tests/integration/mcp/test_memory_search_status_live.py
@@ -15,11 +15,18 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from metronix.core.config import get_settings
 from metronix.core.models import LifecycleStatus, MemoryRecord, MemoryScope
-from metronix.mcp.tools import _memory_deps
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
+from metronix.mcp.tools import _agent_access, _memory_deps
 from metronix.storage.memory_postgres import MemoryPostgresStore
 from metronix.storage.memory_qdrant import MemoryQdrantStore
 
 pytestmark = pytest.mark.integration
+
+
+def _reset_mcp_caches() -> None:
+    _memory_deps._reset_cache_for_tests()
+    _agent_access.get_agent_access_authorizer.cache_clear()
+    _agent_access.get_agent_access_audit_store.cache_clear()
 
 
 async def _cleanup(engine, workspace_id: str) -> None:
@@ -40,6 +47,7 @@ async def test_search_default_filters_out_archived() -> None:
 
     active_id = uuid4().hex
     archived_id = uuid4().hex
+    principal_token = bind_principal(MCPPrincipal("integration-admin", "admin", (workspace_id,)))
     try:
         active_rec = MemoryRecord(
             id=active_id,
@@ -71,7 +79,7 @@ async def test_search_default_filters_out_archived() -> None:
         archived_rec.status = LifecycleStatus.ARCHIVED
         await qdrant.upsert(archived_rec)
 
-        _memory_deps._reset_cache_for_tests()
+        _reset_mcp_caches()
 
         from metronix.mcp.tools.memory_search import metronix_memory_search
 
@@ -101,7 +109,8 @@ async def test_search_default_filters_out_archived() -> None:
         # archived should be included.
         assert archived_id in ids_all
     finally:
-        _memory_deps._reset_cache_for_tests()
+        reset_principal(principal_token)
+        _reset_mcp_caches()
         await qdrant.close()
         await _cleanup(engine, workspace_id)
         await engine.dispose()

--- a/tests/unit/auth/test_agent_access.py
+++ b/tests/unit/auth/test_agent_access.py
@@ -1,0 +1,98 @@
+"""Unit coverage for server-side agent ownership and delegation decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from metronix.mcp.principal import MCPPrincipal
+
+
+@dataclass(frozen=True)
+class _Grant:
+    workspace_id: str
+    agent_id: str
+    principal_user_id: str
+    capability: str
+    grant_type: str
+
+
+class _Store:
+    def __init__(self, grants: list[_Grant]) -> None:
+        self._grants = grants
+
+    async def list_active_grants(
+        self, workspace_id: str, agent_id: str, principal_user_id: str
+    ) -> list[_Grant]:
+        return [
+            grant
+            for grant in self._grants
+            if (grant.workspace_id, grant.agent_id, grant.principal_user_id)
+            == (workspace_id, agent_id, principal_user_id)
+        ]
+
+
+@pytest.mark.asyncio
+async def test_owner_grant_allows_write() -> None:
+    from metronix.auth.agent_access import AgentAccessAuthorizer, AgentCapability
+
+    decision = await AgentAccessAuthorizer(
+        _Store([_Grant("ws-a", "agent-a", "u1", "admin", "owner")])
+    ).authorize(
+        MCPPrincipal("u1", "editor", ("ws-a",)),
+        "ws-a",
+        "agent-a",
+        AgentCapability.WRITE,
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "owner_grant"
+
+
+@pytest.mark.asyncio
+async def test_read_delegate_cannot_write() -> None:
+    from metronix.auth.agent_access import AgentAccessAuthorizer, AgentCapability
+
+    decision = await AgentAccessAuthorizer(
+        _Store([_Grant("ws-a", "agent-a", "u2", "read", "delegate")])
+    ).authorize(
+        MCPPrincipal("u2", "editor", ("ws-a",)),
+        "ws-a",
+        "agent-a",
+        AgentCapability.WRITE,
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "capability_not_granted"
+
+
+@pytest.mark.asyncio
+async def test_workspace_admin_can_manage_unowned_agent() -> None:
+    from metronix.auth.agent_access import AgentAccessAuthorizer, AgentCapability
+
+    decision = await AgentAccessAuthorizer(_Store([])).authorize(
+        MCPPrincipal("admin", "admin", ("ws-a",)),
+        "ws-a",
+        "legacy-agent",
+        AgentCapability.ADMIN,
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "admin_override"
+
+
+@pytest.mark.asyncio
+async def test_missing_principal_is_denied_without_grant_lookup() -> None:
+    from metronix.auth.agent_access import AgentAccessAuthorizer, AgentCapability
+
+    store = _Store([])
+    decision = await AgentAccessAuthorizer(store).authorize(
+        None,
+        "ws-a",
+        "agent-a",
+        AgentCapability.READ,
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "principal_required"

--- a/tests/unit/auth/test_agent_access_migration.py
+++ b/tests/unit/auth/test_agent_access_migration.py
@@ -1,0 +1,12 @@
+"""Contract checks for the agent-access Alembic migration."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_agent_access_migration_declares_next_revision() -> None:
+    migration = importlib.import_module("migrations.versions.032_agent_access_grants")
+
+    assert migration.revision == "032"
+    assert migration.down_revision == "031"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,52 @@ from __future__ import annotations
 
 import pytest
 
+_AGENT_MEMORY_TOOL_TEST_FILES = {
+    "test_mcp_memory_tools.py",
+    "test_memory_batch_store.py",
+    "test_memory_context_mcp.py",
+    "test_memory_list.py",
+    "test_memory_update.py",
+    "test_memory_review_list.py",
+    "test_memory_review_resolve.py",
+}
+
+
+@pytest.fixture(autouse=True)
+def allow_authenticated_agent_memory_tools(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> object:
+    """Model an authenticated, explicitly allowed caller in tool unit tests."""
+    if (
+        request.node.path.name not in _AGENT_MEMORY_TOOL_TEST_FILES
+        or request.node.get_closest_marker("no_agent_principal") is not None
+    ):
+        yield
+        return
+
+    from metronix.activity.context import bind_agent_id, current_agent_id
+    from metronix.auth.agent_access import AgentAccessDecision
+    from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
+    from metronix.mcp.tools import _agent_access
+
+    class AllowingAuthorizer:
+        async def authorize(self, *args: object) -> AgentAccessDecision:
+            return AgentAccessDecision("test-decision", True, "owner_grant")
+
+    class AuditStore:
+        async def insert(self, row: object) -> None:
+            return None
+
+    monkeypatch.setattr(_agent_access, "get_agent_access_authorizer", lambda: AllowingAuthorizer())
+    monkeypatch.setattr(_agent_access, "get_agent_access_audit_store", lambda: AuditStore())
+    token = bind_principal(MCPPrincipal("u1", "editor", ("*",)))
+    agent_token = bind_agent_id("agent-a")
+    try:
+        yield
+    finally:
+        current_agent_id.reset(agent_token)
+        reset_principal(token)
+
 
 @pytest.fixture(autouse=True)
 def clear_lru_caches() -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,8 @@ _AGENT_MEMORY_TOOL_TEST_FILES = {
     "test_memory_batch_store.py",
     "test_memory_context_mcp.py",
     "test_memory_list.py",
+    "test_memory_list_status_filter.py",
+    "test_memory_search_status_filter.py",
     "test_memory_update.py",
     "test_memory_review_list.py",
     "test_memory_review_resolve.py",

--- a/tests/unit/mcp/tools/test_agent_access_guard.py
+++ b/tests/unit/mcp/tools/test_agent_access_guard.py
@@ -1,0 +1,78 @@
+"""MCP agent-memory authorization boundary tests."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
+
+
+@pytest.mark.asyncio
+async def test_missing_principal_is_denied_before_authorizer_store_access():
+    from metronix.mcp.tools._agent_access import require_agent_access
+
+    with pytest.raises(PermissionError, match="unauthorized agent memory access"):
+        await require_agent_access("ws-a", "agent-a", "read")
+
+
+@pytest.mark.asyncio
+async def test_denied_update_does_not_query_memory_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from metronix.auth.agent_access import AgentAccessDecision
+    from metronix.mcp.tools import _agent_access
+    from metronix.mcp.tools.memory_update import metronix_memory_update
+
+    class DenyingAuthorizer:
+        async def authorize(self, *args: object) -> AgentAccessDecision:
+            return AgentAccessDecision("decision", False, "no_active_grant")
+
+    service = AsyncMock()
+    monkeypatch.setattr(_agent_access, "get_agent_access_authorizer", lambda: DenyingAuthorizer())
+    token = bind_principal(MCPPrincipal("u1", "editor", ("ws-a",)))
+    try:
+        with patch(
+            "metronix.mcp.tools.memory_update._memory_deps.build_memory_service_for_workspace",
+            new=AsyncMock(return_value=service),
+        ) as build_service:
+            out = await metronix_memory_update(
+                record_id="foreign-record",
+                agent_id="other-agent",
+                workspace_id="ws-a",
+                content="attempted change",
+            )
+    finally:
+        reset_principal(token)
+
+    assert out["error"]["code"] == "AUTH_REQUIRED"
+    build_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_principal_search_does_not_query_memory_service() -> None:
+    from metronix.mcp.tools.memory_search import metronix_memory_search
+
+    with patch(
+        "metronix.mcp.tools.memory_search._memory_deps.build_memory_service_for_workspace",
+        new=AsyncMock(),
+    ) as build_service:
+        out = await metronix_memory_search(
+            query="blocked", workspace_id="ws-a", agent_id="agent-a"
+        )
+
+    assert out["error"]["code"] == "AUTH_REQUIRED"
+    build_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_review_list_with_agent_id_denies_before_memory_service_without_principal() -> None:
+    from metronix.mcp.tools.memory_review_list import metronix_memory_review_list
+
+    with patch(
+        "metronix.mcp.tools.memory_review_list._memory_deps.build_memory_service_for_workspace",
+        new=AsyncMock(),
+    ) as build_service:
+        out = await metronix_memory_review_list(workspace_id="ws-a", agent_id="agent-a")
+
+    assert out["error"]["code"] == "AUTH_REQUIRED"
+    build_service.assert_not_awaited()

--- a/tests/unit/memory/test_service_review.py
+++ b/tests/unit/memory/test_service_review.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
@@ -134,6 +134,33 @@ class TestListReviewEntries:
 
 
 class TestResolveReviewKeep:
+    async def test_does_not_cascade_to_a_review_outside_the_agent_scope(self) -> None:
+        entry = ReviewEntry(
+            id="r1",
+            workspace_id="ws1",
+            target_id="mem001",
+            target_kind="memory_record",
+            reason="possible_duplicate",
+            related_record_id="foreign-mem",
+            content="dup preview",
+            confidence=0.8,
+            created_at=datetime(2026, 1, 2, tzinfo=UTC),
+        )
+        fs = MagicMock()
+        fs.list_review_entries = AsyncMock(return_value=[entry])
+        fs.find_review_entry = AsyncMock()
+        fs.delete_review_entry = AsyncMock(return_value=True)
+        fs.save_machine_event = AsyncMock(side_effect=lambda evt, **_kw: evt)
+        pg = MagicMock()
+        pg.get = AsyncMock(side_effect=[_record(), None])
+        pg.update_lifecycle = AsyncMock(return_value=_record(status=LifecycleStatus.ACTIVE))
+        service, _ = _make_service(freshness_store=fs, pg_store=pg)
+
+        await service.resolve_review("ws1", review_id="r1", action="keep", agent_id="agent1")
+
+        fs.find_review_entry.assert_not_awaited()
+        fs.delete_review_entry.assert_awaited_once_with("ws1", "r1", agent_id="agent1", conn=ANY)
+
     async def test_keep_transitions_to_active_and_deletes_review(self) -> None:
         fs = MagicMock()
         fs.list_review_entries = AsyncMock(return_value=[_review()])

--- a/tests/unit/test_mcp_agent_memory_auth.py
+++ b/tests/unit/test_mcp_agent_memory_auth.py
@@ -1,0 +1,55 @@
+"""Principal requirements for MCP agent-memory operations."""
+
+from __future__ import annotations
+
+from metronix.mcp.principal import MCPPrincipal
+
+
+async def test_personal_api_key_resolves_owner_as_mcp_principal() -> None:
+    from metronix.mcp.auth import authenticate_http_request
+
+    async def resolve_personal_key(token: str) -> MCPPrincipal | None:
+        if token == "mtk_test":
+            return MCPPrincipal("user-1", "editor", ("ws-a",), auth_method="personal_api_key")
+        return None
+
+    principal = await authenticate_http_request(
+        "Bearer mtk_test",
+        auth_enabled=False,
+        secret_key="unused",
+        principal_resolver=resolve_personal_key,
+    )
+
+    assert principal == MCPPrincipal(
+        "user-1", "editor", ("ws-a",), auth_method="personal_api_key"
+    )
+
+
+async def test_shared_key_stays_without_principal() -> None:
+    from metronix.mcp.auth import authenticate_http_request
+
+    principal = await authenticate_http_request(
+        "Bearer shared-key",
+        auth_enabled=False,
+        secret_key="unused",
+        principal_resolver=None,
+    )
+
+    assert principal is None
+
+
+async def test_personal_api_key_is_accepted_when_jwt_auth_is_enabled() -> None:
+    from metronix.mcp.auth import authenticate_http_request
+
+    async def resolve_personal_key(token: str) -> MCPPrincipal | None:
+        return MCPPrincipal("user-1", "editor", ("ws-a",), auth_method="personal_api_key")
+
+    principal = await authenticate_http_request(
+        "Bearer mtk_test",
+        auth_enabled=True,
+        secret_key="unused",
+        principal_resolver=resolve_personal_key,
+    )
+
+    assert principal is not None
+    assert principal.auth_method == "personal_api_key"

--- a/tests/unit/test_mcp_agent_memory_auth.py
+++ b/tests/unit/test_mcp_agent_memory_auth.py
@@ -27,9 +27,10 @@ async def test_personal_api_key_resolves_owner_as_mcp_principal() -> None:
     assert principal == MCPPrincipal("user-1", "editor", ("ws-a",), auth_method="personal_api_key")
 
 
-async def test_shared_key_stays_without_principal() -> None:
+async def test_shared_key_stays_without_principal(monkeypatch: pytest.MonkeyPatch) -> None:
     from metronix.mcp.auth import authenticate_http_request
 
+    monkeypatch.setenv("METRONIX_MCP_API_KEY", "shared-key")
     principal = await authenticate_http_request(
         "Bearer shared-key",
         auth_enabled=False,

--- a/tests/unit/test_mcp_agent_memory_auth.py
+++ b/tests/unit/test_mcp_agent_memory_auth.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from metronix.mcp.principal import MCPPrincipal
 
 
@@ -20,9 +24,7 @@ async def test_personal_api_key_resolves_owner_as_mcp_principal() -> None:
         principal_resolver=resolve_personal_key,
     )
 
-    assert principal == MCPPrincipal(
-        "user-1", "editor", ("ws-a",), auth_method="personal_api_key"
-    )
+    assert principal == MCPPrincipal("user-1", "editor", ("ws-a",), auth_method="personal_api_key")
 
 
 async def test_shared_key_stays_without_principal() -> None:
@@ -53,3 +55,24 @@ async def test_personal_api_key_is_accepted_when_jwt_auth_is_enabled() -> None:
 
     assert principal is not None
     assert principal.auth_method == "personal_api_key"
+
+
+@pytest.mark.asyncio
+async def test_standalone_http_resolves_an_active_personal_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from metronix.mcp import server
+
+    api_key_store = MagicMock()
+    api_key_store.resolve_key = AsyncMock(return_value={"source": "personal", "user_id": "u1"})
+    user_store = MagicMock()
+    user_store.get_user_by_id = AsyncMock(
+        return_value={"id": "u1", "role": "editor", "workspace_ids": ["ws-a"], "is_active": True}
+    )
+    monkeypatch.setattr(
+        server, "_get_standalone_personal_key_stores", lambda: (api_key_store, user_store)
+    )
+
+    principal = await server._resolve_standalone_mcp_personal_principal("mtk_test")
+
+    assert principal == MCPPrincipal("u1", "editor", ("ws-a",), auth_method="personal_api_key")

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -223,14 +223,16 @@ class TestMemoryDelete:
         with _patch_service(service):
             from metronix.mcp.tools.memory_delete import metronix_memory_delete
 
-            out = await metronix_memory_delete(record_id="rec-42")
+            out = await metronix_memory_delete(record_id="rec-42", agent_id="agent-a")
 
         assert "error" not in out
         assert out["success"] is True
         assert out["found"] is True
         from metronix.mcp.config import get_default_workspace_id
 
-        service.delete.assert_awaited_once_with(get_default_workspace_id(), "rec-42")
+        service.delete.assert_awaited_once_with(
+            get_default_workspace_id(), "rec-42", agent_id="agent-a"
+        )
 
     async def test_memory_delete_not_found(self) -> None:
         service = AsyncMock()
@@ -239,7 +241,7 @@ class TestMemoryDelete:
         with _patch_service(service):
             from metronix.mcp.tools.memory_delete import metronix_memory_delete
 
-            out = await metronix_memory_delete(record_id="nope")
+            out = await metronix_memory_delete(record_id="nope", agent_id="agent-a")
 
         assert "error" in out
         assert out["error"]["code"] == "DOCUMENT_NOT_FOUND"

--- a/tests/unit/test_memory_update.py
+++ b/tests/unit/test_memory_update.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from metronix.core.models import MemoryRecord, MemoryScope
+from metronix.core.models import LifecycleStatus, MemoryRecord, MemoryScope
 from metronix.mcp.tools.memory_update import metronix_memory_update
 from metronix.storage.memory_postgres import MemoryPostgresStore
 
@@ -106,6 +106,23 @@ class TestCountRecords:
 
 
 class TestUpdate:
+    async def test_lifecycle_update_scopes_mutation_to_agent(self) -> None:
+        store, engine = _make_store()
+        conn = AsyncMock()
+        result = MagicMock()
+        result.first.return_value = None
+        conn.execute.return_value = result
+        engine.begin.return_value = _FakeCtx(conn)
+
+        await store.update_lifecycle(
+            "ws1", "mem001", agent_id="agent1", status=LifecycleStatus.ACTIVE
+        )
+
+        sql_text = str(conn.execute.call_args.args[0])
+        params = conn.execute.call_args.args[1]
+        assert "agent_id = :agent_id" in sql_text
+        assert params["agent_id"] == "agent1"
+
     async def test_update_content(self) -> None:
         store, engine = _make_store()
         conn = AsyncMock()
@@ -176,6 +193,7 @@ class TestMemoryUpdateTool:
 
         result = await metronix_memory_update(
             record_id="mem001",
+            agent_id="agent1",
             workspace_id="ws1",
             content="new content",
         )
@@ -201,6 +219,7 @@ class TestMemoryUpdateTool:
 
         result = await metronix_memory_update(
             record_id="mem001",
+            agent_id="agent1",
             workspace_id="ws1",
             tags=["new-tag"],
         )
@@ -220,6 +239,7 @@ class TestMemoryUpdateTool:
 
         result = await metronix_memory_update(
             record_id="nonexistent",
+            agent_id="agent1",
             workspace_id="ws1",
             content="new",
         )
@@ -228,7 +248,7 @@ class TestMemoryUpdateTool:
         assert "not found" in result["error"]["message"].lower()
 
     async def test_no_fields_returns_error(self) -> None:
-        result = await metronix_memory_update(record_id="mem001")
+        result = await metronix_memory_update(record_id="mem001", agent_id="agent1")
 
         assert "error" in result
         assert "at least one" in result["error"]["message"].lower()
@@ -254,6 +274,7 @@ class TestMemoryUpdateTool:
 
         result = await metronix_memory_update(
             record_id="rec1",
+            agent_id="agent1",
             workspace_id="ws1",
             content="new content",
             tags=["new-tag"],


### PR DESCRIPTION
## Summary

- Enforce explicit server-side agent-memory ownership and delegated capability grants across MCP memory operations.
- Require a verified JWT or personal API-key principal; shared MCP API keys remain unable to access agent memory.
- Scope update, delete, review listing, and review resolution to workspace, agent, and record; persist content-free policy-decision audit metadata.
- Support personal API-key principals in both mounted and standalone HTTP MCP transports.

## Validation

- `ruff check src tests/unit/conftest.py tests/integration/mcp/test_agent_access_conformance.py`
- Focused unit, conformance, and Compose-backed integration gate: `69 passed`

## Notes

- Live integration tests used the running Compose service ports: Postgres 5433, Qdrant 6335/6336, and Ollama 11435.
