### PR TITLE
fix(connectors): run the blocking Confluence/Jira client off the event loop (#459)

### DIFF
--- a/src/metronix/connectors/confluence.py
+++ b/src/metronix/connectors/confluence.py
@@ -1,12 +1,14 @@
 """Confluence connector — fetches pages via REST API.
 
 Uses atlassian-python-api for CQL queries and page body retrieval.
-Supports incremental sync via lastModified CQL filter.
+Supports incremental sync via lastModified CQL filter. The atlassian client is
+synchronous (requests-based, no async variant), so every blocking call runs in
+``asyncio.to_thread`` — see ``fetch`` / ``health_check`` (#459).
 """
 
-# TODO: async migration
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import time
 from collections.abc import Iterator
@@ -82,9 +84,13 @@ class ConfluenceConnector(ConnectorInterface):
         space_key = self._config.get("space_key", "")
         base_url = self._config["url"].rstrip("/")
 
+        # The atlassian client is blocking `requests`; keep it off the event
+        # loop so a slow/hung Confluence does not freeze the whole API (#459).
         if since:
-            return self._fetch_incremental(workspace_id, base_url, space_key, since)
-        return self._fetch_full(workspace_id, base_url, space_key)
+            return await asyncio.to_thread(
+                self._fetch_incremental, workspace_id, base_url, space_key, since
+            )
+        return await asyncio.to_thread(self._fetch_full, workspace_id, base_url, space_key)
 
     def _fetch_full(
         self,
@@ -247,7 +253,7 @@ class ConfluenceConnector(ConnectorInterface):
         if self._client is None:
             return False
         try:
-            self._client.get_all_spaces(limit=1)
+            await asyncio.to_thread(self._client.get_all_spaces, limit=1)
             return True
         except Exception:
             return False

--- a/src/metronix/connectors/jira.py
+++ b/src/metronix/connectors/jira.py
@@ -1,12 +1,14 @@
 """Jira connector — fetches issues via REST API.
 
 Uses atlassian-python-api (v4+) with enhanced_jql for Jira Cloud.
-Fetches issue summary, description, comments, and changelog.
+Fetches issue summary, description, comments, and changelog. The atlassian
+client is synchronous (requests-based, no async variant), so the blocking
+pagination loop runs in ``asyncio.to_thread`` — see ``fetch`` (#459).
 """
 
-# TODO: async migration
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import time
 from datetime import datetime
@@ -62,7 +64,6 @@ class JiraConnector(ConnectorInterface):
             raise RuntimeError("Connector not configured — call configure() first")
 
         project_key = self._config.get("project_key", "")
-        documents: list[Document] = []
 
         # JQL's date filter only supports minute precision ("yyyy-MM-dd HH:mm"),
         # so a cursor at 22:09:40 formatted as "22:09" still matches docs from
@@ -75,6 +76,19 @@ class JiraConnector(ConnectorInterface):
         if "ORDER BY" not in jql:
             jql += " ORDER BY updated DESC"
 
+        # The atlassian client is blocking `requests`; keep the pagination loop
+        # off the event loop so a slow/hung Jira does not freeze the API (#459).
+        return await asyncio.to_thread(self._fetch_issues, jql, since, workspace_id)
+
+    def _fetch_issues(
+        self,
+        jql: str,
+        since: datetime | None,
+        workspace_id: str,
+    ) -> list[Document]:
+        """Blocking JQL pagination loop — runs in a worker thread (see ``fetch``)."""
+        assert self._client is not None  # noqa: S101 — configured before fetch() delegates here
+        documents: list[Document] = []
         limit = 50
         next_token: str | None = None
 
@@ -178,7 +192,7 @@ class JiraConnector(ConnectorInterface):
         if self._client is None:
             return False
         try:
-            self._client.get_all_projects(included_archived=None)
+            await asyncio.to_thread(self._client.get_all_projects, included_archived=None)
             return True
         except Exception:
             return False

--- a/src/metronix/connectors/jira.py
+++ b/src/metronix/connectors/jira.py
@@ -139,7 +139,8 @@ class JiraConnector(ConnectorInterface):
 
     # NOTE: sub-minute cursor filtering for the JQL minute-precision trap
     # lives in ``metronix.connectors._filter.is_strictly_after`` and is
-    # applied directly in ``fetch()`` above — no per-connector parser.
+    # applied inline in the ``_fetch_issues`` pagination loop above (which
+    # ``fetch()`` runs in a worker thread) — no per-connector parser.
 
     def _issue_to_document(self, raw_issue: dict, workspace_id: str) -> Document:
         structured = process_jira_issue(raw_issue)

--- a/tests/unit/test_confluence_connector.py
+++ b/tests/unit/test_confluence_connector.py
@@ -337,3 +337,71 @@ class TestConfluenceFetchFull:
 
         with pytest.raises(RuntimeError, match="429"):
             self._run(connector)
+
+
+# ---------------------------------------------------------------------------
+# The atlassian client is blocking `requests`; every call must run off the
+# event loop so a slow/hung Confluence can't freeze the API (#459).
+# ---------------------------------------------------------------------------
+
+
+def _thread_recorder(seen: list[object], return_value: object):
+    import threading
+
+    def _record(*_a: object, **_k: object) -> object:
+        seen.append(threading.current_thread())
+        return return_value
+
+    return _record
+
+
+class TestConfluenceRunsOffTheEventLoop:
+    @staticmethod
+    def _connector() -> ConfluenceConnector:
+        c = ConfluenceConnector()
+        c._config = {
+            "url": "https://co.atlassian.net",
+            "space_key": "ENG",
+            "username": "u",
+            "api_token": "t",
+        }
+        c._client = MagicMock()
+        return c
+
+    @pytest.mark.asyncio
+    async def test_full_fetch_offloads_get_all_pages_from_space(self) -> None:
+        import threading
+
+        connector = self._connector()
+        seen: list[object] = []
+        connector._client.get_all_pages_from_space.side_effect = _thread_recorder(seen, iter(()))
+
+        await connector.fetch("ws1", since=None)
+
+        assert seen and seen[0] is not threading.main_thread()
+
+    @pytest.mark.asyncio
+    async def test_incremental_fetch_offloads_cql(self) -> None:
+        import threading
+        from datetime import UTC, datetime
+
+        connector = self._connector()
+        seen: list[object] = []
+        connector._client.cql.side_effect = _thread_recorder(
+            seen, {"results": [], "totalSize": 0, "size": 0}
+        )
+
+        await connector.fetch("ws1", since=datetime(2026, 1, 1, tzinfo=UTC))
+
+        assert seen and seen[0] is not threading.main_thread()
+
+    @pytest.mark.asyncio
+    async def test_health_check_offloads_get_all_spaces(self) -> None:
+        import threading
+
+        connector = self._connector()
+        seen: list[object] = []
+        connector._client.get_all_spaces.side_effect = _thread_recorder(seen, [])
+
+        assert await connector.health_check() is True
+        assert seen and seen[0] is not threading.main_thread()

--- a/tests/unit/test_jira_connector.py
+++ b/tests/unit/test_jira_connector.py
@@ -188,3 +188,53 @@ class TestFetchPostFilter:
             "filtered-out issue must be skipped BEFORE the expensive parse"
         )
         assert [d.source_id for d in docs] == ["P-NEW"]
+
+
+# ---------------------------------------------------------------------------
+# The atlassian client is blocking `requests`; every call must run off the
+# event loop so a slow/hung Jira can't freeze the API (#459).
+# ---------------------------------------------------------------------------
+
+
+def _thread_recorder(seen: list[object], return_value: object):
+    import threading
+
+    def _record(*_a: object, **_k: object) -> object:
+        seen.append(threading.current_thread())
+        return return_value
+
+    return _record
+
+
+class TestJiraRunsOffTheEventLoop:
+    @staticmethod
+    def _connector() -> JiraConnector:
+        c = JiraConnector()
+        c._config = {"url": "https://co.atlassian.net", "project_key": "P"}
+        c._client = MagicMock()
+        return c
+
+    @pytest.mark.asyncio
+    async def test_fetch_offloads_enhanced_jql(self) -> None:
+        import threading
+
+        connector = self._connector()
+        seen: list[object] = []
+        connector._client.enhanced_jql.side_effect = _thread_recorder(
+            seen, {"issues": [], "isLast": True}
+        )
+
+        await connector.fetch("ws1", since=None)
+
+        assert seen and seen[0] is not threading.main_thread()
+
+    @pytest.mark.asyncio
+    async def test_health_check_offloads_get_all_projects(self) -> None:
+        import threading
+
+        connector = self._connector()
+        seen: list[object] = []
+        connector._client.get_all_projects.side_effect = _thread_recorder(seen, [])
+
+        assert await connector.health_check() is True
+        assert seen and seen[0] is not threading.main_thread()


### PR DESCRIPTION
Fixes #459.

## What happened

`ConfluenceConnector.fetch` and `JiraConnector.fetch` are `async def` but do
blocking `requests` I/O through `atlassian-python-api` **directly on the event
loop**. While such a sync runs, every other coroutine on that loop — MCP tools,
`/api/v1` search, memory ops, OpenAI-compat, `GET /health` — is stalled, up to
the client's default request timeout (`AtlassianRestAPI.__init__ timeout=75`)
*per HTTP call*. Both files carried `# TODO: async migration`.

The chain: `run_connection_sync` (`connectors/connection_sync.py`, `async def`)
is spawned with `asyncio.create_task(...)` from autosync / MCP `source_sync` /
REST `trigger_sync` — same loop as the API — and does
`await connector.fetch(...)`.

### Blocking calls

| File | On the loop |
|---|---|
| `confluence.py` | `get_all_pages_from_space` (full), `cql` + `get_page_by_id` (incremental), `get_all_spaces` (health), `time.sleep(4)` on 429 |
| `jira.py` | `enhanced_jql` (per page), `get_all_projects` (health), `time.sleep(4)` on 429, plus the CPU-heavy `_issue_to_document` (ADF + changelog) |

### No async client

`atlassian-python-api` 5.0.4 has no async variant (verified: `requests.Session`
based, deps `requests` / `oauthlib` / `requests_oauthlib`; no `aiohttp` /
`AsyncClient` anywhere in the package). So the native-async route (notion) is
out — the fix is the **github / gdrive pattern**: keep the sync client, run it
in `asyncio.to_thread` over coarse sync helpers.

## Changes

- **`confluence.py`** — `fetch()` delegates to `_fetch_full` /
  `_fetch_incremental` (already sync) via `await asyncio.to_thread(...)`;
  `health_check` offloads `get_all_spaces`. The helper bodies (CQL/JQL,
  cursor, sub-minute post-filter, 429 `time.sleep`) are untouched.
- **`jira.py`** — the pagination loop is moved verbatim into a sync
  `_fetch_issues(jql, since, workspace_id)` and run via `to_thread`; the JQL
  string is built in `fetch()` (no I/O, stays on the loop); `health_check`
  offloads `get_all_projects`.
- Module docstrings document the "sync client → `to_thread`" pattern (matching
  `gdrive.py`); `# TODO: async migration` markers removed.
- **Tests** — per-connector thread-affinity regression: the blocking client
  call must land on a worker thread, not `threading.main_thread()`. Reverting
  a `to_thread` wrap fails these. `github`/`gdrive` have no such test today, so
  this is a net add.

## Adjacent — not fixed here, also affects github/gdrive

`run_connection_sync` has no `asyncio.wait_for` around `connector.fetch`, and a
`to_thread` task can't be cancelled mid-flight (a `requests` call in a worker
thread won't stop on task cancel). After this PR the loop no longer freezes,
but a hung sync still runs unbounded, and `AutosyncScheduler.cancel_inflight()`
on shutdown cancels the coroutine while the worker thread runs to completion.
That's a per-sync timeout / cancellation concern spanning all `to_thread`
connectors — separate task.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/metronix/connectors/{confluence,jira}.py` — errors unchanged
  vs the `main` baseline (all pre-existing `self._client`-typed-`None` noise; CI
  doesn't gate mypy)
- [x] `tests/unit/test_{confluence,jira}_connector.py` — 41 passed (5 new)
- [x] connector + connection-sync + ingest-sync unit suites — green
- [ ] CI `pytest (unit, with services)`
