### PR TITLE
fix: enforce MCP agent identity consistency

### DIFF
--- a/docs/MCP_API.md
+++ b/docs/MCP_API.md
@@ -33,11 +33,14 @@ value as `agent_id` in memory tool arguments. Metronix uses it to:
 - link an external runtime to an agent record in **Metronix Console** (corporate version).
 
 The id must be **1–64 characters** from `A–Z a–z 0–9 . _ -` (UUIDs and slugs like
-`my-agent-001` qualify; spaces and `/` do not). Invalid ids are dropped from the header and
-rejected by the memory tools with `INVALID_PARAMS`.
+`my-agent-001` qualify; spaces and `/` do not). For authenticated MCP requests, an agent-memory
+tool returns `INVALID_PARAMS` before authorization or data access when the header is missing,
+invalid, or different from the tool's `agent_id` argument.
 
 `X-Agent-Id` does not grant workspace membership or delegation authority. It is request data
 used for attribution and memory partitioning; the server derives hosted access from the JWT.
+When authentication is disabled for a local or stdio connection, memory tools retain the
+tool-argument identity fallback and do not require the header.
 
 ### Full HTTP Example
 

--- a/docs/MCP_API.md
+++ b/docs/MCP_API.md
@@ -39,8 +39,9 @@ invalid, or different from the tool's `agent_id` argument.
 
 `X-Agent-Id` does not grant workspace membership or delegation authority. It is request data
 used for attribution and memory partitioning; the server derives hosted access from the JWT.
-When authentication is disabled for a local or stdio connection, memory tools retain the
-tool-argument identity fallback and do not require the header.
+The header-consistency check is not applied when no authenticated principal exists. This does
+not bypass authorization: agent-memory handlers still return `AUTH_REQUIRED` without a trusted
+principal, including on local or stdio connections.
 
 ### Full HTTP Example
 

--- a/docs/integrations/mcp-reference.md
+++ b/docs/integrations/mcp-reference.md
@@ -28,4 +28,9 @@ credential. It cannot authenticate a hosted MCP user when `AUTH_ENABLED=true`.
 
 `X-Agent-Id` scopes MCP and memory to one agent; use the same value as `agent_id` in memory
 tools and as the agent UUID in Metronix Console (corporate version) when linking a runtime.
-It does not grant workspace membership or delegation authority.
+Authenticated agent-memory calls with a missing, invalid, or mismatched header return
+`INVALID_PARAMS` before authorization or data access. The header does not grant workspace
+membership or delegation authority; existing server-side grants remain authoritative.
+
+For local or stdio connections with authentication disabled, memory tools retain the
+`agent_id` tool-argument fallback and do not require `X-Agent-Id`.

--- a/docs/integrations/mcp-reference.md
+++ b/docs/integrations/mcp-reference.md
@@ -32,5 +32,6 @@ Authenticated agent-memory calls with a missing, invalid, or mismatched header r
 `INVALID_PARAMS` before authorization or data access. The header does not grant workspace
 membership or delegation authority; existing server-side grants remain authoritative.
 
-For local or stdio connections with authentication disabled, memory tools retain the
-`agent_id` tool-argument fallback and do not require `X-Agent-Id`.
+The header-consistency check is not applied when no authenticated principal exists, but this
+does not make memory access anonymous: agent-memory handlers still return `AUTH_REQUIRED`
+without a trusted principal, including on local or stdio connections.

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -11,6 +11,7 @@ Supports dual transport:
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import logging
 import os
