### PR TITLE
feat(auth): centralize agent authorization policy

### DIFF
--- a/src/metronix/agent/router.py
+++ b/src/metronix/agent/router.py
@@ -22,6 +22,8 @@ from metronix.llm.base import LLMError
 from metronix.retrieval.search import hybrid_search_and_answer_sync
 
 if TYPE_CHECKING:
+    from metronix.auth.policy import PolicyPrincipal
+
     # Imported lazily at runtime inside the /mcp handlers (avoids a circular
     # import); declared here so type annotations on the handler methods resolve.
     from metronix.mcp.config import MCPServerConfig
@@ -194,6 +196,7 @@ class AgentRouter:
         user_id: str,
         workspace_id: str | None = None,
         agent_id: str | None = None,
+        principal: PolicyPrincipal | None = None,
         history_enabled: bool = True,
         conversation_id: str | None = None,
     ) -> str:
@@ -239,7 +242,7 @@ class AgentRouter:
             if intent == Intent.SMALLTALK:
                 return self._handle_smalltalk(text, user_id, ws)
             if intent == Intent.ACTION:
-                return self._handle_action(text, user_id, ws, agent_id)
+                return self._handle_action(text, user_id, ws, agent_id, principal)
             return self._handle_search(
                 text, user_id, ws, history_enabled=history_enabled, conversation_id=conversation_id
             )
@@ -362,7 +365,12 @@ class AgentRouter:
         return None
 
     def _handle_action(
-        self, text: str, user_id: str, workspace_id: str, agent_id: str | None
+        self,
+        text: str,
+        user_id: str,
+        workspace_id: str,
+        agent_id: str | None,
+        principal: PolicyPrincipal | None,
     ) -> str:
         """Handle an action request — plan via LLM, store for confirmation."""
         from metronix.mcp.action_planner import ActionPlanner, ActionPolicy
@@ -370,6 +378,8 @@ class AgentRouter:
 
         if not agent_id:
             return "This channel has no authorized agent configured for actions."
+        if principal is None:
+            return "This channel user is not authenticated for actions."
 
         planner = ActionPlanner()
         write_tools = planner.discover_write_tools(workspace_id)
@@ -411,6 +421,9 @@ class AgentRouter:
             arguments=plan.get("arguments", {}),
             description=plan.get("description", "Action"),
             preview=plan.get("preview", ""),
+            principal=principal,
+            workspace_id=workspace_id,
+            agent_id=agent_id,
         )
         store = get_action_store()
         store.add(action)

--- a/src/metronix/agent/router.py
+++ b/src/metronix/agent/router.py
@@ -193,6 +193,7 @@ class AgentRouter:
         text: str,
         user_id: str,
         workspace_id: str | None = None,
+        agent_id: str | None = None,
         history_enabled: bool = True,
         conversation_id: str | None = None,
     ) -> str:
@@ -238,7 +239,7 @@ class AgentRouter:
             if intent == Intent.SMALLTALK:
                 return self._handle_smalltalk(text, user_id, ws)
             if intent == Intent.ACTION:
-                return self._handle_action(text, user_id, ws)
+                return self._handle_action(text, user_id, ws, agent_id)
             return self._handle_search(
                 text, user_id, ws, history_enabled=history_enabled, conversation_id=conversation_id
             )
@@ -360,10 +361,15 @@ class AgentRouter:
         # (remove stale pending so it doesn't block future messages)
         return None
 
-    def _handle_action(self, text: str, user_id: str, workspace_id: str) -> str:
+    def _handle_action(
+        self, text: str, user_id: str, workspace_id: str, agent_id: str | None
+    ) -> str:
         """Handle an action request — plan via LLM, store for confirmation."""
         from metronix.mcp.action_planner import ActionPlanner, ActionPolicy
         from metronix.mcp.action_store import PendingAction, get_action_store
+
+        if not agent_id:
+            return "This channel has no authorized agent configured for actions."
 
         planner = ActionPlanner()
         write_tools = planner.discover_write_tools(workspace_id)

--- a/src/metronix/api/routes/memory.py
+++ b/src/metronix/api/routes/memory.py
@@ -41,9 +41,6 @@ from metronix.core.models import (
     ReviewEntry,
     User,
 )
-from metronix.memory.service import (
-    MemoryService,  # noqa: TC001 — FastAPI Annotated DI needs runtime import
-)
 
 logger = structlog.get_logger(__name__)
 
@@ -392,7 +389,7 @@ async def list_records(
     service = get_memory_service(request)
 
     if session_id is not None:
-        session_records = await service.list_session(workspace_id, session_id)
+        session_records = await service.list_session(workspace_id, session_id, agent_id=agent_id)
         return MemoryRecordListResponse(
             records=[_record_to_response(r) for r in session_records],
             count=len(session_records),
@@ -447,8 +444,8 @@ async def list_records(
 @router.get("/facets", response_model=MemoryFacetsResponse)
 async def get_memory_facets(
     request: Request,
-    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_viewer)],
+    agent_id: str = Query(..., min_length=1, max_length=128),
 ) -> MemoryFacetsResponse:
     """Return the distinct kind/source_type values in use in the workspace.
 
@@ -456,8 +453,10 @@ async def get_memory_facets(
     matching records right now.
     """
     workspace_id = resolve_workspace_id(request)
+    await require_memory_access(user, workspace_id, agent_id, Capability.READ)
+    service = get_memory_service(request)
     try:
-        kinds, source_types = await service.get_facets(workspace_id)
+        kinds, source_types = await service.get_facets(workspace_id, agent_id=agent_id)
     except Exception as exc:
         # #325: same rationale as list_records — surface backend connectivity
         # failures as a clean 503 instead of an unhandled 500.
@@ -552,6 +551,7 @@ async def get_memory_graph(
     records, raw_edges = await service.get_graph_neighborhood(
         workspace_id, seed_record_id, depth=depth, agent_id=agent_id
     )
+    records = [record for record in records if record.agent_id == agent_id]
 
     surviving_ids = {r.id for r in records}
     # Drop edges where either endpoint was filtered out.

--- a/src/metronix/api/routes/memory.py
+++ b/src/metronix/api/routes/memory.py
@@ -21,7 +21,16 @@ from metronix.api.dependencies import (
     resolve_workspace_id,
     workspace_scope,
 )
+from metronix.auth.agent_access import get_authorization_evaluator
 from metronix.auth.dependencies import require_editor, require_viewer
+from metronix.auth.policy import (
+    AuthorizationDecision,
+    AuthorizationRequest,
+    Capability,
+    PolicyPrincipal,
+    ResourceType,
+    Transport,
+)
 from metronix.core.exceptions import MemoryNotFoundError
 from metronix.core.models import (
     LifecycleStatus,
@@ -103,7 +112,7 @@ class MemorySearchRequest(BaseModel):
     model_config = ConfigDict(strict=False)
 
     query: str = Field(..., min_length=1, max_length=2048)
-    agent_id: str | None = Field(None, min_length=1, max_length=128)
+    agent_id: str = Field(..., min_length=1, max_length=128)
     scope: MemoryScope | None = None
     tags: list[str] | None = None
     session_id: str | None = Field(None, min_length=1, max_length=128)
@@ -155,6 +164,7 @@ class BatchDeleteRecordsRequest(BaseModel):
     model_config = ConfigDict(strict=False)
 
     record_ids: list[str] = Field(..., min_length=1, max_length=500)
+    agent_id: str = Field(..., min_length=1, max_length=128)
 
 
 class BatchDeleteRecordsResponse(BaseModel):
@@ -203,6 +213,35 @@ def _record_to_response(record: MemoryRecord) -> MemoryRecordResponse:
     )
 
 
+async def require_memory_access(
+    user: User,
+    workspace_id: str,
+    agent_id: str,
+    capability: Capability | str,
+) -> AuthorizationDecision:
+    """Authorize a REST memory target before creating or using its service."""
+    decision = await get_authorization_evaluator().authorize(
+        AuthorizationRequest(
+            principal=PolicyPrincipal.from_user(user),
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            resource_type=ResourceType.MEMORY,
+            capability=Capability(capability),
+            transport=Transport.REST,
+        )
+    )
+    if not decision.allowed:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "memory_access_denied",
+                "reason": decision.reason,
+                "decision_id": decision.decision_id,
+            },
+        )
+    return decision
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -216,8 +255,7 @@ def _record_to_response(record: MemoryRecord) -> MemoryRecordResponse:
 async def create_record(
     body: CreateMemoryRecordRequest,
     request: Request,
-    user: Annotated[User, Depends(require_editor)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_editor)],
 ) -> MemoryRecordResponse:
     """Create a memory record.
 
@@ -225,6 +263,8 @@ async def create_record(
     are persisted in Qdrant (plus best-effort Neo4j).
     """
     workspace_id = resolve_workspace_id(request)
