### PR TITLE
docs(hermes): document native memory provider

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@
 
 Priority order:
 
-- [`integrations/hermes-agent.md`](integrations/hermes-agent.md)
+- [`integrations/hermes-agent.md`](integrations/hermes-agent.md) — native memory provider and MCP setup
 - [`integrations/openclaw.md`](integrations/openclaw.md)
 - [`integrations/cursor.md`](integrations/cursor.md)
 - [`integrations/claude-desktop.md`](integrations/claude-desktop.md)

--- a/docs/integrations/hermes-agent.md
+++ b/docs/integrations/hermes-agent.md
@@ -4,19 +4,50 @@
 > `METRONIX_MCP_API_KEY`. For hosted `AUTH_ENABLED=true`, put a user JWT in the same Bearer
 > header; the shared key is ignored.
 
-## Recommended mode
+## Choose an integration
 
-Use Metronix Memory as an HTTP MCP server today.
+Metronix supports two complementary Hermes integrations:
 
-That is still the recommended production path right now.
-It is the best-supported integration for search, memory, and retrieval.
+- **Native memory provider** — use the standalone
+  [`hermes-memory-metronix`](https://github.com/mtrnix/hermes-memory-metronix)
+  package when Hermes should prefetch durable memory before a turn and route
+  `memory(action="add")` through Metronix automatically.
+- **HTTP MCP server** — use the MCP configuration below when Hermes needs
+  explicit knowledge-base and memory tools such as `metronix_search_fast` and
+  `metronix_memory_search`.
 
-If you want native Hermes memory-provider hooks such as prefetch injection
-and write-through from `memory(action="add")`, build that as a standalone
-Hermes plugin repo rather than an in-tree Hermes contribution. A scaffold for
-that direction lives in:
+You can install both: the native provider handles Hermes's memory lifecycle,
+while MCP exposes the broader Metronix tool surface.
 
-- `standalone/hermes-memory-metronix/`
+## Native memory provider
+
+Install the published package, then run its interactive setup command:
+
+```bash
+uv tool install "hermes-memory-metronix>=2026.32.3"
+hermes-metronix-setup --generate-token
+```
+
+The setup command installs the provider, stores its non-secret settings in
+`~/.hermes/metronix.json`, writes the REST credential to `~/.hermes/.env`, and
+selects it through `hermes memory setup metronix`.
+
+Verify the provider and its lifecycle with a normal Hermes chat:
+
+```bash
+hermes memory status
+hermes chat
+```
+
+Store a unique fact with Hermes memory, start a fresh chat, and ask for it.
+For a recorded end-to-end example, see the
+[native Hermes smoke video](https://www.youtube.com/watch?v=Sc6QOyD7Yek).
+
+The native provider calls `/api/v1/*`, so it requires a REST JWT or `mtk_…`
+personal API key in `METRONIX_AUTH_TOKEN`. Do **not** use
+`METRONIX_MCP_API_KEY`: that credential is only for `/mcp`.
+
+## MCP mode
 
 ## What you need
 
@@ -79,30 +110,9 @@ metronix_memory_list(workspace_id="MTRNIX", agent_id="<AGENT_UUID>", limit=5)
 
 **Authentication errors:** Confirm the `Authorization: Bearer` header matches the configured MCP mode: a user JWT for `AUTH_ENABLED=true`, or `METRONIX_MCP_API_KEY` for `AUTH_ENABLED=false`.
 
-## Native provider credentials
-
-The standalone native provider calls `/api/v1/*`, so configure a separate,
-revocable REST key on the Hermes host:
-
-```bash
-# Written to the Hermes host's secret environment, never to Metronix .env.
-METRONIX_AUTH_TOKEN=mtk_<one-time-value-from-the-admin-API>
-```
-
-Create a labelled key for the actual user or service identity that should own
-the provider. The provider receives that identity's live role and workspace
-access. The local-mode `METRONIX_MCP_API_KEY` only authorizes `/mcp`; using it
-as `METRONIX_AUTH_TOKEN` returns `401` on `/api/v1/*`. A hosted MCP JWT is
-also not a replacement for a revocable native-provider key.
-
-Rotate a native-provider key by creating a replacement key, updating the
-Hermes secret environment, restarting Hermes, validating `/api/v1/auth/me`
-through the provider, then revoking the old prefix. Email/password login
-remains a fallback for development and JWT refresh; production native
-deployments should prefer the revocable API key.
-
 ## Recommendation
 
-If you already use Hermes-native memory providers, keep them separate mentally.
-Metronix Memory is the durable shared memory and knowledge backend. Treat it like the source of
-truth you can inspect, not an invisible sidecar.
+Use the native provider when Hermes should automatically recall and persist
+durable memory. Use MCP when the agent should explicitly search Metronix's
+knowledge base or call its broader tool surface. Install both when the
+workflow needs both capabilities.

--- a/docs/readme-preview.html
+++ b/docs/readme-preview.html
@@ -213,7 +213,7 @@ make typecheck        # mypy src/metronix/
 make migrate          # alembic upgrade head
 make eval             # search quality eval</code></pre>
 <p>For architecture and product boundaries, see <a href="docs/reference/architecture.md">docs/reference/architecture.md</a> and <a href="docs/product/open-core-boundaries.md">docs/product/open-core-boundaries.md</a>.</p>
-<p><strong>Hermes users:</strong> Metronix Memory integrates as an <strong>MCP server</strong>, not a Hermes-native memory provider. See <a href="docs/integrations/hermes-agent.md">Hermes Agent guide</a>.</p>
+<p><strong>Hermes users:</strong> choose the standalone <a href="https://github.com/mtrnix/hermes-memory-metronix">native memory provider</a> for automatic prefetch and write-through, the <a href="docs/integrations/hermes-agent.md">MCP integration</a> for explicit knowledge-base tools, or install both.</p>
 <h3>External Ports</h3>
 <p>External ports from <code>docker-compose.yml</code>:</p>
 <table><thead><tr><th>Service</th><th>Port</th></tr></thead><tbody><tr><td>API</td><td><code>8000</code></td></tr><tr><td>PostgreSQL</td><td><code>5433</code></td></tr><tr><td>Qdrant HTTP</td><td><code>6335</code></td></tr><tr><td>Qdrant gRPC</td><td><code>6336</code></td></tr><tr><td>Neo4j HTTP</td><td><code>7475</code></td></tr><tr><td>Neo4j bolt</td><td><code>7688</code></td></tr><tr><td>Redis</td><td><code>6380</code></td></tr><tr><td>Ollama</td><td><code>11435</code></td></tr><tr><td>SPLADE</td><td><code>8080</code></td></tr><tr><td>Embedding proxy</td><td><code>8002</code></td></tr><tr><td>Open WebUI</td><td><code>3080</code></td></tr></tbody></table>
@@ -244,25 +244,11 @@ docker compose up -d --build --force-recreate</code></pre>
 <ul><li>Native connector framework for Confluence, Jira, Notion, GitHub, Google Drive, Slack history, and local files.</li><li>File upload APIs for direct ingestion.</li><li>MCP tools for storing and syncing external sources.</li></ul>
 <h3>Agent Memory</h3>
 <ul><li><code>fact</code>, <code>preference</code>, and <code>pinned</code> memory records.</li><li>Workspace and agent scoping.</li><li>Review queue, snapshots, health checks, and freshness lifecycle support.</li></ul>
-<h3>Hermes Memory: Important Distinction</h3>
-<p>If you are using <strong>Hermes Agent</strong>, do <strong>not</strong> start with Hermes' "memory providers" screen and expect Metronix to appear there.</p>
-<p>Hermes currently has two different integration concepts:</p>
-<ul><li><strong>Memory providers</strong> — Hermes-native provider plugins such as <code>honcho</code>, <code>mem0</code>,</li></ul>
-<p><code>hindsight</code>, and similar providers configured via Hermes' own memory setup flow</p>
-<ul><li><strong>MCP servers</strong> — external backends Hermes can call as tools</li></ul>
-<p><strong>Metronix currently integrates with Hermes as an MCP server, not as a Hermes-native memory provider plugin.</strong></p>
-<p>That means:</p>
-<ul><li>use Metronix when you want Hermes to search the KB or read/write memory through</li></ul>
-<p>MCP tools like <code>metronix_search_fast</code>, <code>metronix_memory_search</code>, and <code>metronix_memory_store</code></p>
-<ul><li>use Hermes memory providers when you specifically want Hermes' built-in provider</li></ul>
-<p>plugin system</p>
-<ul><li>use both if you want Hermes-native memory plus Metronix as a richer external</li></ul>
-<p>knowledge and memory backend</p>
-<p><strong>Recommended path today:</strong> connect Hermes to Metronix through <code>/mcp</code>.</p>
-<p>See:</p>
-<ul><li><strong><a href="docs/integrations/hermes.md">Hermes Integration Guide</a></strong> — exact MCP setup for Hermes</li></ul>
-<p>(includes required tool permissions for prompt-based setup)</p>
-<ul><li><strong><a href="https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers">Hermes memory provider docs</a></strong> — what Hermes means by "memory providers"</li><li><strong><a href="https://hermes-agent.nousresearch.com/docs/user-guide/features/tools">Hermes Tools</a></strong> — enable <code>file</code>, <code>terminal</code>, and <code>code_execution</code> if missing</li></ul>
+<h3>Hermes: Native Memory and MCP</h3>
+<p>Metronix supports two complementary Hermes integrations.</p>
+<ul><li><strong>Native memory provider</strong> — install the standalone <a href="https://github.com/mtrnix/hermes-memory-metronix"><code>hermes-memory-metronix</code></a> plugin for automatic prefetch and write-through from Hermes memory.</li><li><strong>MCP server</strong> — connect Metronix at <code>/mcp</code> for explicit knowledge-base and memory tools.</li></ul>
+<p>The native provider calls the REST API with a JWT or personal API key; MCP uses <code>METRONIX_MCP_API_KEY</code>. The credentials are not interchangeable.</p>
+<p>See the <a href="docs/integrations/hermes-agent.md">Hermes integration guide</a> for installation, configuration, and verification.</p>
 <hr>
 <h2>Contributing</h2>
 <p>Metronix Core is open-core. Bug reports, connector additions, documentation improvements, and focused pull requests are welcome.</p>


### PR DESCRIPTION
## Summary

- document the standalone Hermes native memory provider alongside MCP
- link the published PyPI package and native smoke video
- replace stale scaffold-only and MCP-only wording in the guide and preview

## Testing

- `git diff --check`
- verified no stale scaffold path or obsolete native-provider claim remains in the edited public documentation