### PR TITLE
security: require explicit admin password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ SPLADE_SERVICE_URL=http://splade:8080                 # compose -> http://splade
 
 # --- Auth (JWT) — off by default, not part of the basic install ---
 AUTH_ENABLED=false                    # false: local MCP key; true: JWT on /api/v1/* and /mcp
-AUTH_PASSWORD=metronix                # default admin login (admin@metronix.local) — seeded on first start; change in production
+AUTH_PASSWORD=                        # required to seed admin@metronix.local; generate with: openssl rand -base64 32
 
 # --- MCP standalone runner — only for `python -m metronix.mcp`, NOT the API mount ---
 # The API serves /mcp over streamable-http regardless of these. (Auth key is in ZONE 3.)

--- a/README.md
+++ b/README.md
@@ -199,13 +199,13 @@ curl http://localhost:8000/health
 A healthy backend exposes the REST API, the OpenAI-compatible API at `:8000/v1`, and the
 MCP endpoint at `:8000/mcp` (default on the host: `http://localhost:8000/mcp` — the
 `metronix-full-api` container, path `/mcp`; from Docker network: `http://metronix-core:8000/mcp`).
-If you have installed the Metronix Admin Console (e.g. [https://localhost:3000](https://localhost:3000), self-signed cert by default), log in with your Metronix credentials.
-Default credentials:
+If you have installed the Metronix Admin Console (e.g. [https://localhost:3000](https://localhost:3000), self-signed cert by default), log in with your Metronix credentials. Before the first launch, set a unique administrator password in `.env`; do not use a shared or default password:
 
 ```bash
-login: admin@metronix.local
-pass: metronix
+AUTH_PASSWORD="$(openssl rand -base64 32)"
 ```
+
+The seeded administrator email is `admin@metronix.local`.
 
 
 ### 5. Quick Validation
@@ -215,16 +215,20 @@ native MCP Streamable HTTP interface.
 
 #### Option A: REST API
 
-**Step A — Authenticate (get a JWT token)** using the default admin credentials
-(`admin@metronix.local` / `metronix`):
+**Step A — Authenticate (get a JWT token)** with the seeded administrator email
+(`admin@metronix.local`) and the unique password you set in `AUTH_PASSWORD`:
 
 - **Linux/macOS (Bash):**
   ```bash
-  TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d '{"email": "admin@metronix.local", "password": "metronix"}' http://localhost:8000/api/v1/auth/login | jq -r '.token')
+  read -rsp "Metronix admin password: " ADMIN_PASSWORD; echo
+  TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d "$(jq -nc --arg password "$ADMIN_PASSWORD" '{email: "admin@metronix.local", password: $password}')" http://localhost:8000/api/v1/auth/login | jq -r '.token')
   ```
 - **Windows PowerShell:**
   ```powershell
-  $response = Invoke-RestMethod -Method Post -Uri "http://localhost:8000/api/v1/auth/login" -ContentType "application/json" -Body '{"email": "admin@metronix.local", "password": "metronix"}'
+  $adminPassword = Read-Host "Metronix admin password" -AsSecureString
+  $credential = [System.Management.Automation.PSCredential]::new("admin@metronix.local", $adminPassword)
+  $body = @{ email = $credential.UserName; password = $credential.GetNetworkCredential().Password } | ConvertTo-Json
+  $response = Invoke-RestMethod -Method Post -Uri "http://localhost:8000/api/v1/auth/login" -ContentType "application/json" -Body $body
   $TOKEN = $response.token
   ```
 

--- a/src/metronix/api/app.py
+++ b/src/metronix/api/app.py
@@ -149,9 +149,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.info("user_store.init.starting")
         await user_store.ensure_schema()
         logger.info("user_store.schema.done")
-        seeded = await user_store.seed_admin(settings.auth_password)
-        if seeded:
-            logger.info("user_store.admin.seeded", email="admin@metronix.local")
+        if settings.auth_password:
+            seeded = await user_store.seed_admin(settings.auth_password)
+            if seeded:
+                logger.info("user_store.admin.seeded", email="admin@metronix.local")
+        else:
+            logger.warning(
+                "user_store.admin.not_seeded",
+                reason="AUTH_PASSWORD is not configured",
+            )
         app.state.user_store = user_store
         logger.info("user_store.ready")
     except Exception as exc:
@@ -187,7 +193,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.error("api_key_store.init.failed", error=str(exc))
 
     # --- Open WebUI sync (bundled scenario) ---
-    if settings.openwebui_url:
+    if settings.openwebui_url and settings.auth_password:
         try:
             from metronix.auth.openwebui_sync import OpenWebUISync
 
@@ -202,6 +208,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("owui_sync.configured", url=settings.openwebui_url)
         except Exception as exc:
             logger.warning("owui_sync.init.failed", error=str(exc))
+    elif settings.openwebui_url:
+        logger.warning("owui_sync.not_configured", reason="AUTH_PASSWORD is not configured")
 
     # --- PostgresStore (shared) ---
     from metronix.storage.postgres import PostgresStore

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
 
     # --- Auth ---
     auth_enabled: bool = Field(default=False, alias="AUTH_ENABLED")
-    auth_password: str = Field(default="metronix", alias="AUTH_PASSWORD")
+    auth_password: str = Field(default="", alias="AUTH_PASSWORD")
 
     # --- OpenAI-compatible API (for Open WebUI integration) ---
     openai_compat_enabled: bool = Field(True, alias="METRONIX_OPENAI_COMPAT_ENABLED")

--- a/tests/unit/test_auth_api.py
+++ b/tests/unit/test_auth_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,12 @@ from metronix.core.config import Settings
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+def test_auth_password_has_no_public_default() -> None:
+    """Fresh deployments must require an operator-selected admin password."""
+    with patch.dict(os.environ, {}, clear=True):
+        assert Settings().auth_password == ""
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Removes the public default administrator password from the README, configuration template, and runtime defaults.

## Why

A fresh deployment could otherwise seed an administrator account with a well-known credential published in the repository.

## Design

- `AUTH_PASSWORD` is empty by default and `.env.example` requires an operator-provided value.
- Startup seeds the administrator only when `AUTH_PASSWORD` is configured.
- Open WebUI sync is likewise withheld when no admin password is configured.
- README setup and validation instructions generate and prompt for a password instead of publishing it.

## Impact

New deployments that need the Admin Console, JWT auth, or Open WebUI must explicitly set a strong `AUTH_PASSWORD` before the first start. Existing deployments retain their already-seeded accounts.

## Validation

- `uv run --extra dev pytest tests/unit/test_auth_api.py -q` — 17 passed, 1 skipped
- `uv run --extra dev ruff check src/metronix/core/config.py src/metronix/api/app.py tests/unit/test_auth_api.py`
- `uv run --extra dev ruff format --check src/metronix/core/config.py src/metronix/api/app.py tests/unit/test_auth_api.py`
- `git diff --check`
- Searched the README, template, and runtime configuration for the retired public credential.

## Scope

This resolves the immediate seeded-password exposure. It is related to #324; its additional forced-change and self-service Settings features remain open.