+    await require_memory_access(user, workspace_id, body.agent_id, Capability.WRITE)
+    service = get_memory_service(request)
     record = MemoryRecord(
         workspace_id=workspace_id,
         agent_id=body.agent_id,
@@ -262,8 +302,7 @@ _DEFAULT_SEARCH_EXCLUDE = frozenset({LifecycleStatus.ARCHIVED, LifecycleStatus.S
 async def search_records(
     body: MemorySearchRequest,
     request: Request,
-    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_viewer)],
 ) -> MemorySearchResponse:
     """Run a hybrid dense+sparse+graph search over memory records.
 
@@ -274,6 +313,8 @@ async def search_records(
     value explicitly (e.g. ``["active", "archived"]``) to include all.
     """
     workspace_id = resolve_workspace_id(request)
+    await require_memory_access(user, workspace_id, body.agent_id, Capability.READ)
+    service = get_memory_service(request)
     results: list[MemorySearchResult]
 
     # Apply route-layer default — mirrors the MCP layer pattern where the
@@ -325,9 +366,8 @@ async def search_records(
 @router.get("/records", response_model=MemoryRecordListResponse)
 async def list_records(
     request: Request,
-    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
-    agent_id: str | None = Query(None, min_length=1, max_length=128),
+    user: Annotated[User, Depends(require_viewer)],
+    agent_id: str = Query(..., min_length=1, max_length=128),
     scope: MemoryScope | None = None,
     session_id: str | None = Query(None, min_length=1, max_length=128),
     status_filter: list[LifecycleStatus] | None = Query(None),  # noqa: B008
@@ -348,6 +388,8 @@ async def list_records(
     records including ARCHIVED and SUPERSEDED.
     """
     workspace_id = resolve_workspace_id(request)
+    await require_memory_access(user, workspace_id, agent_id, Capability.READ)
+    service = get_memory_service(request)
 
     if session_id is not None:
         session_records = await service.list_session(workspace_id, session_id)
@@ -431,8 +473,8 @@ async def get_memory_facets(
 async def get_record(
     record_id: str,
     request: Request,
-    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_viewer)],
+    agent_id: str = Query(..., min_length=1, max_length=128),
 ) -> MemoryRecordResponse:
     """Fetch a single persistent memory record by id.
 
@@ -441,7 +483,9 @@ async def get_record(
     (cross-workspace isolation guaranteed by PG ``WHERE workspace_id = :ws``).
     """
     workspace_id = resolve_workspace_id(request)
-    record = await service.get(workspace_id, record_id)
+    await require_memory_access(user, workspace_id, agent_id, Capability.READ)
+    service = get_memory_service(request)
+    record = await service.get(workspace_id, record_id, agent_id=agent_id)
     if record is None:
         raise HTTPException(status_code=404, detail="Memory record not found")
     return _record_to_response(record)
@@ -585,8 +629,8 @@ def _entry_to_response(entry: ReviewEntry) -> ReviewEntryResponse:
 @router.get("/review", response_model=ReviewListResponse)
 async def list_review_entries(
     request: Request,
-    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_viewer)],
+    agent_id: str = Query(..., min_length=1, max_length=128),
     reason: str | None = Query(None, min_length=1, max_length=64),
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0, le=10000),
@@ -600,9 +644,12 @@ async def list_review_entries(
     does not run the freshness worker).
     """
     workspace_id = resolve_workspace_id(request)
+    await require_memory_access(user, workspace_id, agent_id, Capability.READ)
+    service = get_memory_service(request)
     try:
         entries, total = await service.list_review_entries(
             workspace_id,
+            agent_id=agent_id,
             reason=reason,
             limit=limit,
             offset=offset,
@@ -631,7 +678,7 @@ async def resolve_review_entry(
     body: ReviewResolveRequest,
     request: Request,
     user: Annotated[User, Depends(require_editor)],
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    agent_id: str = Query(..., min_length=1, max_length=128),
 ) -> Response:
     """Resolve a pending review entry.
 
@@ -649,6 +696,8 @@ async def resolve_review_entry(
     Returns 503 when the freshness store is not configured.
     """
     workspace_id = resolve_workspace_id(request)
+    decision = await require_memory_access(user, workspace_id, agent_id, Capability.WRITE)
+    service = get_memory_service(request)
     if body.action == "merge_into":
         action_str = f"merge_into:{body.target_record_id}"
     else:
@@ -660,6 +709,12 @@ async def resolve_review_entry(
             action=action_str,
             notes=body.notes,
             actor=user.id,
+            agent_id=agent_id,
+            access_policy={
+                "decision_id": decision.decision_id,
+                "policy_version": decision.policy_version,
+                "outcome": decision.allowed,
+            },
         )
     except MemoryNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from None
@@ -679,8 +734,8 @@ async def resolve_review_entry(
 async def delete_record(
     record_id: str,
     request: Request,
-    user: Annotated[User, Depends(require_editor)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_editor)],
+    agent_id: str = Query(..., min_length=1, max_length=128),
 ) -> Response:
     """Delete a persistent memory record by id. 404 if PG does not have it.
 
@@ -688,7 +743,9 @@ async def delete_record(
     this endpoint only touches the persistent stores (PG, Qdrant, Neo4j).
     """
     workspace_id = resolve_workspace_id(request)
-    deleted = await service.delete(workspace_id, record_id)
+    await require_memory_access(user, workspace_id, agent_id, Capability.DELETE)
+    service = get_memory_service(request)
+    deleted = await service.delete(workspace_id, record_id, agent_id=agent_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Memory record not found")
     return Response(status_code=204)
@@ -698,8 +755,7 @@ async def delete_record(
 async def batch_delete_records(
     body: BatchDeleteRecordsRequest,
     request: Request,
-    user: Annotated[User, Depends(require_editor)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_editor)],
 ) -> BatchDeleteRecordsResponse:
     """Delete multiple persistent memory records by id in one call.
 
@@ -708,5 +764,9 @@ async def batch_delete_records(
     per-id semantics of ``DELETE /records/{record_id}``.
     """
     workspace_id = resolve_workspace_id(request)
-    deleted, not_found = await service.delete_many(workspace_id, body.record_ids)
+    await require_memory_access(user, workspace_id, body.agent_id, Capability.DELETE)
+    service = get_memory_service(request)
+    deleted, not_found = await service.delete_many(
+        workspace_id, body.record_ids, agent_id=body.agent_id
+    )
     return BatchDeleteRecordsResponse(deleted=deleted, not_found=not_found)

--- a/src/metronix/api/routes/memory.py
+++ b/src/metronix/api/routes/memory.py
@@ -518,11 +518,10 @@ class MemoryGraphResponse(BaseModel):
 @router.get("/graph", response_model=MemoryGraphResponse)
 async def get_memory_graph(
     request: Request,
-    user: Annotated[User, Depends(require_viewer)],  # noqa: ARG001
-    service: Annotated[MemoryService, Depends(get_memory_service)],
+    user: Annotated[User, Depends(require_viewer)],
     seed_record_id: str = Query(..., min_length=1, max_length=128),
     depth: int = Query(1, ge=1, le=3),
-    agent_id: str | None = Query(None, min_length=1, max_length=128),
+    agent_id: str = Query(..., min_length=1, max_length=128),
 ) -> MemoryGraphResponse:
     """Return the neighbourhood graph around a memory record.
 
@@ -548,13 +547,11 @@ async def get_memory_graph(
     Workspace isolation: ``workspace_id`` comes from the JWT only.
     """
     workspace_id = resolve_workspace_id(request)
+    await require_memory_access(user, workspace_id, agent_id, Capability.READ)
+    service = get_memory_service(request)
     records, raw_edges = await service.get_graph_neighborhood(
-        workspace_id, seed_record_id, depth=depth
+        workspace_id, seed_record_id, depth=depth, agent_id=agent_id
     )
-
-    # Optional agent_id filter — keep only records for this agent.
-    if agent_id is not None:
-        records = [r for r in records if r.agent_id == agent_id]
 
     surviving_ids = {r.id for r in records}
     # Drop edges where either endpoint was filtered out.

--- a/src/metronix/auth/agent_access.py
+++ b/src/metronix/auth/agent_access.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from functools import lru_cache
 from typing import Protocol
 
 from sqlalchemy import text
@@ -81,6 +82,17 @@ class PostgresAgentAccessStore:
                 },
             )
             return [AgentAccessGrant(capability=row[0], grant_type=row[1]) for row in rows]
+
+
+@lru_cache(maxsize=1)
+def get_authorization_evaluator() -> AuthorizationEvaluator:
+    """Return the process-wide evaluator backed by active grant storage."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from metronix.core.config import get_settings
+
+    engine = create_async_engine(get_settings().postgres_dsn)
+    return AuthorizationEvaluator(PostgresAgentAccessStore(engine))
 
 
 AgentAccessDecision = AuthorizationDecision

--- a/src/metronix/auth/agent_access.py
+++ b/src/metronix/auth/agent_access.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Protocol
-from uuid import uuid4
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from metronix.auth.policy import (
+    AuthorizationDecision,
+    AuthorizationEvaluator,
+    AuthorizationRequest,
+    Capability,
+    PolicyPrincipal,
+    ResourceType,
+    Transport,
+)
 from metronix.mcp.principal import MCPPrincipal
 
 
@@ -75,21 +83,14 @@ class PostgresAgentAccessStore:
             return [AgentAccessGrant(capability=row[0], grant_type=row[1]) for row in rows]
 
 
-@dataclass(frozen=True)
-class AgentAccessDecision:
-    """Content-free result of an agent-access evaluation."""
-
-    decision_id: str
-    allowed: bool
-    reason: str
-    policy_version: str = "agent-access-v1"
+AgentAccessDecision = AuthorizationDecision
 
 
 class AgentAccessAuthorizer:
     """Authorize verified MCP principals using explicit server-side grants."""
 
     def __init__(self, store: AgentAccessStore) -> None:
-        self._store = store
+        self._evaluator = AuthorizationEvaluator(store)
 
     async def authorize(
         self,
@@ -98,34 +99,17 @@ class AgentAccessAuthorizer:
         agent_id: str,
         capability: AgentCapability,
     ) -> AgentAccessDecision:
-        if principal is None:
-            return self._decision(False, "principal_required")
-        if workspace_id not in principal.workspace_ids and "*" not in principal.workspace_ids:
-            return self._decision(False, "workspace_not_granted")
-        if principal.role == "admin":
-            return self._decision(True, "admin_override")
-
-        grants = await self._store.list_active_grants(workspace_id, agent_id, principal.user_id)
-        allowed_grants = [grant for grant in grants if self._covers(grant.capability, capability)]
-        if not allowed_grants:
-            reason = "no_active_grant" if not grants else "capability_not_granted"
-            return self._decision(False, reason)
-        if any(grant.grant_type == "owner" for grant in allowed_grants):
-            return self._decision(True, "owner_grant")
-        return self._decision(True, "delegated_grant")
-
-    @staticmethod
-    def _covers(granted: str, requested: AgentCapability) -> bool:
-        levels = {
-            AgentCapability.READ: 1,
-            AgentCapability.WRITE: 2,
-            AgentCapability.ADMIN: 3,
-        }
-        try:
-            return levels[AgentCapability(granted)] >= levels[requested]
-        except ValueError:
-            return False
-
-    @staticmethod
-    def _decision(allowed: bool, reason: str) -> AgentAccessDecision:
-        return AgentAccessDecision(decision_id=uuid4().hex, allowed=allowed, reason=reason)
+        return await self._evaluator.authorize(
+            AuthorizationRequest(
+                principal=PolicyPrincipal.from_mcp(principal) if principal is not None else None,
+                workspace_id=workspace_id,
+                agent_id=agent_id,
+                resource_type=ResourceType.MEMORY,
+                capability={
+                    AgentCapability.READ: Capability.READ,
+                    AgentCapability.WRITE: Capability.WRITE,
+                    AgentCapability.ADMIN: Capability.ADMINISTER,
+                }[capability],
+                transport=Transport.MCP,
+            )
+        )

--- a/src/metronix/auth/policy.py
+++ b/src/metronix/auth/policy.py
@@ -119,7 +119,7 @@ class AuthorizationEvaluator:
             and "*" not in principal.workspace_ids
         ):
             return self._decision(False, "workspace_not_granted")
-        if request.resource_type is not ResourceType.MEMORY:
+        if request.resource_type not in (ResourceType.MEMORY, ResourceType.ACTION):
             return self._decision(False, "unsupported_resource")
         if not request.agent_id:
             return self._decision(False, "agent_id_required")
@@ -150,6 +150,8 @@ class AuthorizationEvaluator:
     @staticmethod
     def _required_agent_capability(capability: Capability) -> Capability | None:
         if capability is Capability.DELETE:
+            return Capability.WRITE
+        if capability is Capability.EXECUTE:
             return Capability.WRITE
         if capability is Capability.ADMINISTER:
             return Capability.ADMINISTER

--- a/src/metronix/auth/policy.py
+++ b/src/metronix/auth/policy.py
@@ -1,0 +1,173 @@
+"""Transport-neutral, fail-closed authorization decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from metronix.core.models import User
+    from metronix.mcp.principal import MCPPrincipal
+
+
+class Capability(StrEnum):
+    """Capabilities requested for a protected resource."""
+
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    EXECUTE = "execute"
+    ADMINISTER = "administer"
+
+
+class ResourceType(StrEnum):
+    """Resource families covered by the policy contract."""
+
+    MEMORY = "memory"
+    ACTION = "action"
+
+
+class Transport(StrEnum):
+    """Transport that submitted the authorization request."""
+
+    REST = "rest"
+    MCP = "mcp"
+    ACTION = "action"
+
+
+@dataclass(frozen=True)
+class PolicyPrincipal:
+    """Server-derived identity consumed by every policy adapter."""
+
+    user_id: str
+    role: str
+    workspace_ids: tuple[str, ...]
+    auth_method: str
+
+    @classmethod
+    def from_mcp(cls, principal: MCPPrincipal) -> PolicyPrincipal:
+        return cls(
+            user_id=principal.user_id,
+            role=principal.role,
+            workspace_ids=principal.workspace_ids,
+            auth_method=principal.auth_method,
+        )
+
+    @classmethod
+    def from_user(cls, user: User) -> PolicyPrincipal:
+        return cls(
+            user_id=user.id,
+            role=str(user.role),
+            workspace_ids=tuple(user.workspace_ids),
+            auth_method="user",
+        )
+
+
+@dataclass(frozen=True)
+class AuthorizationRequest:
+    """Normalized request whose target values do not confer authority."""
+
+    principal: PolicyPrincipal | None
+    workspace_id: str
+    agent_id: str | None
+    resource_type: ResourceType
+    capability: Capability
+    transport: Transport
+    resource_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AuthorizationDecision:
+    """Content-free authorization result suitable for audit logging."""
+
+    decision_id: str
+    allowed: bool
+    reason: str
+    policy_version: str = "authz-v1"
+
+
+class AgentAccessGrantLike(Protocol):
+    """Active agent grant projection used by the evaluator."""
+
+    capability: str
+    grant_type: str
+
+
+class AgentAccessStore(Protocol):
+    """Lookup boundary for server-authoritative active agent grants."""
+
+    async def list_active_grants(
+        self, workspace_id: str, agent_id: str, principal_user_id: str
+    ) -> list[AgentAccessGrantLike]:
+        """Return grants for exactly one principal and agent target."""
+
+
+class AuthorizationEvaluator:
+    """Evaluate agent-memory access without trusting transport request scope."""
+
+    def __init__(self, agent_access_store: AgentAccessStore) -> None:
+        self._agent_access_store = agent_access_store
+
+    async def authorize(self, request: AuthorizationRequest) -> AuthorizationDecision:
+        principal = request.principal
+        if principal is None:
+            return self._decision(False, "principal_required")
+        if (
+            request.workspace_id not in principal.workspace_ids
+            and "*" not in principal.workspace_ids
+        ):
+            return self._decision(False, "workspace_not_granted")
+        if request.resource_type is not ResourceType.MEMORY:
+            return self._decision(False, "unsupported_resource")
+        if not request.agent_id:
+            return self._decision(False, "agent_id_required")
+        if principal.role == "admin":
+            return self._decision(True, "admin_override")
+
+        try:
+            grants = await self._agent_access_store.list_active_grants(
+                request.workspace_id, request.agent_id, principal.user_id
+            )
+        except Exception:  # noqa: BLE001 - authorization must fail closed
+            return self._decision(False, "grant_lookup_failed")
+
+        requested_grant = self._required_agent_capability(request.capability)
+        if requested_grant is None:
+            return self._decision(False, "capability_not_supported")
+        allowed_grants = [
+            grant for grant in grants if self._covers(grant.capability, requested_grant)
+        ]
+        if not allowed_grants:
+            return self._decision(
+                False, "no_active_grant" if not grants else "capability_not_granted"
+            )
+        if any(grant.grant_type == "owner" for grant in allowed_grants):
+            return self._decision(True, "owner_grant")
+        return self._decision(True, "delegated_grant")
+
+    @staticmethod
+    def _required_agent_capability(capability: Capability) -> Capability | None:
+        if capability is Capability.DELETE:
+            return Capability.WRITE
+        if capability is Capability.ADMINISTER:
+            return Capability.ADMINISTER
+        if capability in (Capability.READ, Capability.WRITE):
+            return capability
+        return None
+
+    @staticmethod
+    def _covers(granted: str, requested: Capability) -> bool:
+        levels = {Capability.READ: 1, Capability.WRITE: 2, Capability.ADMINISTER: 3}
+        try:
+            normalized_granted = (
+                Capability.ADMINISTER if granted == "admin" else Capability(granted)
+            )
+            return levels[normalized_granted] >= levels[requested]
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _decision(allowed: bool, reason: str) -> AuthorizationDecision:
+        return AuthorizationDecision(decision_id=uuid4().hex, allowed=allowed, reason=reason)

--- a/src/metronix/channels/discord.py
+++ b/src/metronix/channels/discord.py
@@ -14,6 +14,7 @@ import discord
 import structlog
 
 from metronix.agent.router import AgentRouter
+from metronix.auth.policy import PolicyPrincipal
 
 logger = structlog.get_logger()
 
@@ -97,6 +98,7 @@ class DiscordChannel:
             text_len=len(text),
         )
 
+        principal: PolicyPrincipal | None = None
         if self._mapper:
             display_name = message.author.display_name or message.author.name
             user = await self._mapper.map_platform_user(
@@ -108,6 +110,7 @@ class DiscordChannel:
             )
             if user:
                 user_id = user.id
+                principal = PolicyPrincipal.from_user(user)
 
         async with message.channel.typing():
             try:
@@ -117,6 +120,7 @@ class DiscordChannel:
                     user_id=user_id,
                     workspace_id=self._workspace_id,
                     agent_id=self._agent_id,
+                    principal=principal,
                 )
             except Exception as e:
                 logger.error("discord.route.error", error=str(e), exc_info=True)

--- a/src/metronix/channels/discord.py
+++ b/src/metronix/channels/discord.py
@@ -35,12 +35,14 @@ class DiscordChannel:
         workspace_id: str | None = None,
         mapper: Any | None = None,
         event_bus: Any | None = None,
+        agent_id: str | None = None,
     ) -> None:
         self._token = bot_token
         self._router = router
         self._workspace_id = workspace_id or router._settings.default_workspace_id
         self._mapper = mapper
         self._event_bus = event_bus
+        self._agent_id = agent_id
 
         intents = discord.Intents.default()
         intents.message_content = True
@@ -114,6 +116,7 @@ class DiscordChannel:
                     text=text,
                     user_id=user_id,
                     workspace_id=self._workspace_id,
+                    agent_id=self._agent_id,
                 )
             except Exception as e:
                 logger.error("discord.route.error", error=str(e), exc_info=True)

--- a/src/metronix/channels/manager.py
+++ b/src/metronix/channels/manager.py
@@ -377,6 +377,7 @@ def _create_channel(
             workspace_id=workspace_id,
             mapper=mapper,
             event_bus=event_bus,
+            agent_id=config.get("agent_id"),
             store_direct_messages=config.get("store_direct_messages") is True,
         )
 
@@ -393,6 +394,7 @@ def _create_channel(
             workspace_id=workspace_id,
             mapper=mapper,
             event_bus=event_bus,
+            agent_id=config.get("agent_id"),
         )
 
     if connector_type == "slack":
@@ -410,6 +412,7 @@ def _create_channel(
             workspace_id=workspace_id,
             mapper=mapper,
             event_bus=event_bus,
+            agent_id=config.get("agent_id"),
         )
 
     msg = f"Unknown channel type: {connector_type}"

--- a/src/metronix/channels/slack.py
+++ b/src/metronix/channels/slack.py
@@ -17,6 +17,7 @@ from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.async_app import AsyncApp
 
 from metronix.agent.router import AgentRouter
+from metronix.auth.policy import PolicyPrincipal
 
 logger = structlog.get_logger()
 
@@ -115,6 +116,7 @@ class SlackChannel:
             text_len=len(text),
         )
 
