### PR TITLE
fix(benchmarks): retry empty LoCoMo completions

### DIFF
--- a/benchmarks/locomo/scripts/run_benchmark.py
+++ b/benchmarks/locomo/scripts/run_benchmark.py
@@ -48,6 +48,14 @@ ANSWER_SYSTEM = (
 ANSWER_PROMPT = """Retrieved memories:\n{memory_context}\n\nQuestion: {question}\nAnswer:"""
 
 
+class EmptyChatCompletionError(ValueError):
+    """A provider returned a completion without answer content."""
+
+    def __init__(self, finish_reason: str) -> None:
+        self.finish_reason = finish_reason
+        super().__init__(f"chat model returned an empty answer (finish_reason={finish_reason})")
+
+
 def parse_categories(value: str) -> set[int]:
     try:
         categories = {int(item.strip()) for item in value.split(",") if item.strip()}
@@ -74,7 +82,11 @@ def build_memory_context(results: list[dict]) -> str:
     return "\n\n".join(blocks) if blocks else "(no memories retrieved)"
 
 
-@backoff.on_exception(backoff.expo, (openai.RateLimitError, openai.APIError), max_tries=8)
+@backoff.on_exception(
+    backoff.expo,
+    (openai.RateLimitError, openai.APIError, EmptyChatCompletionError),
+    max_tries=8,
+)
 def chat_complete(client: OpenAI, *, model: str, message: str) -> str:
     completion = client.chat.completions.create(
         model=model,
@@ -86,8 +98,9 @@ def chat_complete(client: OpenAI, *, model: str, message: str) -> str:
         max_tokens=512,
     )
     content = completion.choices[0].message.content
-    if not content:
-        raise ValueError("chat model returned an empty answer")
+    if not isinstance(content, str) or not content.strip():
+        finish_reason = str(completion.choices[0].finish_reason or "unknown")
+        raise EmptyChatCompletionError(finish_reason)
     return content.strip()
 
 
@@ -209,6 +222,7 @@ def run(
     for entry in tqdm(remaining, desc="LoCoMo", unit="q"):
         started = time.perf_counter()
         retrieved_count = 0
+        error: dict[str, str] | None = None
         try:
             hypothesis, retrieved_count = process_question(
                 entry, config=config, chat_client=client
@@ -217,20 +231,25 @@ def run(
             logger.error("Error on %s: %s", entry["question_id"], exc)
             traceback.print_exc()
             hypothesis = f"Error: {type(exc).__name__}"
-        append_result(
-            output_path,
-            {
-                "question_id": entry["question_id"],
-                "sample_id": entry["sample_id"],
-                "category": entry["category"],
-                "question": entry["question"],
-                "answer": entry["answer"],
-                "evidence": entry["evidence"],
-                "hypothesis": hypothesis,
-                "retrieved_count": retrieved_count,
-                "latency_ms": (time.perf_counter() - started) * 1000,
-            },
-        )
+            if isinstance(exc, EmptyChatCompletionError):
+                error = {
+                    "type": "empty_chat_completion",
+                    "finish_reason": exc.finish_reason,
+                }
+        row = {
+            "question_id": entry["question_id"],
+            "sample_id": entry["sample_id"],
+            "category": entry["category"],
+            "question": entry["question"],
+            "answer": entry["answer"],
+            "evidence": entry["evidence"],
+            "hypothesis": hypothesis,
+            "retrieved_count": retrieved_count,
+            "latency_ms": (time.perf_counter() - started) * 1000,
+        }
+        if error is not None:
+            row["error"] = error
+        append_result(output_path, row)
     return output_path
 
 

--- a/tests/unit/benchmarks/locomo/test_locomo_runner.py
+++ b/tests/unit/benchmarks/locomo/test_locomo_runner.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+from benchmarks.locomo.scripts import run_benchmark
 from benchmarks.locomo.scripts.env_config import BenchConfig
-from benchmarks.locomo.scripts.run_benchmark import parse_categories, write_manifest
+from benchmarks.locomo.scripts.run_benchmark import chat_complete, parse_categories, write_manifest
 
 
 def config() -> BenchConfig:
@@ -45,3 +48,73 @@ def test_manifest_records_parity_fields_without_secrets(tmp_path: Path) -> None:
     assert data["top_k"] == 10
     assert "secret-key" not in serialized
     assert "chat-secret" not in serialized
+
+
+def test_chat_complete_retries_an_empty_model_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty provider completions must not become scored benchmark failures."""
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content=None), finish_reason="length")
+            ]
+        ),
+        SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="7 May 2023"))]),
+    ]
+    monkeypatch.setattr("backoff._sync.time.sleep", lambda _: None)
+
+    answer = chat_complete(client, model="test-model", message="When?")
+
+    assert answer == "7 May 2023"
+    assert client.chat.completions.create.call_count == 2
+
+
+def test_chat_complete_reports_empty_completion_finish_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal empty-answer failures must retain safe provider diagnostics."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None), finish_reason="length")]
+    )
+    monkeypatch.setattr("backoff._sync.time.sleep", lambda _: None)
+
+    with pytest.raises(ValueError, match="finish_reason=length"):
+        chat_complete(client, model="test-model", message="When?")
+
+
+def test_run_records_safe_empty_completion_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exhausted empty-answer retries must remain diagnosable without prompt content."""
+    entry = {
+        "question_id": "sample-q0001",
+        "sample_id": "sample",
+        "category": 2,
+        "question": "When?",
+        "answer": "Tomorrow",
+        "evidence": [],
+    }
+    monkeypatch.setattr(run_benchmark, "load_dataset", lambda _: [{}])
+    monkeypatch.setattr(run_benchmark, "iter_questions", lambda *_args, **_kwargs: iter([entry]))
+    monkeypatch.setattr(
+        run_benchmark,
+        "process_question",
+        MagicMock(side_effect=run_benchmark.EmptyChatCompletionError("length")),
+    )
+    monkeypatch.setattr(run_benchmark, "OpenAI", MagicMock())
+    output = tmp_path / "answers.jsonl"
+
+    run_benchmark.run(
+        config=config(),
+        dataset_path=tmp_path / "locomo10.json",
+        output_path=output,
+        categories={2},
+        max_questions=None,
+        force=False,
+        retrieval_mode="flag-off",
+    )
+
+    row = json.loads(output.read_text(encoding="utf-8"))
+    assert row["hypothesis"] == "Error: EmptyChatCompletionError"
+    assert row["error"] == {"type": "empty_chat_completion", "finish_reason": "length"}


### PR DESCRIPTION
Avoid scoring transient empty provider completions as benchmark errors and retain their safe finish reason after retries are exhausted.

<!-- Thanks for contributing to Metronix! Please fill this in. -->

## Summary

<!-- What does this PR do, and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [ ] `ruff format` and `ruff check` pass locally
- [ ] Tests added/updated and `pytest` passes (run with the service stack — see `CONTRIBUTING.md`)
- [ ] Docs updated if behavior or config changed
- [ ] Changes are workspace-scoped where applicable (no cross-workspace data access)
