### PR TITLE
fix(connectors): iterate the Confluence paginator instead of len()-ing it (#460)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,11 @@ dependencies = [
 
 [project.optional-dependencies]
 connectors = [
-    "atlassian-python-api>=5.0.0,<6",
+    # 5.x split Confluence into Cloud/Server clients and made get_all_* return
+    # generators (upstream PR #1616); the connector depends on that contract plus
+    # the 5.0.3/5.0.4 Confluence REST fixes. <6 guards the next major, where
+    # pagination behaviour changed once before (4 -> 5). uv.lock pins the build.
+    "atlassian-python-api>=5.0.4,<6",
     "notion-client>=2.2,<3",
     "PyGithub>=2.5,<3",
     "google-api-python-client>=2.198.0,<3",

--- a/src/metronix/connectors/confluence.py
+++ b/src/metronix/connectors/confluence.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import contextlib
 import time
+from collections.abc import Iterator
 from datetime import datetime
+from typing import Any
 
 import structlog
 
@@ -19,6 +21,28 @@ from metronix.core.interfaces import ConnectorInterface
 from metronix.core.models import Connection, Document
 
 logger = structlog.get_logger()
+
+
+def _iter_pages(result: Any) -> Iterator[dict[str, Any]]:
+    """Normalise ``get_all_pages_from_space``'s return value to an iterator of pages.
+
+    ``atlassian-python-api`` changed this method's contract across majors:
+
+    * ``<= 3.41`` — a ``list``: one page slab of up to ``limit`` items; the
+      caller paginated with ``start`` / ``limit``.
+    * ``4.0.4 - 4.0.7`` — a ``list``: every page, auto-paginated internally.
+    * ``>= 5.0.0`` — a **generator** that walks ``_links.next`` across all pages
+      (upstream PR #1616). ``len()`` on it raises
+      ``TypeError: object of type 'generator' has no len()`` — issue #460.
+
+    A raw ``{"results": [...]}`` dict is also tolerated defensively. The result
+    is always iterated exactly once, so a generator is safe to pass through.
+    """
+    if result is None:
+        return iter(())
+    if isinstance(result, dict):
+        return iter(result.get("results", []))
+    return iter(result)
 
 
 class ConfluenceConnector(ConnectorInterface):
@@ -68,49 +92,38 @@ class ConfluenceConnector(ConnectorInterface):
         base_url: str,
         space_key: str,
     ) -> list[Document]:
-        """Full sync using content API (returns body.storage)."""
+        """Full sync — walk every page in the space (``body.storage`` expanded).
+
+        ``get_all_pages_from_space`` is a lazily-paginated generator in
+        atlassian-python-api 5.x (it follows ``_links.next`` internally); it was
+        a plain list in <= 4.x. ``_iter_pages`` normalises both, so we iterate
+        once — no manual ``start`` / ``limit`` paging and no ``len()`` (see #460).
+
+        The pre-5.x inline per-batch 429 retry is gone: the 5.x paginator raises
+        from inside iteration and cannot be resumed after a sleep. A rate limit
+        (or any transport error) now fails the full sync — ``last_synced_at`` is
+        not advanced and the next scheduled run retries from scratch. Callers
+        that need transparent backoff can enable it at the client level
+        (``backoff_and_retry=True``); tracked separately.
+        """
         documents: list[Document] = []
-        start, limit = 0, 25
         expand = "body.storage,version,history"
+        space_arg = space_key or None
 
-        while True:
-            try:
-                if space_key:
-                    pages = self._client.get_all_pages_from_space(
-                        space_key,
-                        start=start,
-                        limit=limit,
-                        expand=expand,
-                    )
-                else:
-                    pages = self._client.get_all_pages_from_space(
-                        None,
-                        start=start,
-                        limit=limit,
-                        expand=expand,
-                    )
-            except Exception as e:
-                if "429" in str(e) or "Too Many" in str(e):
-                    logger.warning("confluence.rate_limit", start=start)
-                    time.sleep(4)
-                    continue
-                raise
+        pages = self._client.get_all_pages_from_space(space_arg, limit=25, expand=expand)
 
-            if not pages:
-                break
-
-            for page in pages:
+        try:
+            for page in _iter_pages(pages):
                 try:
                     doc = self._page_to_document(page, workspace_id, base_url, space_key)
                     documents.append(doc)
                 except Exception as e:
+                    # one bad page must not abort the whole sync
                     logger.warning("confluence.page.error", error=str(e))
-
-            if len(pages) < limit:
-                break
-            start += limit
-            if len(documents) % 50 < limit:
-                logger.info("confluence.fetch.progress", pages=len(documents))
+        except Exception as e:
+            if "429" in str(e) or "Too Many" in str(e):
+                logger.warning("confluence.rate_limit", fetched=len(documents))
+            raise
 
         logger.info("confluence.fetch.done", pages=len(documents))
         return documents

--- a/tests/unit/test_confluence_connector.py
+++ b/tests/unit/test_confluence_connector.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from metronix.connectors.confluence import ConfluenceConnector
+from metronix.connectors.confluence import ConfluenceConnector, _iter_pages
 from metronix.connectors.confluence_processing import process_confluence_page
 from metronix.connectors.jira import JiraConnector
 from metronix.core.interfaces import ConnectorInterface
@@ -211,3 +213,127 @@ class TestConfluenceFetchPostFilter:
             since=since,
         )
         assert len(docs) == 1
