### PR TITLE
fix(connectors): Confluence Cloud incremental sync via get_content (#468)

### DIFF
--- a/src/metronix/connectors/confluence.py
+++ b/src/metronix/connectors/confluence.py
@@ -142,6 +142,10 @@ class ConfluenceConnector(ConnectorInterface):
         on every sync until the cursor's minute advances past it. We apply a
         precise sub-minute post-filter on ``page.version.when`` to drop those
         boundary docs (MTRNIX-332).
+
+        Page bodies are loaded via ``get_content`` (portable across Server and
+        Cloud in atlassian-python-api 5.x). ``get_page_by_id`` exists only on
+        Server and crashes Cloud incremental sync — issue #468.
         """
         documents: list[Document] = []
         cql = f'space="{space_key}" AND type=page' if space_key else "type=page"
@@ -168,7 +172,9 @@ class ConfluenceConnector(ConnectorInterface):
                 if not page_id:
                     continue
                 try:
-                    page = self._client.get_page_by_id(
+                    # Portable across Server + Cloud (atlassian-python-api 5.x).
+                    # Cloud has no get_page_by_id — see #468.
+                    page = self._client.get_content(
                         page_id,
                         expand="body.storage,version,history",
                     )

--- a/tests/unit/test_confluence_connector.py
+++ b/tests/unit/test_confluence_connector.py
@@ -167,7 +167,7 @@ class TestConfluenceFetchPostFilter:
                 "size": 1,
             }
         )
-        connector._client.get_page_by_id = MagicMock(
+        connector._client.get_content = MagicMock(
             return_value=_page("100", "2026-05-12T22:09:27.000Z")
         )
 
@@ -202,7 +202,7 @@ class TestConfluenceFetchPostFilter:
                 "size": 1,
             }
         )
-        connector._client.get_page_by_id = MagicMock(
+        connector._client.get_content = MagicMock(
             return_value=_page("100", "2026-05-12T22:09:28.000Z")
         )
 
@@ -213,6 +213,51 @@ class TestConfluenceFetchPostFilter:
             since=since,
         )
         assert len(docs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cloud incremental sync — get_content portable path (#468)
+# ---------------------------------------------------------------------------
+
+
+class TestConfluenceFetchIncrementalCloud:
+    def test_cloud_client_without_get_page_by_id_uses_get_content(self) -> None:
+        """Cloud has cql + get_content but no get_page_by_id (atlassian-python-api 5.x)."""
+        from datetime import UTC, datetime
+
+        connector = ConfluenceConnector()
+        connector._config = {
+            "url": "https://co.atlassian.net",
+            "space_key": "X",
+            "username": "u",
+            "api_token": "t",
+        }
+        since = datetime(2026, 1, 1, tzinfo=UTC)
+
+        # Mirror Cloud: cql present, get_page_by_id absent; get_content is the portable API.
+        client = MagicMock(spec=["cql", "get_content"])
+        client.cql.return_value = {
+            "results": [{"content": {"id": "100"}}],
+            "totalSize": 1,
+            "size": 1,
+        }
+        client.get_content.return_value = _page("100", "2026-05-12T22:09:28.000Z")
+        connector._client = client
+
+        docs = connector._fetch_incremental(
+            workspace_id="ws1",
+            base_url="https://co.atlassian.net",
+            space_key="X",
+            since=since,
+        )
+
+        assert len(docs) == 1
+        assert docs[0].source_id == "100"
+        client.get_content.assert_called_once_with(
+            "100",
+            expand="body.storage,version,history",
+        )
+        assert not hasattr(client, "get_page_by_id")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes Confluence **Cloud** incremental sync (`AttributeError: 'Cloud' object has no attribute 'get_page_by_id'`).
- `_fetch_incremental` now uses portable `get_content(...)` (present on both Server and Cloud in `atlassian-python-api` 5.x).
- Updates existing post-filter unit mocks to `get_content` and adds a Cloud-style regression (`spec=["cql", "get_content"]`, no `get_page_by_id`).

Closes #468

## Test plan
- [ ] `pytest tests/unit/test_confluence_connector.py -q`
- [ ] Confirm new `TestConfluenceFetchIncrementalCloud` passes
- [ ] Confirm existing post-filter + `#460` full-sync tests still pass
- [ ] (Optional) Against a real `*.atlassian.net` source with `last_synced_at` set, trigger a second sync and confirm it no longer fails with `get_page_by_id`