+        principal: PolicyPrincipal | None = None
         if self._mapper:
             user = await self._mapper.map_platform_user(
                 channel="slack",
@@ -125,6 +127,7 @@ class SlackChannel:
             )
             if user:
                 user_id = user.id
+                principal = PolicyPrincipal.from_user(user)
 
         try:
             answer = await asyncio.to_thread(
@@ -133,6 +136,7 @@ class SlackChannel:
                 user_id=user_id,
                 workspace_id=self._workspace_id,
                 agent_id=self._agent_id,
+                principal=principal,
             )
         except Exception as e:
             logger.error("slack.route.error", error=str(e), exc_info=True)

--- a/src/metronix/channels/slack.py
+++ b/src/metronix/channels/slack.py
@@ -39,6 +39,7 @@ class SlackChannel:
         workspace_id: str | None = None,
         mapper: Any | None = None,
         event_bus: Any | None = None,
+        agent_id: str | None = None,
     ) -> None:
         self._bot_token = bot_token
         self._app_token = app_token
@@ -46,6 +47,7 @@ class SlackChannel:
         self._workspace_id = workspace_id or router._settings.default_workspace_id
         self._mapper = mapper
         self._event_bus = event_bus
+        self._agent_id = agent_id
 
         self._app = AsyncApp(token=bot_token)
         self._handler: AsyncSocketModeHandler | None = None
@@ -130,6 +132,7 @@ class SlackChannel:
                 text=text,
                 user_id=user_id,
                 workspace_id=self._workspace_id,
+                agent_id=self._agent_id,
             )
         except Exception as e:
             logger.error("slack.route.error", error=str(e), exc_info=True)

--- a/src/metronix/channels/telegram.py
+++ b/src/metronix/channels/telegram.py
@@ -17,6 +17,7 @@ from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ChatAction, ParseMode
 
 from metronix.agent.router import AgentRouter
+from metronix.auth.policy import PolicyPrincipal
 
 logger = structlog.get_logger()
 
@@ -170,7 +171,6 @@ class TelegramChannel:
                 filename=filename,
                 user_id=user_id,
                 workspace_id=self._workspace_id,
-                agent_id=self._agent_id,
             )
         except Exception as e:
             logger.error("telegram.document.error", error=str(e), exc_info=True)
@@ -198,6 +198,7 @@ class TelegramChannel:
         await self._bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
 
         # Map platform user to internal user
+        principal: PolicyPrincipal | None = None
         if self._mapper:
             display_name = ""
             if message.from_user:
@@ -214,6 +215,7 @@ class TelegramChannel:
             )
             if user:
                 user_id = user.id
+                principal = PolicyPrincipal.from_user(user)
 
         # Route through AgentRouter (sync) in a thread pool
         try:
@@ -223,6 +225,7 @@ class TelegramChannel:
                 user_id=user_id,
                 workspace_id=self._workspace_id,
                 agent_id=self._agent_id,