+
+
+# ---------------------------------------------------------------------------
+# _iter_pages — normalise get_all_pages_from_space across library majors (#460)
+# ---------------------------------------------------------------------------
+
+
+class TestIterPages:
+    def test_list_passes_through(self) -> None:
+        assert list(_iter_pages([{"id": "1"}, {"id": "2"}])) == [{"id": "1"}, {"id": "2"}]
+
+    def test_generator_passes_through(self) -> None:
+        gen = (p for p in [{"id": "1"}, {"id": "2"}])
+        assert list(_iter_pages(gen)) == [{"id": "1"}, {"id": "2"}]
+
+    def test_results_dict_is_unwrapped(self) -> None:
+        assert list(_iter_pages({"results": [{"id": "1"}], "size": 1})) == [{"id": "1"}]
+
+    def test_dict_without_results_is_empty(self) -> None:
+        assert list(_iter_pages({"size": 0})) == []
+
+    def test_none_is_empty(self) -> None:
+        assert list(_iter_pages(None)) == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_full — must not call len() on the 5.x paginator (#460)
+# ---------------------------------------------------------------------------
+
+
+class TestConfluenceFetchFull:
+    @staticmethod
+    def _connector() -> ConfluenceConnector:
+        c = ConfluenceConnector()
+        c._config = {
+            "url": "https://co.atlassian.net",
+            "space_key": "ENG",
+            "username": "u",
+            "api_token": "t",
+        }
+        c._client = MagicMock()
+        return c
+
+    def _run(self, connector: ConfluenceConnector, space_key: str = "ENG") -> list:
+        return connector._fetch_full(
+            workspace_id="ws1",
+            base_url="https://co.atlassian.net",
+            space_key=space_key,
+        )
+
+    def test_generator_result_is_fully_consumed(self) -> None:
+        """atlassian-python-api 5.x returns a generator — the #460 crash case."""
+        connector = self._connector()
+        connector._client.get_all_pages_from_space.return_value = (
+            _page(str(i), "2026-05-12T22:09:28.000Z") for i in range(3)
+        )
+
+        docs = self._run(connector)
+
+        assert [d.source_id for d in docs] == ["0", "1", "2"]
+        # one call, no per-page start/limit paging
+        connector._client.get_all_pages_from_space.assert_called_once()
+
+    def test_list_result_still_works(self) -> None:
+        """<= 4.x returned a list — the normaliser keeps that path working."""
+        connector = self._connector()
+        connector._client.get_all_pages_from_space.return_value = [
+            _page("10", "2026-05-12T22:09:28.000Z"),
+            _page("11", "2026-05-12T22:09:28.000Z"),
+        ]
+
+        docs = self._run(connector)
+
+        assert [d.source_id for d in docs] == ["10", "11"]
+
+    def test_empty_generator_yields_no_documents(self) -> None:
+        connector = self._connector()
+        connector._client.get_all_pages_from_space.return_value = iter(())
+
+        assert self._run(connector) == []
+
+    def test_dict_result_is_unwrapped(self) -> None:
+        connector = self._connector()
+        connector._client.get_all_pages_from_space.return_value = {
+            "results": [_page("20", "2026-05-12T22:09:28.000Z")],
+        }
+
+        docs = self._run(connector)
+        assert [d.source_id for d in docs] == ["20"]
+
+    def test_one_bad_page_does_not_abort_the_batch(self) -> None:
+        connector = self._connector()
+        connector._client.get_all_pages_from_space.return_value = iter(
+            [
+                _page("30", "2026-05-12T22:09:28.000Z"),
+                None,  # a malformed page — _page_to_document raises on .get()
+                _page("32", "2026-05-12T22:09:28.000Z"),
+            ]
+        )
+
+        docs = self._run(connector)
+        assert [d.source_id for d in docs] == ["30", "32"]
+
+    def test_no_space_key_passes_none(self) -> None:
+        connector = self._connector()
+        connector._client.get_all_pages_from_space.return_value = iter(())
+
+        self._run(connector, space_key="")
+
+        args, kwargs = connector._client.get_all_pages_from_space.call_args
+        assert args[0] is None
+
+    def test_rate_limit_mid_stream_propagates(self) -> None:
+        """The 5.x paginator cannot be resumed after a sleep — a 429 fails the sync."""
+        connector = self._connector()
+
+        def _boom() -> object:
+            yield _page("40", "2026-05-12T22:09:28.000Z")
+            raise RuntimeError("429 Too Many Requests")
+
+        connector._client.get_all_pages_from_space.return_value = _boom()
+
+        with pytest.raises(RuntimeError, match="429"):
+            self._run(connector)

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.20,<1" },
     { name = "alembic", specifier = ">=1.19.0,<2" },
     { name = "asyncpg", specifier = ">=0.30,<1" },
-    { name = "atlassian-python-api", marker = "extra == 'connectors'", specifier = ">=5.0.0,<6" },
+    { name = "atlassian-python-api", marker = "extra == 'connectors'", specifier = ">=5.0.4,<6" },
     { name = "backoff", marker = "extra == 'dev'", specifier = ">=2.0,<3" },
     { name = "bcrypt", specifier = ">=4.0" },
     { name = "beautifulsoup4", marker = "extra == 'benchmarker'", specifier = ">=4.15.0,<5" },


### PR DESCRIPTION
Fixes #460.

## What happened

Every full / initial Confluence sync crashed with
`TypeError: object of type 'generator' has no len()` at
`connectors/confluence.py`. `_fetch_full` was written for a library version
where `get_all_pages_from_space(...)` returned a **list** (one page slab), and
paged it manually with `start` / `limit`, checking `len(pages) < limit` to stop.

Verified against the **installed** `atlassian-python-api` 5.0.4 (introspection +
package source, not memory):

- `from atlassian import Confluence` builds a dispatch wrapper — `_impl` is
  `atlassian.confluence.cloud.Cloud` for `*.atlassian.net` URLs, else
  `atlassian.confluence.server.Server`.
- On **both** clients, `get_all_pages_from_space` → `ConfluenceBase._get_paged`,
  which `inspect.isgeneratorfunction` confirms is a **generator** — it walks
  `_links.next` across all pages internally. `len()` on it raises; `if not gen`
  is always false; `for page in gen` drains every page, not `limit`.

### Library version history (why the dependency floor moved)

| Version | `get_all_pages_from_space(...)` returns |
|---|---|
| `<= 3.41` | `list` — one page slab; caller pages with `start`/`limit` |
| `4.0.4 – 4.0.7` | `list` — every page, auto-paginated internally |
| `>= 5.0.0` | **generator** — upstream PR #1616 (*"now return generators instead of dicts"*) + PR #1581 (Cloud/Server split) |

`pyproject.toml` had `>=5.0.0,<6`; bumped the floor to `>=5.0.4` (the tested
build; also includes the 5.0.3 Confluence REST-URL compat and 5.0.4
`get_page_id`-returns-None fixes). `<6` guards the next major, where pagination
already changed once (4 → 5). `uv.lock` pins the exact build.

## Changes

- **`_iter_pages(result)`** helper — normalises `get_all_pages_from_space`'s
  return value (list from `<= 4.x`, generator from `5.x`, or a defensive raw
  `{"results": [...]}` dict) into a single-pass iterator of page dicts.
- **`_fetch_full`** — call `get_all_pages_from_space(space_arg, limit=25,
  expand=...)` once and iterate `_iter_pages(...)`. Removed the manual
  `while True` / `start += limit` loop, the `if not pages` check, and the
  `len(pages)` comparison. Per-page `try/except` kept.
- The pre-5.x inline per-batch **429 retry** (`sleep(4); continue`) is dropped —
  the 5.x paginator raises from inside iteration and cannot be resumed after a
  sleep. A 429 (or any transport error) now fails the full sync; `last_synced_at`
  is not advanced and the next scheduled run retries wholesale. Transparent
  backoff is available at the client level (`backoff_and_retry=True`) as a
  separate follow-up.
- **`pyproject.toml` / `uv.lock`** — pin `atlassian-python-api>=5.0.4,<6`.
- **Tests** (`test_confluence_connector.py`) — `_fetch_full` had **zero**
  coverage, which is why #460 shipped. Added:
  - `TestIterPages` — list, generator, `{"results": [...]}`, dict without
    `results`, `None`.
  - `TestConfluenceFetchFull` — generator result (the #460 case) fully consumed
    with exactly one client call; list result still works; empty generator → 0
    docs; dict result unwrapped; one malformed page in the stream does not abort
    the batch; empty `space_key` passes `None`; a 429 mid-stream propagates.

## Out of scope / adjacent findings (not in this PR)

- **#468** — `_fetch_incremental` calls `get_page_by_id`, which
  `atlassian.confluence.cloud.Cloud` does not have (only `Server` and the v2
  client do; Cloud has `get_content`). Confluence **incremental** sync has never
  worked on Cloud since the 5.x split. Separate fix + test. `_fetch_incremental`
  is untouched here — its `cql()` usage returns a dict on both clients in 5.x and
  is unaffected by the generator change.
- **health_check** — `get_all_spaces` is also a lazy generator now, so
  `health_check` never issues its probe request. `health_check` is dead code in
  production today; tracked in **#463**.
- **#459** — Confluence/Jira blocking HTTP on the event loop. Unrelated.
- **Jira** — not affected by #460. `enhanced_jql` returns a dict
  (`GET /rest/api/3/search/jql`) in 5.x; the connector's token pagination is
  correct.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/metronix/connectors/confluence.py` — 9 errors, all pre-existing
  (`self._client` typed `None`, `Document(**{...})` splat); baseline was 10,
  this PR removes one. CI does not gate mypy.
- [x] `tests/unit/test_confluence_connector.py` — 30 passed (12 new)
- [x] connector + ingestion-sync unit suites — green
- [x] the 3 `test_connections_sync.py::test_run_connection_sync_*` errors are
  pre-existing (need a live Postgres; in the repo's known-failing set)
- [ ] CI `pytest (unit, with services)` — green (runs those DB tiers)
