### PR TITLE
fix(env): move .env.example inline comments to their own line (#458)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@
 #
 # All vars mirror src/metronix/core/config.py (Settings) plus a few read directly
 # via os.environ (MCP server, query-expansion LLM, admin cleanup, entity resolver).
+#
+# Comments go on their own line, above the value they annotate. An inline
+# "# ..." after a value is NOT portable: Docker Compose's env_file parser only
+# strips it when a space precedes the '#' AND the value is non-empty, so
+# `KEY=   # note` resolves to the literal value "# note" (issue #458).
 # =============================================================================
 
 
@@ -24,37 +29,54 @@
 # --- Database & service networking — SET BY docker-compose, .env is ignored ---
 # Inside the Docker network the host is the service name; compose injects these.
 # Editing them here has NO effect for docker-compose.yml.
-POSTGRES_HOST=postgres               # compose -> postgres
-POSTGRES_PORT=5432                    # compose -> 5432
-POSTGRES_DB=metronix                  # compose -> metronix
-POSTGRES_USER=metronix                # compose -> metronix
+# compose -> postgres
+POSTGRES_HOST=postgres
+# compose -> 5432
+POSTGRES_PORT=5432
+# compose -> metronix
+POSTGRES_DB=metronix
+# compose -> metronix
+POSTGRES_USER=metronix
 # Leave blank: install.sh generates a strong value (and fills it on a copied .env);
 # a raw `docker compose up` without the installer falls back to metronix_dev.
 POSTGRES_PASSWORD=
-QDRANT_HOST=qdrant                 # compose -> qdrant
-QDRANT_HTTP_PORT=6333                 # container-internal port (leave default)
-QDRANT_GRPC_PORT=6334                 # container-internal port (leave default)
-QDRANT_API_KEY=                       # only for cloud / authenticated Qdrant
+# compose -> qdrant
+QDRANT_HOST=qdrant
+# container-internal port (leave default)
+QDRANT_HTTP_PORT=6333
+# container-internal port (leave default)
+QDRANT_GRPC_PORT=6334
+# only for cloud / authenticated Qdrant
+QDRANT_API_KEY=
 QDRANT_HTTPS=false
-NEO4J_HOST=neo4j                  # compose -> neo4j
-NEO4J_PORT=7687                       # container-internal port (leave default)
+# compose -> neo4j
+NEO4J_HOST=neo4j
+# container-internal port (leave default)
+NEO4J_PORT=7687
 # NEO4J_AUTH: leave unset to use default "neo4j/<NEO4J_PASSWORD>"; set to "none" to disable auth
 # NEO4J_AUTH=
-REDIS_HOST=redis                  # compose -> redis
-REDIS_PORT=6379                       # compose -> 6379
-REDIS_DB=0                            # compose -> 0
+# compose -> redis
+REDIS_HOST=redis
+# compose -> 6379
+REDIS_PORT=6379
+# compose -> 0
+REDIS_DB=0
 REDIS_PASSWORD=
-SPLADE_SERVICE_URL=http://splade:8080                 # compose -> http://splade:8080
+# compose -> http://splade:8080
+SPLADE_SERVICE_URL=http://splade:8080
 # OLLAMA_HOST: see ZONE 3 — bundled Ollama is forced to http://ollama:11434 by
 # compose; only an EXTERNAL Ollama (separate deployment) makes use of an override.
 
 # --- Auth (JWT) — off by default, not part of the basic install ---
-AUTH_ENABLED=false                    # false: local MCP key; true: JWT on /api/v1/* and /mcp
-AUTH_PASSWORD=                        # required to seed admin@metronix.local; generate with: openssl rand -base64 32
+# false: local MCP key; true: JWT on /api/v1/* and /mcp
+AUTH_ENABLED=false
+# required to seed admin@metronix.local; generate with: openssl rand -base64 32
+AUTH_PASSWORD=
 
 # --- MCP standalone runner — only for `python -m metronix.mcp`, NOT the API mount ---
 # The API serves /mcp over streamable-http regardless of these. (Auth key is in ZONE 3.)
-METRONIX_MCP_TRANSPORT=stdio          # stdio | streamable-http
+# stdio | streamable-http
+METRONIX_MCP_TRANSPORT=stdio
 METRONIX_MCP_HOST=127.0.0.1
 METRONIX_MCP_PORT=8765
 
@@ -72,8 +94,10 @@ OLLAMA_LLM_MODEL=qwen2.5:3b
 # If OLLAMA_LLM_HOST is empty, the main Ollama is reused.
 OLLAMA_LLM_HOST=
 OLLAMA_LLM_PORT=11434
-OLLAMA_NUM_CTX=32768                  # context window for Ollama chat
-OLLAMA_REQUEST_TIMEOUT=               # seconds; empty = library default
+# context window for Ollama chat
+OLLAMA_NUM_CTX=32768
+# seconds; empty = library default
+OLLAMA_REQUEST_TIMEOUT=
 
 # --- Freshness pipeline — NO worker ships with docker-compose.yml ---
 # Master flag is off; the producer is a no-op. Leave disabled unless you also
@@ -93,7 +117,8 @@ METRONIX_FRESHNESS_MAX_CONSECUTIVE_ERRORS=10
 # endpoint only when *_API_BASE_URL / *_PROVIDER below are set; otherwise the
 # local OLLAMA_LLM_MODEL is used.
 METRONIX_FRESHNESS_LLM_MODEL=qwen2.5:3b
-METRONIX_FRESHNESS_LLM_PROVIDER=      # set with API_BASE_URL -> auto "custom"
+# set with API_BASE_URL -> auto "custom"
+METRONIX_FRESHNESS_LLM_PROVIDER=
 METRONIX_FRESHNESS_LLM_API_BASE_URL=
 METRONIX_FRESHNESS_LLM_API_KEY=
 METRONIX_FRESHNESS_HEARTBEAT_TTL_SECONDS=20
@@ -108,13 +133,16 @@ METRONIX_FRESHNESS_WEIGHT=0.0
 METRONIX_FRESHNESS_KB_STALE_AFTER_DAYS=90
 
 # --- LLM generation telemetry (opt-in; internal fine-tuning bootstrap, PROJ-336) ---
-METRONIX_LLM_TELEMETRY_ENABLED=false  # master kill-switch; false -> no-op
+# master kill-switch; false -> no-op
+METRONIX_LLM_TELEMETRY_ENABLED=false
 METRONIX_LLM_TELEMETRY_RETENTION_DAYS=0
 METRONIX_LLM_TELEMETRY_OPT_OUT_CACHE_TTL_SECONDS=60
 
 # --- Ops / dev tooling ---
-ALLOW_CLEANUP=false                   # gate destructive /api/v1/admin/cleanup*
-BENCHMARKER_EMBEDDING_PROXY_URL=http://localhost:8001   # dev eval tool only
+# gate destructive /api/v1/admin/cleanup*
+ALLOW_CLEANUP=false
+# dev eval tool only
+BENCHMARKER_EMBEDDING_PROXY_URL=http://localhost:8001
 
 # --- Legacy connector / channel env vars (transitional) ---
 # Connector creds (CONFLUENCE_*, JIRA_*, NOTION_TOKEN, GITHUB_TOKEN, GDRIVE_*,
@@ -132,11 +160,16 @@ BENCHMARKER_EMBEDDING_PROXY_URL=http://localhost:8001   # dev eval tool only
 # #############################################################################
 
 # --- Application ---
-METRONIX_ENV=development              # development | staging | production
-METRONIX_HOST=0.0.0.0                 # bind address (0.0.0.0 = all interfaces)
-METRONIX_PORT=8000                    # in-container API port (host maps to :8001)
-METRONIX_LOG_LEVEL=INFO               # DEBUG | INFO | WARNING | ERROR | CRITICAL
-CORS_ORIGINS=*                        # comma-separated list, or * for all
+# development | staging | production
+METRONIX_ENV=development
+# bind address (0.0.0.0 = all interfaces)
+METRONIX_HOST=0.0.0.0
+# in-container API port (host maps to :8001)
+METRONIX_PORT=8000
+# DEBUG | INFO | WARNING | ERROR | CRITICAL
+METRONIX_LOG_LEVEL=INFO
+# comma-separated list, or * for all
+CORS_ORIGINS=*
 
 # --- File storage & workspace defaults ---
 FILE_STORE_PATH=./data/files
@@ -144,44 +177,63 @@ FILE_STORE_PATH=./data/files
 # Used together with AGENT_UUID in the agent runtime — see connecting_to_agent.md.
 DEFAULT_WORKSPACE_ID=MTRNIX
 DEFAULT_WORKSPACE_NAME=MTRNIX
-WORKSPACE_PERSISTENCE=neo4j           # neo4j | postgres
+# neo4j | postgres
+WORKSPACE_PERSISTENCE=neo4j
 
 # --- Model defaults (override only if you need a specific model) ---
 # The local chat/graph model lives in OLLAMA_LLM_MODEL (see the Ollama LLM
 # section above). For external answer generation use LLM_PROVIDER=custom with
 # an endpoint (see ZONE 3 below).
-OLLAMA_EMBED_MODEL=nomic-embed-text   # 768-dim; always used for embeddings
-METRONIX_AUX_LLM_TIMEOUT=10           # aux LLM (expansion/classifier) timeout, sec
-LLM_FALLBACK_PROVIDER=                # fallback provider if primary fails
+# 768-dim; always used for embeddings
+OLLAMA_EMBED_MODEL=nomic-embed-text
+# aux LLM (expansion/classifier) timeout, sec
+METRONIX_AUX_LLM_TIMEOUT=10
+# fallback provider if primary fails
+LLM_FALLBACK_PROVIDER=
 
 # --- OpenAI-compatible API (OpenWebUI / LibreChat / OAI clients) ---
-METRONIX_OPENAI_COMPAT_ENABLED=true   # enable /v1/models and /v1/chat/completions
+# enable /v1/models and /v1/chat/completions
+METRONIX_OPENAI_COMPAT_ENABLED=true
 
 # --- Search pipeline: feature toggles ---
-QUERY_EXPANSION_ENABLED=true          # LLM-based query expansion
-RERANKER_ENABLED=false                # bge-reranker-v2-m3 cross-encoder (disabled - hangs on model download)
-QUERY_CLASSIFIER_ENABLED=true         # hybrid rule+LLM query classifier
-HYDE_ENABLED=false                    # HyDE for short/vague queries
-ADAPTIVE_RRF_ENABLED=false            # adaptive RRF fusion (regresses metrics, off)
-ENABLE_SEMANTIC_MATCHING=true         # semantic entity matching in resolver
+# LLM-based query expansion
+QUERY_EXPANSION_ENABLED=true
+# bge-reranker-v2-m3 cross-encoder (disabled - hangs on model download)
+RERANKER_ENABLED=false
+# hybrid rule+LLM query classifier
+QUERY_CLASSIFIER_ENABLED=true
+# HyDE for short/vague queries
+HYDE_ENABLED=false
+# adaptive RRF fusion (regresses metrics, off)
+ADAPTIVE_RRF_ENABLED=false
+# semantic entity matching in resolver
+ENABLE_SEMANTIC_MATCHING=true
 METRONIX_HIERARCHICAL_CHUNKING_ENABLED=true
 
 # --- Search pipeline: PROJ-397 retrieval fixes (defaults = today's behaviour) ---
-METRONIX_RETRIEVAL_SCORING_NORMALIZE_ACTIVE_ONLY=true   # S1 (safe on)
-METRONIX_RETRIEVAL_SLOT_EXTRACTION_ENABLED=false        # B0 (regex-only when off)
+# S1 (safe on)
+METRONIX_RETRIEVAL_SCORING_NORMALIZE_ACTIVE_ONLY=true
+# B0 (regex-only when off)
+METRONIX_RETRIEVAL_SLOT_EXTRACTION_ENABLED=false
 METRONIX_RETRIEVAL_SLOT_EXTRACTION_TIMEOUT=6
-METRONIX_RETRIEVAL_GRAPH_NER_ENABLED=false              # G1
-METRONIX_RETRIEVAL_FUTURE_DATE_FALLBACK_ENABLED=false   # M6
+# G1
+METRONIX_RETRIEVAL_GRAPH_NER_ENABLED=false
+# M6
+METRONIX_RETRIEVAL_FUTURE_DATE_FALLBACK_ENABLED=false
 
 # --- Search pipeline: HyDE tuning ---
 HYDE_MAX_WORDS=4
 HYDE_TIMEOUT=8
 
 # --- Search pipeline: budget & recall ---
-SEARCH_MAX_TOTAL_CHARS=40000          # max context chars sent to LLM
-SEARCH_MAX_FRAGMENT_CHARS=8000        # max chars per single fragment
-SEARCH_POOL_MULTIPLIER=3              # fetch N× more results than needed
-SEARCH_POOL_MIN=15                    # minimum candidate pool size
+# max context chars sent to LLM
+SEARCH_MAX_TOTAL_CHARS=40000
+# max chars per single fragment
+SEARCH_MAX_FRAGMENT_CHARS=8000
+# fetch N× more results than needed
+SEARCH_POOL_MULTIPLIER=3
+# minimum candidate pool size
+SEARCH_POOL_MIN=15
 RECALL_TOP_N_DENSE=30
 RECALL_TOP_N_EXACT=10
 RECALL_TOP_N_METADATA=10
@@ -195,24 +247,31 @@ LLM_CONTEXT_MAX_TOKENS=10000
 LLM_ANSWER_RESERVE_TOKENS=1500
 
 # --- Search pipeline: sparse retrieval ---
-SPLADE_ENABLED=true                   # SPLADE replaces BM25; BM25 is the fallback
+# SPLADE replaces BM25; BM25 is the fallback
+SPLADE_ENABLED=true
 SPLADE_MODEL=naver/splade-cocondenser-ensembledistil
 SPLADE_MAX_LENGTH=256
-BM25_VOCAB_SIZE=30000                 # BM25 fallback vocabulary size
+# BM25 fallback vocabulary size
+BM25_VOCAB_SIZE=30000
 
 # --- Search pipeline: embedding cache & ingest concurrency ---
-EMBEDDING_CACHE_TTL=3600              # seconds
+# seconds
+EMBEDDING_CACHE_TTL=3600
 EMBEDDING_CACHE_MAXSIZE=2048
-INGEST_EMBED_CONCURRENCY=2            # caps ingest-path embedding calls
+# caps ingest-path embedding calls
+INGEST_EMBED_CONCURRENCY=2
 
 # --- Graph extraction ---
 GRAPH_EXTRACTION_ENABLED=true
-GRAPH_EXTRACTION_WORKERS=1            # raise (e.g. 4) to speed up graph phase
+# raise (e.g. 4) to speed up graph phase
+GRAPH_EXTRACTION_WORKERS=1
 GRAPH_EXTRACTION_MIN_CHARS=100
-GRAPH_EXTRACTION_LLM_TIMEOUT=300      # per-call NER timeout (s); raise on slow local CPU, lower for fast endpoints
+# per-call NER timeout (s); raise on slow local CPU, lower for fast endpoints
+GRAPH_EXTRACTION_LLM_TIMEOUT=300
 
 # --- Agent memory (WS1) ---
-METRONIX_MEMORY_SESSION_TTL=14400     # session memory TTL (seconds; 4h)
+# session memory TTL (seconds; 4h)
+METRONIX_MEMORY_SESSION_TTL=14400
 METRONIX_MEMORY_SEARCH_DENSE_WEIGHT=0.6
 METRONIX_MEMORY_SEARCH_GRAPH_WEIGHT=0.3
 METRONIX_MEMORY_SEARCH_SESSION_WEIGHT=0.1
@@ -244,16 +303,19 @@ METRONIX_SEARCH_FAST_INCLUDE_METADATA=true
 # or a cloud API. URL and model are required; the API key is optional
 # (leave blank for a local/internal endpoint with no auth):
 #   LLM_PROVIDER=custom
-#   LLM_PROVIDER_URL=http://host.docker.internal:11434/v1   # or https://api.deepseek.com/v1
-#   LLM_PROVIDER_MODEL=llama3.1:8b                           # or deepseek-chat (required)
-#   LLM_PROVIDER_API_KEY=                                    # optional; blank = no auth
+#   LLM_PROVIDER_URL=http://host.docker.internal:11434/v1   (or https://api.deepseek.com/v1)
+#   LLM_PROVIDER_MODEL=llama3.1:8b                          (or deepseek-chat — required)
+#   LLM_PROVIDER_API_KEY=                                   (optional; blank = no auth)
 #
 LLM_PROVIDER=ollama
 LLM_PROVIDER_URL=
-LLM_PROVIDER_API_KEY=                 # optional; blank = no auth on the endpoint
-LLM_PROVIDER_MODEL=                   # required when LLM_PROVIDER=custom
+# optional; blank = no auth on the endpoint
+LLM_PROVIDER_API_KEY=
+# required when LLM_PROVIDER=custom
+LLM_PROVIDER_MODEL=
 
-OLLAMA_HOST=http://ollama:11434    # bundled stack overrides this to http://ollama:11434
+# bundled stack overrides this to http://ollama:11434
+OLLAMA_HOST=http://ollama:11434
 
 # --- 2) MCP auth token ------------------------------------------------------
 # Legacy Bearer token for local /mcp clients when AUTH_ENABLED=false.

--- a/install.sh
+++ b/install.sh
@@ -1205,10 +1205,11 @@ connect_agent() {
 }
 
 # Return the value .env.example ships for a given key (empty if absent).
-# Strips trailing inline comments so the placeholder check matches bare values.
+# .env.example keeps comments on their own line (issue #458), so the value is
+# taken verbatim; only trailing whitespace is trimmed as a guard.
 example_val() {
   grep -E "^$1=" "$EXAMPLE_FILE" 2>/dev/null | head -1 | cut -d= -f2- \
-    | sed 's/[[:space:]]#.*//' | sed 's/[[:blank:]]*$//'
+    | sed 's/[[:blank:]]*$//'
 }
 
 # Is $2 a real, reusable value for secret $1 — i.e. something safe to KEEP instead of

--- a/tests/unit/test_env_example.py
+++ b/tests/unit/test_env_example.py
@@ -1,0 +1,87 @@
+"""`.env.example` must survive Docker Compose's env_file parser (issue #458).
+
+Compose parses `env_file` with compose-spec/compose-go's `dotenv` package. For an
+unquoted line it:
+
+  1. strips leading whitespace from the value (`locateKeyName`), then
+  2. removes an inline comment only at the first literal " #" — a space
+     immediately followed by '#' (`extractVarValue`: `strings.Cut(value, " #")`),
+     then trims trailing whitespace.
+
+So `KEY=value   # note` -> `value`, but `KEY=   # note` -> the leading spaces are
+gone first, the value now *starts* with '#', there is no " #" to cut, and the
+whole `# note` becomes the value.
+
+This project keeps every comment on its own line above the assignment, so the
+check here is strict: no assignment line may carry an inline `#` at all.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ENV_EXAMPLE = Path(".env.example")
+
+# compose-go dotenv `isSpace`: space, tab, vertical tab, form feed, CR, NEL, NBSP.
+_COMPOSE_WHITESPACE = " \t\v\f\r\x85\xa0"
+
+_ASSIGNMENT = re.compile(r"^(?:export\s+)?([A-Za-z0-9_.\-\[\]]+)=(.*)$")
+
+# Keys that #458 caught resolving to their comment text — anchor them explicitly.
+_PREVIOUSLY_BROKEN = (
+    "QDRANT_API_KEY",
+    "AUTH_PASSWORD",
+    "OLLAMA_REQUEST_TIMEOUT",
+    "METRONIX_FRESHNESS_LLM_PROVIDER",
+    "LLM_FALLBACK_PROVIDER",
+    "LLM_PROVIDER_API_KEY",
+    "LLM_PROVIDER_MODEL",
+)
+
+
+def _assignments() -> dict[str, tuple[int, str]]:
+    """{key: (line_number, raw_rhs)} for every KEY=... line in .env.example."""
+    out: dict[str, tuple[int, str]] = {}
+    for n, line in enumerate(ENV_EXAMPLE.read_text().splitlines(), start=1):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        m = _ASSIGNMENT.match(line)
+        assert m, f".env.example line {n} is neither blank, a comment, nor KEY=VALUE: {line!r}"
+        out[m.group(1)] = (n, m.group(2))
+    return out
+
+
+def _compose_value(rhs: str) -> str:
+    """Resolve a raw right-hand side the way compose-go's dotenv parser would."""
+    value = rhs.lstrip(_COMPOSE_WHITESPACE)
+    if value[:1] in ('"', "'"):
+        # quoted values are a different code path; .env.example uses none
+        return value
+    value, _, _ = value.partition(" #")
+    return value.rstrip(_COMPOSE_WHITESPACE)
+
+
+def test_no_assignment_line_carries_an_inline_comment() -> None:
+    offenders = [(n, key, rhs) for key, (n, rhs) in _assignments().items() if "#" in rhs]
+    assert not offenders, (
+        "inline `#` after a value — move the comment to its own line above "
+        f"(issue #458): {[f'L{n} {k}' for n, k, _ in offenders]}"
+    )
+
+
+def test_no_value_resolves_to_comment_text_under_compose() -> None:
+    leaked = {
+        key: _compose_value(rhs)
+        for key, (_, rhs) in _assignments().items()
+        if _compose_value(rhs).startswith("#") or " #" in _compose_value(rhs)
+    }
+    assert not leaked, f"compose would read these as comment text: {leaked}"
+
+
+def test_previously_broken_keys_now_resolve_empty() -> None:
+    values = _assignments()
+    for key in _PREVIOUSLY_BROKEN:
+        assert key in values, f"{key} vanished from .env.example"
+        n, rhs = values[key]
+        assert _compose_value(rhs) == "", f"L{n} {key} -> {_compose_value(rhs)!r}, expected empty"


### PR DESCRIPTION
Fixes #458.

## What happened

`docker-compose.yml` loads `.env` via `env_file:`, which Compose parses with
`compose-spec/compose-go`'s `dotenv` package. For an unquoted line it:

1. strips **leading** whitespace from the value (`locateKeyName`:
   `strings.TrimLeftFunc(src[offset:], isSpace)`), then
2. removes an inline comment only at the first literal `" #"` — a space
   immediately followed by `#` (`extractVarValue`: `strings.Cut(value, " #")`),
   then trims trailing whitespace.

So `KEY=value   # note` → `value`, but for an intended-**empty** value
`KEY=   # note` the leading spaces are removed first, the value now *starts*
with `#`, there is no `" #"` to cut, and the whole `# note` becomes the value.

`.env.example` had **7 lines** that hit this (value resolves to `# ...`):
`QDRANT_API_KEY`, `AUTH_PASSWORD`, `OLLAMA_REQUEST_TIMEOUT`,
`METRONIX_FRESHNESS_LLM_PROVIDER`, `LLM_FALLBACK_PROVIDER`,
`LLM_PROVIDER_API_KEY`, `LLM_PROVIDER_MODEL` — plus **50 more** `KEY=value  # …`
lines that currently work only because a space precedes the `#`.

Observed downstream (from #458): `LLM_FALLBACK_PROVIDER` →
`Unknown LLM provider: # fallback provider…` on every primary-LLM failure;
`QDRANT_API_KEY` → "insecure connection" warning + a junk key sent to an
authenticated Qdrant; `AUTH_PASSWORD` → the seeded admin password is comment
text.

Blast radius: `docker compose up -d` (`cp .env.example .env`) breaks all 7.
`install.sh` rewrites lines for keys it sets, but of the 7 only
`LLM_PROVIDER_{API_KEY,MODEL}` are set (and only on `--mode answers`), so the
other 5 break via `install.sh` too. `install.sh` already carried a workaround
(`example_val()` stripped inline comments so its placeholder check wouldn't
compare against comment text).

## Changes

- **`.env.example`** — every inline comment (all 57 lines, not just the 7 that
  break) moved to its own line directly above the assignment. This is the only
  form that is correct under every parser (compose-go, python-dotenv,
  `set -a; source`, `docker run --env-file`, and the benchmark loader), and it
  matches the style the ZONE 3 section and the `.env.benchmark.example` files
  already use. Header gains a short note explaining the convention.
- **`install.sh`** — drop the now-unnecessary `sed 's/[[:space:]]#.*//'` from
  `example_val()`; the value is taken verbatim (trailing whitespace still
  trimmed as a guard).
- **`tests/unit/test_env_example.py`** (new) — parses `.env.example`
  line-by-line, emulates the compose-go `dotenv` rules, and asserts (a) every
  non-comment line is `KEY=VALUE`, (b) no line carries an inline `#` at all,
  (c) no value resolves to comment text under Compose, (d) the 7 keys from
  #458 resolve to empty.

## Adjacent finding (not in this PR)

**#470** — the benchmark env loader
(`benchmarks/*/scripts/env_config.py::_parse_env_file`) strips no inline
comments *at all* and also reads the repo-root `.env`, so it diverges from the
Compose `env_file` parser. The `.env.benchmark.example` templates themselves are
clean; the parser is the latent trap. Filed separately.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `tests/unit/test_env_example.py` — 3 passed
- [x] `tests/unit/test_mcp_docs.py` — 40 passed (it reads `.env.example`, incl.
  the parametrised `PUBLIC_MCP_MODE_DOCS` check)
- [x] `bash -n install.sh` — OK; `tests/installer/test_install.sh` — 49 passed /
  3 failed, **identical on the clean tree** (the 3 are a docker-volume-removal
  path the sandbox can't stub — pre-existing)
- [x] a script emulation of the compose-go parser over the new `.env.example`
  reports 128 assignment lines, 0 inline-comment leaks, 0 `#`-after-`=`
- [ ] CI: `installer` (shellcheck + `bash -n`) and `pytest (unit, with services)`
