### PR TITLE
test(mcp): relax transport error text contract

### DIFF
--- a/tests/unit/test_mcp_transport.py
+++ b/tests/unit/test_mcp_transport.py
@@ -160,10 +160,9 @@ def test_mounted_stateless_mcp_authorizes_each_tool_call_with_its_request_princi
         "isError": False,
     }
     assert _sse_payload(user_b_reusing_a_context)["result"]["isError"] is True
-    assert (
-        "No access to workspace 'ws-a'"
-        in (_sse_payload(user_b_reusing_a_context)["result"]["content"][0]["text"])
-    )
+    # The transport must deny cross-workspace access, but the MCP SDK owns the
+    # public rendering of unexpected handler exceptions. Do not expose or
+    # depend on an authorization exception's implementation detail here.
     assert _sse_payload(user_b_call)["result"] == {
         "content": [
             {


### PR DESCRIPTION
## Summary

- Preserve the stateless MCP cross-workspace denial assertion.
- Stop treating the MCP SDK's rendered unexpected-handler exception text as a Metronix transport contract.

## Motivation

MCP 2.1.1 intentionally sanitizes unexpected tool exception messages sent to clients. The prior assertion blocked dependency upgrades despite the authorization boundary continuing to work.

## Design Decisions

- Keep the observable authorization guarantee: a principal reusing another workspace receives `isError: true`.
- Leave production transport behavior unchanged and avoid requiring detailed authorization errors to be exposed to clients.

## Repository Rules Followed

- Focused change on a `codex/` branch with a DCO sign-off.
- No new dependencies or unrelated refactoring.

## Risks

- Client-visible text from unexpected MCP tool exceptions remains SDK-defined by design; authorization denial remains covered by the structured error flag.

## Testing

- `uv run --extra dev pytest tests/unit/test_mcp_transport.py -q` (MCP 2.0 lock): passed.
- `uv run --extra dev --with 'mcp==2.1.1' pytest tests/unit/test_mcp_transport.py -q`: passed.
- Ruff check and format check: passed.
- Full service-backed unit suite was not run locally because no Docker services are available in the clean isolated clone; required GitHub Actions CI remains the merge gate.

## Documentation

- No user-facing behavior or documentation changes.

## Additional Notes

- This unblocks rebasing Dependabot PR #442 after the compatibility contract lands.