@@ -176,6 +177,44 @@ def _project_arguments(
     return {"__truncated__": True, "preview": serialized[:256]}, True
 
 
+def _agent_identity_error(
+    handler_signature: inspect.Signature,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    transport_agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Validate authenticated transport identity against a tool target.
+
+    Tools without an ``agent_id`` parameter are outside the agent-memory
+    boundary. Unauthenticated local/stdio calls retain their historical
+    argument fallback; callers invoke this helper only when a principal exists.
+    """
+    from metronix.core.utils import is_valid_agent_id
+    from metronix.mcp.errors import ErrorCode, MCPError
+
+    if "agent_id" not in handler_signature.parameters:
+        return None
+
+    if not transport_agent_id or not is_valid_agent_id(transport_agent_id):
+        return {
+            "error": MCPError(
+                code=ErrorCode.INVALID_PARAMS,
+                message="A valid X-Agent-Id header is required for authenticated agent tools",
+            ).to_dict()
+        }
+
+    bound = handler_signature.bind_partial(*args, **kwargs)
+    tool_agent_id = bound.arguments.get("agent_id")
+    if tool_agent_id is not None and tool_agent_id != transport_agent_id:
+        return {
+            "error": MCPError(
+                code=ErrorCode.INVALID_PARAMS,
+                message="X-Agent-Id must match the agent_id tool argument",
+            ).to_dict()
+        }
+    return None
+
+
 def _wrap_tool_with_activity(
     tool_name: str,
     handler: Callable[..., Awaitable[Any]],
@@ -187,6 +226,8 @@ def _wrap_tool_with_activity(
     No-ops when ``bus`` is None or ``agent_id`` cannot be resolved.
     """
 
+    handler_signature = inspect.signature(handler)
+
     @wraps(handler)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         from metronix.mcp.config import resolve_workspace_id
@@ -196,7 +237,16 @@ def _wrap_tool_with_activity(
         start = time.monotonic()
         principal = get_current_principal()
         transport_agent_id = current_agent_id.get()
-        handler_agent_id = transport_agent_id or kwargs.get("agent_id")
+        if principal is not None:
+            identity_error = _agent_identity_error(
+                handler_signature, args, kwargs, transport_agent_id
+            )
+            if identity_error is not None:
+                return identity_error
+
+        bound_arguments = handler_signature.bind_partial(*args, **kwargs).arguments
+        tool_agent_id = bound_arguments.get("agent_id")
+        handler_agent_id = transport_agent_id or tool_agent_id
         # In JWT mode, only transport middleware context is trusted for caller
         # attribution. Authentication-disabled local/stdio mode retains the
         # legacy tool-argument fallback.

--- a/src/metronix/mcp/server.py
+++ b/src/metronix/mcp/server.py
@@ -186,8 +186,8 @@ def _agent_identity_error(
     """Validate authenticated transport identity against a tool target.
 
     Tools without an ``agent_id`` parameter are outside the agent-memory
-    boundary. Unauthenticated local/stdio calls retain their historical
-    argument fallback; callers invoke this helper only when a principal exists.
+    boundary. The consistency check applies only when a principal exists;
+    authorization inside each handler remains authoritative in every mode.
     """
     from metronix.core.utils import is_valid_agent_id
     from metronix.mcp.errors import ErrorCode, MCPError

--- a/tests/integration/mcp/test_agent_access_conformance.py
+++ b/tests/integration/mcp/test_agent_access_conformance.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from metronix.activity.context import bind_agent_id, current_agent_id
 from metronix.auth.policy import AuthorizationEvaluator
 from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 
@@ -40,6 +43,15 @@ class _AuditStore:
         return None
 
 
+@contextmanager
+def _transport_agent(agent_id: str) -> Iterator[None]:
+    token = bind_agent_id(agent_id)
+    try:
+        yield
+    finally:
+        current_agent_id.reset(token)
+
+
 @pytest.fixture
 def evaluator(monkeypatch: pytest.MonkeyPatch) -> AuthorizationEvaluator:
     from metronix.mcp.tools import _agent_access
@@ -67,9 +79,12 @@ async def test_delegated_read_can_call_search_for_the_explicitly_shared_agent(
     service.search = AsyncMock(return_value=[])
     token = bind_principal(MCPPrincipal("delegate", "editor", ("ws-a",)))
     try:
-        with patch(
-            "metronix.mcp.tools.memory_search._memory_deps.build_memory_service_for_workspace",
-            new=AsyncMock(return_value=service),
+        with (
+            patch(
+                "metronix.mcp.tools.memory_search._memory_deps.build_memory_service_for_workspace",
+                new=AsyncMock(return_value=service),
+            ),
+            _transport_agent("shared-agent"),
         ):
             out = await metronix_memory_search(
                 query="recall", workspace_id="ws-a", agent_id="shared-agent"
@@ -102,12 +117,16 @@ async def test_delegated_read_cannot_write_or_swap_to_another_agent(
                 new=AsyncMock(return_value=store_service),
             ) as build_store,
         ):
-            swapped = await metronix_memory_search(
-                query="recall", workspace_id="ws-a", agent_id="owner-agent"
-            )
-            write = await metronix_memory_store(
-                content="attempted mutation", workspace_id="ws-a", agent_id="shared-agent"
-            )
+            with _transport_agent("owner-agent"):
+                swapped = await metronix_memory_search(
+                    query="recall", workspace_id="ws-a", agent_id="owner-agent"
+                )
+            with _transport_agent("shared-agent"):
+                write = await metronix_memory_store(
+                    content="attempted mutation",
+                    workspace_id="ws-a",
+                    agent_id="shared-agent",
+                )
     finally:
         reset_principal(token)
 
@@ -137,12 +156,17 @@ async def test_review_actions_use_the_same_agent_capability_decision(
                 new=AsyncMock(return_value=service),
             ) as build_resolve,
         ):
-            list_out = await metronix_memory_review_list(
-                workspace_id="ws-a", agent_id="owner-agent"
-            )
-            resolve_out = await metronix_memory_review_resolve(
-                review_id="review-1", action="keep", workspace_id="ws-a", agent_id="shared-agent"
-            )
+            with _transport_agent("owner-agent"):
+                list_out = await metronix_memory_review_list(
+                    workspace_id="ws-a", agent_id="owner-agent"
+                )
+            with _transport_agent("shared-agent"):
+                resolve_out = await metronix_memory_review_resolve(
+                    review_id="review-1",
+                    action="keep",
+                    workspace_id="ws-a",
+                    agent_id="shared-agent",
+                )
     finally:
         reset_principal(token)
 
@@ -150,3 +174,32 @@ async def test_review_actions_use_the_same_agent_capability_decision(
     assert resolve_out["error"]["code"] == "AUTH_REQUIRED"
     build_list.assert_not_awaited()
     build_resolve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mismatched_transport_agent_is_rejected_before_access_or_storage() -> None:
+    from metronix.mcp.tools.memory_store import metronix_memory_store
+
+    access = AsyncMock()
+    build_service = AsyncMock()
+    principal_token = bind_principal(MCPPrincipal("owner", "editor", ("ws-a",)))
+    try:
+        with (
+            _transport_agent("header-agent"),
+            patch("metronix.mcp.tools._agent_access.require_agent_access", access),
+            patch(
+                "metronix.mcp.tools.memory_store._memory_deps.build_memory_service_for_workspace",
+                build_service,
+            ),
+        ):
+            result = await metronix_memory_store(
+                content="must not be stored",
+                workspace_id="ws-a",
+                agent_id="tool-agent",
+            )
+    finally:
+        reset_principal(principal_token)
+
+    assert result["error"]["code"] == "INVALID_PARAMS"
+    access.assert_not_awaited()
+    build_service.assert_not_awaited()

--- a/tests/integration/mcp/test_memory_review_end_to_end.py
+++ b/tests/integration/mcp/test_memory_review_end_to_end.py
@@ -20,6 +20,7 @@ import pytest
 from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from metronix.activity.context import bind_agent_id, current_agent_id
 from metronix.core.config import get_settings
 from metronix.core.models import (
     LifecycleStatus,
@@ -37,7 +38,7 @@ pytestmark = pytest.mark.integration
 
 def _reset_mcp_caches() -> None:
     _memory_deps._reset_cache_for_tests()
-    _agent_access.get_agent_access_authorizer.cache_clear()
+    _agent_access.get_authorization_evaluator.cache_clear()
     _agent_access.get_agent_access_audit_store.cache_clear()
 
 
@@ -73,6 +74,7 @@ async def test_memory_review_resolve_keep_end_to_end() -> None:
     pg_store = MemoryPostgresStore(engine)
     freshness_store = FreshnessStore(engine)
     principal_token = bind_principal(MCPPrincipal(principal_user_id, "editor", (workspace_id,)))
+    agent_token = bind_agent_id(agent_id)
 
     try:
         async with engine.begin() as conn:
@@ -173,10 +175,11 @@ async def test_memory_review_resolve_keep_end_to_end() -> None:
             workspace_id, "memory_record", record_id
         )
         assert any(
-            e.event_type == "freshness_review_resolved" and e.actor == "mcp:agent-access-v1"
+            e.event_type == "freshness_review_resolved" and e.actor == "mcp:authz-v1"
             for e in events
         )
     finally:
+        current_agent_id.reset(agent_token)
         reset_principal(principal_token)
         _reset_mcp_caches()
         await _cleanup(engine, workspace_id)

--- a/tests/integration/mcp/test_memory_search_status_live.py
+++ b/tests/integration/mcp/test_memory_search_status_live.py
@@ -13,6 +13,7 @@ import pytest
 from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from metronix.activity.context import bind_agent_id, current_agent_id
 from metronix.core.config import get_settings
 from metronix.core.models import LifecycleStatus, MemoryRecord, MemoryScope
 from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
@@ -25,7 +26,7 @@ pytestmark = pytest.mark.integration
 
 def _reset_mcp_caches() -> None:
     _memory_deps._reset_cache_for_tests()
-    _agent_access.get_agent_access_authorizer.cache_clear()
+    _agent_access.get_authorization_evaluator.cache_clear()
     _agent_access.get_agent_access_audit_store.cache_clear()
 
 
@@ -48,6 +49,7 @@ async def test_search_default_filters_out_archived() -> None:
     active_id = uuid4().hex
     archived_id = uuid4().hex
     principal_token = bind_principal(MCPPrincipal("integration-admin", "admin", (workspace_id,)))
+    agent_token = bind_agent_id("agent-it")
     try:
         active_rec = MemoryRecord(
             id=active_id,
@@ -109,6 +111,7 @@ async def test_search_default_filters_out_archived() -> None:
         # archived should be included.
         assert archived_id in ids_all
     finally:
+        current_agent_id.reset(agent_token)
         reset_principal(principal_token)
         _reset_mcp_caches()
         await qdrant.close()

--- a/tests/unit/mcp/tools/test_agent_access_guard.py
+++ b/tests/unit/mcp/tools/test_agent_access_guard.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from metronix.activity.context import bind_agent_id, current_agent_id
 from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 
 
@@ -58,6 +59,7 @@ async def test_denied_update_does_not_query_memory_service(
     service = AsyncMock()
     monkeypatch.setattr(_agent_access, "get_authorization_evaluator", lambda: DenyingEvaluator())
     token = bind_principal(MCPPrincipal("u1", "editor", ("ws-a",)))
+    agent_token = bind_agent_id("other-agent")
     try:
         with patch(
             "metronix.mcp.tools.memory_update._memory_deps.build_memory_service_for_workspace",
@@ -70,6 +72,7 @@ async def test_denied_update_does_not_query_memory_service(
                 content="attempted change",
             )
     finally:
+        current_agent_id.reset(agent_token)
         reset_principal(token)
 
     assert out["error"]["code"] == "AUTH_REQUIRED"

--- a/tests/unit/test_mcp_tool_wrapper.py
+++ b/tests/unit/test_mcp_tool_wrapper.py
@@ -177,7 +177,7 @@ async def test_wrapper_binds_agent_id_to_contextvar(
     assert current_agent_id.get() is None  # reset on exit
 
 
-async def test_activity_uses_server_resolved_context_not_raw_tool_arguments(
+async def test_authenticated_matching_agent_identity_reaches_handler_and_activity(
     bus_spy: tuple[EventBus, list[tuple[str, dict[str, object]]]],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -201,16 +201,80 @@ async def test_activity_uses_server_resolved_context_not_raw_tool_arguments(
     principal_token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
     agent_token = bind_agent_id("transport-agent")
     try:
-        await wrapped(agent_id="raw-target-agent", workspace_id="  ws-a  ")
+        result = await wrapped(agent_id="transport-agent", workspace_id="  ws-a  ")
     finally:
         current_agent_id.reset(agent_token)
         reset_principal(principal_token)
 
+    assert result == "ok"
     payload = next(p for n, p in calls if n == evt.TOOL_CALLED)
     assert payload["workspace_id"] == "ws-a"
     assert payload["agent_id"] == "transport-agent"
     assert telemetry_contexts[0]["workspace_id"] == "ws-a"
     assert telemetry_contexts[0]["agent_id"] == "transport-agent"
+
+
+@pytest.mark.parametrize("transport_agent_id", [None, "invalid agent/id"])
+async def test_authenticated_agent_tool_rejects_missing_or_invalid_header_before_handler(
+    transport_agent_id: str | None,
+) -> None:
+    called = False
+
+    async def my_tool(*, agent_id: str, workspace_id: str) -> str:
+        nonlocal called
+        called = True
+        return "ok"
+
+    wrapped = _wrap_tool_with_activity("my_tool", my_tool, bus_getter=lambda: None)
+    principal_token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    agent_token = bind_agent_id(transport_agent_id)
+    try:
+        result = await wrapped(agent_id="tool-agent", workspace_id="ws-a")
+    finally:
+        current_agent_id.reset(agent_token)
+        reset_principal(principal_token)
+
+    assert result["error"]["code"] == "INVALID_PARAMS"
+    assert "X-Agent-Id" in result["error"]["message"]
+    assert called is False
+
+
+async def test_authenticated_agent_tool_rejects_mismatch_before_handler() -> None:
+    called = False
+
+    async def my_tool(*, agent_id: str, workspace_id: str) -> str:
+        nonlocal called
+        called = True
+        return "ok"
+
+    wrapped = _wrap_tool_with_activity("my_tool", my_tool, bus_getter=lambda: None)
+    principal_token = bind_principal(MCPPrincipal("u1", "viewer", ("ws-a",)))
+    agent_token = bind_agent_id("transport-agent")
+    try:
+        result = await wrapped(agent_id="tool-agent", workspace_id="ws-a")
+    finally:
+        current_agent_id.reset(agent_token)
+        reset_principal(principal_token)
+
+    assert result["error"]["code"] == "INVALID_PARAMS"
+    assert "must match" in result["error"]["message"]
+    assert called is False
+
+
+async def test_unauthenticated_local_agent_tool_keeps_argument_fallback() -> None:
+    captured: list[str | None] = []
+
+    async def my_tool(*, agent_id: str) -> str:
+        captured.append(current_agent_id.get())
+        return "ok"
+
+    wrapped = _wrap_tool_with_activity("my_tool", my_tool, bus_getter=lambda: None)
+
+    result = await wrapped(agent_id="local-agent")
+
+    assert result == "ok"
+    assert captured == ["local-agent"]
+    assert current_agent_id.get() is None
 
 
 async def test_denied_workspace_does_not_emit_tenant_scoped_activity(

--- a/tests/unit/test_mcp_tool_wrapper.py
+++ b/tests/unit/test_mcp_tool_wrapper.py
@@ -261,7 +261,7 @@ async def test_authenticated_agent_tool_rejects_mismatch_before_handler() -> Non
     assert called is False
 
 
-async def test_unauthenticated_local_agent_tool_keeps_argument_fallback() -> None:
+async def test_wrapper_keeps_argument_context_without_principal() -> None:
     captured: list[str | None] = []
 
     async def my_tool(*, agent_id: str) -> str:

--- a/tests/unit/test_memory_batch_store.py
+++ b/tests/unit/test_memory_batch_store.py
@@ -148,7 +148,7 @@ class TestMemoryBatchStore:
         stored = MemoryRecord(
             id="id1",
             workspace_id="ws1",
-            agent_id="hermes",
+            agent_id="agent-a",
             scope=MemoryScope.SESSION,
             source_type="",
             content="session fact",
@@ -164,7 +164,7 @@ class TestMemoryBatchStore:
 
             result = await metronix_memory_batch_store(
                 records=[{"content": "session fact"}],
-                agent_id="hermes",
+                agent_id="agent-a",
                 workspace_id="ws1",
                 scope="session",
                 session_id="sess1",

--- a/tests/unit/test_memory_context_mcp.py
+++ b/tests/unit/test_memory_context_mcp.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from metronix.activity.context import bind_agent_id, current_agent_id
 from metronix.core.models import AssembledContext
 from metronix.mcp.principal import MCPPrincipal, bind_principal, reset_principal
 from metronix.mcp.tools.memory_context import metronix_memory_get_context
+
+
+@pytest.fixture(autouse=True)
+def matching_transport_agent() -> object:
+    """Use the same authenticated transport identity as this module's tool calls."""
+    token = bind_agent_id("agent-1")
+    try:
+        yield
+    finally:
+        current_agent_id.reset(token)
 
 
 class TestMemoryGetContextFlagOff:
@@ -44,7 +57,7 @@ class TestMemoryGetContextValidation:
             query="test",
         )
         assert "error" in result
-        assert "must be 1-64 chars" in result["error"]["message"]
+        assert "must match" in result["error"]["message"]
 
     async def test_missing_workspace_id(self) -> None:
         result = await metronix_memory_get_context(

--- a/tests/unit/test_memory_update.py
+++ b/tests/unit/test_memory_update.py
@@ -7,9 +7,23 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from metronix.activity.context import bind_agent_id, current_agent_id
 from metronix.core.models import LifecycleStatus, MemoryRecord, MemoryScope
 from metronix.mcp.tools.memory_update import metronix_memory_update
 from metronix.storage.memory_postgres import MemoryPostgresStore
+
+
+@pytest.fixture(autouse=True)
+def matching_transport_agent() -> object:
+    """Use the same authenticated transport identity as this module's tool calls."""
+    token = bind_agent_id("agent1")
+    try:
+        yield
+    finally:
+        current_agent_id.reset(token)
+
 
 # ---------------------------------------------------------------------------
 # Helpers (same pattern as test_memory_postgres.py)


### PR DESCRIPTION
## Summary
- reject missing, invalid, or mismatched `X-Agent-Id` values for authenticated agent-memory MCP calls before authorization or data access
- preserve handler-level authorization as authoritative when no principal exists, including local/stdio connections
- align unit and integration fixtures with authenticated transport identity
- update MCP documentation and regression coverage

## Verification
- GitHub Actions `pytest (unit, with services)`: passed
- GitHub Actions Ruff formatting and lint: passed
- GitHub Actions CodeQL for Python and JavaScript/TypeScript: passed
- focused identity and documentation suite: 75 passed
- live Postgres, Qdrant, and Ollama MCP integration tests: 2 passed

Closes #427