### PR TITLE
fix(installer): rebuild stack after bootstrap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ The bootstrap installs the latest tagged release. Update it later with:
 curl -fsSL https://mtrnix.com/install.sh | bash -s -- --update -- -y
 ```
 
+`--update` checks out the newest release, rebuilds, and restarts the stack while preserving
+your `.env` and Docker data volumes.
+
 Use `--version <tag>` for a reproducible release or `--branch main` for an explicitly
 bleeding-edge checkout. Full installer flags must follow a `--` separator.
 

--- a/install.md
+++ b/install.md
@@ -344,6 +344,14 @@ A healthy backend exposes:
 
 ## Using `./install.sh` beyond the first run
 
+When installed through the web bootstrap, use `--update` to download the newest tagged
+release and safely rebuild it in place. Existing `.env` values and Docker data volumes are
+preserved:
+
+```bash
+curl -fsSL https://mtrnix.com/install.sh | bash -s -- --update -- -y
+```
+
 If `.env` or containers already exist, re-running `./install.sh` **inspects** the deployment
 and offers a menu instead of blindly overwriting config:
 

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ CHAT_API_KEY=""      # bearer token for the endpoint (optional; blank = no auth)
 ENABLE_WEBUI=false
 ENABLE_ADMIN=false     # install the Metronix Admin Console web UI (profile admin); --kb is a deprecated alias
 ASSUME_YES=false
+UPDATE=false
 RECONFIGURE=false
 FRESH_DOCKER_RESET=false
 CONNECT_HERMES=false    # run the Hermes connection step (and, with -y, apply without prompt)
@@ -122,6 +123,7 @@ Options:
   --metronix-url <url>     MCP URL written into the agent config
                            (default http://localhost:8000/mcp)
   -y, --yes                Non-interactive: use defaults/flags, never prompt
+  --update                 Rebuild and restart an existing stack, preserving data
   --reconfigure            Re-run configuration even if .env already exists
   --fresh-docker-reset     Delete Metronix Docker containers, images, volumes,
                            orphan containers, and build cache before reinstalling
@@ -163,6 +165,7 @@ parse_args() {
       --admin)      ENABLE_ADMIN=true; shift ;;
       --kb)         warn "--kb is deprecated, use --admin (renamed to Metronix Admin Console)"; ENABLE_ADMIN=true; shift ;;
       -y|--yes)      ASSUME_YES=true; shift ;;
+      --update)      UPDATE=true; shift ;;
       --reconfigure) RECONFIGURE=true; shift ;;
       --fresh-docker-reset) FRESH_DOCKER_RESET=true; shift ;;
       -h|--help)     usage; exit 0 ;;
@@ -1684,6 +1687,14 @@ diagnose_state() {
 # Offer the user a menu based on what diagnose_state() found. Sets RESUME_ACTION
 # to one of: start | rebuild | reconfigure | reset | freshreset | fixenv | exit.
 resume_menu() {
+  # Bootstrap passes --update after it checks out a new release. Rebuild even
+  # when the current stack is healthy so Compose picks up the new sources.
+  # `rebuild` uses `down` without `-v`, preserving all Metronix data volumes.
+  if [[ "$UPDATE" == true ]]; then
+    RESUME_ACTION="rebuild"
+    return
+  fi
+
   # In -y / non-interactive mode, pick the most reasonable action automatically.
   if [[ "$ASSUME_YES" == true ]]; then
     if [[ "$DIAG_API_OK" == yes ]]; then RESUME_ACTION="exit"; return; fi

--- a/scripts/install-bootstrap.sh
+++ b/scripts/install-bootstrap.sh
@@ -188,10 +188,14 @@ prepare_checkout() {
 
 run_full_installer() {
   info "Starting the full Metronix installer ..."
+  local full_args=("${INSTALL_ARGS[@]}")
+  # A source update must rebuild running services; otherwise a healthy stack
+  # would exit before Docker sees the newly checked-out sources.
+  [[ "$UPDATE" == true ]] && full_args=(--update "${full_args[@]}")
   if { : </dev/tty; } 2>/dev/null; then
-    bash "$INSTALL_DIR/install.sh" "${INSTALL_ARGS[@]}" < /dev/tty
+    bash "$INSTALL_DIR/install.sh" "${full_args[@]}" < /dev/tty
   else
-    bash "$INSTALL_DIR/install.sh" "${INSTALL_ARGS[@]}"
+    bash "$INSTALL_DIR/install.sh" "${full_args[@]}"
   fi
 }
 

--- a/tests/installer/test_bootstrap.sh
+++ b/tests/installer/test_bootstrap.sh
@@ -56,7 +56,7 @@ git -C "$SOURCE" commit -m v2 >/dev/null
 git -C "$SOURCE" tag v2.0.0
 git -C "$SOURCE" push origin main --tags >/dev/null
 run_bootstrap --update --dir "$DEST" -- -y
-chk "update installs newest tag" "$(grep '^V2:' "$OUT")" "V2:-y"
+chk "update installs newest tag and forwards rebuild intent" "$(grep '^V2:' "$OUT")" "V2:--update -y"
 
 printf 'local note\n' > "$DEST/local-note.txt"
 run_bootstrap --update --dir "$DEST" -- -y

--- a/tests/installer/test_resume.sh
+++ b/tests/installer/test_resume.sh
@@ -105,6 +105,20 @@ run_resume "yes" "yes" "yes" "" 'ASSUME_YES=true' ''
 # In -y / non-interactive, healthy => exit
 chk "auto-action=exit" "$(printf '%s' "$LASTOUT" | grep -oE 'ACTION=[a-z]*')" "ACTION=exit"
 
+echo "Case R7b: --update rebuilds a healthy stack"
+d7b="$(mktemp -d)"
+cat > "$d7b/r.sh" <<EOF
+source "$INSTALL"
+parse_args --update -y
+DIAG_ENV="yes"; DIAG_API_OK="yes"; DIAG_ANY_EXIST="yes"
+DIAG_ENV_ISSUES=""; DIAG_ANY_UNHEALTHY="no"; DIAG_VOL_EXISTS="no"
+RESUME_ACTION=""
+resume_menu >/dev/null 2>&1
+echo "ACTION=\$RESUME_ACTION"
+EOF
+out="$(bash "$d7b/r.sh" 2>&1)"; rm -rf "$d7b"
+chk "update forces rebuild" "$(printf '%s' "$out" | grep -oE 'ACTION=[a-z]*')" "ACTION=rebuild"
+
 echo "Case R8: interactive menu with env issues -> fixenv first option"
 # Interactive: env has issues. Choice 1 should map to fixenv (first dynamic option).
 d8="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Make the web bootstrap pass explicit update intent to the full installer.

## Root cause

The bootstrap checked out the newest release, but the full installer saw a healthy stack and exited before Docker rebuilt the updated sources.

## Behavior

`curl -fsSL https://mtrnix.com/install.sh | bash -s -- --update -- -y` now rebuilds and restarts the stack while preserving `.env` and Docker data volumes.

## Testing

- `make test-installer`
- `bash tests/installer/test_resume.sh`