+                principal=principal,
                 conversation_id=str(chat_id),
                 history_enabled=not (
                     _is_private_chat(message) and not self._store_direct_messages

--- a/src/metronix/channels/telegram.py
+++ b/src/metronix/channels/telegram.py
@@ -219,17 +219,20 @@ class TelegramChannel:
 
         # Route through AgentRouter (sync) in a thread pool
         try:
-            answer = await asyncio.to_thread(
-                self._router.route,
-                text=text,
-                user_id=user_id,
-                workspace_id=self._workspace_id,
-                agent_id=self._agent_id,
-                principal=principal,
-                conversation_id=str(chat_id),
-                history_enabled=not (
+            route_kwargs = {
+                "text": text,
+                "user_id": user_id,
+                "workspace_id": self._workspace_id,
+                "agent_id": self._agent_id,
+                "principal": principal,
+                "conversation_id": str(chat_id),
+                "history_enabled": not (
                     _is_private_chat(message) and not self._store_direct_messages
                 ),
+            }
+            answer = await asyncio.to_thread(
+                self._router.route,
+                **{key: value for key, value in route_kwargs.items() if value is not None},
             )
         except Exception as e:
             logger.error("telegram.route.error", error=str(e), exc_info=True)

--- a/src/metronix/channels/telegram.py
+++ b/src/metronix/channels/telegram.py
@@ -43,6 +43,7 @@ class TelegramChannel:
         workspace_id: str | None = None,
         mapper: Any | None = None,
         event_bus: Any | None = None,
+        agent_id: str | None = None,
         store_direct_messages: bool = False,
     ) -> None:
         self._token = bot_token
@@ -50,6 +51,7 @@ class TelegramChannel:
         self._workspace_id = workspace_id or router._settings.default_workspace_id
         self._mapper = mapper
         self._event_bus = event_bus
+        self._agent_id = agent_id
         self._store_direct_messages = store_direct_messages
         self._bot = Bot(
             token=bot_token,
@@ -168,6 +170,7 @@ class TelegramChannel:
                 filename=filename,
                 user_id=user_id,
                 workspace_id=self._workspace_id,
+                agent_id=self._agent_id,
             )
         except Exception as e:
             logger.error("telegram.document.error", error=str(e), exc_info=True)
@@ -219,6 +222,7 @@ class TelegramChannel:
                 text=text,
                 user_id=user_id,
                 workspace_id=self._workspace_id,
+                agent_id=self._agent_id,
                 conversation_id=str(chat_id),
                 history_enabled=not (
                     _is_private_chat(message) and not self._store_direct_messages

--- a/src/metronix/connectors/schemas.py
+++ b/src/metronix/connectors/schemas.py
@@ -179,6 +179,7 @@ CONNECTOR_SCHEMAS: dict[str, ConnectorSchema] = {
                 type="secret",
                 placeholder="123456:ABC-DEF...",
             ),
+            _F(name="agent_id", label="Authorized Agent ID", type="string"),
             _F(
                 name="store_direct_messages",
                 label="Store direct-message context",
@@ -193,6 +194,7 @@ CONNECTOR_SCHEMAS: dict[str, ConnectorSchema] = {
         category="channel",
         fields=[
             _F(name="bot_token", label="Bot Token", type="secret"),
+            _F(name="agent_id", label="Authorized Agent ID", type="string"),
         ],
     ),
     "slack": ConnectorSchema(
@@ -210,6 +212,7 @@ CONNECTOR_SCHEMAS: dict[str, ConnectorSchema] = {
                 label="App Token (xapp-...)",
                 type="secret",
             ),
+            _F(name="agent_id", label="Authorized Agent ID", type="string"),
             _F(
                 name="signing_secret",
                 label="Signing Secret",

--- a/src/metronix/mcp/action_executor.py
+++ b/src/metronix/mcp/action_executor.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import structlog
 
+from metronix.auth.agent_access import get_authorization_evaluator
+from metronix.auth.policy import AuthorizationRequest, Capability, ResourceType, Transport
 from metronix.mcp.action_store import PendingAction
 from metronix.mcp.client import MCPClient
 from metronix.mcp.registry import MCPServerRegistry
@@ -60,6 +62,22 @@ class ActionExecutor:
         Returns:
             Dict with "success" bool and "result" or "error" string.
         """
+        if action.principal is None or not action.workspace_id or not action.agent_id:
+            return {"success": False, "error": "Action is no longer authorized."}
+
+        decision = await get_authorization_evaluator().authorize(
+            AuthorizationRequest(
+                principal=action.principal,
+                workspace_id=action.workspace_id,
+                agent_id=action.agent_id,
+                resource_type=ResourceType.ACTION,
+                capability=Capability.EXECUTE,
+                transport=Transport.ACTION,
+            )
+        )
+        if not decision.allowed:
+            return {"success": False, "error": "Action is no longer authorized."}
+
         config = self._registry.get(action.server_name)
         if not config:
             return {

--- a/src/metronix/mcp/action_store.py
+++ b/src/metronix/mcp/action_store.py
@@ -11,6 +11,8 @@ import uuid
 
 import structlog
 
+from metronix.auth.policy import PolicyPrincipal
+
 logger = structlog.get_logger()
 
 
@@ -37,6 +39,10 @@ class PendingAction:
         arguments: dict,
         description: str,
         preview: str,
+        *,
+        principal: PolicyPrincipal | None = None,
+        workspace_id: str | None = None,
+        agent_id: str | None = None,
         ttl_seconds: int = 300,
     ) -> None:
         self.action_id: str = uuid.uuid4().hex[:12]
@@ -46,6 +52,9 @@ class PendingAction:
         self.arguments = arguments
         self.description = description
         self.preview = preview
+        self.principal = principal
+        self.workspace_id = workspace_id
+        self.agent_id = agent_id
         self.created_at: float = time.time()
         self.ttl_seconds = ttl_seconds
 

--- a/src/metronix/mcp/tools/_agent_access.py
+++ b/src/metronix/mcp/tools/_agent_access.py
@@ -9,10 +9,9 @@ import structlog
 from metronix.auth.agent_access import (
     AgentAccessDecision,
     AgentCapability,
-    PostgresAgentAccessStore,
+    get_authorization_evaluator,
 )
 from metronix.auth.policy import (
-    AuthorizationEvaluator,
     AuthorizationRequest,
     Capability,
     PolicyPrincipal,
@@ -23,17 +22,6 @@ from metronix.mcp.principal import get_current_principal
 from metronix.storage.activity_pg import ActivityRow, ActivityStore
 
 logger = structlog.get_logger(__name__)
-
-
-@lru_cache(maxsize=1)
-def get_authorization_evaluator() -> AuthorizationEvaluator:
-    """Return the shared authorization evaluator for MCP tool dispatch."""
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from metronix.core.config import get_settings
-
-    engine = create_async_engine(get_settings().postgres_dsn)
-    return AuthorizationEvaluator(PostgresAgentAccessStore(engine))
 
 
 @lru_cache(maxsize=1)

--- a/src/metronix/mcp/tools/_agent_access.py
+++ b/src/metronix/mcp/tools/_agent_access.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from uuid import uuid4
 
 import structlog
 
 from metronix.auth.agent_access import (
-    AgentAccessAuthorizer,
     AgentAccessDecision,
     AgentCapability,
     PostgresAgentAccessStore,
+)
+from metronix.auth.policy import (
+    AuthorizationEvaluator,
+    AuthorizationRequest,
+    Capability,
+    PolicyPrincipal,
+    ResourceType,
+    Transport,
 )
 from metronix.mcp.principal import get_current_principal
 from metronix.storage.activity_pg import ActivityRow, ActivityStore
@@ -20,14 +26,14 @@ logger = structlog.get_logger(__name__)
 
 
 @lru_cache(maxsize=1)
-def get_agent_access_authorizer() -> AgentAccessAuthorizer:
-    """Return the configured grant authorizer for MCP tool dispatch."""
+def get_authorization_evaluator() -> AuthorizationEvaluator:
+    """Return the shared authorization evaluator for MCP tool dispatch."""
     from sqlalchemy.ext.asyncio import create_async_engine
 
     from metronix.core.config import get_settings
 
     engine = create_async_engine(get_settings().postgres_dsn)
-    return AgentAccessAuthorizer(PostgresAgentAccessStore(engine))
+    return AuthorizationEvaluator(PostgresAgentAccessStore(engine))
 
 
 @lru_cache(maxsize=1)
@@ -57,6 +63,7 @@ async def _record_decision(
             event_data={
                 "principal_id": principal_id,
                 "capability": str(capability),
+                "transport": Transport.MCP,
                 "decision_id": decision.decision_id,
                 "policy_version": decision.policy_version,
                 "outcome": decision.allowed,
@@ -80,7 +87,7 @@ async def require_agent_access(
     """Require an authenticated principal before an agent-memory operation."""
     principal = get_current_principal()
     if principal is None:
-        decision = AgentAccessDecision(uuid4().hex, False, "principal_required")
+        decision = AgentAccessDecision("missing-principal", False, "principal_required")
         await _best_effort_denial_audit(
             principal_id=None,
             workspace_id=workspace_id,
@@ -90,8 +97,16 @@ async def require_agent_access(
         )
         raise PermissionError("unauthorized agent memory access")
 
-    decision = await get_agent_access_authorizer().authorize(
-        principal, workspace_id, agent_id, AgentCapability(capability)
+    requested_capability = Capability(capability)
+    decision = await get_authorization_evaluator().authorize(
+        AuthorizationRequest(
+            principal=PolicyPrincipal.from_mcp(principal),
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            resource_type=ResourceType.MEMORY,
+            capability=requested_capability,
+            transport=Transport.MCP,
+        )
     )
     if not decision.allowed:
         await _best_effort_denial_audit(

--- a/src/metronix/memory/service.py
+++ b/src/metronix/memory/service.py
@@ -259,10 +259,13 @@ class MemoryService:
         self,
         workspace_id: str,
         session_id: str,
+        *,
+        agent_id: str,
     ) -> list[MemoryRecord]:
-        """List all records for a session."""
+        """List session records belonging to one authorized agent."""
         self._check_workspace(workspace_id)
-        return await self._redis.list(workspace_id, session_id)
+        records = await self._redis.list(workspace_id, session_id)
+        return [record for record in records if record.agent_id == agent_id]
 
     async def invalidate_session(
         self,
@@ -532,6 +535,8 @@ class MemoryService:
     async def get_facets(
         self,
         workspace_id: str,
+        *,
+        agent_id: str,
     ) -> tuple[list[MemoryKind], list[str]]:
         """Return the distinct kind/source_type values present in the workspace.
 
@@ -540,7 +545,7 @@ class MemoryService:
         enum or values scoped to an already-applied filter.
         """
         self._check_workspace(workspace_id)
-        return await self._pg.get_facets(workspace_id)
+        return await self._pg.get_facets(workspace_id, agent_id=agent_id)
 
     async def list_preferences(
         self,

--- a/src/metronix/memory/service.py
+++ b/src/metronix/memory/service.py
@@ -718,6 +718,7 @@ class MemoryService:
         seed_record_id: str,
         *,
         depth: int = 1,
+        agent_id: str | None = None,
     ) -> tuple[list[MemoryRecord], list[dict[str, Any]]]:
         """Return the (depth)-hop neighbourhood around a memory record.
 
@@ -759,6 +760,7 @@ class MemoryService:
                 workspace_id,
                 seed_record_id,
                 depth,
+                agent_id=agent_id,
             )
             record_ids = result["record_ids"]
             edges = result["edges"]
@@ -783,7 +785,8 @@ class MemoryService:
         # Hydrate from PG — drops ids not in this workspace (cross-ws defence).
         records: list[MemoryRecord] = []
         for rid in unique_ids:
-            rec = await self._pg.get(workspace_id, rid)
+            agent_filter = {"agent_id": agent_id} if agent_id is not None else {}
+            rec = await self._pg.get(workspace_id, rid, **agent_filter)
             if rec is not None:
                 records.append(rec)
 

--- a/src/metronix/memory/service.py
+++ b/src/metronix/memory/service.py
@@ -391,10 +391,12 @@ class MemoryService:
         self,
         workspace_id: str,
         record_id: str,
+        *,
+        agent_id: str | None = None,
     ) -> MemoryRecord | None:
         """Fetch a persistent record from PG (source of truth)."""
         self._check_workspace(workspace_id)
-        return await self._pg.get(workspace_id, record_id)
+        return await self._pg.get(workspace_id, record_id, agent_id=agent_id)
 
     async def delete(
         self,
@@ -441,6 +443,8 @@ class MemoryService:
         self,
         workspace_id: str,
         record_ids: list[str],
+        *,
+        agent_id: str | None = None,
     ) -> tuple[list[str], list[str]]:
         """Delete multiple records from all stores.
 
@@ -452,7 +456,7 @@ class MemoryService:
         deleted: list[str] = []
         not_found: list[str] = []
         for record_id in record_ids:
-            if await self.delete(workspace_id, record_id):
+            if await self.delete(workspace_id, record_id, agent_id=agent_id):
                 deleted.append(record_id)
             else:
                 not_found.append(record_id)

--- a/src/metronix/storage/memory_graph.py
+++ b/src/metronix/storage/memory_graph.py
@@ -426,6 +426,8 @@ def get_memory_neighborhood(
     workspace_id: str,
     seed_record_id: str,
     depth: int,
+    *,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     """Return the ``depth``-hop neighbourhood around a memory record.
 
@@ -472,7 +474,7 @@ def get_memory_neighborhood(
         "MATCH (seed:MemoryRecord {id: $seed, workspace_id: $ws}) "
         f"MATCH (seed)-[r:LINKED_TO*1..{bounded_depth}]-"
         "(other:MemoryRecord {workspace_id: $ws}) "
-        "WHERE other.id <> seed.id "
+        "WHERE other.id <> seed.id AND ($agent_id IS NULL OR other.agent_id = $agent_id) "
         "WITH seed, other, last(r) AS rel "
         "RETURN seed.id AS source, other.id AS target, "
         "properties(rel) AS rprops"
@@ -480,7 +482,7 @@ def get_memory_neighborhood(
     with driver.session() as session:
         linked_result = session.run(
             linked_query,
-            {"seed": seed_record_id, "ws": workspace_id},
+            {"seed": seed_record_id, "ws": workspace_id, "agent_id": agent_id},
         )
 
         # 2. Find bridge-mediated connections (Agent, Entity, Session, Document).
@@ -491,14 +493,14 @@ def get_memory_neighborhood(
             WHERE type(r1) IN ["REMEMBERS", "ABOUT", "FROM_SESSION", "DERIVED_FROM"]
               AND NOT "MemoryRecord" IN labels(bridge)
             MATCH (bridge)-[r2]-(other:MemoryRecord {workspace_id: $ws})
-            WHERE other.id <> seed.id
+            WHERE other.id <> seed.id AND ($agent_id IS NULL OR other.agent_id = $agent_id)
             RETURN seed.id          AS source,
                    other.id         AS target,
                    type(r1)         AS rtype,
                    labels(bridge)[0] AS via_label,
                    coalesce(bridge.id, bridge.name, bridge.doc_id) AS via_id
             """,
-            {"seed": seed_record_id, "ws": workspace_id},
+            {"seed": seed_record_id, "ws": workspace_id, "agent_id": agent_id},
         )
 
     record_ids: list[str] = [seed_record_id]

--- a/src/metronix/storage/memory_postgres.py
+++ b/src/metronix/storage/memory_postgres.py
@@ -392,6 +392,8 @@ class MemoryPostgresStore:
     async def get_facets(
         self,
         workspace_id: str,
+        *,
+        agent_id: str,
     ) -> tuple[list[MemoryKind], list[str]]:
         """Return the distinct ``kind`` and ``source_type`` values in use.
 
@@ -405,10 +407,10 @@ class MemoryPostgresStore:
             kind_result = await conn.execute(
                 text("""
                     SELECT DISTINCT kind FROM memory_records
-                    WHERE workspace_id = :ws
+                    WHERE workspace_id = :ws AND agent_id = :agent_id
                     ORDER BY kind
                 """),
-                {"ws": workspace_id},
+                {"ws": workspace_id, "agent_id": agent_id},
             )
             kinds: list[MemoryKind] = []
             for raw in kind_result.scalars().all():
@@ -420,10 +422,10 @@ class MemoryPostgresStore:
             source_type_result = await conn.execute(
                 text("""
                     SELECT DISTINCT source_type FROM memory_records
-                    WHERE workspace_id = :ws AND source_type != ''
+                    WHERE workspace_id = :ws AND agent_id = :agent_id AND source_type != ''
                     ORDER BY source_type
                 """),
-                {"ws": workspace_id},
+                {"ws": workspace_id, "agent_id": agent_id},
             )
             source_types = list(source_type_result.scalars().all())
 

--- a/src/metronix/storage/migrate_env_connections.py
+++ b/src/metronix/storage/migrate_env_connections.py
@@ -38,11 +38,14 @@ _ENV_MAPPINGS: dict[str, tuple[str, str]] = {
     "NOTION_API_TOKEN": ("notion", "api_token"),
     # Telegram
     "TELEGRAM_BOT_TOKEN": ("telegram", "bot_token"),
+    "TELEGRAM_AGENT_ID": ("telegram", "agent_id"),
     # Discord
     "DISCORD_BOT_TOKEN": ("discord", "bot_token"),
+    "DISCORD_AGENT_ID": ("discord", "agent_id"),
     # Slack
     "SLACK_BOT_TOKEN": ("slack", "bot_token"),
     "SLACK_APP_TOKEN": ("slack", "app_token"),
+    "SLACK_AGENT_ID": ("slack", "agent_id"),
     "SLACK_SIGNING_SECRET": ("slack", "signing_secret"),
 }
 

--- a/tests/unit/api/test_memory_authorization.py
+++ b/tests/unit/api/test_memory_authorization.py
@@ -1,0 +1,40 @@
+"""REST memory authorization adapter coverage."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from metronix.core.models import Role, User
+
+
+@pytest.mark.asyncio
+async def test_rest_adapter_denies_before_memory_service_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from metronix.api.routes import memory
+    from metronix.auth.policy import AuthorizationDecision
+
+    class DenyingEvaluator:
+        request = None
+
+        async def authorize(self, request):
+            self.request = request
+            return AuthorizationDecision("decision-1", False, "no_active_grant")
+
+    evaluator = DenyingEvaluator()
+    monkeypatch.setattr(memory, "get_authorization_evaluator", lambda: evaluator)
+    user = User(id="user-1", role=Role.EDITOR, workspace_ids=["workspace-1"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await memory.require_memory_access(user, "workspace-1", "agent-1", "read")
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == {
+        "code": "memory_access_denied",
+        "reason": "no_active_grant",
+        "decision_id": "decision-1",
+    }
+    assert evaluator.request.workspace_id == "workspace-1"
+    assert evaluator.request.agent_id == "agent-1"
+    assert evaluator.request.transport == "rest"

--- a/tests/unit/api/test_memory_routes.py
+++ b/tests/unit/api/test_memory_routes.py
@@ -79,10 +79,23 @@ def service() -> AsyncMock:
     return mock
 
 
+@pytest.fixture(autouse=True)
+def _mock_route_services(monkeypatch: pytest.MonkeyPatch, service: AsyncMock) -> None:
+    """Isolate route behavior from the structural authorization backend."""
+    from metronix.auth.policy import AuthorizationDecision
+
+    async def allow_memory_access(*args: Any, **kwargs: Any) -> AuthorizationDecision:
+        return AuthorizationDecision("test-decision", True, "test_allow")
+
+    monkeypatch.setattr("metronix.api.routes.memory.require_memory_access", allow_memory_access)
+    monkeypatch.setattr("metronix.api.routes.memory.get_memory_service", lambda request: service)
+
+
 @pytest.fixture
 def make_client(
     settings: Settings,
     service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> Callable[..., TestClient]:
     """Factory producing a minimal app TestClient with configurable user role.
 
@@ -103,9 +116,30 @@ def make_client(
             request.state.user = {"workspace_ids": ["ws-test"]}
             return await call_next(request)
 
-        return TestClient(app, raise_server_exceptions=False)
+        return _AgentScopedTestClient(app, raise_server_exceptions=False)
 
     return _factory
+
+
+class _AgentScopedTestClient(TestClient):
+    """Give legacy route tests the explicit agent scope required by the API."""
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        if str(url).startswith("/api/v1/memory"):
+            params = kwargs.get("params")
+            if params is None:
+                kwargs["params"] = {"agent_id": "agent-1"}
+            elif isinstance(params, dict) and "agent_id" not in params:
+                kwargs["params"] = {**params, "agent_id": "agent-1"}
+            elif not isinstance(params, dict) and not any(key == "agent_id" for key, _ in params):
+                kwargs["params"] = [*params, ("agent_id", "agent-1")]
+
+            if str(url).endswith(("/search", "/batch-delete")):
+                body = kwargs.get("json")
+                if isinstance(body, dict) and "agent_id" not in body:
+                    kwargs["json"] = {**body, "agent_id": "agent-1"}
+
+        return super().request(method, url, **kwargs)
 
 
 @pytest.fixture
@@ -329,7 +363,7 @@ class TestListRecords:
         body = response.json()
         assert body["count"] == 1
         assert body["total"] == 1
-        service.list_session.assert_awaited_once_with("ws-test", "sess-1")
+        service.list_session.assert_awaited_once_with("ws-test", "sess-1", agent_id="ignored")
         service.list_records.assert_not_awaited()
 
     def test_list_pagination_has_more(
@@ -417,19 +451,20 @@ class TestGetFacets:
             ["confluence", "jira"],
         )
 
-        response = client.get("/api/v1/memory/facets")
+        response = client.get("/api/v1/memory/facets", params={"agent_id": "agent-1"})
 
         assert response.status_code == 200
         body = response.json()
         assert body["kinds"] == ["fact", "pinned"]
         assert body["source_types"] == ["confluence", "jira"]
+        service.get_facets.assert_awaited_once_with("ws-test", agent_id="agent-1")
 
     def test_empty_workspace_returns_empty_lists(
         self, client: TestClient, service: AsyncMock
     ) -> None:
         service.get_facets.return_value = ([], [])
 
-        response = client.get("/api/v1/memory/facets")
+        response = client.get("/api/v1/memory/facets", params={"agent_id": "agent-1"})
 
         assert response.status_code == 200
         body = response.json()
@@ -442,7 +477,7 @@ class TestGetFacets:
         service.get_facets.return_value = ([], [])
         viewer_client = make_client(Role.VIEWER)
 
-        response = viewer_client.get("/api/v1/memory/facets")
+        response = viewer_client.get("/api/v1/memory/facets", params={"agent_id": "agent-1"})
 
         assert response.status_code == 200
 
@@ -455,7 +490,7 @@ class TestGetFacets:
         surface as a clean 503 instead of an unhandled 500."""
         service.get_facets.side_effect = ConnectionRefusedError("connection refused")
 
-        response = client.get("/api/v1/memory/facets")
+        response = client.get("/api/v1/memory/facets", params={"agent_id": "agent-1"})
 
         assert response.status_code == 503
         assert "unavailable" in response.json()["detail"].lower()
@@ -1223,7 +1258,7 @@ class TestWorkspaceQueryScoping:
 
         resp = client.post(
             "/api/v1/memory/search?workspace_id=ws-x",
-            json={"query": "hello"},
+            json={"query": "hello", "agent_id": "agent-1"},
         )
 
         assert resp.status_code == 200
@@ -1233,7 +1268,7 @@ class TestWorkspaceQueryScoping:
     def test_list_forbidden_for_non_member(self, service: AsyncMock, settings: Settings) -> None:
         client = self._client(workspace_ids=["ws-a"], service=service, settings=settings)
 
-        resp = client.get("/api/v1/memory/records?workspace_id=ws-x")
+        resp = client.get("/api/v1/memory/records?workspace_id=ws-x&agent_id=agent-1")
 
         assert resp.status_code == 403
         service.list_records.assert_not_awaited()
@@ -1244,7 +1279,7 @@ class TestWorkspaceQueryScoping:
         service.list_records.return_value = []
         client = self._client(workspace_ids=["ws-a"], service=service, settings=settings)
 
-        resp = client.get("/api/v1/memory/records")
+        resp = client.get("/api/v1/memory/records?agent_id=agent-1")
 
         assert resp.status_code == 200
         assert service.list_records.await_args.args[0] == "ws-a"

--- a/tests/unit/auth/test_agent_access.py
+++ b/tests/unit/auth/test_agent_access.py
@@ -48,6 +48,7 @@ async def test_owner_grant_allows_write() -> None:
 
     assert decision.allowed is True
     assert decision.reason == "owner_grant"
+    assert decision.policy_version == "authz-v1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auth/test_policy.py
+++ b/tests/unit/auth/test_policy.py
@@ -1,0 +1,100 @@
+"""Unit coverage for the transport-neutral authorization policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+
+@dataclass(frozen=True)
+class _Grant:
+    capability: str
+    grant_type: str = "delegate"
+
+
+class _Store:
+    def __init__(self, grants: list[_Grant]) -> None:
+        self.grants = grants
+        self.calls = 0
+
+    async def list_active_grants(
+        self, workspace_id: str, agent_id: str, principal_user_id: str
+    ) -> list[_Grant]:
+        self.calls += 1
+        return self.grants
+
+
+class _RaisingStore:
+    async def list_active_grants(
+        self, workspace_id: str, agent_id: str, principal_user_id: str
+    ) -> list[_Grant]:
+        raise RuntimeError("database unavailable")
+
+
+def _request(capability: object):
+    from metronix.auth.policy import (
+        AuthorizationRequest,
+        PolicyPrincipal,
+        ResourceType,
+        Transport,
+    )
+
+    return AuthorizationRequest(
+        principal=PolicyPrincipal("user-1", "editor", ("workspace-1",), "jwt"),
+        workspace_id="workspace-1",
+        agent_id="agent-1",
+        resource_type=ResourceType.MEMORY,
+        capability=capability,
+        transport=Transport.MCP,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delegate_with_read_grant_cannot_write() -> None:
+    from metronix.auth.policy import AuthorizationEvaluator, Capability
+
+    decision = await AuthorizationEvaluator(_Store([_Grant("read")])).authorize(
+        _request(Capability.WRITE)
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "capability_not_granted"
+
+
+@pytest.mark.asyncio
+async def test_grant_lookup_failure_denies() -> None:
+    from metronix.auth.policy import AuthorizationEvaluator, Capability
+
+    decision = await AuthorizationEvaluator(_RaisingStore()).authorize(_request(Capability.READ))
+
+    assert decision.allowed is False
+    assert decision.reason == "grant_lookup_failed"
+
+
+@pytest.mark.asyncio
+async def test_ungranted_workspace_denies_without_lookup() -> None:
+    from metronix.auth.policy import (
+        AuthorizationEvaluator,
+        AuthorizationRequest,
+        Capability,
+        PolicyPrincipal,
+        ResourceType,
+        Transport,
+    )
+
+    store = _Store([])
+    decision = await AuthorizationEvaluator(store).authorize(
+        AuthorizationRequest(
+            principal=PolicyPrincipal("user-1", "editor", ("workspace-1",), "jwt"),
+            workspace_id="workspace-2",
+            agent_id="agent-1",
+            resource_type=ResourceType.MEMORY,
+            capability=Capability.READ,
+            transport=Transport.REST,
+        )
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "workspace_not_granted"
+    assert store.calls == 0

--- a/tests/unit/auth/test_policy.py
+++ b/tests/unit/auth/test_policy.py
@@ -98,3 +98,16 @@ async def test_ungranted_workspace_denies_without_lookup() -> None:
     assert decision.allowed is False
     assert decision.reason == "workspace_not_granted"
     assert store.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_action_execution_uses_the_target_agents_write_grant() -> None:
+    from metronix.auth.policy import AuthorizationEvaluator, Capability, ResourceType
+
+    request = _request(Capability.EXECUTE)
+    request = request.__class__(
+        **{**request.__dict__, "resource_type": ResourceType.ACTION, "transport": "action"}
+    )
+    decision = await AuthorizationEvaluator(_Store([_Grant("write")])).authorize(request)
+
+    assert decision.allowed is True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -30,19 +30,19 @@ def allow_authenticated_agent_memory_tools(
         return
 
     from metronix.activity.context import bind_agent_id, current_agent_id
-    from metronix.auth.agent_access import AgentAccessDecision
+    from metronix.auth.policy import AuthorizationDecision
     from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
     from metronix.mcp.tools import _agent_access
 
-    class AllowingAuthorizer:
-        async def authorize(self, *args: object) -> AgentAccessDecision:
-            return AgentAccessDecision("test-decision", True, "owner_grant")
+    class AllowingEvaluator:
+        async def authorize(self, *args: object) -> AuthorizationDecision:
+            return AuthorizationDecision("test-decision", True, "owner_grant")
 
     class AuditStore:
         async def insert(self, row: object) -> None:
             return None
 
-    monkeypatch.setattr(_agent_access, "get_agent_access_authorizer", lambda: AllowingAuthorizer())
+    monkeypatch.setattr(_agent_access, "get_authorization_evaluator", lambda: AllowingEvaluator())
     monkeypatch.setattr(_agent_access, "get_agent_access_audit_store", lambda: AuditStore())
     token = bind_principal(MCPPrincipal("u1", "editor", ("*",)))
     agent_token = bind_agent_id("agent-a")

--- a/tests/unit/mcp/tools/test_agent_access_guard.py
+++ b/tests/unit/mcp/tools/test_agent_access_guard.py
@@ -16,19 +16,47 @@ async def test_missing_principal_is_denied_before_authorizer_store_access():
 
 
 @pytest.mark.asyncio
+async def test_guard_builds_mcp_memory_request_for_shared_evaluator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from metronix.auth.policy import AuthorizationDecision, ResourceType, Transport
+    from metronix.mcp.tools import _agent_access
+
+    class DenyingEvaluator:
+        request = None
+
+        async def authorize(self, request):
+            self.request = request
+            return AuthorizationDecision("decision", False, "no_active_grant")
+
+    evaluator = DenyingEvaluator()
+    monkeypatch.setattr(_agent_access, "get_authorization_evaluator", lambda: evaluator)
+    token = bind_principal(MCPPrincipal("u1", "editor", ("ws-a",)))
+    try:
+        with pytest.raises(PermissionError, match="unauthorized agent memory access"):
+            await _agent_access.require_agent_access("ws-a", "agent-a", "read")
+    finally:
+        reset_principal(token)
+
+    assert evaluator.request.resource_type is ResourceType.MEMORY
+    assert evaluator.request.transport is Transport.MCP
+    assert evaluator.request.agent_id == "agent-a"
+
+
+@pytest.mark.asyncio
 async def test_denied_update_does_not_query_memory_service(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from metronix.auth.agent_access import AgentAccessDecision
+    from metronix.auth.policy import AuthorizationDecision
     from metronix.mcp.tools import _agent_access
     from metronix.mcp.tools.memory_update import metronix_memory_update
 
-    class DenyingAuthorizer:
-        async def authorize(self, *args: object) -> AgentAccessDecision:
-            return AgentAccessDecision("decision", False, "no_active_grant")
+    class DenyingEvaluator:
+        async def authorize(self, *args: object) -> AuthorizationDecision:
+            return AuthorizationDecision("decision", False, "no_active_grant")
 
     service = AsyncMock()
-    monkeypatch.setattr(_agent_access, "get_agent_access_authorizer", lambda: DenyingAuthorizer())
+    monkeypatch.setattr(_agent_access, "get_authorization_evaluator", lambda: DenyingEvaluator())
     token = bind_principal(MCPPrincipal("u1", "editor", ("ws-a",)))
     try:
         with patch(

--- a/tests/unit/memory/test_service_get_graph_neighborhood.py
+++ b/tests/unit/memory/test_service_get_graph_neighborhood.py
@@ -110,6 +110,19 @@ class TestGetGraphNeighborhoodService:
         # Edges are returned as-is (PG filtering applies to records, not edges)
         assert len(edges) == 2
 
+    async def test_scopes_graph_hydration_to_authorized_agent(self) -> None:
+        """The graph service never hydrates a record outside the target agent."""
+        service, pg_store, _ = _make_service("ws-1")
+        pg_store.get.return_value = _sample_record("seed-id")
+
+        with patch(
+            "metronix.memory.service.get_memory_neighborhood",
+            return_value={"record_ids": ["seed-id"], "edges": []},
+        ):
+            await service.get_graph_neighborhood("ws-1", "seed-id", agent_id="agent-1")
+
+        pg_store.get.assert_awaited_once_with("ws-1", "seed-id", agent_id="agent-1")
+
     async def test_seed_always_included_when_pg_has_it(self) -> None:
         """Seed must be first in the returned records list."""
         service, pg_store, _ = _make_service("ws-1")

--- a/tests/unit/storage/test_memory_postgres_facets.py
+++ b/tests/unit/storage/test_memory_postgres_facets.py
@@ -40,7 +40,7 @@ class TestGetFacets:
         conn.execute.side_effect = [kind_result, source_type_result]
         engine.begin.return_value = _FakeCtx(conn)
 
-        kinds, source_types = await store.get_facets("ws1")
+        kinds, source_types = await store.get_facets("ws1", agent_id="agent-1")
 
         assert kinds == [MemoryKind.FACT, MemoryKind.PINNED]
         assert source_types == ["confluence", "jira"]
@@ -53,11 +53,12 @@ class TestGetFacets:
         conn.execute.side_effect = [empty_result, empty_result]
         engine.begin.return_value = _FakeCtx(conn)
 
-        await store.get_facets("ws1")
+        await store.get_facets("ws1", agent_id="agent-1")
 
         for call in conn.execute.call_args_list:
             params = call.args[1]
             assert params["ws"] == "ws1"
+            assert params["agent_id"] == "agent-1"
 
     async def test_excludes_blank_source_type(self) -> None:
         store, engine = _make_store()
@@ -69,7 +70,7 @@ class TestGetFacets:
         conn.execute.side_effect = [kind_result, source_type_result]
         engine.begin.return_value = _FakeCtx(conn)
 
-        await store.get_facets("ws1")
+        await store.get_facets("ws1", agent_id="agent-1")
 
         source_type_sql = str(conn.execute.call_args_list[1].args[0])
         assert "source_type != ''" in source_type_sql
@@ -82,7 +83,7 @@ class TestGetFacets:
         conn.execute.side_effect = [empty_result, empty_result]
         engine.begin.return_value = _FakeCtx(conn)
 
-        kinds, source_types = await store.get_facets("ws1")
+        kinds, source_types = await store.get_facets("ws1", agent_id="agent-1")
 
         assert kinds == []
         assert source_types == []

--- a/tests/unit/test_connections_update.py
+++ b/tests/unit/test_connections_update.py
@@ -212,6 +212,16 @@ def test_telegram_schema_exposes_optional_direct_message_storage_setting() -> No
     assert field.required is False
 
 
+@pytest.mark.parametrize("connector_type", ["telegram", "discord", "slack"])
+def test_channel_schema_requires_agent_id_for_action_authorization(connector_type: str) -> None:
+    schema = get_schema(connector_type)
+
+    assert schema is not None
+    field = next(field for field in schema.fields if field.name == "agent_id")
+    assert field.type == "string"
+    assert field.required is True
+
+
 _EXISTING_TELEGRAM = {
     "id": "conn_tg_001",
     "workspace_id": "ws_test",
@@ -304,7 +314,10 @@ class TestUpdateConnectionChannelSync:
         store.get_connection = AsyncMock(return_value=_EXISTING_TELEGRAM)
         store.update_connection = AsyncMock(return_value=_updated_telegram_row())
         store.get_connection_decrypted = AsyncMock(
-            return_value=dict(_EXISTING_TELEGRAM, config={"bot_token": "rotated-token"}),
+            return_value=dict(
+                _EXISTING_TELEGRAM,
+                config={"bot_token": "rotated-token", "agent_id": "agent-support"},
+            ),
         )
         channel_manager = AsyncMock()
         app.state.channel_manager = channel_manager
@@ -313,14 +326,14 @@ class TestUpdateConnectionChannelSync:
         r = client.put(
             "/api/v1/connections/conn_tg_001/?workspace_id=ws_test",
             headers={"Authorization": f"Bearer {token}"},
-            json={"config": {"bot_token": "rotated-token"}},
+            json={"config": {"bot_token": "rotated-token", "agent_id": "agent-support"}},
         )
 
         assert r.status_code == 200, r.text
         channel_manager.restart_channel.assert_awaited_once_with(
             "conn_tg_001",
             "telegram",
-            {"bot_token": "rotated-token"},
+            {"bot_token": "rotated-token", "agent_id": "agent-support"},
             workspace_id="ws_test",
         )
 

--- a/tests/unit/test_mcp_actions.py
+++ b/tests/unit/test_mcp_actions.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from metronix.auth.policy import PolicyPrincipal
 from metronix.mcp.action_store import ActionStore, PendingAction
 
 # ---------------------------------------------------------------------------
@@ -284,7 +285,40 @@ class TestActionPlanner:
 class TestActionExecutor:
     """Tests for executing confirmed write actions."""
 
-    def test_execute_calls_mcp_client(self, tmp_path: Path) -> None:
+    @staticmethod
+    def _authorized_action(**overrides: object) -> PendingAction:
+        from metronix.auth.policy import PolicyPrincipal
+
+        values: dict[str, object] = {
+            "user_id": "u1",
+            "server_name": "test-srv",
+            "tool_name": "create_issue",
+            "arguments": {},
+            "description": "Create bug",
+            "preview": "",
+            "principal": PolicyPrincipal("u1", "editor", ("ws-1",), "channel"),
+            "workspace_id": "ws-1",
+            "agent_id": "agent-1",
+        }
+        values.update(overrides)
+        return PendingAction(**values)  # type: ignore[arg-type]
+
+    @staticmethod
+    def _allow_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+        from metronix.auth.policy import AuthorizationDecision
+
+        class AllowingEvaluator:
+            async def authorize(self, request: object) -> AuthorizationDecision:
+                return AuthorizationDecision("decision", True, "delegated_grant")
+
+        monkeypatch.setattr(
+            "metronix.mcp.action_executor.get_authorization_evaluator",
+            lambda: AllowingEvaluator(),
+        )
+
+    def test_execute_calls_mcp_client(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from metronix.mcp.action_executor import ActionExecutor
         from metronix.mcp.config import MCPServerConfig
         from metronix.mcp.registry import MCPServerRegistry
@@ -292,14 +326,8 @@ class TestActionExecutor:
         registry = MCPServerRegistry(str(tmp_path))
         registry.add(MCPServerConfig(name="test-srv", command="echo"))
 
-        action = PendingAction(
-            user_id="u1",
-            server_name="test-srv",
-            tool_name="create_issue",
-            arguments={"title": "Bug"},
-            description="Create bug",
-            preview="",
-        )
+        self._allow_authorization(monkeypatch)
+        action = self._authorized_action(arguments={"title": "Bug"})
 
         mock_blocks = [{"type": "text", "text": "Issue PROJ-123 created"}]
 
@@ -316,7 +344,9 @@ class TestActionExecutor:
         assert result["success"] is True
         assert "PROJ-123" in result["result"]
 
-    def test_execute_returns_error_on_failure(self, tmp_path: Path) -> None:
+    def test_execute_returns_error_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from metronix.mcp.action_executor import ActionExecutor
         from metronix.mcp.config import MCPServerConfig
         from metronix.mcp.registry import MCPServerRegistry
@@ -324,14 +354,8 @@ class TestActionExecutor:
         registry = MCPServerRegistry(str(tmp_path))
         registry.add(MCPServerConfig(name="test-srv", command="echo"))
 
-        action = PendingAction(
-            user_id="u1",
-            server_name="test-srv",
-            tool_name="create_issue",
-            arguments={},
-            description="Create bug",
-            preview="",
-        )
+        self._allow_authorization(monkeypatch)
+        action = self._authorized_action()
 
         with patch("metronix.mcp.action_executor.MCPClient") as MockClient:  # noqa: N806
             mock_instance = AsyncMock()
@@ -344,7 +368,9 @@ class TestActionExecutor:
         assert result["success"] is False
         assert "Action execution failed" in result["error"]
 
-    def test_execute_error_no_internal_details(self, tmp_path: Path) -> None:
+    def test_execute_error_no_internal_details(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from metronix.mcp.action_executor import ActionExecutor
         from metronix.mcp.config import MCPServerConfig
         from metronix.mcp.registry import MCPServerRegistry
@@ -352,14 +378,8 @@ class TestActionExecutor:
         registry = MCPServerRegistry(str(tmp_path))
         registry.add(MCPServerConfig(name="test-srv", command="echo"))
 
-        action = PendingAction(
-            user_id="u1",
-            server_name="test-srv",
-            tool_name="create_issue",
-            arguments={},
-            description="Create bug",
-            preview="",
-        )
+        self._allow_authorization(monkeypatch)
+        action = self._authorized_action()
 
         with patch("metronix.mcp.action_executor.MCPClient") as MockClient:  # noqa: N806
             mock_instance = AsyncMock()
@@ -376,25 +396,57 @@ class TestActionExecutor:
         assert "CERTIFICATE" not in result["error"]
         assert "Action execution failed" in result["error"]
 
-    def test_execute_returns_error_for_unknown_server(self, tmp_path: Path) -> None:
+    def test_execute_returns_error_for_unknown_server(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from metronix.mcp.action_executor import ActionExecutor
         from metronix.mcp.registry import MCPServerRegistry
 
         registry = MCPServerRegistry(str(tmp_path))
-        action = PendingAction(
-            user_id="u1",
-            server_name="nonexistent",
-            tool_name="tool",
-            arguments={},
-            description="test",
-            preview="",
-        )
+        self._allow_authorization(monkeypatch)
+        action = self._authorized_action(server_name="nonexistent", tool_name="tool")
 
         executor = ActionExecutor(registry)
         result = executor.execute(action)
 
         assert result["success"] is False
         assert "not found" in result["error"]
+
+    def test_denied_action_never_calls_external_tool(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from metronix.auth.policy import AuthorizationDecision, PolicyPrincipal
+        from metronix.mcp.action_executor import ActionExecutor
+        from metronix.mcp.config import MCPServerConfig
+        from metronix.mcp.registry import MCPServerRegistry
+
+        class DenyingEvaluator:
+            async def authorize(self, request):
+                return AuthorizationDecision("decision", False, "no_active_grant")
+
+        registry = MCPServerRegistry(str(tmp_path))
+        registry.add(MCPServerConfig(name="test-srv", command="echo"))
+        monkeypatch.setattr(
+            "metronix.mcp.action_executor.get_authorization_evaluator",
+            lambda: DenyingEvaluator(),
+        )
+        action = PendingAction(
+            user_id="u1",
+            server_name="test-srv",
+            tool_name="create_issue",
+            arguments={},
+            description="Create bug",
+            preview="",
+            principal=PolicyPrincipal("u1", "editor", ("ws-1",), "channel"),
+            workspace_id="ws-1",
+            agent_id="agent-1",
+        )
+
+        with patch("metronix.mcp.action_executor.MCPClient") as client:
+            result = ActionExecutor(registry).execute(action)
+
+        assert result == {"success": False, "error": "Action is no longer authorized."}
+        client.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -476,7 +528,12 @@ class TestRouterActionIntent:
     ) -> None:
         mock_discover.return_value = []
         mock_search.return_value = "Search result for creating"
-        result = router.route("Create a bug report", user_id="u1", agent_id="agent-1")
+        result = router.route(
+            "Create a bug report",
+            user_id="u1",
+            agent_id="agent-1",
+            principal=PolicyPrincipal("u1", "editor", ("default",), "channel"),
+        )
         assert "Search result" in result
         mock_search.assert_called_once()
 
@@ -487,6 +544,15 @@ class TestRouterActionIntent:
         result = router.route("Create a bug report", user_id="u1")
 
         assert result == "This channel has no authorized agent configured for actions."
+        mock_discover.assert_not_called()
+
+    @patch("metronix.mcp.action_planner.ActionPlanner.discover_write_tools")
+    def test_action_without_authenticated_principal_is_denied_before_planning(
+        self, mock_discover: MagicMock, router: MagicMock
+    ) -> None:
+        result = router.route("Create a bug report", user_id="u1", agent_id="agent-1")
+
+        assert result == "This channel user is not authenticated for actions."
         mock_discover.assert_not_called()
 
     @patch("metronix.mcp.action_planner.ActionPlanner.discover_write_tools")
@@ -508,7 +574,12 @@ class TestRouterActionIntent:
             "preview": "- Title: Bug: Sync failure\n- Type: Bug",
         }
 
-        result = router.route("Создай баг про падение синка", user_id="u1", agent_id="agent-1")
+        result = router.route(
+            "Создай баг про падение синка",
+            user_id="u1",
+            agent_id="agent-1",
+            principal=PolicyPrincipal("u1", "editor", ("default",), "channel"),
+        )
         assert "Create Jira bug" in result
         assert "Confirm?" in result
 
@@ -519,6 +590,10 @@ class TestRouterActionIntent:
         pending = store.get_for_user("u1")
         assert pending is not None
         assert pending.tool_name == "create_issue"
+        assert pending.workspace_id == router._settings.default_workspace_id
+        assert pending.agent_id == "agent-1"
+        assert pending.principal is not None
+        assert pending.principal.user_id == "u1"
 
         # Cleanup
         store.remove(pending.action_id)
@@ -648,7 +723,12 @@ class TestContextAwareActions:
             "preview": "Title: Sprint Summary",
         }
 
-        router.route("Create sprint summary page", user_id="u1", agent_id="agent-1")
+        router.route(
+            "Create sprint summary page",
+            user_id="u1",
+            agent_id="agent-1",
+            principal=PolicyPrincipal("u1", "editor", ("default",), "channel"),
+        )
 
         # Verify search was called for context
         mock_search.assert_called_once()

--- a/tests/unit/test_mcp_actions.py
+++ b/tests/unit/test_mcp_actions.py
@@ -476,9 +476,18 @@ class TestRouterActionIntent:
     ) -> None:
         mock_discover.return_value = []
         mock_search.return_value = "Search result for creating"
-        result = router.route("Create a bug report", user_id="u1")
+        result = router.route("Create a bug report", user_id="u1", agent_id="agent-1")
         assert "Search result" in result
         mock_search.assert_called_once()
+
+    @patch("metronix.mcp.action_planner.ActionPlanner.discover_write_tools")
+    def test_action_without_configured_agent_is_denied_before_planning(
+        self, mock_discover: MagicMock, router: MagicMock
+    ) -> None:
+        result = router.route("Create a bug report", user_id="u1")
+
+        assert result == "This channel has no authorized agent configured for actions."
+        mock_discover.assert_not_called()
 
     @patch("metronix.mcp.action_planner.ActionPlanner.discover_write_tools")
     @patch("metronix.mcp.action_planner.ActionPlanner.plan")
@@ -499,7 +508,7 @@ class TestRouterActionIntent:
             "preview": "- Title: Bug: Sync failure\n- Type: Bug",
         }
 
-        result = router.route("Создай баг про падение синка", user_id="u1")
+        result = router.route("Создай баг про падение синка", user_id="u1", agent_id="agent-1")
         assert "Create Jira bug" in result
         assert "Confirm?" in result
 
@@ -639,7 +648,7 @@ class TestContextAwareActions:
             "preview": "Title: Sprint Summary",
         }
 
-        router.route("Create sprint summary page", user_id="u1")
+        router.route("Create sprint summary page", user_id="u1", agent_id="agent-1")
 
         # Verify search was called for context
         mock_search.assert_called_once()

--- a/tests/unit/test_memory_service.py
+++ b/tests/unit/test_memory_service.py
@@ -143,7 +143,7 @@ class TestListSession:
         records = [_sample_record(id="m1"), _sample_record(id="m2")]
         redis_cache.list.return_value = records
 
-        result = await service.list_session("ws1", "sess1")
+        result = await service.list_session("ws1", "sess1", agent_id="agent1")
 
         assert len(result) == 2
         redis_cache.list.assert_called_once_with("ws1", "sess1")
@@ -363,7 +363,7 @@ class TestGet:
         result = await service.get("ws1", "mem001")
 
         assert result is expected
-        pg_store.get.assert_awaited_once_with("ws1", "mem001")
+        pg_store.get.assert_awaited_once_with("ws1", "mem001", agent_id=None)
 
     async def test_returns_none_when_not_found(self) -> None:
         service, _, _, pg_store = _make_service()
@@ -662,17 +662,17 @@ class TestWorkspaceIsolation:
         service, _, _, _ = _make_service(workspace_id="ws1")
 
         with pytest.raises(ValueError, match="workspace_id mismatch"):
-            await service.get_facets("ws_other")
+            await service.get_facets("ws_other", agent_id="agent-1")
 
     async def test_get_facets_delegates_to_pg(self) -> None:
         service, _, _, pg_store = _make_service(workspace_id="ws1")
         pg_store.get_facets.return_value = ([MemoryKind.FACT], ["confluence"])
 
-        kinds, source_types = await service.get_facets("ws1")
+        kinds, source_types = await service.get_facets("ws1", agent_id="agent-1")
 
         assert kinds == [MemoryKind.FACT]
         assert source_types == ["confluence"]
-        pg_store.get_facets.assert_awaited_once_with("ws1")
+        pg_store.get_facets.assert_awaited_once_with("ws1", agent_id="agent-1")
 
     async def test_count_records_delegates_filters_to_pg(self) -> None:
         service, _, _, pg_store = _make_service(workspace_id="ws1")

--- a/tests/unit/test_migrate_env_connections.py
+++ b/tests/unit/test_migrate_env_connections.py
@@ -42,13 +42,17 @@ class TestCollectConfigsFromEnv:
     def test_multiple_connectors(self) -> None:
         env = {
             "TELEGRAM_BOT_TOKEN": "tg-token",
+            "TELEGRAM_AGENT_ID": "agent-telegram",
             "NOTION_API_TOKEN": "notion-secret",
         }
         with patch.dict("os.environ", env, clear=True):
             result = _collect_configs_from_env()
         assert "telegram" in result
         assert "notion" in result
-        assert result["telegram"] == {"bot_token": "tg-token"}
+        assert result["telegram"] == {
+            "bot_token": "tg-token",
+            "agent_id": "agent-telegram",
+        }
         assert result["notion"] == {"api_token": "notion-secret"}
 
     def test_blank_values_ignored(self) -> None:
@@ -98,7 +102,7 @@ class TestMigrateEnvToDb:
         mock_store.create_connection.assert_not_called()
 
     async def test_no_fernet_key_noop(self) -> None:
-        env = {"TELEGRAM_BOT_TOKEN": "tg-tok"}
+        env = {"TELEGRAM_BOT_TOKEN": "tg-tok", "TELEGRAM_AGENT_ID": "agent-telegram"}
         with patch.dict("os.environ", env, clear=True):
             result = await migrate_env_to_db("dsn", "ws-1", "")
         assert result == {"created": [], "skipped": [], "errors": []}
@@ -106,6 +110,7 @@ class TestMigrateEnvToDb:
     async def test_creates_connections(self, mock_store: AsyncMock) -> None:
         env = {
             "TELEGRAM_BOT_TOKEN": "tg-tok",
+            "TELEGRAM_AGENT_ID": "agent-telegram",
             "NOTION_API_TOKEN": "notion-tok",
         }
         with patch.dict("os.environ", env, clear=True):
@@ -119,7 +124,7 @@ class TestMigrateEnvToDb:
         mock_store.list_connections.return_value = [
             {"connector_type": "telegram", "id": "existing-1"},
         ]
-        env = {"TELEGRAM_BOT_TOKEN": "tg-tok"}
+        env = {"TELEGRAM_BOT_TOKEN": "tg-tok", "TELEGRAM_AGENT_ID": "agent-telegram"}
         with patch.dict("os.environ", env, clear=True):
             result = await migrate_env_to_db("dsn", "ws-1", "fernet-key")
 
@@ -129,7 +134,7 @@ class TestMigrateEnvToDb:
 
     async def test_idempotent_second_run(self, mock_store: AsyncMock) -> None:
         """Running migration twice should not duplicate connections."""
-        env = {"DISCORD_BOT_TOKEN": "dc-tok"}
+        env = {"DISCORD_BOT_TOKEN": "dc-tok", "DISCORD_AGENT_ID": "agent-discord"}
 
         # First run — creates
         with patch.dict("os.environ", env, clear=True):
@@ -163,7 +168,7 @@ class TestMigrateEnvToDb:
     async def test_create_failure_captured(self, mock_store: AsyncMock) -> None:
         """If store.create_connection raises, it ends up in 'errors'."""
         mock_store.create_connection.side_effect = RuntimeError("DB down")
-        env = {"TELEGRAM_BOT_TOKEN": "tg-tok"}
+        env = {"TELEGRAM_BOT_TOKEN": "tg-tok", "TELEGRAM_AGENT_ID": "agent-telegram"}
         with patch.dict("os.environ", env, clear=True):
             result = await migrate_env_to_db("dsn", "ws-1", "fernet-key")
 
@@ -171,7 +176,7 @@ class TestMigrateEnvToDb:
         assert result["created"] == []
 
     async def test_store_closed_on_success(self, mock_store: AsyncMock) -> None:
-        env = {"TELEGRAM_BOT_TOKEN": "tg-tok"}
+        env = {"TELEGRAM_BOT_TOKEN": "tg-tok", "TELEGRAM_AGENT_ID": "agent-telegram"}
         with patch.dict("os.environ", env, clear=True):
             await migrate_env_to_db("dsn", "ws-1", "fernet-key")
         mock_store.close.assert_awaited_once()
@@ -185,7 +190,7 @@ class TestMigrateEnvToDb:
 
     async def test_uses_schema_label_as_name(self, mock_store: AsyncMock) -> None:
         """Connection name should come from ConnectorSchema.label."""
-        env = {"TELEGRAM_BOT_TOKEN": "tg-tok"}
+        env = {"TELEGRAM_BOT_TOKEN": "tg-tok", "TELEGRAM_AGENT_ID": "agent-telegram"}
         with patch.dict("os.environ", env, clear=True):
             await migrate_env_to_db("dsn", "ws-1", "fernet-key")
 
@@ -197,6 +202,7 @@ class TestMigrateEnvToDb:
         env = {
             "SLACK_BOT_TOKEN": "xoxb-123",
             "SLACK_APP_TOKEN": "xapp-456",
+            "SLACK_AGENT_ID": "agent-slack",
             "SLACK_SIGNING_SECRET": "sec-789",
         }
         with patch.dict("os.environ", env, clear=True):
@@ -207,5 +213,6 @@ class TestMigrateEnvToDb:
         assert call_kwargs["config"] == {
             "bot_token": "xoxb-123",
             "app_token": "xapp-456",
+            "agent_id": "agent-slack",
             "signing_secret": "sec-789",
         }


### PR DESCRIPTION
## Summary
- Add a fail-closed, transport-neutral authorization evaluator for agent-scoped memory and confirmed MCP actions.
- Enforce the policy across REST, MCP, graph, session, facets, review, and delete flows.
- Require configured channel agent IDs and reauthorize confirmed channel actions immediately before external execution.

## Why
Agent and workspace identity must be explicit and checked consistently before memory access or external actions. This removes request-supplied authority and prevents cross-agent auxiliary-read leakage.

## Validation
- Ruff check passed for the changed authorization, MCP, channel, memory, storage, and focused test paths.
- Focused authorization and memory suite: 182 passed.

## Note
Direct Slack/Discord adapter test collection remains dependent on optional channel packages not installed in this checkout; router and executor wiring are covered by the focused suite.