### PR TITLE
fix(sync): delete-before-add on connector re-ingest, skip when unchanged (#461)

### DIFF
--- a/src/metronix/connectors/connection_sync.py
+++ b/src/metronix/connectors/connection_sync.py
@@ -282,6 +282,7 @@ async def run_connection_sync(
 
         # Phase 1: Persist raw documents to PostgreSQL (source of truth)
         upsert_result: dict[str, Any] | None = None
+        upsert_error: str | None = None
         try:
             upsert_result = await store.upsert_raw_documents(
                 workspace_id=workspace_id,
@@ -298,6 +299,7 @@ async def run_connection_sync(
                 unchanged=upsert_result["unchanged"],
             )
         except Exception as e:
+            upsert_error = sanitize_error(str(e))
             logger.warning("sync.raw_documents.error", error=str(e))
 
         # Phase 1b: Enqueue KB freshness jobs for changed docs (PROJ-313).
@@ -348,7 +350,8 @@ async def run_connection_sync(
             # Phase 1 persist failed — we do not know what changed. Writing to
             # Qdrant on top of an unknown PG state is worse than skipping.
             docs_to_ingest = []
-            errors_list.append("raw_documents persist failed; Qdrant ingest skipped")
+            msg = "raw_documents persist failed; Qdrant ingest skipped"
+            errors_list.append(f"{msg}: {upsert_error}" if upsert_error else msg)
         elif upsert_result.get("changed_source_ids"):
             changed_ids = set(upsert_result["changed_source_ids"])
             docs_to_ingest = [d for d in documents if d.source_id in changed_ids]
@@ -396,6 +399,28 @@ async def run_connection_sync(
                     )
             except Exception as e:
                 logger.warning("sync.mark_synced.error", error=str(e))
+
+            # Phase 3b: The ingest above ran with ``incremental=True``, which
+            # deletes each re-ingested doc's graph node (delete-before-add in
+            # ``ingest_documents``) but not its ``graph_synced`` flag — and it
+            # ran with ``skip_graph=True``, so nothing rebuilt the node inline.
+            # For new / content-changed docs ``upsert_raw_documents`` already
+            # set ``graph_synced=false``; a sidecar-only refresh (#440) leaves
+            # it ``true``, so Phase 4 below would never rebuild the node that
+            # was just deleted — permanent graph loss until the next content
+            # change (#461). Force the re-ingested source ids unsynced so the
+            # graph sweeper picks them up. Idempotent for the already-false
+            # rows.
+            try:
+                ingested_source_ids = [d.source_id for d in docs_to_ingest if d.source_id]
+                if ingested_source_ids:
+                    await store.mark_documents_graph_unsynced_by_source(
+                        workspace_id=workspace_id,
+                        connector_type=connector_type,
+                        source_ids=ingested_source_ids,
+                    )
+            except Exception as e:
+                logger.warning("sync.mark_graph_unsynced.error", error=str(e))
         elif upsert_result is None:
             status = "failed"
         else:

--- a/src/metronix/connectors/connection_sync.py
+++ b/src/metronix/connectors/connection_sync.py
@@ -339,8 +339,17 @@ async def run_connection_sync(
                     payload={"connector_type": connector_type, "source_id": src_id},
                 )
 
-        # Phase 2: Ingest into Qdrant (only new/updated docs, skip unchanged)
-        if upsert_result and upsert_result.get("changed_source_ids"):
+        # Phase 2: Ingest into Qdrant. Every ingest is delete-before-add per
+        # doc_label (``incremental=True``): Qdrant point ids are random UUIDs,
+        # so re-ingesting a document without first dropping its old points
+        # duplicates every chunk (#461). ``delete_by_doc_labels`` is a cheap
+        # no-op for a genuinely new document that has no points yet.
+        if upsert_result is None:
+            # Phase 1 persist failed — we do not know what changed. Writing to
+            # Qdrant on top of an unknown PG state is worse than skipping.
+            docs_to_ingest = []
+            errors_list.append("raw_documents persist failed; Qdrant ingest skipped")
+        elif upsert_result.get("changed_source_ids"):
             changed_ids = set(upsert_result["changed_source_ids"])
             docs_to_ingest = [d for d in documents if d.source_id in changed_ids]
             logger.info(
@@ -350,7 +359,10 @@ async def run_connection_sync(
                 skipped=len(documents) - len(docs_to_ingest),
             )
         else:
-            docs_to_ingest = documents
+            # Nothing new or changed — Qdrant already holds these chunks;
+            # re-ingesting would duplicate them (#461).
+            docs_to_ingest = []
+            logger.info("sync.nothing_to_ingest", total=len(documents))
 
         if docs_to_ingest:
             result = await ingest_documents(
@@ -359,6 +371,7 @@ async def run_connection_sync(
                 connector_type,
                 source_role=connector.source_role,
                 skip_graph=True,
+                incremental=True,
             )
             documents_new = result.documents_new
             documents_updated = result.documents_updated
@@ -383,6 +396,8 @@ async def run_connection_sync(
                     )
             except Exception as e:
                 logger.warning("sync.mark_synced.error", error=str(e))
+        elif upsert_result is None:
+            status = "failed"
         else:
             status = "success"
 

--- a/src/metronix/mcp/sync.py
+++ b/src/metronix/mcp/sync.py
@@ -142,7 +142,10 @@ class MCPSyncManager:
             docs_to_ingest,
             workspace_id,
             connector_type=f"mcp:{config.name}",
-            incremental=not force_full,
+            # Always delete-before-add per doc_label. On force_full the whole
+            # batch is re-ingested; without the delete, random-UUID Qdrant
+            # points make that a second full copy of every chunk (#461).
+            incremental=True,
         )
 
         logger.info(

--- a/src/metronix/storage/postgres.py
+++ b/src/metronix/storage/postgres.py
@@ -1544,6 +1544,47 @@ class PostgresStore:
                 },
             )
 
+    async def mark_documents_graph_unsynced_by_source(
+        self,
+        workspace_id: str,
+        connector_type: str,
+        source_ids: list[str],
+    ) -> None:
+        """Force ``graph_synced=false`` for the given source docs.
+
+        Used by the connector sync after a ``skip_graph=True`` incremental
+        Qdrant re-ingest: that path deletes each re-ingested doc's graph node
+        (delete-before-add in ``ingest_documents``) without touching
+        ``graph_synced``. For a sidecar-only refresh (#440) the row is left
+        ``graph_synced=true``, so the decoupled graph sweeper would never
+        rebuild the node it just lost (#461). Clearing the flag re-enqueues
+        the doc for extraction; a no-op for rows already ``false``.
+        """
+        if not source_ids:
+            return
+
+        logger.info(
+            "postgres.raw_documents.mark_graph_unsynced_by_source",
+            count=len(source_ids),
+        )
+
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                text("""
+                    UPDATE raw_documents
+                    SET graph_synced = false,
+                        graph_synced_at = NULL
+                    WHERE workspace_id = :workspace_id
+                      AND connector_type = :connector_type
+                      AND source_id = ANY(:source_ids)
+                """),
+                {
+                    "workspace_id": workspace_id,
+                    "connector_type": connector_type,
+                    "source_ids": source_ids,
+                },
+            )
+
     async def mark_documents_graph_failed(
         self,
         workspace_id: str,

--- a/tests/unit/test_connections_sync.py
+++ b/tests/unit/test_connections_sync.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 
 from metronix.connectors.connection_sync import run_connection_sync
 from metronix.core.config import Settings
+from metronix.core.interfaces import ConnectorInterface
 from metronix.core.models import Document, SyncResult
 from metronix.storage.pg_connection import get_session
 from metronix.storage.pg_models import ConnectionRow, SyncLogRow
@@ -273,6 +274,156 @@ async def test_run_connection_sync_marks_failed_on_exception(store, seeded_ids):
         assert any("Jira 500" in e for e in row.errors)
         assert conn.status == "error"
         assert "Jira 500" in (conn.error_message or "")
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — delete-before-add, and don't re-ingest what hasn't changed (#461)
+#
+# These run without a live PG: ``store`` is a mock and the sync's terminal
+# writes are asserted on the mock rather than on DB rows.
+# ---------------------------------------------------------------------------
+
+
+def _doc(ws: str, source_id: str = "J-1") -> Document:
+    return Document(
+        source_type="jira",
+        source_id=source_id,
+        url="",
+        workspace_id=ws,
+        title="t",
+        content="c",
+        author="a",
+        metadata={},
+    )
+
+
+def _mock_connector(docs: list[Document]) -> MagicMock:
+    # spec=ConnectorInterface → no load_cursor/take_cursor, so the cursor
+    # helpers skip (no get_connector_state / set_connector_state needed).
+    c = MagicMock(spec=ConnectorInterface)
+    c.source_role = "task_tracker"
+    c.configure = AsyncMock()
+    c.fetch = AsyncMock(return_value=docs)
+    return c
+
+
+def _mock_store(upsert: AsyncMock) -> MagicMock:
+    store = MagicMock()
+    store.upsert_raw_documents = upsert
+    store.get_raw_document = AsyncMock(return_value=None)
+    store.mark_documents_synced_by_source = AsyncMock()
+    store.update_sync_log = AsyncMock()
+    store.update_connection_status = AsyncMock()
+    return store
+
+
+def _synced_status(store: MagicMock) -> tuple[str | None, str | None]:
+    """(sync_logs status, connections status) from the terminal writes."""
+    log_status = store.update_sync_log.await_args.kwargs.get("status")
+    conn_status = store.update_connection_status.await_args.kwargs.get("status")
+    return log_status, conn_status
+
+
+@pytest.mark.asyncio
+async def test_phase2_ingests_with_delete_before_add() -> None:
+    """#461: the connector sync path must pass ``incremental=True`` so a doc's
+    old Qdrant points are dropped before re-add — random-UUID points otherwise
+    accumulate a second full copy of every chunk."""
+    store = _mock_store(
+        AsyncMock(
+            return_value={"new": 1, "updated": 0, "unchanged": 0, "changed_source_ids": ["J-1"]}
+        )
+    )
+    mock_ingest = AsyncMock(return_value=_empty_ingest_result())
+    registry = MagicMock(create=MagicMock(return_value=_mock_connector([_doc("ws1")])))
+
+    with (
+        patch("metronix.connectors.connection_sync.get_registry", return_value=registry),
+        patch("metronix.ingestion.pipeline.ingest_documents", mock_ingest),
+        patch(
+            "metronix.ingestion.pipeline.process_all_unsynced_graphs",
+            AsyncMock(return_value={"ok": 0, "errors": 0}),
+        ),
+    ):
+        await run_connection_sync(
+            sync_id="s1",
+            connection_id="c1",
+            connector_type="jira",
+            config={"url": "http://x"},
+            workspace_id="ws1",
+            store=store,
+            event_bus=None,
+        )
+
+    mock_ingest.assert_awaited_once()
+    assert mock_ingest.await_args.kwargs.get("incremental") is True
+
+
+@pytest.mark.asyncio
+async def test_phase2_skips_ingest_when_nothing_changed() -> None:
+    """#461: an unchanged re-fetch (force_full / second connector on the same
+    source / cursor reset / CQL-JQL minute boundary) must NOT re-ingest —
+    Qdrant already holds these chunks."""
+    store = _mock_store(
+        AsyncMock(return_value={"new": 0, "updated": 0, "unchanged": 1, "changed_source_ids": []})
+    )
+    mock_ingest = AsyncMock(return_value=_empty_ingest_result())
+    registry = MagicMock(create=MagicMock(return_value=_mock_connector([_doc("ws1")])))
+
+    with (
+        patch("metronix.connectors.connection_sync.get_registry", return_value=registry),
+        patch("metronix.ingestion.pipeline.ingest_documents", mock_ingest),
+        patch(
+            "metronix.ingestion.pipeline.process_all_unsynced_graphs",
+            AsyncMock(return_value={"ok": 0, "errors": 0}),
+        ),
+    ):
+        await run_connection_sync(
+            sync_id="s2",
+            connection_id="c2",
+            connector_type="jira",
+            config={"url": "http://x"},
+            workspace_id="ws1",
+            store=store,
+            event_bus=None,
+        )
+
+    mock_ingest.assert_not_awaited()
+    log_status, conn_status = _synced_status(store)
+    assert log_status == "success"
+    assert conn_status == "active"
+
+
+@pytest.mark.asyncio
+async def test_phase2_failed_persist_is_not_reported_as_success() -> None:
+    """A raw_documents persist failure must not be masked as a successful sync,
+    and must not trigger a full re-ingest on top of an unknown PG state (#461)."""
+    store = _mock_store(AsyncMock(side_effect=RuntimeError("raw_documents INSERT failed")))
+    mock_ingest = AsyncMock(return_value=_empty_ingest_result())
+    registry = MagicMock(create=MagicMock(return_value=_mock_connector([_doc("ws1")])))
+
+    with (
+        patch("metronix.connectors.connection_sync.get_registry", return_value=registry),
+        patch("metronix.ingestion.pipeline.ingest_documents", mock_ingest),
+        patch(
+            "metronix.ingestion.pipeline.process_all_unsynced_graphs",
+            AsyncMock(return_value={"ok": 0, "errors": 0}),
+        ),
+    ):
+        await run_connection_sync(
+            sync_id="s3",
+            connection_id="c3",
+            connector_type="jira",
+            config={"url": "http://x"},
+            workspace_id="ws1",
+            store=store,
+            event_bus=None,
+        )
+
+    mock_ingest.assert_not_awaited()
+    log_status, conn_status = _synced_status(store)
+    assert log_status != "success"
+    assert conn_status == "error"
 
 
 async def test_run_connection_sync_failed_does_not_advance_cursor(store, seeded_ids):

--- a/tests/unit/test_connections_sync.py
+++ b/tests/unit/test_connections_sync.py
@@ -312,6 +312,7 @@ def _mock_store(upsert: AsyncMock) -> MagicMock:
     store.upsert_raw_documents = upsert
     store.get_raw_document = AsyncMock(return_value=None)
     store.mark_documents_synced_by_source = AsyncMock()
+    store.mark_documents_graph_unsynced_by_source = AsyncMock()
     store.update_sync_log = AsyncMock()
     store.update_connection_status = AsyncMock()
     return store
@@ -322,6 +323,11 @@ def _synced_status(store: MagicMock) -> tuple[str | None, str | None]:
     log_status = store.update_sync_log.await_args.kwargs.get("status")
     conn_status = store.update_connection_status.await_args.kwargs.get("status")
     return log_status, conn_status
+
+
+def _sync_log_errors(store: MagicMock) -> list[str]:
+    """The ``errors`` list handed to the terminal sync_logs write."""
+    return list(store.update_sync_log.await_args.kwargs.get("errors") or [])
 
 
 @pytest.mark.asyncio
@@ -397,7 +403,8 @@ async def test_phase2_skips_ingest_when_nothing_changed() -> None:
 @pytest.mark.asyncio
 async def test_phase2_failed_persist_is_not_reported_as_success() -> None:
     """A raw_documents persist failure must not be masked as a successful sync,
-    and must not trigger a full re-ingest on top of an unknown PG state (#461)."""
+    and must not trigger a full re-ingest on top of an unknown PG state (#461).
+    The captured (sanitized) persist error is carried into the sync_logs row."""
     store = _mock_store(AsyncMock(side_effect=RuntimeError("raw_documents INSERT failed")))
     mock_ingest = AsyncMock(return_value=_empty_ingest_result())
     registry = MagicMock(create=MagicMock(return_value=_mock_connector([_doc("ws1")])))
@@ -424,6 +431,54 @@ async def test_phase2_failed_persist_is_not_reported_as_success() -> None:
     log_status, conn_status = _synced_status(store)
     assert log_status != "success"
     assert conn_status == "error"
+    errors = _sync_log_errors(store)
+    assert any("persist failed" in e and "raw_documents INSERT failed" in e for e in errors)
+
+
+@pytest.mark.asyncio
+async def test_phase2_sidecar_refresh_reenqueues_graph_extraction() -> None:
+    """#461 regression: a sidecar-only refresh (#440) — content unchanged, so
+    ``upsert_raw_documents`` leaves ``graph_synced=true``, but the ``source_id``
+    is still returned in ``changed_source_ids`` — hits the ``incremental=True``
+    ``skip_graph=True`` re-ingest, which deletes the doc's graph node. The sync
+    must force that source id ``graph_synced=false`` so the decoupled sweeper
+    rebuilds it; otherwise the graph node is lost until the next content change.
+    """
+    store = _mock_store(
+        AsyncMock(
+            # counted as unchanged, but still flagged for re-ingest — the
+            # sidecar-drift shape from PostgresStore.upsert_raw_documents.
+            return_value={"new": 0, "updated": 0, "unchanged": 1, "changed_source_ids": ["J-1"]}
+        )
+    )
+    mock_ingest = AsyncMock(return_value=_empty_ingest_result())
+    registry = MagicMock(create=MagicMock(return_value=_mock_connector([_doc("ws1")])))
+
+    with (
+        patch("metronix.connectors.connection_sync.get_registry", return_value=registry),
+        patch("metronix.ingestion.pipeline.ingest_documents", mock_ingest),
+        patch(
+            "metronix.ingestion.pipeline.process_all_unsynced_graphs",
+            AsyncMock(return_value={"ok": 0, "errors": 0}),
+        ),
+    ):
+        await run_connection_sync(
+            sync_id="s4",
+            connection_id="c4",
+            connector_type="jira",
+            config={"url": "http://x"},
+            workspace_id="ws1",
+            store=store,
+            event_bus=None,
+        )
+
+    mock_ingest.assert_awaited_once()
+    assert mock_ingest.await_args.kwargs.get("skip_graph") is True
+    store.mark_documents_graph_unsynced_by_source.assert_awaited_once()
+    kw = store.mark_documents_graph_unsynced_by_source.await_args.kwargs
+    assert kw.get("workspace_id") == "ws1"
+    assert kw.get("connector_type") == "jira"
+    assert kw.get("source_ids") == ["J-1"]
 
 
 async def test_run_connection_sync_failed_does_not_advance_cursor(store, seeded_ids):

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -446,6 +446,11 @@ class TestMCPSyncManager:
 
         # force_full bypasses hash check
         mock_ingest.assert_called_once()
+        # ...but still deletes-before-add: force_full re-ingests the whole batch,
+        # and without incremental=True the random-UUID Qdrant points would make
+        # that a second full copy of every chunk (#461). Guards the
+        # `incremental=not force_full` inversion from regressing.
+        assert mock_ingest.call_args.kwargs.get("incremental") is True
 
     @pytest.mark.asyncio
     async def test_sync_all_empty(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #461.

## What happened

`run_connection_sync` Phase 2 (`connectors/connection_sync.py`) called
`ingest_documents(...)` **without `incremental=True`**, and its fallback branch
re-ingested the whole fetched batch whenever `changed_source_ids` was empty:

```python
if upsert_result and upsert_result.get("changed_source_ids"):
    docs_to_ingest = [d for d in documents if d.source_id in changed_ids]
else:
    docs_to_ingest = documents            # <- re-ingest everything
result = await ingest_documents(docs_to_ingest, ...)   # <- no incremental flag
```

Qdrant point ids are random UUIDs (`AsyncQdrantVectorStore.add_document`:
`qdrant_id = str(uuid.uuid4())`), so a document re-ingested without first
dropping its old points gets a **second full copy of every chunk** — measured
3 → 6 → 9. The dedup index can't stop it: `DeduplicationIndex.check_and_add`
only flags a near-duplicate **from a different `doc_label`** ("Same-document
chunks are not flagged (handled by delete-before-reingest)"). The only
delete-before-add path is `ingest_documents(incremental=True)` →
`delete_by_doc_labels([doc.source_id])`, which Phase 2 never triggered.

`raw_documents` dedups on `content_hash` and stays at N rows; only the Qdrant
index grows — PG and the index diverge. `changed_source_ids` is empty (→ the
fallback) whenever every fetched doc is unchanged and already `qdrant_synced`:
**force_full**, a **second connector on the same source** (`raw_documents` is
keyed `(workspace_id, connector_type, source_id)`, not `connection_id`), a
**cursor reset**, and **CQL/JQL minute-boundary re-emits**.

## Changes

**`connectors/connection_sync.py` — Phase 2**
- Always `incremental=True` on the `ingest_documents` call. `delete_by_doc_labels`
  is a cheap no-op for a brand-new doc (scroll finds nothing → 0), so this is
  safe for `new` docs and correct for `updated` ones (whose stale chunks were
  previously left behind too).
- Three explicit branches instead of the `if/else`:
  - `upsert_result is None` (persist raised) → **skip ingest**, add the
    sanitized persist error so the sync is not reported `success` (was: full
    re-ingest onto an unknown PG state, marked `success`).
  - `changed_source_ids` non-empty → ingest only those docs (unchanged).
  - otherwise (nothing changed) → **skip ingest** — Qdrant already holds these
    chunks (was: re-ingest the whole batch → the #461 duplication).

**`connectors/connection_sync.py` — Phase 3b (graph rebuild)** — addressing the
review: `incremental=True` also fires `_delete_graph_node` inside
`ingest_documents` (delete-before-add), but the ingest runs `skip_graph=True`
so nothing rebuilds inline, and the delete never touches `graph_synced`. For
`new` / content-changed docs that's fine — `upsert_raw_documents` already set
`graph_synced=false`, so the Phase 4 sweeper rebuilds them. For a **sidecar-only
refresh** (#440 — content unchanged, so `graph_synced` stays `true`, but the
`source_id` is still returned in `changed_source_ids`) the sweeper would never
pick the doc back up → the graph node stays deleted until the next content
change.

Phase 3b now clears `graph_synced` for the re-ingested `source_id`s via the new
`PostgresStore.mark_documents_graph_unsynced_by_source`, so Phase 4 rebuilds
them. It's a no-op for the rows `upsert_raw_documents` already left unsynced, so
only the sidecar rows actually flip. Local to `connection_sync` — the shared
`ingest_documents` pipeline and its other callers are untouched.

**`mcp/sync.py`** — the MCP-client connector had the same class of bug:
`incremental=not force_full` inverted it exactly on the `force_full` path
(force_full → `docs_to_ingest = all_docs`, `incremental=False` → duplicate).
Now `incremental=True`. (No graph concern here — this path runs
`ingest_documents` with `skip_graph=False`, so the node is rebuilt inline.)

**Behaviour note:** with this PR a connector **`force_full`** re-fetches from
source and refreshes `raw_documents.fetched_at`, but **no longer rewrites Qdrant
for documents whose content is unchanged** — the index already holds those
chunks. This is intentional (#461); a genuine "rebuild the index from scratch"
still needs a reindex path, not `force_full`.

**Tests** (`test_connections_sync.py`, mocked store — no live PG):
1. `run_connection_sync` passes `incremental=True` to `ingest_documents`.
2. an unchanged re-fetch (`changed_source_ids == []`) does **not** call
   `ingest_documents` and finishes `status=success` / connection `active`.
3. an `upsert_raw_documents` failure does **not** call `ingest_documents`,
   finishes non-`success` / connection `error`, and carries the sanitized
   persist error into the `sync_logs` row.
4. **(review regression)** a sidecar-drift shape (`unchanged=1`,
   `changed_source_ids=["J-1"]`) re-ingests with `skip_graph=True` **and** calls
   `mark_documents_graph_unsynced_by_source(source_ids=["J-1"])` so Phase 4
   rebuilds the node the incremental delete dropped.

`test_mcp_client.py::test_sync_server_force_full` now also asserts
`incremental=True`, guarding the `incremental=not force_full` inversion from
regressing.

## Adjacent — not fixed here

`AsyncQdrantVectorStore.delete_by_doc_labels` returns `len(scroll(limit=100))`,
so the deleted count is under-reported past 100 points on a single `doc_label`
(the `client.delete(points_selector=filt)` itself is unbounded). Metric/log
only; noted in #457.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy connection_sync.py mcp/sync.py storage/postgres.py` — error counts
  unchanged vs `main` (pre-existing `mcp/sync.py` no-any-return; the 22
  `postgres.py` errors are all pre-existing `changed_source_ids`/`dict` noise)
- [x] the 4 `test_phase2_*` tests + `test_sync_server_force_full` — pass locally
  (mocked store, no PG)
- [x] `test_connection_sync_refactor.py`, `test_connection_sync_cursor.py`,
  `test_ingest_sync_shared.py`, `test_mcp_client.py` — pass
- [x] `test_raw_documents.py` — 5 pre-existing failures (SQLite test schema
  lacks the `graph_failed` column, per #440); identical on `main`
- [ ] CI `pytest (unit, with services)` — runs the live-PG
  `test_connections_sync.py` tiers
