### PR TITLE
fix(deps): block incompatible benchmark-qed minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # benchmark-qed 0.4 removed the provider module used by Metronix's
+    # benchmarker.  Its 0.x minor release is therefore breaking; retain the
+    # explicit <0.4 compatibility cap in pyproject.toml until it is migrated.
+    ignore:
+      - dependency-name: "benchmark-qed"
+        update-types:
+          - "version-update:semver-minor"
 
   # GitHub Actions versions used in workflows.
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Ignore `benchmark-qed` minor version updates in Dependabot.
- Preserve the existing `<0.4` compatibility cap until the benchmarker is migrated.

## Motivation

Dependabot PR #383 upgraded `benchmark-qed` to 0.4.0, which removed `benchmark_qed.llm.provider.openai`. The unit workflow consequently fails while collecting seven benchmarker-related tests.

## Design Decisions

- Ignore only SemVer minor updates for this 0.x dependency, because 0.4 is incompatible.
- Patch and security updates remain eligible.

## Repository Rules Followed

- Change is limited to Dependabot configuration and uses a conventional, signed-off commit.

## Risks

- Future compatible 0.x minor releases require an explicit review and removal or adjustment of this rule.

## Testing

- `ruby -e ... YAML.load_file(".github/dependabot.yml")`
- `UV_CACHE_DIR=/private/tmp/metronix-uv-cache uv lock --check`
- `git diff --check`
- `make test` could not start locally because `.venv/bin/pytest` is absent; CI provides the service-backed suite.

## Documentation

- Added an inline rationale beside the Dependabot rule.