### PR TITLE
refactor(storage): route store construction through a backend factory (Phase 0)

### DIFF
--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -1,0 +1,176 @@
+# Storage layer
+
+Metronix is heading toward two editions that share one memory/retrieval core and
+differ only in the physical storage layer:
+
+- **heavy / multi-tenant** — PostgreSQL + Qdrant + Neo4j + Redis (today's stack);
+- **light / single-user** — SQLite, no separate vector service, a null/embedded
+  graph, external model host.
+
+This document tracks the seam between the two and is the **porting checklist** for
+anyone writing a non-PostgreSQL implementation of a store.
+
+---
+
+## The seam: `STORAGE_BACKEND` + `metronix.storage.factory`
+
+`STORAGE_BACKEND` (`Settings.storage_backend`, default `postgres`) selects the
+relational backend. It is validated at config load and re-checked in
+`metronix.storage.factory.require_supported_backend()`.
+
+Every construction of the two relational stores goes through the factory:
+
+| Factory function | Builds | Backs |
+|---|---|---|
+| `build_document_store(dsn)` | `PostgresStore` | `raw_documents`, `connections`, `sync_logs`, `connector_state`, dedup fingerprints, trace tables |
+| `build_memory_store(engine)` | `MemoryPostgresStore` | `memory_records`, `review_entries`, dedup-simhash helpers |
+
+### What Phase 0 did
+
+- Added `STORAGE_BACKEND` (only `postgres` accepted) and `metronix/storage/factory.py`.
+- Routed the scattered `PostgresStore(...)` / `MemoryPostgresStore(...)` calls in
+  the hot paths through the factory: `mcp/tools/_memory_deps.py`,
+  `mcp/tools/_source_deps.py`, `api/dependencies.py`, `api/app.py` (lifespan +
+  proxy builder), `ingestion/pipeline.py`, `memory/freshness/worker.py`,
+  `export/deps.py`, `app.py` (launcher).
+
+### What Phase 0 did **not** do (deliberately, to keep behaviour byte-identical)
+
+- No interface / `Protocol` extracted yet — the factory returns the concrete
+  Postgres classes. Deriving `MemoryStorePort` / `DocumentStorePort` /
+  `ConnectionStorePort` from the real method surface is Phase 2.
+- Engine creation and caching still live at the call sites
+  (`create_async_engine(...)`, `app.state.memory_pg_engine`). Moving the
+  connection lifecycle behind the factory is Phase 2/3.
+- No `ensure_schema()` for the core tables — schema is still alembic-only. A
+  portable schema path (or a second migration set) is Phase 3.
+
+### Remaining direct constructions (mechanical follow-up, not in Phase 0)
+
+`api/routes/{graph,files,connections,admin}.py` (all behind an
+`app.state.postgres` fallback that the lifespan already populates),
+`benchmarker/api/generation.py`, `storage/migrate_env_connections.py` (a
+pre-boot script). These construct only in isolated/test setups on the real path;
+converting them also touches `test_files_routes.py` / `test_upload_alias.py` /
+`test_benchmarker_endpoints.py`, so they were left for a follow-up PR.
+
+---
+
+## Porting checklist — non-portable SQL per store
+
+Each store below is a concrete `asyncpg`/SQLAlchemy class holding raw SQL
+strings. A SQLite (or other) implementation must replace the constructs listed.
+Line numbers are approximate — grep the construct.
+
+### `storage/memory_postgres.py` — `MemoryPostgresStore` (~53 KB) · **hardest**
+
+| Construct | Where | Notes for a port |
+|---|---|---|
+| `tags @> CAST(:x AS jsonb)` (containment) | tag filter (~702, 714) | SQLite: `json_each` + `EXISTS`, or a tags join table |
+| `tags \|\| CAST(:x AS jsonb)` (jsonb concat) | tag merge on update (~703) | rebuild the array in Python or `json_group_array` |
+| `jsonb_agg(e) FROM jsonb_array_elements_text(CAST(:x AS jsonb)) WHERE NOT tags @> jsonb_build_array(e)` | dedup-append tags (~712–714) | needs an algorithmic rewrite, not a shim |
+| `= ANY(:list)` | `kind` / `source_type` / `status` / `id` filters (~314–377, 549, 1032, 1056, 1086) | SQLite: expand to `IN (...)` with bound params |
+| `unnest(CAST(:ids AS text[]))` + `unnest(CAST(:simhashes AS bigint[]))` | batch simhash lookup (~1290) | SQLite: `json_each` over two arrays, or a temp table |
+| `NOW() - make_interval(days => :days)` | stale / recent windows (~1088, 1140) | SQLite: `datetime('now', :days \|\| ' days')` |
+| `date_trunc('day', created_at)::date` | activity histogram (~1165) | SQLite: `date(created_at)` |
+| `INTERVAL '1 minute'` | last-accessed throttle (~1035) | SQLite: `datetime(..., '-1 minute')` |
+| `CAST(:x AS jsonb)` on `metadata` | insert/update (~197, 200) | store JSON as `TEXT`; `_as_json_dict` already tolerates str |
+| `ON CONFLICT (id) DO UPDATE` + `RETURNING` | upsert (~200), ~22 `RETURNING` sites | SQLite ≥ 3.35 supports both; verify `EXCLUDED` forms |
+| `content_simhash` as signed `BIGINT` via `_to_pg_bigint` / `_from_pg_bigint` | (~28, 48) | SQLite `INTEGER` is 64-bit signed — the conversion helpers already produce that |
+
+### `storage/postgres.py` — `PostgresStore` (~79 KB) · **largest**
+
+| Construct | Where | Notes |
+|---|---|---|
+| `SELECT ... FOR UPDATE` | `update_connection` (~472) | SQLite serialises writers DB-wide — drop the clause or app-lock |
+| `claim_connection_for_sync` / `release_sync_claim` — conditional `UPDATE ... WHERE status != 'syncing' ... RETURNING id` and `WHERE sync_claim_id = :id RETURNING id` (#425) | (~587, ~632) | correctness leans on row-level MVCC; a SQLite port implements the claim with single-writer semantics or an app-level lock, exposed as an explicit port method in Phase 2 |
+| `ON CONFLICT (...) DO UPDATE` | `set_connector_state` (~169), fingerprints | SQLite ≥ 3.35 |
+| `= ANY(:ids)` / `= ANY(:source_ids)` | unsync / fingerprint queries (~1499, 1538, 1575) | expand to `IN (...)` |
+| `CAST(:x AS JSONB)` / `::jsonb` | `connector_state`, sync-log errors (~433, 843, 939) | JSON as `TEXT` |
+| `pg_try_advisory_lock` / `pg_advisory_lock` | (~1430) | SQLite: a file lock or in-process lock |
+| `EXTRACT(EPOCH FROM (:now - created_at)) * 1000` | duration calc (also `recovery.py:47`) | SQLite: `(julianday(:now) - julianday(created_at)) * 86400000` |
+
+### `storage/conversation_postgres.py` — `ConversationPostgresStore`
+
+| Construct | Where | Notes |
+|---|---|---|
+| `FOR UPDATE SKIP LOCKED` | compaction-claim queue (~329) | **no SQLite equivalent** — move the queue into the single process or Redis |
+| `FOR UPDATE` | (~400) | drop / app-lock |
+| `jsonb_array_elements_text(CAST(:event_ids AS jsonb))` | (~451) | `json_each` |
+| `ON CONFLICT` + `RETURNING` | (~250, ~354) | SQLite ≥ 3.35 |
+
+*Flag-gated off by default (`METRONIX_CONVERSATION_COMPACTION_ENABLED=false`) — lowest priority; may be marked "postgres-only, not in the light build".*
+
+### `storage/freshness_pg.py` — `FreshnessStore`
+
+| Construct | Where | Notes |
+|---|---|---|
+| `ON CONFLICT` | lifecycle upserts (~121) | SQLite ≥ 3.35 |
+| `CAST(:payload AS jsonb)` | (~369) | JSON as `TEXT` |
+| Redis heartbeat / lock coordination (`CoordinationStore`) | freshness queue | not SQL — a light edition needs an in-process lock or drops the pipeline |
+
+*Also flag-gated off by default (`METRONIX_FRESHNESS_ENABLED=false`).*
+
+### `storage/activity_pg.py` — `ActivityStore`
+
+| Construct | Where | Notes |
+|---|---|---|
+| `event_type = ANY(:event_types)` | list filter (~89) | expand to `IN (...)` |
+
+Append-only insert + one filtered list — the smallest store, first target for the
+port extraction (Phase 1).
+
+### `storage/recovery.py` — startup recovery (module functions, sync engine)
+
+| Construct | Where | Notes |
+|---|---|---|
+| `EXTRACT(EPOCH FROM (:now - created_at)) * 1000` | (~47) | see `postgres.py` note |
+| `CAST(:err AS jsonb)` | (~46) | JSON as `TEXT` |
+| runs on the **sync** engine (`pg_connection.py`) | — | shares the sync-engine wart with `WorkspaceManager` |
+
+### Non-relational stores (separate ports, later phases)
+
+| Store | File | Light-edition replacement |
+|---|---|---|
+| `QdrantVectorStore` / `AsyncQdrantVectorStore` | `storage/qdrant.py` | `sqlite-vec` `vec0` virtual table in the same DB file, or `pgvector` / in-process cosine scan. Surface to preserve: `add_document`, `search_dense`, `search_hybrid`, `delete_by_doc_labels`, `scroll`, `get_stats`, `_ensure_collection` |
+| `MemoryQdrantStore` | `storage/memory_qdrant.py` | same; surface: `upsert`, `search`, `get`, `scroll`, `delete`, `delete_by_agent`, `update_payload` |
+| Neo4j graph | `storage/{neo4j_graph,graph_ops,graph_entities,memory_graph}.py` (module functions) | recursive SQL over link tables (mnemosyne pattern), or a null graph. Already best-effort / try-except-wrapped on every read path |
+| `RedisSessionCache` + queue/locks | `storage/{memory_redis,redis}.py` | in-process dict + `asyncio.Lock`; not on the base "put doc / ask / save note" path |
+
+---
+
+## Schema provisioning
+
+34 alembic migrations, async env (`asyncpg`) + a psycopg2 sync DSN for the
+migration advisory lock. **18** call sites use raw PostgreSQL-only DDL/DML in
+`op.execute` — `gen_random_uuid()`, `md5()`, `::text` / `::jsonb` casts,
+`ANY(:x)`, partial indexes (`CREATE INDEX ... WHERE ...`), `ARRAY` / `JSONB`
+column types (migrations 001, 004, 009, 023, 025, 027, 032, …).
+
+Porting options (Phase 3):
+
+1. **Second hand-written migration set** (`migrations/sqlite/`) — mnemosyne does
+   exactly this. Accepts the duplication; avoids a lowest-common-denominator DDL.
+2. **Per-store `ensure_schema()`** — the auth stores (`UserStore`, `ApiKeyStore`,
+   `PlatformUserMapper`) already do this and already run on SQLite in tests.
+
+The Postgres edition keeps alembic; the new path is additive.
+
+## Driver
+
+`postgresql+asyncpg` throughout the app; `postgresql://` (psycopg2) for
+migrations and the legacy sync `pg_connection.py` (`WorkspaceManager`, trace
+writes). Finishing the long-postponed async migration of `pg_connection.py`
+removes a second hidden Postgres coupling.
+
+---
+
+## Roadmap (summary)
+
+| Phase | Scope |
+|---|---|
+| **0 (this)** | `STORAGE_BACKEND` + factory; centralize construction; this doc. No behaviour change. |
+| 1 | Ports for the low-surface stores: `ActivityStore`, auth stores, vector, graph, session cache. Independent PRs. |
+| 2 | Ports for `MemoryPostgresStore`, then `PostgresStore` (split into document / connection / trace), then conversation + freshness. |
+| 3 | Schema provisioning path (second migration set or `ensure_schema()`). |
+| — | SQLite implementations land *after* the ports exist, as their own PRs. |

--- a/src/metronix/api/app.py
+++ b/src/metronix/api/app.py
@@ -212,9 +212,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.warning("owui_sync.not_configured", reason="AUTH_PASSWORD is not configured")
 
     # --- PostgresStore (shared) ---
-    from metronix.storage.postgres import PostgresStore
+    from metronix.storage.factory import build_document_store
 
-    store = PostgresStore(settings.postgres_dsn)
+    store = build_document_store(settings.postgres_dsn)
     app.state.postgres = store
 
     # Temporary conversation events already carry a per-row expiry. The worker
@@ -581,8 +581,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         from metronix.proxy.service import ProxyService
         from metronix.proxy.tool_result import ToolResultEnricher
         from metronix.storage.conversation_postgres import ConversationPostgresStore
+        from metronix.storage.factory import build_memory_store
         from metronix.storage.llm_upstream_credentials import LlmUpstreamCredentialsStore
-        from metronix.storage.memory_postgres import MemoryPostgresStore
         from metronix.storage.memory_qdrant import MemoryQdrantStore
         from metronix.storage.memory_redis import RedisSessionCache
         from metronix.storage.redis import RedisStore
@@ -654,7 +654,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
             pg_store = getattr(app.state, "memory_pg_store", None)
             if pg_store is None:
-                pg_store = MemoryPostgresStore(engine)
+                pg_store = build_memory_store(engine)
                 app.state.memory_pg_store = pg_store
 
             redis_cache = getattr(app.state, "redis_cache", None)

--- a/src/metronix/api/dependencies.py
+++ b/src/metronix/api/dependencies.py
@@ -233,6 +233,7 @@ def get_memory_service(request: Request) -> MemoryService:
 
     from metronix.memory.search import MemorySearchService
     from metronix.memory.service import MemoryService
+    from metronix.storage.factory import build_memory_store
     from metronix.storage.memory_postgres import MemoryPostgresStore
     from metronix.storage.memory_qdrant import MemoryQdrantStore
     from metronix.storage.memory_redis import RedisSessionCache
@@ -273,7 +274,7 @@ def get_memory_service(request: Request) -> MemoryService:
         if engine is None:
             engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
             request.app.state.memory_pg_engine = engine
-        pg_store = MemoryPostgresStore(engine)
+        pg_store = build_memory_store(engine)
         request.app.state.memory_pg_store = pg_store
 
     qdrant_store = MemoryQdrantStore(
@@ -368,6 +369,7 @@ def get_memory_health_service(request: Request) -> MemoryHealthService:
     from sqlalchemy.ext.asyncio import create_async_engine
 
     from metronix.memory.health import MemoryHealthService
+    from metronix.storage.factory import build_memory_store
     from metronix.storage.memory_postgres import MemoryPostgresStore
 
     settings: Settings = request.app.state.settings
@@ -392,7 +394,7 @@ def get_memory_health_service(request: Request) -> MemoryHealthService:
         if engine is None:
             engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
             request.app.state.memory_pg_engine = engine
-        pg_store = MemoryPostgresStore(engine)
+        pg_store = build_memory_store(engine)
         request.app.state.memory_pg_store = pg_store
 
     health_service = MemoryHealthService(
@@ -419,6 +421,7 @@ def get_memory_snapshot_service(request: Request) -> MemorySnapshotService:
     from sqlalchemy.ext.asyncio import create_async_engine
 
     from metronix.memory.snapshot import MemorySnapshotService
+    from metronix.storage.factory import build_memory_store
     from metronix.storage.memory_postgres import MemoryPostgresStore
     from metronix.storage.memory_qdrant import MemoryQdrantStore
 
@@ -444,7 +447,7 @@ def get_memory_snapshot_service(request: Request) -> MemorySnapshotService:
         if engine is None:
             engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
             request.app.state.memory_pg_engine = engine
-        pg_store = MemoryPostgresStore(engine)
+        pg_store = build_memory_store(engine)
         request.app.state.memory_pg_store = pg_store
 
     qdrant_store = MemoryQdrantStore(
@@ -480,6 +483,7 @@ def get_raw_document_service(request: Request) -> RawDocumentReadService:
     as :func:`get_memory_health_service`).
     """
     from metronix.knowledge.service import RawDocumentReadService
+    from metronix.storage.factory import build_document_store
     from metronix.storage.postgres import PostgresStore
 
     settings: Settings = request.app.state.settings
@@ -499,7 +503,7 @@ def get_raw_document_service(request: Request) -> RawDocumentReadService:
     # not present (common in minimal test-app setups).
     pg_store: PostgresStore | None = getattr(request.app.state, "postgres", None)
     if pg_store is None:
-        pg_store = PostgresStore(settings.postgres_dsn)
+        pg_store = build_document_store(settings.postgres_dsn)
         request.app.state.postgres = pg_store
 
     service = RawDocumentReadService(pg_store, workspace_id=workspace_id)

--- a/src/metronix/app.py
+++ b/src/metronix/app.py
@@ -74,9 +74,9 @@ async def run_all() -> None:
 
     # Create channel manager (shared store instance)
     from metronix.channels.manager import ChannelManager
-    from metronix.storage.postgres import PostgresStore
+    from metronix.storage.factory import build_document_store
 
-    store = PostgresStore(settings.postgres_dsn)
+    store = build_document_store(settings.postgres_dsn)
 
     # Platform user mapper — resolves channel identities to internal users
     mapper = None

--- a/src/metronix/core/config.py
+++ b/src/metronix/core/config.py
@@ -183,6 +183,18 @@ class Settings(BaseSettings):
     default_workspace_name: str = Field("MTRNIX", alias="DEFAULT_WORKSPACE_NAME")
     workspace_persistence: str = Field("neo4j", alias="WORKSPACE_PERSISTENCE")
 
+    # --- Storage backend (edition split — see docs/STORAGE.md) ---
+    storage_backend: str = Field(
+        "postgres",
+        alias="STORAGE_BACKEND",
+        description=(
+            "Relational storage backend. 'postgres' is the only implementation "
+            "today; the knob exists so a future lightweight (single-user) edition "
+            "can add one without re-touching call sites. Constructed via "
+            "metronix.storage.factory."
+        ),
+    )
+
     # --- Search tuning ---
     search_max_total_chars: int = Field(40000, alias="SEARCH_MAX_TOTAL_CHARS")
     search_max_fragment_chars: int = Field(8000, alias="SEARCH_MAX_FRAGMENT_CHARS")
@@ -616,6 +628,18 @@ class Settings(BaseSettings):
         allowed = {"development", "staging", "production"}
         if v not in allowed:
             msg = f"env must be one of {allowed}, got '{v}'"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("storage_backend")
+    @classmethod
+    def validate_storage_backend(cls, v: str) -> str:
+        allowed = {"postgres"}
+        if v not in allowed:
+            msg = (
+                f"storage_backend must be one of {sorted(allowed)}, got '{v}'. "
+                "Only PostgreSQL is implemented today — see docs/STORAGE.md."
+            )
             raise ValueError(msg)
         return v
 

--- a/src/metronix/export/deps.py
+++ b/src/metronix/export/deps.py
@@ -8,8 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from metronix.export.jobs import ExportJobStore
 from metronix.export.service import ExportService
 from metronix.export.tokens import ExportTokenStore
-from metronix.storage.memory_postgres import MemoryPostgresStore
-from metronix.storage.postgres import PostgresStore
+from metronix.storage.factory import build_document_store, build_memory_store
 from metronix.storage.redis import RedisStore
 
 if TYPE_CHECKING:
@@ -40,8 +39,8 @@ def build_export_service(settings: Settings) -> ExportService:
         return _SERVICE
 
     engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
-    pg_doc_store = PostgresStore(settings.postgres_dsn)
-    mem_store = MemoryPostgresStore(engine)
+    pg_doc_store = build_document_store(settings.postgres_dsn)
+    mem_store = build_memory_store(engine)
     redis_store = RedisStore(settings.redis_url)
 
     _SERVICE = ExportService(

--- a/src/metronix/ingestion/pipeline.py
+++ b/src/metronix/ingestion/pipeline.py
@@ -158,6 +158,7 @@ async def ingest_documents(
         SyncResult with ingestion statistics.
     """
     from metronix.core.config import Settings
+    from metronix.storage.factory import build_document_store
     from metronix.storage.postgres import PostgresStore
     from metronix.storage.qdrant import get_async_hybrid_store
 
@@ -171,7 +172,7 @@ async def ingest_documents(
     _pg_dsn = postgres_dsn or _settings.postgres_dsn
     pg_store: PostgresStore | None = None
     try:
-        pg_store = PostgresStore(_pg_dsn)
+        pg_store = build_document_store(_pg_dsn)
         existing_fps = await pg_store.batch_load_fingerprints(workspace_id)
         if existing_fps:
             dedup_index.load(existing_fps)

--- a/src/metronix/mcp/tools/_memory_deps.py
+++ b/src/metronix/mcp/tools/_memory_deps.py
@@ -46,8 +46,8 @@ async def build_memory_service_for_workspace(workspace_id: str) -> MemoryService
         from metronix.mcp.server import get_activity_bus
         from metronix.memory.search import MemorySearchService
         from metronix.memory.service import MemoryService
+        from metronix.storage.factory import build_memory_store
         from metronix.storage.freshness_pg import FreshnessStore
-        from metronix.storage.memory_postgres import MemoryPostgresStore
         from metronix.storage.memory_qdrant import MemoryQdrantStore
         from metronix.storage.memory_redis import RedisSessionCache
         from metronix.storage.redis import RedisStore
@@ -61,7 +61,7 @@ async def build_memory_service_for_workspace(workspace_id: str) -> MemoryService
         )
 
         engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
-        pg_store = MemoryPostgresStore(engine)
+        pg_store = build_memory_store(engine)
         # MTRNIX-314: FreshnessStore wires the review-queue methods on
         # MemoryService. Shares the same AsyncEngine as MemoryPostgresStore.
         freshness_store = FreshnessStore(engine)

--- a/src/metronix/mcp/tools/_source_deps.py
+++ b/src/metronix/mcp/tools/_source_deps.py
@@ -11,6 +11,7 @@ Underscore prefix intentional — internal to ``mcp/tools``.
 from __future__ import annotations
 
 from metronix.core.config import get_settings
+from metronix.storage.factory import build_document_store
 from metronix.storage.postgres import PostgresStore
 
 _STORE: PostgresStore | None = None
@@ -26,7 +27,7 @@ def get_store() -> PostgresStore:
     """
     global _STORE
     if _STORE is None:
-        _STORE = PostgresStore(get_settings().postgres_dsn)
+        _STORE = build_document_store(get_settings().postgres_dsn)
     return _STORE
 
 

--- a/src/metronix/memory/freshness/worker.py
+++ b/src/metronix/memory/freshness/worker.py
@@ -486,10 +486,9 @@ async def _build_worker() -> FreshnessWorker:
     from metronix.freshness.stages.reconciler import Reconciler
     from metronix.ingestion.freshness.target_raw_document import RawDocumentTarget
     from metronix.memory.freshness.target_memory import MemoryTarget
+    from metronix.storage.factory import build_document_store, build_memory_store
     from metronix.storage.freshness_pg import FreshnessStore
-    from metronix.storage.memory_postgres import MemoryPostgresStore
     from metronix.storage.memory_qdrant import MemoryQdrantStore
-    from metronix.storage.postgres import PostgresStore
     from metronix.storage.qdrant import AsyncQdrantVectorStore
     from metronix.storage.redis import RedisStore
 
@@ -497,7 +496,7 @@ async def _build_worker() -> FreshnessWorker:
     redis = RedisStore(settings.redis_url)
     coordination = CoordinationStore(redis=redis)
     engine = create_async_engine(settings.postgres_dsn, pool_pre_ping=True)
-    memory_pg_store = MemoryPostgresStore(engine)
+    memory_pg_store = build_memory_store(engine)
     freshness_store = FreshnessStore(engine)
 
     # --- Memory pipeline ---
@@ -542,7 +541,7 @@ async def _build_worker() -> FreshnessWorker:
     )
 
     # --- KB pipeline ---
-    kb_pg_store = PostgresStore(settings.postgres_dsn)
+    kb_pg_store = build_document_store(settings.postgres_dsn)
     _kb_qdrant_cache: dict[str, AsyncQdrantVectorStore] = {}
 
     def kb_qdrant_factory(ws: str) -> AsyncQdrantVectorStore:

--- a/src/metronix/storage/factory.py
+++ b/src/metronix/storage/factory.py
@@ -1,0 +1,76 @@
+"""Single construction point for the relational stores.
+
+Phase 0 of the storage-layer extraction (see ``docs/STORAGE.md``). Every call
+site that used to do ``PostgresStore(dsn)`` or ``MemoryPostgresStore(engine)``
+now goes through :func:`build_document_store` / :func:`build_memory_store`, so a
+future lightweight (single-user) edition can register a second backend in
+exactly one place instead of chasing constructor calls across the codebase.
+
+Today ``postgres`` is the only supported backend and the behaviour here is
+byte-identical to calling the concrete constructors directly — this module adds
+a seam, not a feature. ``STORAGE_BACKEND`` is validated at config load
+(:class:`~metronix.core.config.Settings`) and re-checked here so the invariant
+is also enforced at the storage seam itself.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from metronix.core.config import get_settings
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+    from metronix.storage.memory_postgres import MemoryPostgresStore
+    from metronix.storage.postgres import PostgresStore
+
+#: Relational backends this build can construct. A future edition adds ``"sqlite"``.
+SUPPORTED_BACKENDS = frozenset({"postgres"})
+
+
+def require_supported_backend() -> str:
+    """Return the configured ``STORAGE_BACKEND``, or raise if this build lacks it.
+
+    Defensive re-check of the same invariant ``Settings`` validates at load —
+    keeps the failure legible and located at the storage seam if a caller
+    constructs ``Settings`` some other way, or the config validator is later
+    relaxed ahead of a backend actually being wired.
+    """
+    backend = get_settings().storage_backend
+    if backend not in SUPPORTED_BACKENDS:
+        raise ValueError(
+            f"STORAGE_BACKEND={backend!r} is not supported by this build "
+            f"(supported: {sorted(SUPPORTED_BACKENDS)}). "
+            "See docs/STORAGE.md for the edition-split roadmap."
+        )
+    return backend
+
+
+def build_document_store(dsn: str) -> PostgresStore:
+    """Construct the document / connection / sync-log store.
+
+    Backs ``raw_documents``, ``connections``, ``sync_logs``, ``connector_state``
+    and the trace tables. For the ``postgres`` backend this mirrors
+    ``PostgresStore(dsn)`` exactly — the store still creates and owns its own
+    engine.
+    """
+    require_supported_backend()
+    from metronix.storage.postgres import PostgresStore
+
+    return PostgresStore(dsn)
+
+
+def build_memory_store(engine: AsyncEngine) -> MemoryPostgresStore:
+    """Construct the agent-memory record store on a caller-owned engine.
+
+    Backs ``memory_records``, ``review_entries`` and the dedup-fingerprint
+    helpers. For the ``postgres`` backend this mirrors
+    ``MemoryPostgresStore(engine)`` exactly. Engine creation and caching stay
+    with the caller in Phase 0; a later phase moves the connection lifecycle
+    behind the factory.
+    """
+    require_supported_backend()
+    from metronix.storage.memory_postgres import MemoryPostgresStore
+
+    return MemoryPostgresStore(engine)

--- a/tests/unit/storage/test_factory.py
+++ b/tests/unit/storage/test_factory.py
@@ -1,0 +1,55 @@
+"""Phase 0 storage factory — the single construction seam for the relational stores.
+
+Behaviour must stay byte-identical to calling the concrete constructors directly
+for the only supported backend (``postgres``); the guard rejects anything else.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from metronix.core import config as config_mod
+from metronix.storage import factory
+from metronix.storage.memory_postgres import MemoryPostgresStore
+from metronix.storage.postgres import PostgresStore
+
+_DSN = "postgresql+asyncpg://user:pw@localhost:5432/metronix"
+
+
+class _FakeSettings:
+    def __init__(self, backend: str) -> None:
+        self.storage_backend = backend
+
+
+def test_require_supported_backend_returns_postgres_by_default() -> None:
+    assert factory.require_supported_backend() == "postgres"
+
+
+def test_build_document_store_returns_postgres_store() -> None:
+    assert isinstance(factory.build_document_store(_DSN), PostgresStore)
+
+
+def test_build_memory_store_wraps_the_given_engine() -> None:
+    sentinel = object()
+    store = factory.build_memory_store(sentinel)  # type: ignore[arg-type]
+    assert isinstance(store, MemoryPostgresStore)
+    assert store._engine is sentinel
+
+
+@pytest.mark.parametrize("entrypoint", ["require_supported_backend", "build_document_store"])
+def test_unsupported_backend_is_rejected_at_the_seam(monkeypatch, entrypoint: str) -> None:
+    monkeypatch.setattr(factory, "get_settings", lambda: _FakeSettings("sqlite"))
+
+    with pytest.raises(ValueError, match=r"STORAGE_BACKEND.*docs/STORAGE\.md"):
+        if entrypoint == "require_supported_backend":
+            factory.require_supported_backend()
+        else:
+            factory.build_document_store(_DSN)
+
+
+def test_settings_validator_rejects_unknown_backend(monkeypatch) -> None:
+    monkeypatch.setenv("STORAGE_BACKEND", "mongodb")
+    monkeypatch.setattr(config_mod, "_settings", None)
+    with pytest.raises(ValueError, match="storage_backend must be one of"):
+        config_mod.Settings()
+    monkeypatch.setattr(config_mod, "_settings", None)

--- a/tests/unit/test_mcp_source_deps.py
+++ b/tests/unit/test_mcp_source_deps.py
@@ -11,7 +11,7 @@ class _FakeSettings:
 
 def test_resolve_defaults_workspace_to_server_default(monkeypatch):
     monkeypatch.setattr(_source_deps, "get_settings", lambda: _FakeSettings())
-    monkeypatch.setattr(_source_deps, "PostgresStore", lambda dsn: ("store", dsn))
+    monkeypatch.setattr(_source_deps, "build_document_store", lambda dsn: ("store", dsn))
     _source_deps._reset_cache_for_tests()
 
     ws_id, store, key = _source_deps.resolve(None)
@@ -22,7 +22,7 @@ def test_resolve_defaults_workspace_to_server_default(monkeypatch):
 
 def test_resolve_uses_given_workspace(monkeypatch):
     monkeypatch.setattr(_source_deps, "get_settings", lambda: _FakeSettings())
-    monkeypatch.setattr(_source_deps, "PostgresStore", lambda dsn: ("store", dsn))
+    monkeypatch.setattr(_source_deps, "build_document_store", lambda dsn: ("store", dsn))
     _source_deps._reset_cache_for_tests()
 
     ws_id, _store, _key = _source_deps.resolve("teamA")
@@ -34,7 +34,7 @@ def test_resolve_raises_without_fernet_key(monkeypatch):
         fernet_key = ""
 
     monkeypatch.setattr(_source_deps, "get_settings", lambda: _NoKey())
-    monkeypatch.setattr(_source_deps, "PostgresStore", lambda dsn: ("store", dsn))
+    monkeypatch.setattr(_source_deps, "build_document_store", lambda dsn: ("store", dsn))
     _source_deps._reset_cache_for_tests()
 
     with pytest.raises(ValueError, match="FERNET_KEY"):


### PR DESCRIPTION
## What

Introduces `STORAGE_BACKEND` (only `postgres` accepted today) and
`metronix/storage/factory.py` as the **single construction point** for the two
relational stores, and routes the scattered `PostgresStore(...)` /
`MemoryPostgresStore(...)` calls in the hot paths through it.

This is **Phase 0** of splitting Metronix into two editions that share one
memory/retrieval core and differ only in the physical storage layer:

- **heavy / multi-tenant** — today's PostgreSQL + Qdrant + Neo4j + Redis stack;
- **light / single-user** — SQLite, no separate vector service, embedded/null
  graph, external model host.

Before a second backend can exist, the places that build a store have to stop
being scattered across the codebase. That is all this PR does.

## Behaviour change

**None.** For the `postgres` backend the factory functions are literally:

```python
def build_document_store(dsn):     # -> PostgresStore(dsn)
def build_memory_store(engine):    # -> MemoryPostgresStore(engine)
```

plus a `require_supported_backend()` guard that raises if `STORAGE_BACKEND` is
anything other than `postgres`. No SQL touched, no schema change, no alembic
change, engine creation and `app.state` caching left exactly where they were.

## Changes

- **`core/config.py`** — new `storage_backend: str = "postgres"` setting
  (`STORAGE_BACKEND`), rejected at config load if not `postgres`.
- **`storage/factory.py`** (new) — `require_supported_backend()`,
  `build_document_store(dsn)`, `build_memory_store(engine)`.
- Routed through the factory:
  - `mcp/tools/_memory_deps.py`, `mcp/tools/_source_deps.py`
  - `api/dependencies.py` (`get_memory_service`, `get_memory_health_service`,
    `get_memory_snapshot_service`, `get_raw_document_service`)
  - `api/app.py` (lifespan shared store + proxy service builder)
  - `ingestion/pipeline.py`, `memory/freshness/worker.py`
  - `export/deps.py`, `app.py` (unified launcher)
- **`docs/STORAGE.md`** (new) — the seam, what Phase 0 did / did not do, and a
  **porting checklist**: the non-portable SQL per store (`@>` / `jsonb_agg` /
  `unnest(bigint[])` / `= ANY` / `make_interval` / `FOR UPDATE SKIP LOCKED` /
  `pg_advisory_lock` / the #425 conditional-UPDATE claim / …), plus notes on the
  34 alembic migrations and the async/sync driver split. This is the reference
  for whoever writes the SQLite implementations later.
- **`tests/unit/storage/test_factory.py`** (new) — factory returns the concrete
  Postgres classes; the guard and the config validator reject a non-postgres
  backend.
- **`tests/unit/test_mcp_source_deps.py`** — patches `build_document_store`
  instead of `PostgresStore` (the construction point moved into the factory).

## Deliberately out of scope (Phase 0 keeps behaviour byte-identical)

- No `Protocol` / interface extracted yet — the factory returns the concrete
  classes. Deriving `MemoryStorePort` / `DocumentStorePort` /
  `ConnectionStorePort` from the real method surface is Phase 2.
- Engine creation + caching stay at the call sites. Moving the connection
  lifecycle behind the factory is Phase 2/3.
- No portable schema path — still alembic-only. Phase 3.

## Remaining direct constructions (mechanical follow-up, not here)

`api/routes/{graph,files,connections,admin}.py` (all behind an
`app.state.postgres` fallback the lifespan already populates — the real path
never constructs), `benchmarker/api/generation.py`,
`storage/migrate_env_connections.py` (a pre-boot script). Converting them also
churns `test_files_routes.py` / `test_upload_alias.py` /
`test_benchmarker_endpoints.py`, so they are a follow-up PR to keep this one
reviewable.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on all changed files
- [x] `tests/unit/storage/test_factory.py` — 6 new, green
- [x] `tests/unit/test_mcp_source_deps.py` — updated, green
- [x] full `tests/unit` — net delta vs `origin/main` is **0** (see below)
- [x] `mypy src/metronix/` — no new real errors; the pre-existing
  pydantic-plugin "Missing named argument" noise gains one entry for the new
  field (CI does not gate mypy)

---

### Full-suite result (local)

`tests/unit` (`-m "not integration"`): **3265 passed, 9 failed, 88 errors**.

- The **88 errors** are the live-Postgres tiers (`test_connections_sync`,
  `test_postgres_sync_logs`, `test_sync_recovery`, `test_benchmarker_crud`,
  `test_dashboard_sync`) — no reachable Postgres in this environment,
  pre-existing.
- The **9-10 failures** (`test_raw_documents::{TestGetUnsyncedDocuments,
  TestMarkDocumentsSynced,TestProcessUnsyncedGraphs}`, `test_splade`,
  `test_llm_generic_provider`, `test_name_aliases`, `test_token_budget`) are
  **identical with and without this change** — verified by an A/B run of the
  exact set on `origin/main` vs this branch: `10 failed, 17 passed` both times,
  same test names. The `test_raw_documents` ones are the known SQLite
  test-schema `graph_failed` gap (noted in #440); the rest are
  model/service-dependent.

Net delta from this PR: **0**.
