### PR TITLE
feat(benchmarks): reproducible PPR flag-off/flag-on harness (issue #156)

### DIFF
--- a/benchmarks/_shared/compare.py
+++ b/benchmarks/_shared/compare.py
@@ -1,0 +1,351 @@
+"""Compare two benchmark runs from the artifacts they wrote.
+
+A run (LongMemEval or LoCoMo) leaves next to its ``answers.jsonl``:
+
+- ``.manifest.json``      — dataset sha256, repo revision + dirty, config, and
+                            the ``question_ids_sha256`` of the exact set it ran.
+- ``.query_set.json``     — the ordered question-id list.
+- ``.retrieval.eval.json`` (LongMemEval) / the ``retrieval`` + ``latency``
+  blocks inside ``.eval.json`` (LoCoMo) — recall@k and per-phase latency.
+
+Two runs are comparable only when every identity field matches and only the
+declared retrieval mode differs (the PPR A/B variable). ``compare`` then reports
+the recall@10 delta and applies the gate.
+
+Stdlib only — this is imported from the main venv (which has no bench deps) as
+well as run standalone.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_MANIFEST_SUFFIX = ".manifest.json"
+_QUERY_SET_SUFFIX = ".query_set.json"
+_RETRIEVAL_EVAL_SUFFIX = ".retrieval.eval.json"
+_ANSWER_EVAL_SUFFIX = ".eval.json"
+
+# metrics a gate / regression check may name (higher is better)
+GATE_METRICS: tuple[str, ...] = (
+    "recall_at_10",
+    "recall_at_5",
+    "answer_metric",
+)
+
+
+@dataclass(frozen=True)
+class RunArtifacts:
+    results_path: Path
+    manifest: dict[str, Any]
+    query_set: dict[str, Any]
+    retrieval_eval: dict[str, Any] | None
+    answer_eval: dict[str, Any] | None
+
+    @property
+    def benchmark(self) -> str:
+        return str(self.manifest.get("benchmark", "unknown"))
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else None
+
+
+def load_run(results_path: Path | str) -> RunArtifacts:
+    """Load the sidecars for one run's ``answers.jsonl``."""
+    results_path = Path(results_path)
+    manifest = _load_json(results_path.with_suffix(results_path.suffix + _MANIFEST_SUFFIX))
+    query_set = _load_json(results_path.with_suffix(results_path.suffix + _QUERY_SET_SUFFIX))
+    if manifest is None or query_set is None:
+        raise FileNotFoundError(
+            f"{results_path} is missing its .manifest.json / .query_set.json — "
+            "re-run the benchmark (step 1+ of the reproducible harness)"
+        )
+    return RunArtifacts(
+        results_path=results_path,
+        manifest=manifest,
+        query_set=query_set,
+        retrieval_eval=_load_json(
+            results_path.with_suffix(results_path.suffix + _RETRIEVAL_EVAL_SUFFIX)
+        ),
+        answer_eval=_load_json(
+            results_path.with_suffix(results_path.suffix + _ANSWER_EVAL_SUFFIX)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normalized metrics
+# ---------------------------------------------------------------------------
+
+
+def _phase_percentile(latency: Mapping[str, Any] | None, phase: str, key: str) -> float | None:
+    if not isinstance(latency, Mapping):
+        return None
+    stats = latency.get("phases", {}).get(phase)
+    return stats.get(key) if isinstance(stats, Mapping) else None
+
+
+def metrics(run: RunArtifacts) -> dict[str, Any]:
+    """One flat shape for both benchmarks.
+
+    ``answer_metric`` is token-F1 for LoCoMo and — when the judge ran — accuracy
+    for LongMemEval; ``None`` when the judge output is not available.
+    """
+    recall_report: Mapping[str, Any] | None
+    latency_report: Mapping[str, Any] | None
+    answer_metric: float | None
+    answer_metric_name: str
+    error_count = 0
+
+    if run.benchmark == "locomo":
+        ev = run.answer_eval or {}
+        recall_report = ev.get("retrieval")
+        latency_report = ev.get("latency")
+        answer_metric = ev.get("overall_score")
+        answer_metric_name = "token_f1"
+        error_count = int(ev.get("error_count", 0) or 0)
+    else:  # longmemeval
+        recall_report = run.retrieval_eval
+        latency_report = run.retrieval_eval.get("latency") if run.retrieval_eval else None
+        answer_metric, answer_metric_name = _longmemeval_answer_metric(run)
+
+    recall = recall_report.get("recall", {}) if isinstance(recall_report, Mapping) else {}
+    eligible = (
+        int(recall_report.get("eligible_count", 0)) if isinstance(recall_report, Mapping) else 0
+    )
+
+    return {
+        "benchmark": run.benchmark,
+        "recall_at_10": recall.get("10"),
+        "recall_at_5": recall.get("5"),
+        "recall_eligible_count": eligible,
+        "search_latency_p50_ms": _phase_percentile(latency_report, "search_ms", "p50_ms"),
+        "search_latency_p95_ms": _phase_percentile(latency_report, "search_ms", "p95_ms"),
+        "total_latency_p95_ms": _phase_percentile(latency_report, "total_ms", "p95_ms"),
+        "answer_metric": answer_metric,
+        "answer_metric_name": answer_metric_name,
+        "error_count": error_count,
+    }
+
+
+def _longmemeval_answer_metric(run: RunArtifacts) -> tuple[float | None, str]:
+    """LongMemEval judge accuracy from a ``*.eval-<judge>`` sidecar, if present."""
+    for path in sorted(run.results_path.parent.glob(f"{run.results_path.name}.eval-*")):
+        labelled = [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        marks = [
+            1 if isinstance(row, dict) and row.get("autoeval_label", {}).get("label") else 0
+            for row in labelled
+        ]
+        if marks:
+            return sum(marks) / len(marks), "judge_accuracy"
+    return None, "judge_accuracy"
+
+
+# ---------------------------------------------------------------------------
+# Comparability
+# ---------------------------------------------------------------------------
+
+
+def check_comparable(
+    baseline: RunArtifacts,
+    current: RunArtifacts,
+    *,
+    allow_dirty: bool = False,
+    allow_same_mode: bool = False,
+) -> list[str]:
+    """Reasons the two runs are NOT comparable (empty list == comparable)."""
+    reasons: list[str] = []
+
+    def _cmp(label: str, a: Any, b: Any) -> None:
+        if a != b:
+            reasons.append(f"{label} differs: {a!r} vs {b!r}")
+
+    bm, cm = baseline.manifest, current.manifest
+    _cmp("benchmark", bm.get("benchmark"), cm.get("benchmark"))
+    _cmp("dataset sha256", _get(bm, "dataset", "sha256"), _get(cm, "dataset", "sha256"))
+    _cmp(
+        "question set (question_ids_sha256)",
+        baseline.query_set.get("question_ids_sha256"),
+        current.query_set.get("question_ids_sha256"),
+    )
+    _cmp(
+        "repository revision",
+        _get(bm, "repository", "revision"),
+        _get(cm, "repository", "revision"),
+    )
+    for label, run in (("baseline", baseline), ("current", current)):
+        if _get(run.manifest, "repository", "dirty") is True and not allow_dirty:
+            reasons.append(f"{label} run was made from a dirty working tree (pass --allow-dirty)")
+    for key in ("top_k", "chat_model", "chat_base_url", "judge_model", "judge_base_url"):
+        if key in bm.get("config", {}) or key in cm.get("config", {}):
+            _cmp(f"config.{key}", _get(bm, "config", key), _get(cm, "config", key))
+    _cmp(
+        "mcp endpoint",
+        _get(bm, "stack", "mcp_endpoint_identity"),
+        _get(cm, "stack", "mcp_endpoint_identity"),
+    )
+
+    base_mode = _get(bm, "stack", "operator_declared_retrieval_mode")
+    cur_mode = _get(cm, "stack", "operator_declared_retrieval_mode")
+    if base_mode == cur_mode and not allow_same_mode:
+        reasons.append(
+            f"both runs declare the same retrieval mode ({base_mode!r}) — nothing to A/B "
+            "(pass --allow-same-mode for a repeatability check)"
+        )
+
+    for label, run in (("baseline", baseline), ("current", current)):
+        if metrics(run)["error_count"]:
+            reasons.append(f"{label} run has benchmark errors — treat it as a failed leg")
+
+    return reasons
+
+
+def _get(mapping: Mapping[str, Any], *path: str) -> Any:
+    node: Any = mapping
+    for key in path:
+        if not isinstance(node, Mapping):
+            return None
+        node = node.get(key)
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Comparison + gate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MetricDelta:
+    metric: str
+    baseline: float | None
+    current: float | None
+    delta: float | None
+
+
+def compare(
+    baseline: RunArtifacts,
+    current: RunArtifacts,
+    *,
+    gates: Mapping[str, float] | None = None,
+    max_regressions: Mapping[str, float] | None = None,
+    allow_dirty: bool = False,
+    allow_same_mode: bool = False,
+) -> dict[str, Any]:
+    gates = dict(gates or {})
+    max_regressions = dict(max_regressions or {})
+    _validate_metric_names(gates, max_regressions)
+
+    incompatibilities = check_comparable(
+        baseline, current, allow_dirty=allow_dirty, allow_same_mode=allow_same_mode
+    )
+    bm, cm = metrics(baseline), metrics(current)
+
+    tracked = sorted(
+        {"recall_at_10", "recall_at_5", "answer_metric"} | set(gates) | set(max_regressions)
+    )
+    deltas: dict[str, MetricDelta] = {}
+    for name in tracked:
+        b, c = _as_float(bm.get(name)), _as_float(cm.get(name))
+        deltas[name] = MetricDelta(
+            metric=name,
+            baseline=b,
+            current=c,
+            delta=(c - b) if (b is not None and c is not None) else None,
+        )
+
+    gate_failures: list[str] = []
+    for name, floor in gates.items():
+        value = _as_float(cm.get(name))
+        if value is None:
+            gate_failures.append(f"{name}: not available in the current run")
+        elif value < floor:
+            gate_failures.append(f"{name}={value:.4f} is below the gate floor {floor:.4f}")
+
+    regressions: list[str] = []
+    for name, max_decline in max_regressions.items():
+        d = deltas.get(name)
+        if d is None or d.delta is None:
+            regressions.append(f"{name}: delta not computable (metric missing in a run)")
+        elif d.delta < -max_decline:
+            regressions.append(f"{name} declined by {-d.delta:.4f} (> allowed {max_decline:.4f})")
+
+    passed = not incompatibilities and not gate_failures and not regressions
+    return {
+        "schema_version": 1,
+        "verdict": "PASS" if passed else "FAIL",
+        "comparable": not incompatibilities,
+        "incompatibilities": incompatibilities,
+        "baseline": {
+            "results": str(baseline.results_path),
+            "retrieval_mode": _get(baseline.manifest, "stack", "operator_declared_retrieval_mode"),
+            "run_id": baseline.manifest.get("run_id"),
+        },
+        "current": {
+            "results": str(current.results_path),
+            "retrieval_mode": _get(current.manifest, "stack", "operator_declared_retrieval_mode"),
+            "run_id": current.manifest.get("run_id"),
+        },
+        "metrics": {
+            name: {"baseline": d.baseline, "current": d.current, "delta": d.delta}
+            for name, d in deltas.items()
+        },
+        "recall_eligible": {
+            "baseline": bm["recall_eligible_count"],
+            "current": cm["recall_eligible_count"],
+        },
+        "answer_metric_name": cm["answer_metric_name"],
+        "gate_failures": gate_failures,
+        "regressions": regressions,
+    }
+
+
+def _validate_metric_names(*groups: Mapping[str, float]) -> None:
+    for group in groups:
+        for name, limit in group.items():
+            if name not in GATE_METRICS:
+                raise ValueError(f"unknown gate metric {name!r} (choose from {GATE_METRICS})")
+            if isinstance(limit, bool) or not isinstance(limit, (int, float)) or limit < 0:
+                raise ValueError(f"gate value for {name} must be a non-negative number")
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f else None  # drop NaN
+
+
+def parse_metric_assignment(value: str) -> tuple[str, float]:
+    """``recall_at_10=0.62`` -> ``("recall_at_10", 0.62)``."""
+    key, _, raw = value.partition("=")
+    key = key.strip()
+    try:
+        limit = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"expected METRIC=NUMBER, got {value!r}") from exc
+    _validate_metric_names({key: limit})
+    return key, limit
+
+
+def collect_assignments(values: Sequence[str]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for value in values:
+        key, limit = parse_metric_assignment(value)
+        if key in out:
+            raise ValueError(f"metric {key!r} given twice")
+        out[key] = limit
+    return out

--- a/benchmarks/_shared/compare.py
+++ b/benchmarks/_shared/compare.py
@@ -120,12 +120,16 @@ def metrics(run: RunArtifacts) -> dict[str, Any]:
     eligible = (
         int(recall_report.get("eligible_count", 0)) if isinstance(recall_report, Mapping) else 0
     )
+    suspect = (
+        int(recall_report.get("suspect_count", 0)) if isinstance(recall_report, Mapping) else 0
+    )
 
     return {
         "benchmark": run.benchmark,
         "recall_at_10": recall.get("10"),
         "recall_at_5": recall.get("5"),
         "recall_eligible_count": eligible,
+        "search_suspect_count": suspect,
         "search_latency_p50_ms": _phase_percentile(latency_report, "search_ms", "p50_ms"),
         "search_latency_p95_ms": _phase_percentile(latency_report, "search_ms", "p95_ms"),
         "total_latency_p95_ms": _phase_percentile(latency_report, "total_ms", "p95_ms"),
@@ -187,7 +191,16 @@ def check_comparable(
     for label, run in (("baseline", baseline), ("current", current)):
         if _get(run.manifest, "repository", "dirty") is True and not allow_dirty:
             reasons.append(f"{label} run was made from a dirty working tree (pass --allow-dirty)")
-    for key in ("top_k", "chat_model", "chat_base_url", "judge_model", "judge_base_url"):
+    for key in (
+        "top_k",
+        "workspace",
+        "chat_model",
+        "chat_base_url",
+        "chat_temperature",
+        "chat_max_tokens",
+        "judge_model",
+        "judge_base_url",
+    ):
         if key in bm.get("config", {}) or key in cm.get("config", {}):
             _cmp(f"config.{key}", _get(bm, "config", key), _get(cm, "config", key))
     _cmp(
@@ -195,6 +208,19 @@ def check_comparable(
         _get(bm, "stack", "mcp_endpoint_identity"),
         _get(cm, "stack", "mcp_endpoint_identity"),
     )
+    # The stack probe (best-effort) — a leg run with Qdrant/Neo4j down is not a
+    # clean comparison point. Missing probes on both sides are not flagged.
+    b_probe = _get(bm, "stack", "probe") or {}
+    c_probe = _get(cm, "stack", "probe") or {}
+    if bool(b_probe.get("probe")) != bool(c_probe.get("probe")):
+        reasons.append(
+            "stack probe availability differs: one leg reached the server, the other did not"
+        )
+    for field in ("qdrant", "neo4j", "qdrant_collections"):
+        b_val = b_probe.get(field)
+        c_val = c_probe.get(field)
+        if b_val is not None or c_val is not None:
+            _cmp(f"stack probe {field}", b_val, c_val)
 
     base_mode = _get(bm, "stack", "operator_declared_retrieval_mode")
     cur_mode = _get(cm, "stack", "operator_declared_retrieval_mode")
@@ -204,9 +230,23 @@ def check_comparable(
             "(pass --allow-same-mode for a repeatability check)"
         )
 
+    # A run where the workspace was reset and one where it was not carry
+    # different amounts of residual memory — not the same measurement.
+    _cmp(
+        "workspace reset",
+        _get(bm, "stack", "workspace_reset"),
+        _get(cm, "stack", "workspace_reset"),
+    )
+
     for label, run in (("baseline", baseline), ("current", current)):
-        if metrics(run)["error_count"]:
+        run_metrics = metrics(run)
+        if run_metrics["error_count"]:
             reasons.append(f"{label} run has benchmark errors — treat it as a failed leg")
+        if run_metrics["search_suspect_count"]:
+            reasons.append(
+                f"{label} run has {run_metrics['search_suspect_count']} question(s) where the "
+                "agent's own memory returned nothing — a degraded retrieval leg, not a clean run"
+            )
 
     return reasons
 

--- a/benchmarks/_shared/latency.py
+++ b/benchmarks/_shared/latency.py
@@ -1,0 +1,48 @@
+"""Latency percentiles for the benchmark runners.
+
+Standalone (the runners' venv has no ``metronix``); byte-for-byte the same as
+``scripts/run_eval.py::latency_summary``, kept honest by a parity test in the
+main suite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+
+def summarize(measurements_ms: Iterable[float]) -> dict[str, float]:
+    """``{mean_ms, p50_ms, p95_ms, max_ms}`` with linear-interpolated percentiles."""
+    ordered = sorted(float(m) for m in measurements_ms)
+    if not ordered:
+        raise ValueError("latency summary requires at least one measurement")
+
+    def percentile(fraction: float) -> float:
+        position = fraction * (len(ordered) - 1)
+        lower = int(position)
+        upper = min(lower + 1, len(ordered) - 1)
+        return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+    return {
+        "mean_ms": sum(ordered) / len(ordered),
+        "p50_ms": percentile(0.50),
+        "p95_ms": percentile(0.95),
+        "max_ms": ordered[-1],
+    }
+
+
+_PHASES = ("ingest_ms", "search_ms", "answer_ms", "total_ms")
+
+
+def aggregate_latency(rows: Sequence[dict], *, phases: Sequence[str] = _PHASES) -> dict[str, Any]:
+    """Per-phase percentile summary over the rows that recorded that phase.
+
+    ``search_ms`` is the phase a retrieval-latency ceiling would gate on; it
+    includes the MCP round-trip, not just server compute.
+    """
+    out: dict[str, Any] = {"count": len(rows), "phases": {}}
+    for phase in phases:
+        values = [float(r[phase]) for r in rows if isinstance(r.get(phase), (int, float))]
+        if values:
+            out["phases"][phase] = {"n": len(values), **summarize(values)}
+    return out

--- a/benchmarks/_shared/manifest.py
+++ b/benchmarks/_shared/manifest.py
@@ -191,6 +191,43 @@ def manifest_path(results_path: Path | str) -> Path:
     return p.with_suffix(p.suffix + _MANIFEST_SUFFIX)
 
 
+def resolve_run_identity(
+    results_path: Path | str,
+    *,
+    benchmark: str,
+    retrieval_mode: str = "unspecified",
+    prefix_override: str | None = None,
+    fresh: bool = False,
+) -> tuple[str, str]:
+    """Return ``(run_id, agent_id_prefix)`` for this run.
+
+    A fresh run gets a new ``run_id`` and an agent-id prefix that embeds it, so a
+    later run cannot search over this run's stored memories. A **resume** (the
+    manifest already exists and ``fresh`` is False) reads both back, so every
+    question in one results file uses one memory namespace.
+    """
+    existing = manifest_path(results_path)
+    if not fresh and existing.is_file():
+        try:
+            data = json.loads(existing.read_text(encoding="utf-8"))
+            prior_id = data["run_id"]
+            prior_prefix = data["config"]["agent_id_prefix"]
+        except (OSError, ValueError, KeyError, TypeError):
+            pass
+        else:
+            if isinstance(prior_id, str) and isinstance(prior_prefix, str):
+                return prior_id, prior_prefix
+
+    run_id = uuid4().hex
+    if prefix_override:
+        return run_id, prefix_override
+    parts = [benchmark]
+    if retrieval_mode and retrieval_mode != "unspecified":
+        parts.append(retrieval_mode)
+    parts.append(run_id[:8])
+    return run_id, "-".join(parts)
+
+
 def query_set_path(results_path: Path | str) -> Path:
     p = Path(results_path)
     return p.with_suffix(p.suffix + _QUERY_SET_SUFFIX)

--- a/benchmarks/_shared/manifest.py
+++ b/benchmarks/_shared/manifest.py
@@ -1,0 +1,230 @@
+"""Shared run-identity manifest for the agent-memory benchmarks.
+
+Both LongMemEval and LoCoMo write a ``<results>.manifest.json`` and a
+``<results>.query_set.json`` next to their answers file so any two runs can be
+checked for comparability after the fact:
+
+- ``manifest.json`` — dataset bytes (sha256), the exact ordered question set
+  (``question_ids_sha256``), repository revision + dirty flag, and the full
+  retrieval configuration the run used.
+- ``query_set.json`` — the ordered list of ``question_id`` values actually
+  executed, so a later run can replay exactly the same set.
+
+Secrets never enter a manifest: callers pass an already-sanitized ``config`` /
+``stack`` mapping (endpoint identity, model names — no keys).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+MANIFEST_SCHEMA_VERSION = 2
+QUERY_SET_SCHEMA_VERSION = 1
+
+_MANIFEST_SUFFIX = ".manifest.json"
+_QUERY_SET_SUFFIX = ".query_set.json"
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+def sha256_file(path: Path | str) -> str:
+    """Streaming SHA-256 of a file's bytes."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def question_ids_digest(question_ids: Sequence[str]) -> str:
+    """Order-sensitive digest of the exact question-id list a run executed.
+
+    Newline-joined so a reordering, an addition, or a removal all change the
+    hash. This is the machine-checkable form of "same set of queries".
+    """
+    return sha256_text("\n".join(question_ids))
+
+
+def sanitized_endpoint_identity(url: str) -> str:
+    """Normalized ``scheme://host[:port]/path`` — no credentials, no query.
+
+    Lets a manifest record *which* Metronix a run hit without leaking a token
+    that may be embedded in the URL.
+    """
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    host = parsed.hostname
+    if not scheme or host is None:
+        raise ValueError(f"not an absolute URL: {url!r}")
+    host = host.lower()
+    if ":" in host:  # IPv6 literal
+        host = f"[{host}]"
+    port = parsed.port
+    is_default = (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    netloc = host if port is None or is_default else f"{host}:{port}"
+    return urlunsplit((scheme, netloc, parsed.path.rstrip("/"), "", ""))
+
+
+# ---------------------------------------------------------------------------
+# Repository identity
+# ---------------------------------------------------------------------------
+
+
+def git_revision(repo_root: Path | str) -> dict[str, Any]:
+    """Return ``{"revision": <sha|"unknown">, "dirty": <bool|None>}``.
+
+    ``dirty`` is ``None`` when the working tree state could not be read (no git,
+    not a repo) — distinct from a known-clean ``False``.
+    """
+
+    def _run(args: list[str]) -> str | None:
+        try:
+            return subprocess.run(
+                ["git", *args],
+                cwd=str(repo_root),
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    revision = _run(["rev-parse", "HEAD"])
+    porcelain = _run(["status", "--porcelain"])
+    return {
+        "revision": revision or "unknown",
+        "dirty": bool(porcelain) if porcelain is not None else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Query set
+# ---------------------------------------------------------------------------
+
+
+def build_query_set(
+    *,
+    benchmark: str,
+    selector: Mapping[str, Any],
+    question_ids: Sequence[str],
+) -> dict[str, Any]:
+    """The ordered question set a run will execute, plus its digest."""
+    ids = list(question_ids)
+    return {
+        "schema_version": QUERY_SET_SCHEMA_VERSION,
+        "benchmark": benchmark,
+        "order": "dataset",
+        "selector": dict(selector),
+        "question_count": len(ids),
+        "question_ids_sha256": question_ids_digest(ids),
+        "question_ids": ids,
+    }
+
+
+def query_set_summary(query_set: Mapping[str, Any]) -> dict[str, Any]:
+    """The query set without the full id list — small enough to embed in a manifest."""
+    return {
+        "order": query_set["order"],
+        "selector": dict(query_set["selector"]),
+        "question_count": query_set["question_count"],
+        "question_ids_sha256": query_set["question_ids_sha256"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(
+    *,
+    benchmark: str,
+    repo_root: Path | str,
+    dataset: Mapping[str, Any],
+    query_set: Mapping[str, Any],
+    config: Mapping[str, Any],
+    stack: Mapping[str, Any],
+    metrics_requested: Sequence[str],
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Assemble the run-identity manifest.
+
+    ``query_set`` is the full object from :func:`build_query_set`; only its
+    summary is embedded here (the full id list lives in ``query_set.json``).
+    """
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "benchmark": benchmark,
+        "run_id": run_id or uuid4().hex,
+        "started_at": datetime.now(UTC).isoformat(),
+        "repository": git_revision(repo_root),
+        "dataset": dict(dataset),
+        "query_set": query_set_summary(query_set),
+        "config": dict(config),
+        "stack": dict(stack),
+        "metrics_requested": list(metrics_requested),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Artifact paths + IO
+# ---------------------------------------------------------------------------
+
+
+def manifest_path(results_path: Path | str) -> Path:
+    p = Path(results_path)
+    return p.with_suffix(p.suffix + _MANIFEST_SUFFIX)
+
+
+def query_set_path(results_path: Path | str) -> Path:
+    p = Path(results_path)
+    return p.with_suffix(p.suffix + _QUERY_SET_SUFFIX)
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def write_manifest(results_path: Path | str, manifest: Mapping[str, Any]) -> Path:
+    return _write_json(manifest_path(results_path), manifest)
+
+
+def write_query_set(results_path: Path | str, query_set: Mapping[str, Any]) -> Path:
+    return _write_json(query_set_path(results_path), query_set)
+
+
+def load_query_set(path: Path | str) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("question_ids"), list):
+        raise ValueError(f"not a benchmark query_set file: {path}")
+    return data
+
+
+def write_run_artifacts(
+    results_path: Path | str,
+    *,
+    manifest: Mapping[str, Any],
+    query_set: Mapping[str, Any],
+) -> tuple[Path, Path]:
+    """Write both sidecars; return ``(manifest_path, query_set_path)``."""
+    return (
+        write_manifest(results_path, manifest),
+        write_query_set(results_path, query_set),
+    )

--- a/benchmarks/_shared/oracle.py
+++ b/benchmarks/_shared/oracle.py
@@ -1,0 +1,110 @@
+"""Oracle (evidence) session tags for a benchmark question.
+
+The runners ingest one memory record per haystack session, tagged
+``session_<idx>`` where ``idx`` is the 0-based position of that session in the
+list handed to the MCP client. ``metronix_memory_search`` hits carry those tags,
+so recall@k reduces to "is the oracle session's record in the top-k hits".
+
+Abstention questions (LongMemEval ``*_abs`` ids, LoCoMo category 5) have no
+correct retrieval target — callers exclude them from the recall aggregate.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections.abc import Sequence
+
+_LOCOMO_DIA_RE = re.compile(r"^D(\d+):\d+$")
+
+
+def session_tag(index: int) -> str:
+    return f"session_{index}"
+
+
+def _is_session_tag(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("session_") and value[8:].isdigit()
+
+
+def retrieved_session_tags(search_results: Sequence[dict]) -> list[str]:
+    """Ordered ``session_<idx>`` tags, one per search hit.
+
+    A hit is represented by its first ``session_*`` tag. Hits with none (should
+    not happen for benchmark-ingested records) are dropped.
+    """
+    tags: list[str] = []
+    for hit in search_results:
+        record = hit.get("record") if isinstance(hit, dict) else None
+        for tag in (record or {}).get("tags", []) or []:
+            if _is_session_tag(tag):
+                tags.append(tag)
+                break
+    return tags
+
+
+# ---------------------------------------------------------------------------
+# LongMemEval
+# ---------------------------------------------------------------------------
+
+
+def longmemeval_is_abstention(entry: dict) -> bool:
+    return "_abs" in str(entry.get("question_id", ""))
+
+
+def longmemeval_oracle_tags(entry: dict) -> set[str]:
+    """Map ``answer_session_ids`` to ``session_<idx>`` via ``haystack_session_ids``."""
+    position = {sid: i for i, sid in enumerate(entry.get("haystack_session_ids") or [])}
+    return {
+        session_tag(position[sid])
+        for sid in entry.get("answer_session_ids") or []
+        if sid in position
+    }
+
+
+# ---------------------------------------------------------------------------
+# LoCoMo
+# ---------------------------------------------------------------------------
+
+
+def locomo_is_abstention(entry: dict) -> bool:
+    try:
+        return int(entry.get("category", 0)) == 5
+    except (TypeError, ValueError):
+        return False
+
+
+def _parse_evidence(evidence: object) -> list[str]:
+    """LoCoMo ``evidence`` is a Python-repr string like ``"['D1:3', 'D2:8']"``."""
+    if isinstance(evidence, (list, tuple)):
+        items: Sequence[object] = evidence
+    elif isinstance(evidence, str):
+        stripped = evidence.strip()
+        if not stripped:
+            return []
+        if stripped[0] in "[(":
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (ValueError, SyntaxError):
+                return []
+            items = parsed if isinstance(parsed, (list, tuple)) else [parsed]
+        else:
+            items = [stripped]
+    else:
+        return []
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def locomo_oracle_tags(entry: dict) -> set[str]:
+    """Map ``evidence`` dialogue refs (``D<n>:<turn>``) to ``session_<idx>``.
+
+    ``entry["session_numbers"]`` is the sorted list of session numbers in the
+    order the runner ingests them (see ``dataset.iter_questions``).
+    """
+    session_numbers = entry.get("session_numbers") or []
+    order = {number: index for index, number in enumerate(session_numbers)}
+    tags: set[str] = set()
+    for ref in _parse_evidence(entry.get("evidence")):
+        match = _LOCOMO_DIA_RE.match(ref)
+        if match is not None and int(match.group(1)) in order:
+            tags.add(session_tag(order[int(match.group(1))]))
+    return tags

--- a/benchmarks/_shared/retrieval_eval.py
+++ b/benchmarks/_shared/retrieval_eval.py
@@ -82,6 +82,11 @@ def aggregate_recall(
     for row in eligible:
         groups.setdefault(str(row.get(group_key, "unknown")), []).append(row)
 
+    # A question whose own sessions were stored but whose search returned
+    # nothing points at a degraded retrieval leg, not missing evidence. Any
+    # non-zero count here means the run is not a clean measurement.
+    suspect_count = sum(1 for r in rows if r.get("search_suspect") is True)
+
     return {
         "schema_version": SCHEMA_VERSION,
         "recall_ks": list(ks),
@@ -89,6 +94,7 @@ def aggregate_recall(
         "question_count": len(rows),
         "eligible_count": len(eligible),
         "excluded_count": len(rows) - len(eligible),
+        "suspect_count": suspect_count,
         "recall": recall_for(eligible),
         "by_group": {
             name: {"count": len(subset), "recall": recall_for(subset)}

--- a/benchmarks/_shared/retrieval_eval.py
+++ b/benchmarks/_shared/retrieval_eval.py
@@ -1,0 +1,105 @@
+"""Per-row recall@k for the benchmark runners, and its aggregation.
+
+The benchmark runners run in an isolated venv without ``metronix`` installed, so
+this carries a standalone ``recall_at_k``. It is byte-for-byte the same formula
+as ``metronix.benchmarker.services.metrics.retrieval.recall_at_k``; a parity
+test in the main suite keeps the two honest.
+
+Each answers-JSONL row the runner produces carries, for a question with a known
+evidence session:
+
+    recall_at_5, recall_at_10  : float
+    oracle_session_tags        : list[str]
+    retrieved_session_tags     : list[str]
+    recall_gate_eligible       : bool  (False for abstention / no-oracle rows)
+    <group_key>                : question_type (LongMemEval) | category (LoCoMo)
+
+recall@10 over the ``recall_gate_eligible`` rows is the retrieval gate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+RECALL_KS: tuple[int, ...] = (5, 10)
+SEARCH_K_FLOOR = max(RECALL_KS)
+SCHEMA_VERSION = 1
+
+
+def recall_at_k(retrieved: Sequence[str], expected: set[str], k: int) -> float:
+    """``|top_k ∩ expected| / |expected|``. 0.0 when there is nothing to recall."""
+    if not retrieved or not expected or k <= 0:
+        return 0.0
+    top_k = set(retrieved[:k])
+    return sum(1 for item in expected if item in top_k) / len(expected)
+
+
+def recall_row(
+    oracle_tags: set[str],
+    retrieved_tags: Sequence[str],
+    *,
+    eligible: bool,
+    ks: Sequence[int] = RECALL_KS,
+) -> dict[str, Any]:
+    """The recall fields for one answers-JSONL row.
+
+    ``eligible`` is the caller's non-abstention verdict; a row is only counted
+    toward the gate when it is both non-abstention *and* has an oracle session.
+    """
+    retrieved = list(retrieved_tags)
+    row: dict[str, Any] = {
+        "oracle_session_tags": sorted(oracle_tags),
+        "retrieved_session_tags": retrieved,
+        "recall_gate_eligible": bool(eligible and oracle_tags),
+    }
+    for k in ks:
+        row[f"recall_at_{k}"] = recall_at_k(retrieved, oracle_tags, k)
+    return row
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def aggregate_recall(
+    rows: Iterable[dict],
+    *,
+    ks: Sequence[int] = RECALL_KS,
+    group_key: str = "question_type",
+) -> dict[str, Any]:
+    """Overall + per-group mean recall@k over the eligible rows."""
+    rows = list(rows)
+    eligible = [r for r in rows if r.get("recall_gate_eligible") is True]
+
+    def recall_for(subset: list[dict]) -> dict[str, float]:
+        return {
+            str(k): _mean([float(r[f"recall_at_{k}"]) for r in subset if f"recall_at_{k}" in r])
+            for k in ks
+        }
+
+    groups: dict[str, list[dict]] = {}
+    for row in eligible:
+        groups.setdefault(str(row.get(group_key, "unknown")), []).append(row)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "recall_ks": list(ks),
+        "group_key": group_key,
+        "question_count": len(rows),
+        "eligible_count": len(eligible),
+        "excluded_count": len(rows) - len(eligible),
+        "recall": recall_for(eligible),
+        "by_group": {
+            name: {"count": len(subset), "recall": recall_for(subset)}
+            for name, subset in sorted(groups.items())
+        },
+    }
+
+
+def gate_value(report: dict[str, Any], k: int = 10) -> float | None:
+    """The number a recall gate compares — mean recall@k, or ``None`` when
+    nothing was eligible (an all-abstention run cannot be gated)."""
+    if report.get("eligible_count", 0) == 0:
+        return None
+    return report.get("recall", {}).get(str(k))

--- a/benchmarks/_shared/stack.py
+++ b/benchmarks/_shared/stack.py
@@ -1,0 +1,69 @@
+"""Best-effort Metronix stack probing and workspace reset for the runners.
+
+Uses ``httpx`` (in the runners' venv). Everything here degrades gracefully — a
+probe failure never aborts a benchmark, it just records ``"unavailable"`` in the
+manifest so the comparator can see the difference.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+_TIMEOUT = httpx.Timeout(15.0)
+
+
+def probe_stack(api_url: str) -> dict[str, Any]:
+    """A snapshot of what the server will tell us — health + store connectivity.
+
+    The API does not expose the embedding model or the retrieval flags, so those
+    stay operator-declared; this records the parts it does expose so a leg run
+    with (say) Neo4j down is visibly not comparable to one with it up.
+    """
+    api_url = api_url.rstrip("/")
+    snapshot: dict[str, Any] = {}
+    try:
+        with httpx.Client(timeout=_TIMEOUT, trust_env=False) as client:
+            health = client.get(f"{api_url}/health")
+            snapshot["health"] = (
+                health.json().get("status", health.status_code)
+                if health.headers.get("content-type", "").startswith("application/json")
+                else health.status_code
+            )
+            status = client.get(f"{api_url}/api/v1/admin/status")
+            if status.status_code == 200:
+                body = status.json()
+                dbs = body.get("databases", {})
+                snapshot["cleanup_allowed"] = body.get("cleanup_allowed")
+                snapshot["qdrant"] = (dbs.get("qdrant") or {}).get("status")
+                snapshot["qdrant_collections"] = (dbs.get("qdrant") or {}).get("collections_count")
+                snapshot["neo4j"] = (dbs.get("neo4j") or {}).get("status")
+            else:
+                snapshot["admin_status"] = status.status_code
+    except (httpx.HTTPError, ValueError) as exc:
+        return {"probe": "unavailable", "reason": type(exc).__name__}
+    return snapshot
+
+
+def reset_workspace(api_url: str, workspace_id: str) -> str:
+    """DELETE all data for ``workspace_id``. Returns a short status string.
+
+    Needs ``ALLOW_CLEANUP=true`` on the server. Any failure is reported, not
+    raised — the caller records the string in the manifest.
+    """
+    api_url = api_url.rstrip("/")
+    try:
+        with httpx.Client(timeout=_TIMEOUT, trust_env=False) as client:
+            response = client.request(
+                "DELETE",
+                f"{api_url}/api/v1/admin/cleanup/workspace/{workspace_id}",
+                headers={"X-Confirm-Cleanup": "yes"},
+            )
+    except httpx.HTTPError as exc:
+        return f"unavailable ({type(exc).__name__})"
+    if response.status_code == 200:
+        return "reset"
+    if response.status_code in (400, 403):
+        return "unavailable (ALLOW_CLEANUP not enabled on the server)"
+    return f"unavailable (HTTP {response.status_code})"

--- a/benchmarks/compare_runs.py
+++ b/benchmarks/compare_runs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Compare two benchmark runs and apply the recall@10 gate.
+
+    python benchmarks/compare_runs.py \\
+        BASELINE/answers.jsonl CURRENT/answers.jsonl \\
+        --gate recall_at_10=0.60 \\
+        --max-regression recall_at_10=0.03
+
+Exit code is 0 only when the two runs are comparable (same dataset bytes, same
+question set, same repo revision, clean tree, only the declared retrieval mode
+differs) AND every gate / regression check passes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from benchmarks._shared import compare  # noqa: E402
+
+
+def _fmt(value: float | None) -> str:
+    return "  n/a  " if value is None else f"{value:8.4f}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("baseline", type=Path, help="baseline run's answers.jsonl")
+    parser.add_argument("current", type=Path, help="current run's answers.jsonl")
+    parser.add_argument(
+        "--gate",
+        action="append",
+        default=[],
+        metavar="METRIC=FLOOR",
+        help="absolute floor the current run must clear (e.g. recall_at_10=0.6)",
+    )
+    parser.add_argument(
+        "--max-regression",
+        action="append",
+        default=[],
+        metavar="METRIC=DECLINE",
+        help="largest permitted drop vs. the baseline (e.g. recall_at_10=0.03)",
+    )
+    parser.add_argument("--output", type=Path, help="write the JSON comparison report here")
+    parser.add_argument("--allow-dirty", action="store_true", help="permit a dirty-tree run")
+    parser.add_argument(
+        "--allow-same-mode",
+        action="store_true",
+        help="permit both runs declaring the same retrieval mode (repeatability check)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        gates = compare.collect_assignments(args.gate)
+        regressions = compare.collect_assignments(args.max_regression)
+        baseline = compare.load_run(args.baseline)
+        current = compare.load_run(args.current)
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    report = compare.compare(
+        baseline,
+        current,
+        gates=gates,
+        max_regressions=regressions,
+        allow_dirty=args.allow_dirty,
+        allow_same_mode=args.allow_same_mode,
+    )
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    b_mode = report["baseline"]["retrieval_mode"]
+    c_mode = report["current"]["retrieval_mode"]
+    print(f"baseline [{b_mode}]  vs  current [{c_mode}]")
+    print(f"{'metric':<16} {'baseline':>8} {'current':>8} {'delta':>9}")
+    for name, m in report["metrics"].items():
+        delta = "   n/a" if m["delta"] is None else f"{m['delta']:+9.4f}"
+        print(f"{name:<16} {_fmt(m['baseline'])} {_fmt(m['current'])} {delta}")
+    print(
+        f"recall-eligible: baseline {report['recall_eligible']['baseline']}  "
+        f"current {report['recall_eligible']['current']}"
+    )
+
+    for reason in report["incompatibilities"]:
+        print(f"  NOT COMPARABLE: {reason}", file=sys.stderr)
+    for reason in report["gate_failures"]:
+        print(f"  GATE FAIL: {reason}", file=sys.stderr)
+    for reason in report["regressions"]:
+        print(f"  REGRESSION: {reason}", file=sys.stderr)
+
+    print(f"\n{report['verdict']}")
+    return 0 if report["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/locomo/README.md
+++ b/benchmarks/locomo/README.md
@@ -40,5 +40,17 @@ Artifacts are written under `results/`:
   per-category token-F1. Category 5 (abstention) is excluded from the recall
   aggregate.
 
+## Compare two runs
+
+```bash
+python ../compare_runs.py \
+  results/<flag-off>.jsonl results/<flag-on>.jsonl \
+  --gate recall_at_10=0.60 --max-regression recall_at_10=0.03
+```
+
+Refuses to compare unless the two runs used the same dataset bytes, the same
+question set, and the same repo revision (clean tree), differing only in the
+declared retrieval mode. Exits non-zero on a gate or regression breach.
+
 For the complete PPR flag-off/on procedure and report template, see
 [`docs/benchmarks/ppr-evaluation-runbook.md`](../../docs/benchmarks/ppr-evaluation-runbook.md).

--- a/benchmarks/locomo/README.md
+++ b/benchmarks/locomo/README.md
@@ -28,10 +28,15 @@ The default subset is categories 1–4 (1,540 answerable questions). Add categor
 
 Artifacts are written under `results/`:
 
-- `*.jsonl`: answers, ground truth, category, retrieval count, and latency.
-- `*.jsonl.manifest.json`: pinned dataset, Git revision, model, workspace,
-  `top_k`, categories, and operator-confirmed retrieval mode.
-- `*.jsonl.eval.json`: overall and per-category official token-F1 results.
+- `*.jsonl`: answers, ground truth, category, retrieval count, latency, and
+  per-question `recall_at_5` / `recall_at_10` (evidence session vs. retrieved).
+- `*.jsonl.manifest.json`: pinned dataset + sha256, Git revision + dirty flag,
+  the question-set digest (`question_ids_sha256`), model, workspace, `top_k`,
+  categories, sanitized MCP endpoint, and operator-confirmed retrieval mode.
+- `*.jsonl.query_set.json`: the exact ordered `question_id` list the run ran.
+- `*.jsonl.eval.json`: aggregated **recall@10 / recall@5** (the retrieval gate,
+  overall + per-category) plus official per-category token-F1. Category 5
+  (abstention) is excluded from the recall aggregate.
 
 For the complete PPR flag-off/on procedure and report template, see
 [`docs/benchmarks/ppr-evaluation-runbook.md`](../../docs/benchmarks/ppr-evaluation-runbook.md).

--- a/benchmarks/locomo/README.md
+++ b/benchmarks/locomo/README.md
@@ -26,6 +26,13 @@ The default subset is categories 1–4 (1,540 answerable questions). Add categor
 ./run.sh --categories 1,2,3,4,5 --retrieval-mode flag-off
 ```
 
+Each run mints a fresh run-scoped agent-id namespace
+(`locomo-<mode>-<run_id>`), so no two runs read each other's stored memories;
+a resume of the same `results/*.jsonl` reuses its namespace. Add
+`--reset-workspace` to delete the workspace's data first (needs
+`ALLOW_CLEANUP=true` on the server) — the comparator refuses to compare a reset
+leg against a non-reset one.
+
 Artifacts are written under `results/`:
 
 - `*.jsonl`: answers, ground truth, category, retrieval count, per-question
@@ -33,7 +40,10 @@ Artifacts are written under `results/`:
   latency (`ingest_ms` / `search_ms` / `answer_ms` / `total_ms`).
 - `*.jsonl.manifest.json`: pinned dataset + sha256, Git revision + dirty flag,
   the question-set digest (`question_ids_sha256`), model, workspace, `top_k`,
-  categories, sanitized MCP endpoint, and operator-confirmed retrieval mode.
+  `chat_temperature` / `chat_max_tokens`, categories, sanitized MCP endpoint,
+  operator-confirmed retrieval mode, the run-scoped `run_id` + agent-id prefix,
+  `workspace_reset` (from `--reset-workspace`), and a best-effort stack probe
+  (Qdrant/Neo4j status).
 - `*.jsonl.query_set.json`: the exact ordered `question_id` list the run ran.
 - `*.jsonl.eval.json`: aggregated **recall@10 / recall@5** (the retrieval gate,
   overall + per-category), per-phase latency (p50/p95/max), and official
@@ -49,8 +59,10 @@ python ../compare_runs.py \
 ```
 
 Refuses to compare unless the two runs used the same dataset bytes, the same
-question set, and the same repo revision (clean tree), differing only in the
-declared retrieval mode. Exits non-zero on a gate or regression breach.
+question set, the same repo revision (clean tree), the same sampling knobs,
+workspace, `workspace_reset` state and stack probe, and had no degraded
+retrieval legs (`suspect_count == 0`) — differing only in the declared
+retrieval mode. Exits non-zero on a gate or regression breach.
 
 For the complete PPR flag-off/on procedure and report template, see
 [`docs/benchmarks/ppr-evaluation-runbook.md`](../../docs/benchmarks/ppr-evaluation-runbook.md).

--- a/benchmarks/locomo/README.md
+++ b/benchmarks/locomo/README.md
@@ -28,15 +28,17 @@ The default subset is categories 1–4 (1,540 answerable questions). Add categor
 
 Artifacts are written under `results/`:
 
-- `*.jsonl`: answers, ground truth, category, retrieval count, latency, and
-  per-question `recall_at_5` / `recall_at_10` (evidence session vs. retrieved).
+- `*.jsonl`: answers, ground truth, category, retrieval count, per-question
+  `recall_at_5` / `recall_at_10` (evidence session vs. retrieved), and split
+  latency (`ingest_ms` / `search_ms` / `answer_ms` / `total_ms`).
 - `*.jsonl.manifest.json`: pinned dataset + sha256, Git revision + dirty flag,
   the question-set digest (`question_ids_sha256`), model, workspace, `top_k`,
   categories, sanitized MCP endpoint, and operator-confirmed retrieval mode.
 - `*.jsonl.query_set.json`: the exact ordered `question_id` list the run ran.
 - `*.jsonl.eval.json`: aggregated **recall@10 / recall@5** (the retrieval gate,
-  overall + per-category) plus official per-category token-F1. Category 5
-  (abstention) is excluded from the recall aggregate.
+  overall + per-category), per-phase latency (p50/p95/max), and official
+  per-category token-F1. Category 5 (abstention) is excluded from the recall
+  aggregate.
 
 For the complete PPR flag-off/on procedure and report template, see
 [`docs/benchmarks/ppr-evaluation-runbook.md`](../../docs/benchmarks/ppr-evaluation-runbook.md).

--- a/benchmarks/locomo/run.sh
+++ b/benchmarks/locomo/run.sh
@@ -14,6 +14,7 @@ categories="1,2,3,4"
 max_questions=""
 output=""
 force=0
+reset_workspace=0
 while (($#)); do
   case "$1" in
     --retrieval-mode) mode="${2:?missing retrieval mode}"; shift 2 ;;
@@ -21,6 +22,7 @@ while (($#)); do
     --max-questions) max_questions="${2:?missing maximum}"; shift 2 ;;
     --output) output="${2:?missing output}"; shift 2 ;;
     --force) force=1; shift ;;
+    --reset-workspace) reset_workspace=1; shift ;;
     --smoke) max_questions=3; shift ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
@@ -35,6 +37,7 @@ args=(run --retrieval-mode "$mode" --categories "$categories")
 [[ -n "$max_questions" ]] && args+=(--max-questions "$max_questions")
 [[ -n "$output" ]] && args+=(--output "$output")
 ((force)) && args+=(--force)
+((reset_workspace)) && args+=(--reset-workspace)
 .venv/bin/python scripts/run_benchmark.py "${args[@]}"
 
 if [[ -n "$output" ]]; then

--- a/benchmarks/locomo/scripts/dataset.py
+++ b/benchmarks/locomo/scripts/dataset.py
@@ -9,6 +9,9 @@ from collections import Counter
 from collections.abc import Iterator
 from pathlib import Path
 
+BENCH_ROOT = Path(__file__).resolve().parents[1]
+DATASET_PATH = BENCH_ROOT / "data" / "locomo10.json"
+
 UPSTREAM_COMMIT = "3eb6f2c585f5e1699204e3c3bdf7adc5c28cb376"
 DATASET_SHA256 = "79fa87e90f04081343b8c8debecb80a9a6842b76a7aa537dc9fdf651ea698ff4"
 DATASET_URL = (
@@ -59,8 +62,15 @@ def download_dataset(path: Path, *, force: bool = False) -> Path:
     return path
 
 
-def sessions_from_conversation(conversation: dict) -> tuple[list[list[dict]], list[str]]:
-    sessions: list[list[dict]] = []
+def sessions_from_conversation(
+    conversation: dict,
+) -> tuple[list[list[dict]], list[str], list[int]]:
+    """Return ``(sessions, dates, session_numbers)`` in ingest order.
+
+    ``session_numbers[i]`` is the LoCoMo session number (the ``D<n>`` in an
+    evidence ref) of ``sessions[i]`` — needed to map evidence to the
+    ``session_<i>`` tag the runner stores.
+    """
     dates: list[str] = []
     session_numbers = sorted(
         int(key.removeprefix("session_"))
@@ -69,16 +79,16 @@ def sessions_from_conversation(conversation: dict) -> tuple[list[list[dict]], li
         and key.removeprefix("session_").isdigit()
         and isinstance(value, list)
     )
+    sessions: list[list[dict]] = []
     for number in session_numbers:
         sessions.append(conversation[f"session_{number}"])
-        date = conversation.get(f"session_{number}_date_time", "")
-        dates.append(str(date))
-    return sessions, dates
+        dates.append(str(conversation.get(f"session_{number}_date_time", "")))
+    return sessions, dates, session_numbers
 
 
 def iter_questions(dataset: list[dict], *, categories: set[int]) -> Iterator[dict]:
     for sample in dataset:
-        sessions, dates = sessions_from_conversation(sample["conversation"])
+        sessions, dates, session_numbers = sessions_from_conversation(sample["conversation"])
         for index, qa in enumerate(sample["qa"], start=1):
             category = int(qa["category"])
             if category not in categories:
@@ -88,6 +98,7 @@ def iter_questions(dataset: list[dict], *, categories: set[int]) -> Iterator[dic
                 "sample_id": sample["sample_id"],
                 "sessions": sessions,
                 "dates": dates,
+                "session_numbers": session_numbers,
                 "question": str(qa["question"]),
                 "answer": str(qa.get("answer", "")),
                 "category": category,

--- a/benchmarks/locomo/scripts/evaluate.py
+++ b/benchmarks/locomo/scripts/evaluate.py
@@ -14,7 +14,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from benchmarks._shared import retrieval_eval  # noqa: E402
+from benchmarks._shared import latency, retrieval_eval  # noqa: E402
 
 
 def _stem(word: str) -> str:
@@ -96,6 +96,7 @@ def evaluate_rows(rows: list[dict]) -> dict[str, object]:
             str(key): sum(values) / len(values) for key, values in sorted(category_values.items())
         },
         "retrieval": retrieval_eval.aggregate_recall(rows, group_key="category"),
+        "latency": latency.aggregate_latency(rows),
         "questions": scored_rows,
     }
 
@@ -122,11 +123,17 @@ def main() -> int:
     output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
     r10 = retrieval_eval.gate_value(report["retrieval"], k=10)
     r5 = retrieval_eval.gate_value(report["retrieval"], k=5)
+    search = report["latency"]["phases"].get("search_ms", {})
     print(
         f"LoCoMo  recall@10={_fmt(r10)}  recall@5={_fmt(r5)}  "
         f"token-F1={report['overall_score']:.4f}  "
         f"({report['retrieval']['eligible_count']}/{report['question_count']} recall-eligible)"
     )
+    if search:
+        print(
+            f"        search_ms  p50={search['p50_ms']:.0f}  p95={search['p95_ms']:.0f}  "
+            f"max={search['max_ms']:.0f}"
+        )
     print(f"Report: {output}")
     return 1 if report["error_count"] else 0
 

--- a/benchmarks/locomo/scripts/evaluate.py
+++ b/benchmarks/locomo/scripts/evaluate.py
@@ -129,6 +129,11 @@ def main() -> int:
         f"token-F1={report['overall_score']:.4f}  "
         f"({report['retrieval']['eligible_count']}/{report['question_count']} recall-eligible)"
     )
+    if report["retrieval"].get("suspect_count"):
+        print(
+            f"        WARNING: {report['retrieval']['suspect_count']} question(s) retrieved "
+            "nothing from their own stored memory — a degraded retrieval leg, not a clean run"
+        )
     if search:
         print(
             f"        search_ms  p50={search['p50_ms']:.0f}  p95={search['p95_ms']:.0f}  "

--- a/benchmarks/locomo/scripts/evaluate.py
+++ b/benchmarks/locomo/scripts/evaluate.py
@@ -6,8 +6,15 @@ import argparse
 import json
 import re
 import string
+import sys
 from collections import Counter, defaultdict
 from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from benchmarks._shared import retrieval_eval  # noqa: E402
 
 
 def _stem(word: str) -> str:
@@ -78,7 +85,7 @@ def evaluate_rows(rows: list[dict]) -> dict[str, object]:
         )
     all_scores = [item["score"] for item in scored_rows]
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "question_count": len(rows),
         "error_count": error_count,
         "overall_score": sum(all_scores) / len(all_scores),
@@ -88,6 +95,7 @@ def evaluate_rows(rows: list[dict]) -> dict[str, object]:
         "category_scores": {
             str(key): sum(values) / len(values) for key, values in sorted(category_values.items())
         },
+        "retrieval": retrieval_eval.aggregate_recall(rows, group_key="category"),
         "questions": scored_rows,
     }
 
@@ -112,9 +120,19 @@ def main() -> int:
     report = evaluate_rows(load_jsonl(args.results))
     output = args.output or args.results.with_suffix(args.results.suffix + ".eval.json")
     output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
-    print(f"LoCoMo score: {report['overall_score']:.4f} ({report['question_count']} questions)")
+    r10 = retrieval_eval.gate_value(report["retrieval"], k=10)
+    r5 = retrieval_eval.gate_value(report["retrieval"], k=5)
+    print(
+        f"LoCoMo  recall@10={_fmt(r10)}  recall@5={_fmt(r5)}  "
+        f"token-F1={report['overall_score']:.4f}  "
+        f"({report['retrieval']['eligible_count']}/{report['question_count']} recall-eligible)"
+    )
     print(f"Report: {output}")
     return 1 if report["error_count"] else 0
+
+
+def _fmt(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.4f}"
 
 
 if __name__ == "__main__":

--- a/benchmarks/locomo/scripts/run_benchmark.py
+++ b/benchmarks/locomo/scripts/run_benchmark.py
@@ -127,6 +127,7 @@ def append_result(path: Path, row: dict) -> None:
 
 
 def process_question(entry: dict, *, config: BenchConfig, chat_client: OpenAI) -> tuple[str, dict]:
+    started = time.perf_counter()
     client = MetronixMCPClient(
         mcp_url=config.metronix_mcp_url,
         api_key=config.metronix_mcp_api_key,
@@ -137,18 +138,21 @@ def process_question(entry: dict, *, config: BenchConfig, chat_client: OpenAI) -
     # Search deep enough for recall@10 even when the answer prompt uses a
     # smaller top_k; only ``retrieve_top_k`` hits reach the LLM.
     search_k = max(config.retrieve_top_k, retrieval_eval.SEARCH_K_FLOOR)
-    results = client.ingest_and_search(
+    outcome = client.ingest_and_search(
         sessions=entry["sessions"],
         dates=entry["dates"],
         format_session_text=format_session_text,
         query=entry["question"],
         top_k=search_k,
     )
+    results = outcome["results"]
     answer_hits = results[: config.retrieve_top_k]
     prompt = ANSWER_PROMPT.format(
         memory_context=build_memory_context(answer_hits), question=entry["question"]
     )
+    answer_started = time.perf_counter()
     hypothesis = chat_complete(chat_client, model=config.chat_model, message=prompt)
+    answer_ms = (time.perf_counter() - answer_started) * 1000
 
     retrieval = retrieval_eval.recall_row(
         oracle.locomo_oracle_tags(entry),
@@ -156,6 +160,10 @@ def process_question(entry: dict, *, config: BenchConfig, chat_client: OpenAI) -
         eligible=not oracle.locomo_is_abstention(entry),
     )
     retrieval["retrieved_count"] = len(answer_hits)
+    retrieval["ingest_ms"] = outcome["ingest_ms"]
+    retrieval["search_ms"] = outcome["search_ms"]
+    retrieval["answer_ms"] = answer_ms
+    retrieval["total_ms"] = (time.perf_counter() - started) * 1000
     return hypothesis, retrieval
 
 
@@ -207,7 +215,12 @@ def build_run_artifacts(
             ),
             "operator_declared_retrieval_mode": retrieval_mode,
         },
-        metrics_requested=["recall_at_10", "recall_at_5", "answer_token_f1"],
+        metrics_requested=[
+            "recall_at_10",
+            "recall_at_5",
+            "answer_token_f1",
+            "search_latency_p50_p95",
+        ],
     )
     return manifest, query_set
 
@@ -285,8 +298,10 @@ def run(
             "answer": entry["answer"],
             "evidence": entry["evidence"],
             "hypothesis": hypothesis,
-            "latency_ms": (time.perf_counter() - started) * 1000,
             **retrieval,
+            # authoritative wall clock — also covers the exception path, where
+            # process_question returned no total_ms
+            "total_ms": (time.perf_counter() - started) * 1000,
         }
         if error is not None:
             row["error"] = error

--- a/benchmarks/locomo/scripts/run_benchmark.py
+++ b/benchmarks/locomo/scripts/run_benchmark.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import subprocess
 import sys
 import time
 import traceback
+from collections.abc import Sequence
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -25,6 +25,7 @@ REPO_ROOT = BENCH_ROOT.parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from benchmarks._shared import manifest as run_manifest  # noqa: E402
 from benchmarks.locomo.scripts.dataset import (  # noqa: E402
     DATASET_SHA256,
     DATASET_URL,
@@ -82,6 +83,10 @@ def build_memory_context(results: list[dict]) -> str:
     return "\n\n".join(blocks) if blocks else "(no memories retrieved)"
 
 
+CHAT_TEMPERATURE = 0.0
+CHAT_MAX_TOKENS = 512
+
+
 @backoff.on_exception(
     backoff.expo,
     (openai.RateLimitError, openai.APIError, EmptyChatCompletionError),
@@ -94,8 +99,8 @@ def chat_complete(client: OpenAI, *, model: str, message: str) -> str:
             {"role": "system", "content": ANSWER_SYSTEM},
             {"role": "user", "content": message},
         ],
-        temperature=0.0,
-        max_tokens=512,
+        temperature=CHAT_TEMPERATURE,
+        max_tokens=CHAT_MAX_TOKENS,
     )
     content = completion.choices[0].message.content
     if not isinstance(content, str) or not content.strip():
@@ -146,48 +151,72 @@ def default_output_path() -> Path:
     return RESULTS_DIR / f"{timestamp}.jsonl"
 
 
+def build_run_artifacts(
+    *,
+    config: BenchConfig,
+    categories: set[int],
+    retrieval_mode: str,
+    entries: Sequence[dict],
+    run_id: str | None = None,
+) -> tuple[dict, dict]:
+    """Return ``(manifest, query_set)`` for the exact question set to be run."""
+    ids = [entry["question_id"] for entry in entries]
+    query_set = run_manifest.build_query_set(
+        benchmark="locomo",
+        selector={"categories": sorted(categories)},
+        question_ids=ids,
+    )
+    manifest = run_manifest.build_manifest(
+        benchmark="locomo",
+        repo_root=REPO_ROOT,
+        run_id=run_id,
+        dataset={
+            "name": "locomo10",
+            "source_url": DATASET_URL,
+            "upstream_ref": UPSTREAM_COMMIT,
+            "sha256": DATASET_SHA256,
+            "question_count": len(ids),
+        },
+        query_set=query_set,
+        config={
+            "workspace": config.workspace_id,
+            "top_k": config.retrieve_top_k,
+            "agent_id_prefix": config.agent_id_prefix,
+            "chat_model": config.chat_model,
+            "chat_base_url": config.chat_base_url,
+            "chat_temperature": CHAT_TEMPERATURE,
+            "chat_max_tokens": CHAT_MAX_TOKENS,
+            "categories": sorted(categories),
+        },
+        stack={
+            "mcp_endpoint_identity": run_manifest.sanitized_endpoint_identity(
+                config.metronix_mcp_url
+            ),
+            "operator_declared_retrieval_mode": retrieval_mode,
+        },
+        metrics_requested=["answer_token_f1"],
+    )
+    return manifest, query_set
+
+
 def write_manifest(
     path: Path,
     *,
     config: BenchConfig,
     categories: set[int],
     retrieval_mode: str,
-    dataset_path: Path,
+    dataset_path: Path,  # noqa: ARG001 — kept for call-site compatibility; sha comes from dataset.py
+    entries: Sequence[dict] = (),
 ) -> Path:
-    try:
-        revision = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=REPO_ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        revision = "unknown"
-    manifest_path = path.with_suffix(path.suffix + ".manifest.json")
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "benchmark": "locomo",
-                "repository_revision": revision,
-                "operator_declared_retrieval_mode": retrieval_mode,
-                "workspace": config.workspace_id,
-                "top_k": config.retrieve_top_k,
-                "chat_model": config.chat_model,
-                "chat_base_url": config.chat_base_url,
-                "categories": sorted(categories),
-                "dataset": {
-                    "path": str(dataset_path),
-                    "upstream_commit": UPSTREAM_COMMIT,
-                    "sha256": DATASET_SHA256,
-                },
-            },
-            indent=2,
-            sort_keys=True,
-        ),
-        encoding="utf-8",
+    """Write ``<path>.manifest.json`` and ``<path>.query_set.json``; return the manifest path."""
+    manifest, query_set = build_run_artifacts(
+        config=config,
+        categories=categories,
+        retrieval_mode=retrieval_mode,
+        entries=entries,
+    )
+    manifest_path, _ = run_manifest.write_run_artifacts(
+        path, manifest=manifest, query_set=query_set
     )
     return manifest_path
 
@@ -215,6 +244,7 @@ def run(
         categories=categories,
         retrieval_mode=retrieval_mode,
         dataset_path=dataset_path,
+        entries=entries,
     )
     done = load_completed_ids(output_path)
     remaining = [entry for entry in entries if entry["question_id"] not in done]

--- a/benchmarks/locomo/scripts/run_benchmark.py
+++ b/benchmarks/locomo/scripts/run_benchmark.py
@@ -26,7 +26,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from benchmarks._shared import manifest as run_manifest  # noqa: E402
+from benchmarks._shared import oracle, retrieval_eval  # noqa: E402
 from benchmarks.locomo.scripts.dataset import (  # noqa: E402
+    DATASET_PATH,
     DATASET_SHA256,
     DATASET_URL,
     UPSTREAM_COMMIT,
@@ -39,7 +41,6 @@ from benchmarks.locomo.scripts.env_config import BenchConfig  # noqa: E402
 from benchmarks.longmemeval.scripts.metronix_client import MetronixMCPClient  # noqa: E402
 
 logger = logging.getLogger(__name__)
-DATASET_PATH = BENCH_ROOT / "data" / "locomo10.json"
 RESULTS_DIR = BENCH_ROOT / "results"
 
 ANSWER_SYSTEM = (
@@ -125,7 +126,7 @@ def append_result(path: Path, row: dict) -> None:
         handle.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 
-def process_question(entry: dict, *, config: BenchConfig, chat_client: OpenAI) -> tuple[str, int]:
+def process_question(entry: dict, *, config: BenchConfig, chat_client: OpenAI) -> tuple[str, dict]:
     client = MetronixMCPClient(
         mcp_url=config.metronix_mcp_url,
         api_key=config.metronix_mcp_api_key,
@@ -133,17 +134,29 @@ def process_question(entry: dict, *, config: BenchConfig, chat_client: OpenAI) -
         agent_id=f"{config.agent_id_prefix}-{entry['question_id']}",
         source_type="locomo",
     )
+    # Search deep enough for recall@10 even when the answer prompt uses a
+    # smaller top_k; only ``retrieve_top_k`` hits reach the LLM.
+    search_k = max(config.retrieve_top_k, retrieval_eval.SEARCH_K_FLOOR)
     results = client.ingest_and_search(
         sessions=entry["sessions"],
         dates=entry["dates"],
         format_session_text=format_session_text,
         query=entry["question"],
-        top_k=config.retrieve_top_k,
+        top_k=search_k,
     )
+    answer_hits = results[: config.retrieve_top_k]
     prompt = ANSWER_PROMPT.format(
-        memory_context=build_memory_context(results), question=entry["question"]
+        memory_context=build_memory_context(answer_hits), question=entry["question"]
     )
-    return chat_complete(chat_client, model=config.chat_model, message=prompt), len(results)
+    hypothesis = chat_complete(chat_client, model=config.chat_model, message=prompt)
+
+    retrieval = retrieval_eval.recall_row(
+        oracle.locomo_oracle_tags(entry),
+        oracle.retrieved_session_tags(results),
+        eligible=not oracle.locomo_is_abstention(entry),
+    )
+    retrieval["retrieved_count"] = len(answer_hits)
+    return hypothesis, retrieval
 
 
 def default_output_path() -> Path:
@@ -194,7 +207,7 @@ def build_run_artifacts(
             ),
             "operator_declared_retrieval_mode": retrieval_mode,
         },
-        metrics_requested=["answer_token_f1"],
+        metrics_requested=["recall_at_10", "recall_at_5", "answer_token_f1"],
     )
     return manifest, query_set
 
@@ -251,12 +264,10 @@ def run(
     client = OpenAI(api_key=config.chat_api_key, base_url=config.chat_base_url)
     for entry in tqdm(remaining, desc="LoCoMo", unit="q"):
         started = time.perf_counter()
-        retrieved_count = 0
+        retrieval: dict = {"retrieved_count": 0}
         error: dict[str, str] | None = None
         try:
-            hypothesis, retrieved_count = process_question(
-                entry, config=config, chat_client=client
-            )
+            hypothesis, retrieval = process_question(entry, config=config, chat_client=client)
         except Exception as exc:  # keep resumable artifacts after isolated failures
             logger.error("Error on %s: %s", entry["question_id"], exc)
             traceback.print_exc()
@@ -274,8 +285,8 @@ def run(
             "answer": entry["answer"],
             "evidence": entry["evidence"],
             "hypothesis": hypothesis,
-            "retrieved_count": retrieved_count,
             "latency_ms": (time.perf_counter() - started) * 1000,
+            **retrieval,
         }
         if error is not None:
             row["error"] = error

--- a/benchmarks/locomo/scripts/run_benchmark.py
+++ b/benchmarks/locomo/scripts/run_benchmark.py
@@ -27,6 +27,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from benchmarks._shared import manifest as run_manifest  # noqa: E402
 from benchmarks._shared import oracle, retrieval_eval  # noqa: E402
+from benchmarks._shared import stack as stack_probe  # noqa: E402
 from benchmarks.locomo.scripts.dataset import (  # noqa: E402
     DATASET_PATH,
     DATASET_SHA256,
@@ -160,6 +161,9 @@ def process_question(entry: dict, *, config: BenchConfig, chat_client: OpenAI) -
         eligible=not oracle.locomo_is_abstention(entry),
     )
     retrieval["retrieved_count"] = len(answer_hits)
+    # This agent's own sessions were just stored — retrieving nothing means the
+    # search path was degraded (a dropped Qdrant/graph leg), not "no evidence".
+    retrieval["search_suspect"] = not results and bool(entry["sessions"])
     retrieval["ingest_ms"] = outcome["ingest_ms"]
     retrieval["search_ms"] = outcome["search_ms"]
     retrieval["answer_ms"] = answer_ms
@@ -179,6 +183,8 @@ def build_run_artifacts(
     retrieval_mode: str,
     entries: Sequence[dict],
     run_id: str | None = None,
+    workspace_reset: str = "no",
+    stack_snapshot: dict | None = None,
 ) -> tuple[dict, dict]:
     """Return ``(manifest, query_set)`` for the exact question set to be run."""
     ids = [entry["question_id"] for entry in entries]
@@ -214,6 +220,8 @@ def build_run_artifacts(
                 config.metronix_mcp_url
             ),
             "operator_declared_retrieval_mode": retrieval_mode,
+            "workspace_reset": workspace_reset,
+            "probe": stack_snapshot or {},
         },
         metrics_requested=[
             "recall_at_10",
@@ -233,6 +241,9 @@ def write_manifest(
     retrieval_mode: str,
     dataset_path: Path,  # noqa: ARG001 — kept for call-site compatibility; sha comes from dataset.py
     entries: Sequence[dict] = (),
+    run_id: str | None = None,
+    workspace_reset: str = "no",
+    stack_snapshot: dict | None = None,
 ) -> Path:
     """Write ``<path>.manifest.json`` and ``<path>.query_set.json``; return the manifest path."""
     manifest, query_set = build_run_artifacts(
@@ -240,6 +251,9 @@ def write_manifest(
         categories=categories,
         retrieval_mode=retrieval_mode,
         entries=entries,
+        run_id=run_id,
+        workspace_reset=workspace_reset,
+        stack_snapshot=stack_snapshot,
     )
     manifest_path, _ = run_manifest.write_run_artifacts(
         path, manifest=manifest, query_set=query_set
@@ -256,14 +270,30 @@ def run(
     max_questions: int | None,
     force: bool,
     retrieval_mode: str,
+    agent_id_prefix: str | None = None,
+    reset_workspace: bool = False,
 ) -> Path:
-    config = replace(config, agent_id_prefix=f"locomo-{retrieval_mode}")
+    run_id, prefix = run_manifest.resolve_run_identity(
+        output_path,
+        benchmark="locomo",
+        retrieval_mode=retrieval_mode,
+        prefix_override=agent_id_prefix,
+        fresh=force,
+    )
+    config = replace(config, agent_id_prefix=prefix)
     dataset = load_dataset(dataset_path)
     entries = list(iter_questions(dataset, categories=categories))
     if max_questions is not None:
         entries = entries[:max_questions]
     if force:
         output_path.unlink(missing_ok=True)
+
+    reset_status = "no"
+    if reset_workspace:
+        reset_status = stack_probe.reset_workspace(config.metronix_api_url, config.workspace_id)
+        print(f"  WORKSPACE RESET: {reset_status}")
+    snapshot = stack_probe.probe_stack(config.metronix_api_url)
+
     write_manifest(
         output_path,
         config=config,
@@ -271,6 +301,9 @@ def run(
         retrieval_mode=retrieval_mode,
         dataset_path=dataset_path,
         entries=entries,
+        run_id=run_id,
+        workspace_reset=reset_status,
+        stack_snapshot=snapshot,
     )
     done = load_completed_ids(output_path)
     remaining = [entry for entry in entries if entry["question_id"] not in done]
@@ -328,6 +361,22 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Operator-confirmed server mode; restart Metronix with the matching PPR flag",
     )
+    run_parser.add_argument(
+        "--agent-id-prefix",
+        default=None,
+        help=(
+            "Pin the agent-id namespace instead of deriving a run-scoped one. "
+            "Use only to resume a run whose manifest was lost."
+        ),
+    )
+    run_parser.add_argument(
+        "--reset-workspace",
+        action="store_true",
+        help=(
+            "DELETE all workspace data before the run (needs ALLOW_CLEANUP=true on "
+            "the server). The outcome is recorded in the manifest."
+        ),
+    )
     return parser
 
 
@@ -355,6 +404,8 @@ def main() -> int:
         max_questions=args.max_questions,
         force=args.force,
         retrieval_mode=args.retrieval_mode,
+        agent_id_prefix=args.agent_id_prefix,
+        reset_workspace=args.reset_workspace,
     )
     print(f"Results: {output}")
     return 0

--- a/benchmarks/longmemeval/README.md
+++ b/benchmarks/longmemeval/README.md
@@ -4,6 +4,12 @@ Run the [LongMemEval-S](https://github.com/xiaowu0162/LongMemEval) agent-memory 
 
 **Full guide:** [`docs/benchmarks/longmemeval.md`](../../docs/benchmarks/longmemeval.md)
 
+The dataset is pinned to Hugging Face revision
+`98d7416c24c778c2fee6e6f3006e7a073259d48f` of
+[`xiaowu0162/longmemeval-cleaned`](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned)
+and verified against a recorded SHA-256 on every download and every run
+(`scripts/dataset.py`). Re-pin deliberately — the scripts never track `main`.
+
 ## Configuration file
 
 Benchmark settings live in **`benchmarks/longmemeval/.env.benchmark`** — not the repo-root `.env` used by Docker.
@@ -68,8 +74,10 @@ See Path B in [`docs/benchmarks/longmemeval.md`](../../docs/benchmarks/longmemev
 | Path | Description |
 |------|-------------|
 | `results/*.jsonl` | Generated hypotheses (`question_id`, `hypothesis`) |
+| `results/*.jsonl.manifest.json` | Run identity: pinned dataset + sha256, repo revision, question-set digest, retrieval config |
+| `results/*.jsonl.query_set.json` | The exact ordered `question_id` list the run executed |
 | `results/*.jsonl.eval-*` | Judge output with per-question labels |
-| `data/` | Downloaded LongMemEval datasets |
+| `data/` | Downloaded LongMemEval datasets (sha256-verified) |
 
 ## Makefile targets (Linux / macOS, from repo root)
 

--- a/benchmarks/longmemeval/README.md
+++ b/benchmarks/longmemeval/README.md
@@ -73,10 +73,10 @@ See Path B in [`docs/benchmarks/longmemeval.md`](../../docs/benchmarks/longmemev
 
 | Path | Description |
 |------|-------------|
-| `results/*.jsonl` | Per-question `hypothesis` + `recall_at_5` / `recall_at_10` (oracle vs. retrieved sessions) |
+| `results/*.jsonl` | Per-question `hypothesis`, `recall_at_5` / `recall_at_10`, and split latency (`ingest_ms` / `search_ms` / `answer_ms` / `total_ms`) |
 | `results/*.jsonl.manifest.json` | Run identity: pinned dataset + sha256, repo revision, question-set digest, retrieval config |
 | `results/*.jsonl.query_set.json` | The exact ordered `question_id` list the run executed |
-| `results/*.jsonl.retrieval.eval.json` | Aggregated **recall@10 / recall@5** (the retrieval gate), overall + by `question_type` |
+| `results/*.jsonl.retrieval.eval.json` | Aggregated **recall@10 / recall@5** (the retrieval gate) + per-phase latency (p50/p95/max), overall + by `question_type` |
 | `results/*.jsonl.eval-*` | Judge output with per-question labels (answer accuracy) |
 | `data/` | Downloaded LongMemEval datasets (sha256-verified) |
 

--- a/benchmarks/longmemeval/README.md
+++ b/benchmarks/longmemeval/README.md
@@ -73,11 +73,17 @@ See Path B in [`docs/benchmarks/longmemeval.md`](../../docs/benchmarks/longmemev
 
 | Path | Description |
 |------|-------------|
-| `results/*.jsonl` | Generated hypotheses (`question_id`, `hypothesis`) |
+| `results/*.jsonl` | Per-question `hypothesis` + `recall_at_5` / `recall_at_10` (oracle vs. retrieved sessions) |
 | `results/*.jsonl.manifest.json` | Run identity: pinned dataset + sha256, repo revision, question-set digest, retrieval config |
 | `results/*.jsonl.query_set.json` | The exact ordered `question_id` list the run executed |
-| `results/*.jsonl.eval-*` | Judge output with per-question labels |
+| `results/*.jsonl.retrieval.eval.json` | Aggregated **recall@10 / recall@5** (the retrieval gate), overall + by `question_type` |
+| `results/*.jsonl.eval-*` | Judge output with per-question labels (answer accuracy) |
 | `data/` | Downloaded LongMemEval datasets (sha256-verified) |
+
+> `--max-questions N` takes the first N of the dataset, and LongMemEval-S is
+> ordered by `question_type` — a small N covers only one type. Two runs at the
+> same N are still comparable (identical `question_ids_sha256`); they just aren't
+> representative. Use the full set for a headline number.
 
 ## Makefile targets (Linux / macOS, from repo root)
 

--- a/benchmarks/longmemeval/README.md
+++ b/benchmarks/longmemeval/README.md
@@ -85,6 +85,18 @@ See Path B in [`docs/benchmarks/longmemeval.md`](../../docs/benchmarks/longmemev
 > same N are still comparable (identical `question_ids_sha256`); they just aren't
 > representative. Use the full set for a headline number.
 
+## Compare two runs
+
+```bash
+python ../compare_runs.py \
+  results/<baseline>.jsonl results/<current>.jsonl \
+  --gate recall_at_10=0.60 --max-regression recall_at_10=0.03
+```
+
+Refuses to compare unless the two runs used the same dataset bytes, the same
+question set, the same repo revision (clean tree), and differ only in the
+declared retrieval mode. Exits non-zero on a gate or regression breach.
+
 ## Makefile targets (Linux / macOS, from repo root)
 
 ```bash

--- a/benchmarks/longmemeval/README.md
+++ b/benchmarks/longmemeval/README.md
@@ -74,7 +74,7 @@ See Path B in [`docs/benchmarks/longmemeval.md`](../../docs/benchmarks/longmemev
 | Path | Description |
 |------|-------------|
 | `results/*.jsonl` | Per-question `hypothesis`, `recall_at_5` / `recall_at_10`, and split latency (`ingest_ms` / `search_ms` / `answer_ms` / `total_ms`) |
-| `results/*.jsonl.manifest.json` | Run identity: pinned dataset + sha256, repo revision, question-set digest, retrieval config |
+| `results/*.jsonl.manifest.json` | Run identity: pinned dataset + sha256, repo revision, question-set digest, retrieval config (incl. `chat_temperature` / `chat_max_tokens`), run-scoped `run_id` + agent-id prefix, `workspace_reset`, and a best-effort Qdrant/Neo4j stack probe |
 | `results/*.jsonl.query_set.json` | The exact ordered `question_id` list the run executed |
 | `results/*.jsonl.retrieval.eval.json` | Aggregated **recall@10 / recall@5** (the retrieval gate) + per-phase latency (p50/p95/max), overall + by `question_type` |
 | `results/*.jsonl.eval-*` | Judge output with per-question labels (answer accuracy) |
@@ -94,8 +94,15 @@ python ../compare_runs.py \
 ```
 
 Refuses to compare unless the two runs used the same dataset bytes, the same
-question set, the same repo revision (clean tree), and differ only in the
-declared retrieval mode. Exits non-zero on a gate or regression breach.
+question set, the same repo revision (clean tree), the same sampling knobs,
+workspace, `workspace_reset` state and stack probe, and had no degraded
+retrieval legs (`suspect_count == 0`) — differing only in the declared
+retrieval mode. Exits non-zero on a gate or regression breach.
+
+Each run derives a fresh run-scoped agent-id namespace
+(`longmemeval-<mode>-<run_id>`); a resume of the same results file reuses it.
+Add `--retrieval-mode flag-off|flag-on` (and optionally `--reset-workspace`) to
+`run.sh` for a PPR A/B.
 
 ## Makefile targets (Linux / macOS, from repo root)
 

--- a/benchmarks/longmemeval/run.ps1
+++ b/benchmarks/longmemeval/run.ps1
@@ -47,6 +47,9 @@ if (-not (Test-Path $Output)) {
 Write-Host ""
 Write-Host "Results: $Output"
 
+Write-Host "==> Retrieval recall@k (no LLM cost)"
+& $VenvPython scripts/evaluate_retrieval.py --results $Output
+
 if (-not $RunOnly) {
     Write-Host "==> Evaluation (LLM judge)"
     & $VenvPython scripts/evaluate_results.py --results $Output --variant $Variant

--- a/benchmarks/longmemeval/run.ps1
+++ b/benchmarks/longmemeval/run.ps1
@@ -23,7 +23,7 @@ if ($Smoke) {
 }
 
 Write-Host "==> Preflight"
-& $VenvPython scripts/preflight.py --ensure-workspace
+& $VenvPython scripts/preflight.py --ensure-workspace --variant $Variant
 
 $Timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
 $Output = Join-Path $Root "results\${Timestamp}_${Variant}.jsonl"

--- a/benchmarks/longmemeval/run.ps1
+++ b/benchmarks/longmemeval/run.ps1
@@ -5,7 +5,9 @@ param(
     [int]$MaxQuestions = 0,
     [ValidateSet("oracle", "s")]
     [string]$Variant = "s",
-    [switch]$Force
+    [switch]$Force,
+    [string]$RetrievalMode = "",
+    [switch]$ResetWorkspace
 )
 
 $ErrorActionPreference = "Stop"
@@ -35,6 +37,12 @@ if ($MaxQuestions -gt 0) {
 }
 if ($Force) {
     $RunArgs += "--force"
+}
+if ($RetrievalMode -ne "") {
+    $RunArgs += @("--declare-retrieval-mode", $RetrievalMode)
+}
+if ($ResetWorkspace) {
+    $RunArgs += "--reset-workspace"
 }
 
 Write-Host "==> Running benchmark -> $Output"

--- a/benchmarks/longmemeval/run.sh
+++ b/benchmarks/longmemeval/run.sh
@@ -11,19 +11,24 @@ MAX_QUESTIONS=""
 VARIANT="s"
 FORCE=0
 OUTPUT=""
+RETRIEVAL_MODE=""
+RESET_WORKSPACE=0
 
 usage() {
   cat <<'EOF'
 Usage: ./run.sh [options]
 
 Options:
-  --smoke            Run oracle variant with 3 questions (pipeline check)
-  --run-only         Skip LLM judge evaluation
-  --max-questions N  Limit number of questions
-  --variant oracle|s Dataset variant (default: s)
-  --output PATH      Write hypotheses to this path
-  --force            Delete output file before run
-  -h, --help         Show this help
+  --smoke               Run oracle variant with 3 questions (pipeline check)
+  --run-only            Skip LLM judge evaluation
+  --max-questions N     Limit number of questions
+  --variant oracle|s    Dataset variant (default: s)
+  --output PATH         Write hypotheses to this path
+  --force               Delete output file before run
+  --retrieval-mode M    Operator-confirmed server mode recorded in the manifest
+                        (e.g. flag-off / flag-on for a PPR A/B)
+  --reset-workspace     DELETE workspace data before the run (needs ALLOW_CLEANUP)
+  -h, --help            Show this help
 EOF
 }
 
@@ -35,6 +40,8 @@ while [[ $# -gt 0 ]]; do
     --variant) VARIANT="$2"; shift 2 ;;
     --output) OUTPUT="$2"; shift 2 ;;
     --force) FORCE=1; shift ;;
+    --retrieval-mode) RETRIEVAL_MODE="$2"; shift 2 ;;
+    --reset-workspace) RESET_WORKSPACE=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
@@ -76,6 +83,12 @@ if [[ -n "$MAX_QUESTIONS" ]]; then
 fi
 if [[ "$FORCE" -eq 1 ]]; then
   RUN_ARGS+=(--force)
+fi
+if [[ -n "$RETRIEVAL_MODE" ]]; then
+  RUN_ARGS+=(--declare-retrieval-mode "$RETRIEVAL_MODE")
+fi
+if [[ "$RESET_WORKSPACE" -eq 1 ]]; then
+  RUN_ARGS+=(--reset-workspace)
 fi
 
 echo "==> Running benchmark -> $OUTPUT"

--- a/benchmarks/longmemeval/run.sh
+++ b/benchmarks/longmemeval/run.sh
@@ -62,7 +62,7 @@ if [[ "$SMOKE" -eq 1 ]]; then
 fi
 
 echo "==> Preflight"
-"$PYTHON" scripts/preflight.py --ensure-workspace
+"$PYTHON" scripts/preflight.py --ensure-workspace --variant "$VARIANT"
 
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 if [[ -z "$OUTPUT" ]]; then

--- a/benchmarks/longmemeval/run.sh
+++ b/benchmarks/longmemeval/run.sh
@@ -89,6 +89,9 @@ fi
 echo ""
 echo "Results: $OUTPUT"
 
+echo "==> Retrieval recall@k (no LLM cost)"
+"$PYTHON" scripts/evaluate_retrieval.py --results "$OUTPUT"
+
 if [[ "$RUN_ONLY" -eq 0 ]]; then
   echo "==> Evaluation (LLM judge)"
   "$PYTHON" scripts/evaluate_results.py --results "$OUTPUT" --variant "$VARIANT"

--- a/benchmarks/longmemeval/scripts/dataset.py
+++ b/benchmarks/longmemeval/scripts/dataset.py
@@ -1,0 +1,143 @@
+"""Pinned LongMemEval-cleaned dataset download, validation, and identity.
+
+Mirrors ``benchmarks/locomo/scripts/dataset.py``: the files are pinned to a
+specific Hugging Face revision and verified against a recorded SHA-256 on every
+download and every run, so two runs cannot silently use different data.
+
+Source: https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.request
+from pathlib import Path
+
+BENCH_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = BENCH_ROOT / "data"
+
+# xiaowu0162/longmemeval-cleaned @ main — "Upload folder using huggingface_hub",
+# 2025-09-19. Re-pin (and re-record the hashes below) deliberately, never by
+# tracking ``main``.
+HF_REVISION = "98d7416c24c778c2fee6e6f3006e7a073259d48f"
+_HF_RESOLVE = (
+    f"https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/{HF_REVISION}"
+)
+
+VARIANTS: dict[str, dict[str, str]] = {
+    "oracle": {
+        "filename": "longmemeval_oracle.json",
+        "url": f"{_HF_RESOLVE}/longmemeval_oracle.json",
+        "sha256": "821a2034d219ab45846873dd14c14f12cfe7776e73527a483f9dac095d38620c",
+    },
+    "s": {
+        "filename": "longmemeval_s_cleaned.json",
+        "url": f"{_HF_RESOLVE}/longmemeval_s_cleaned.json",
+        "sha256": "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442",
+    },
+}
+
+VARIANT_NAMES = tuple(VARIANTS)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def dataset_path(variant: str) -> Path:
+    _require_variant(variant)
+    return DATA_DIR / VARIANTS[variant]["filename"]
+
+
+def _require_variant(variant: str) -> None:
+    if variant not in VARIANTS:
+        raise ValueError(f"unknown LongMemEval variant {variant!r} (choose from {VARIANT_NAMES})")
+
+
+def validate_dataset(data: object) -> list[dict]:
+    """Structural check: a JSON array of question objects with ``question_id``."""
+    if not isinstance(data, list):
+        raise ValueError("LongMemEval dataset root must be a JSON array")
+    for index, entry in enumerate(data):
+        if not isinstance(entry, dict) or not isinstance(entry.get("question_id"), str):
+            raise ValueError(f"LongMemEval entry {index} has no question_id")
+    return data
+
+
+def download_dataset(variant: str, *, force: bool = False) -> Path:
+    """Download (if missing / forced) and verify the pinned dataset file."""
+    _require_variant(variant)
+    spec = VARIANTS[variant]
+    path = dataset_path(variant)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not path.exists() or force:
+        temporary = path.with_suffix(path.suffix + ".part")
+        try:
+            urllib.request.urlretrieve(spec["url"], temporary)
+            if sha256(temporary) != spec["sha256"]:
+                raise ValueError(
+                    f"downloaded LongMemEval {variant} dataset SHA-256 does not match the "
+                    f"pinned value (expected {spec['sha256']})"
+                )
+            with temporary.open(encoding="utf-8") as handle:
+                validate_dataset(json.load(handle))
+            temporary.replace(path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    verify_dataset(variant)
+    return path
+
+
+def verify_dataset(variant: str) -> Path:
+    """Raise unless the local file exists and matches the pinned SHA-256."""
+    _require_variant(variant)
+    path = dataset_path(variant)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"LongMemEval {variant} dataset not found: {path}\n"
+            f"Run: python scripts/run_benchmark.py download --variant {variant}"
+        )
+    if sha256(path) != VARIANTS[variant]["sha256"]:
+        raise ValueError(
+            f"local LongMemEval {variant} dataset SHA-256 does not match the pinned value "
+            f"({path}); re-download with --force"
+        )
+    return path
+
+
+def load_dataset(variant: str) -> list[dict]:
+    """Verify identity, then load and structurally validate the dataset."""
+    path = verify_dataset(variant)
+    with path.open(encoding="utf-8") as handle:
+        return validate_dataset(json.load(handle))
+
+
+def select_questions(dataset: list[dict], *, max_questions: int | None = None) -> list[dict]:
+    """Deterministic question selection: dataset order, first ``max_questions``."""
+    return dataset if max_questions is None else dataset[:max_questions]
+
+
+def question_ids(dataset: list[dict], *, max_questions: int | None = None) -> list[str]:
+    return [
+        entry["question_id"] for entry in select_questions(dataset, max_questions=max_questions)
+    ]
+
+
+def dataset_identity(variant: str, *, question_count: int) -> dict[str, object]:
+    """The ``dataset`` block for a run manifest."""
+    spec = VARIANTS[variant]
+    return {
+        "name": "longmemeval-cleaned",
+        "variant": variant,
+        "source_url": spec["url"],
+        "upstream_ref": HF_REVISION,
+        "sha256": spec["sha256"],
+        "question_count": question_count,
+    }

--- a/benchmarks/longmemeval/scripts/evaluate_results.py
+++ b/benchmarks/longmemeval/scripts/evaluate_results.py
@@ -15,8 +15,8 @@ VENDOR_EVAL = BENCH_ROOT / "vendor" / "evaluate_qa.py"
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
+import dataset as lme_dataset  # noqa: E402
 from env_config import BenchConfig, load_dotenv, validate_judge_env  # noqa: E402
-from run_benchmark import DATA_DIR, DATASET_FILENAMES  # noqa: E402
 
 
 def main() -> int:
@@ -44,10 +44,13 @@ def main() -> int:
 
     print(f"Judge config: model={config.judge_model} base_url={config.judge_base_url}")
 
-    ref_file = DATA_DIR / DATASET_FILENAMES[args.variant]
-    if not ref_file.exists():
-        print(f"ERROR: reference dataset not found: {ref_file}")
-        print("Run setup or: python scripts/run_benchmark.py download --variant", args.variant)
+    try:
+        ref_file = lme_dataset.verify_dataset(args.variant)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: reference dataset failed verification: {exc}")
         return 1
 
     if not VENDOR_EVAL.exists():

--- a/benchmarks/longmemeval/scripts/evaluate_retrieval.py
+++ b/benchmarks/longmemeval/scripts/evaluate_retrieval.py
@@ -19,7 +19,7 @@ REPO_ROOT = SCRIPT_DIR.parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from benchmarks._shared import retrieval_eval  # noqa: E402
+from benchmarks._shared import latency, retrieval_eval  # noqa: E402
 
 
 def load_jsonl(path: Path) -> list[dict]:
@@ -53,6 +53,7 @@ def main() -> int:
         return 1
 
     report = retrieval_eval.aggregate_recall(rows, group_key="question_type")
+    report["latency"] = latency.aggregate_latency(rows)
     output = args.output or args.results.with_suffix(args.results.suffix + ".retrieval.eval.json")
     output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
@@ -64,6 +65,12 @@ def main() -> int:
     )
     for name, group in report["by_group"].items():
         print(f"    {name}: recall@10={_fmt(group['recall'].get('10'))} ({group['count']})")
+    search = report["latency"]["phases"].get("search_ms", {})
+    if search:
+        print(
+            f"    search_ms  p50={search['p50_ms']:.0f}  p95={search['p95_ms']:.0f}  "
+            f"max={search['max_ms']:.0f}"
+        )
     print(f"Report: {output}")
     return 0
 

--- a/benchmarks/longmemeval/scripts/evaluate_retrieval.py
+++ b/benchmarks/longmemeval/scripts/evaluate_retrieval.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Aggregate the per-row recall@k the LongMemEval runner wrote.
+
+The runner records ``recall_at_5`` / ``recall_at_10`` and
+``recall_gate_eligible`` on every answers-JSONL row. This step sums them into
+``<results>.retrieval.eval.json`` — no LLM calls, no cost. The LLM-judge answer
+accuracy stays in ``evaluate_results.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks._shared import retrieval_eval  # noqa: E402
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError(f"result line {number} is not an object")
+        rows.append(row)
+    return rows
+
+
+def _fmt(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.4f}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Aggregate LongMemEval retrieval recall@k")
+    parser.add_argument("--results", required=True, type=Path, help="Answers JSONL file")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    rows = load_jsonl(args.results)
+    if not any("recall_gate_eligible" in r for r in rows):
+        print(
+            "ERROR: results have no recall fields — they predate the recall harness. "
+            "Re-run with --force."
+        )
+        return 1
+
+    report = retrieval_eval.aggregate_recall(rows, group_key="question_type")
+    output = args.output or args.results.with_suffix(args.results.suffix + ".retrieval.eval.json")
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    r10 = retrieval_eval.gate_value(report, k=10)
+    r5 = retrieval_eval.gate_value(report, k=5)
+    print(
+        f"LongMemEval  recall@10={_fmt(r10)}  recall@5={_fmt(r5)}  "
+        f"({report['eligible_count']}/{report['question_count']} recall-eligible)"
+    )
+    for name, group in report["by_group"].items():
+        print(f"    {name}: recall@10={_fmt(group['recall'].get('10'))} ({group['count']})")
+    print(f"Report: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/longmemeval/scripts/evaluate_retrieval.py
+++ b/benchmarks/longmemeval/scripts/evaluate_retrieval.py
@@ -63,6 +63,11 @@ def main() -> int:
         f"LongMemEval  recall@10={_fmt(r10)}  recall@5={_fmt(r5)}  "
         f"({report['eligible_count']}/{report['question_count']} recall-eligible)"
     )
+    if report.get("suspect_count"):
+        print(
+            f"    WARNING: {report['suspect_count']} question(s) retrieved nothing from their "
+            "own stored memory — a degraded retrieval leg, not a clean measurement"
+        )
     for name, group in report["by_group"].items():
         print(f"    {name}: recall@10={_fmt(group['recall'].get('10'))} ({group['count']})")
     search = report["latency"]["phases"].get("search_ms", {})

--- a/benchmarks/longmemeval/scripts/metronix_client.py
+++ b/benchmarks/longmemeval/scripts/metronix_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import Any
 
 import httpx
@@ -74,8 +75,13 @@ class MetronixMCPClient:
         format_session_text,
         query: str,
         top_k: int,
-    ) -> list[dict[str, Any]]:
-        """Ingest haystack sessions and search memory in one MCP session."""
+    ) -> dict[str, Any]:
+        """Ingest haystack sessions and search memory in one MCP session.
+
+        Returns ``{"results": [...], "ingest_ms": float, "search_ms": float}``.
+        ``ingest_ms`` / ``search_ms`` are wall-clock and include the MCP
+        round-trip, not just server compute.
+        """
         return asyncio.run(
             self._ingest_and_search_async(
                 sessions=sessions,
@@ -94,7 +100,7 @@ class MetronixMCPClient:
         format_session_text,
         query: str,
         top_k: int,
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         try:
             from mcp import ClientSession
             from mcp.client.streamable_http import streamable_http_client
@@ -119,6 +125,7 @@ class MetronixMCPClient:
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
 
+                ingest_started = time.perf_counter()
                 for idx, (session_turns, date) in enumerate(zip(sessions, dates, strict=False)):
                     text = format_session_text(session_turns, date=date)
                     await self._memory_store(
@@ -129,9 +136,16 @@ class MetronixMCPClient:
                         source_type=self.source_type,
                     )
 
+                search_started = time.perf_counter()
                 payload = await self._memory_search(session, query=query, top_k=top_k)
+                search_finished = time.perf_counter()
+
                 results = payload.get("results", [])
-                return results if isinstance(results, list) else []
+                return {
+                    "results": results if isinstance(results, list) else [],
+                    "ingest_ms": (search_started - ingest_started) * 1000,
+                    "search_ms": (search_finished - search_started) * 1000,
+                }
 
     async def _memory_store(
         self,

--- a/benchmarks/longmemeval/scripts/preflight.py
+++ b/benchmarks/longmemeval/scripts/preflight.py
@@ -11,6 +11,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
+import dataset as lme_dataset  # noqa: E402
 from env_config import (  # noqa: E402
     DEFAULT_ENV_PATH,
     REPO_ENV_PATH,
@@ -62,6 +63,15 @@ def main() -> int:
     parser.add_argument(
         "--copy-metronix-key-hint", action="store_true", help="Print repo-root key hint"
     )
+    parser.add_argument(
+        "--variant",
+        choices=list(lme_dataset.VARIANT_NAMES),
+        default="s",
+        help="Dataset variant whose SHA-256 to verify (default: s)",
+    )
+    parser.add_argument(
+        "--skip-dataset-check", action="store_true", help="Do not verify the dataset SHA-256"
+    )
     args = parser.parse_args()
 
     load_dotenv()
@@ -87,6 +97,19 @@ def main() -> int:
     env_rc = _print_env_status(config)
     if env_rc != 0:
         return env_rc
+
+    if not args.skip_dataset_check:
+        expected_sha = lme_dataset.VARIANTS[args.variant]["sha256"]
+        try:
+            path = lme_dataset.verify_dataset(args.variant)
+            print(f"  dataset ({args.variant}): verified {expected_sha}")
+            print(f"    {path}")
+        except FileNotFoundError as exc:
+            print(f"ERROR: {exc}")
+            return 1
+        except ValueError as exc:
+            print(f"ERROR: dataset validation failed: {exc}")
+            return 1
 
     if args.ensure_workspace:
         try:

--- a/benchmarks/longmemeval/scripts/run_benchmark.py
+++ b/benchmarks/longmemeval/scripts/run_benchmark.py
@@ -8,7 +8,6 @@ import json
 import logging
 import sys
 import traceback
-import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -19,32 +18,23 @@ from tqdm import tqdm
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 BENCH_ROOT = SCRIPT_DIR.parent
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
+REPO_ROOT = BENCH_ROOT.parents[1]
+for _path in (SCRIPT_DIR, REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
 
+import dataset as lme_dataset  # noqa: E402
 from env_config import BenchConfig, load_dotenv  # noqa: E402
 from metronix_client import MetronixMCPClient  # noqa: E402
 
+from benchmarks._shared import manifest as run_manifest  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
-DATA_DIR = BENCH_ROOT / "data"
+DATA_DIR = lme_dataset.DATA_DIR
 RESULTS_DIR = BENCH_ROOT / "results"
-
-DATASET_URLS = {
-    "oracle": (
-        "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
-        "resolve/main/longmemeval_oracle.json"
-    ),
-    "s": (
-        "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
-        "resolve/main/longmemeval_s_cleaned.json"
-    ),
-}
-
-DATASET_FILENAMES = {
-    "oracle": "longmemeval_oracle.json",
-    "s": "longmemeval_s_cleaned.json",
-}
+DATASET_FILENAMES = {name: spec["filename"] for name, spec in lme_dataset.VARIANTS.items()}
+DATASET_VARIANTS = lme_dataset.VARIANT_NAMES
 
 ANSWER_SYSTEM = (
     "You are a helpful chat assistant. You have access to memories retrieved "
@@ -101,30 +91,16 @@ restate them.
 information is truly absent from the memories."""
 
 
-def download_datasets(variants: list[str] | None = None) -> None:
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    for variant in variants or list(DATASET_URLS):
-        url = DATASET_URLS[variant]
-        filepath = DATA_DIR / DATASET_FILENAMES[variant]
-        if filepath.exists():
-            size_mb = filepath.stat().st_size / (1024 * 1024)
-            print(f"  {filepath.name} already exists ({size_mb:.1f} MB), skipping")
-            continue
-        print(f"  Downloading {filepath.name} ...")
-        urllib.request.urlretrieve(url, filepath)
-        size_mb = filepath.stat().st_size / (1024 * 1024)
-        print(f"  Saved {filepath.name} ({size_mb:.1f} MB)")
+def download_datasets(variants: list[str] | None = None, *, force: bool = False) -> None:
+    for variant in variants or list(lme_dataset.VARIANT_NAMES):
+        path = lme_dataset.download_dataset(variant, force=force)
+        size_mb = path.stat().st_size / (1024 * 1024)
+        print(f"  {path.name} ready ({size_mb:.1f} MB), sha256 verified")
 
 
 def load_dataset(variant: str) -> list[dict]:
-    filepath = DATA_DIR / DATASET_FILENAMES[variant]
-    if not filepath.exists():
-        raise FileNotFoundError(
-            f"Dataset not found: {filepath}\n"
-            f"Run: python scripts/run_benchmark.py download --variant {variant}"
-        )
-    with filepath.open(encoding="utf-8") as handle:
-        return json.load(handle)
+    """Load the pinned dataset, verifying its SHA-256 first (see ``dataset.py``)."""
+    return lme_dataset.load_dataset(variant)
 
 
 def format_session_text(session: list[dict], date: str = "") -> str:
@@ -171,6 +147,10 @@ def append_result(path: Path, question_id: str, hypothesis: str) -> None:
         handle.write(json.dumps({"question_id": question_id, "hypothesis": hypothesis}) + "\n")
 
 
+CHAT_TEMPERATURE = 0.0
+CHAT_MAX_TOKENS = 1024
+
+
 @backoff.on_exception(backoff.expo, (openai.RateLimitError, openai.APIError), max_tries=8)
 def chat_complete(client: OpenAI, *, model: str, user_message: str) -> str:
     completion = client.chat.completions.create(
@@ -179,8 +159,8 @@ def chat_complete(client: OpenAI, *, model: str, user_message: str) -> str:
             {"role": "system", "content": ANSWER_SYSTEM},
             {"role": "user", "content": user_message},
         ],
-        temperature=0.0,
-        max_tokens=1024,
+        temperature=CHAT_TEMPERATURE,
+        max_tokens=CHAT_MAX_TOKENS,
     )
     return completion.choices[0].message.content.strip()
 
@@ -227,6 +207,50 @@ def default_output_path(variant: str) -> Path:
     return RESULTS_DIR / f"{timestamp}_{variant}.jsonl"
 
 
+def build_run_artifacts(
+    *,
+    variant: str,
+    entries: list[dict],
+    config: BenchConfig,
+    max_questions: int | None,
+    retrieval_mode: str,
+    run_id: str | None = None,
+) -> tuple[dict, dict]:
+    """Return ``(manifest, query_set)`` for the exact question set to be run."""
+    ids = [entry["question_id"] for entry in entries]
+    query_set = run_manifest.build_query_set(
+        benchmark="longmemeval",
+        selector={"variant": variant, "max_questions": max_questions},
+        question_ids=ids,
+    )
+    manifest = run_manifest.build_manifest(
+        benchmark="longmemeval",
+        repo_root=REPO_ROOT,
+        run_id=run_id,
+        dataset=lme_dataset.dataset_identity(variant, question_count=len(ids)),
+        query_set=query_set,
+        config={
+            "workspace": config.workspace_id,
+            "top_k": config.retrieve_top_k,
+            "agent_id_prefix": config.agent_id_prefix,
+            "chat_model": config.chat_model,
+            "chat_base_url": config.chat_base_url,
+            "chat_temperature": CHAT_TEMPERATURE,
+            "chat_max_tokens": CHAT_MAX_TOKENS,
+            "judge_model": config.judge_model,
+            "judge_base_url": config.judge_base_url,
+        },
+        stack={
+            "mcp_endpoint_identity": run_manifest.sanitized_endpoint_identity(
+                config.metronix_mcp_url
+            ),
+            "operator_declared_retrieval_mode": retrieval_mode,
+        },
+        metrics_requested=["answer_accuracy"],
+    )
+    return manifest, query_set
+
+
 def run_benchmark(
     *,
     variant: str,
@@ -235,16 +259,29 @@ def run_benchmark(
     max_questions: int | None = None,
     resume: bool = True,
     force: bool = False,
+    retrieval_mode: str = "unspecified",
 ) -> Path:
     dataset = load_dataset(variant)
-    if max_questions is not None:
-        dataset = dataset[:max_questions]
+    entries = lme_dataset.select_questions(dataset, max_questions=max_questions)
 
     if force and output_path.exists():
         output_path.unlink()
 
+    manifest, query_set = build_run_artifacts(
+        variant=variant,
+        entries=entries,
+        config=config,
+        max_questions=max_questions,
+        retrieval_mode=retrieval_mode,
+    )
+    m_path, q_path = run_manifest.write_run_artifacts(
+        output_path, manifest=manifest, query_set=query_set
+    )
+    print(f"  MANIFEST: {m_path}")
+    print(f"  QUERY SET: {q_path} ({query_set['question_ids_sha256'][:12]}…)")
+
     done_ids = load_completed_ids(output_path) if resume else set()
-    remaining = [entry for entry in dataset if entry["question_id"] not in done_ids]
+    remaining = [entry for entry in entries if entry["question_id"] not in done_ids]
     if not remaining:
         print("All questions already completed.")
         return output_path
@@ -256,7 +293,7 @@ def run_benchmark(
     print(f"  CHAT MODEL: {config.chat_model}")
     print(f"  CHAT BASE URL: {config.chat_base_url}")
     print(f"  WORKSPACE: {config.workspace_id}")
-    print(f"  QUESTIONS: {len(remaining)} (of {len(dataset)} after resume)")
+    print(f"  QUESTIONS: {len(remaining)} (of {len(entries)} after resume)")
     print(f"  OUTPUT: {output_path}")
     print("=" * 60)
 
@@ -276,9 +313,9 @@ def run_benchmark(
 
 
 def cmd_download(args: argparse.Namespace) -> int:
-    variants = [args.variant] if args.variant else list(DATASET_URLS)
-    print("Downloading LongMemEval datasets ...")
-    download_datasets(variants)
+    variants = [args.variant] if args.variant else list(DATASET_VARIANTS)
+    print(f"Downloading LongMemEval datasets (pinned @ {lme_dataset.HF_REVISION[:12]}) ...")
+    download_datasets(variants, force=args.force)
     print("Download complete.")
     return 0
 
@@ -307,6 +344,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         max_questions=args.max_questions,
         resume=not args.no_resume,
         force=args.force,
+        retrieval_mode=args.declare_retrieval_mode,
     )
     return 0
 
@@ -318,14 +356,17 @@ def build_parser() -> argparse.ArgumentParser:
     download_parser = subparsers.add_parser("download", help="Download dataset files")
     download_parser.add_argument(
         "--variant",
-        choices=list(DATASET_URLS),
+        choices=list(DATASET_VARIANTS),
         default="s",
         help="Dataset variant to download",
+    )
+    download_parser.add_argument(
+        "--force", action="store_true", help="Re-download even if the file exists"
     )
     download_parser.set_defaults(func=cmd_download)
 
     run_parser = subparsers.add_parser("run", help="Run benchmark generation")
-    run_parser.add_argument("--variant", choices=list(DATASET_URLS), default="s")
+    run_parser.add_argument("--variant", choices=list(DATASET_VARIANTS), default="s")
     run_parser.add_argument("--output", help="Output JSONL path")
     run_parser.add_argument("--max-questions", type=int, help="Limit number of questions")
     run_parser.add_argument("--workspace", help="Metronix workspace ID")
@@ -336,6 +377,12 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--no-resume", action="store_true", help="Do not skip completed IDs")
     run_parser.add_argument(
         "--force", action="store_true", help="Delete existing output before run"
+    )
+    run_parser.add_argument(
+        "--declare-retrieval-mode",
+        default="unspecified",
+        help="Operator-confirmed server retrieval mode, recorded in the run manifest "
+        "(e.g. flag-off / flag-on for a PPR A/B)",
     )
     run_parser.set_defaults(func=cmd_run)
 

--- a/benchmarks/longmemeval/scripts/run_benchmark.py
+++ b/benchmarks/longmemeval/scripts/run_benchmark.py
@@ -28,6 +28,7 @@ from env_config import BenchConfig, load_dotenv  # noqa: E402
 from metronix_client import MetronixMCPClient  # noqa: E402
 
 from benchmarks._shared import manifest as run_manifest  # noqa: E402
+from benchmarks._shared import oracle, retrieval_eval  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -141,10 +142,15 @@ def load_completed_ids(path: Path) -> set[str]:
     return done
 
 
-def append_result(path: Path, question_id: str, hypothesis: str) -> None:
+def append_result(
+    path: Path, question_id: str, hypothesis: str, *, extra: dict | None = None
+) -> None:
+    """Append one JSONL row. ``question_id`` + ``hypothesis`` first (the judge
+    and resume logic only need those); ``extra`` carries recall / latency."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    row = {"question_id": question_id, "hypothesis": hypothesis, **(extra or {})}
     with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps({"question_id": question_id, "hypothesis": hypothesis}) + "\n")
+        handle.write(json.dumps(row) + "\n")
 
 
 CHAT_TEMPERATURE = 0.0
@@ -170,7 +176,8 @@ def process_question(
     *,
     config: BenchConfig,
     chat_client: OpenAI,
-) -> str:
+) -> tuple[str, dict]:
+    """Return ``(hypothesis, retrieval)`` — the answer plus recall@k fields."""
     question_id = entry["question_id"]
     agent_id = f"{config.agent_id_prefix}-{question_id}"
     mcp_client = MetronixMCPClient(
@@ -185,21 +192,33 @@ def process_question(
     question = entry["question"]
     current_date = entry.get("question_date", "")
 
+    # Search deep enough for recall@10 even when the answer prompt uses a
+    # smaller top_k; only ``retrieve_top_k`` hits reach the LLM.
+    search_k = max(config.retrieve_top_k, retrieval_eval.SEARCH_K_FLOOR)
     search_results = mcp_client.ingest_and_search(
         sessions=sessions,
         dates=dates,
         format_session_text=format_session_text,
         query=question,
-        top_k=config.retrieve_top_k,
+        top_k=search_k,
     )
-    memory_context = build_memory_context(search_results)
+    answer_hits = search_results[: config.retrieve_top_k]
 
     user_message = ANSWER_PROMPT.format(
-        memory_context=memory_context,
+        memory_context=build_memory_context(answer_hits),
         current_date=current_date,
         question=question,
     )
-    return chat_complete(chat_client, model=config.chat_model, user_message=user_message)
+    hypothesis = chat_complete(chat_client, model=config.chat_model, user_message=user_message)
+
+    retrieval = retrieval_eval.recall_row(
+        oracle.longmemeval_oracle_tags(entry),
+        oracle.retrieved_session_tags(search_results),
+        eligible=not oracle.longmemeval_is_abstention(entry),
+    )
+    retrieval["retrieved_count"] = len(answer_hits)
+    retrieval["question_type"] = entry.get("question_type", "unknown")
+    return hypothesis, retrieval
 
 
 def default_output_path(variant: str) -> Path:
@@ -246,7 +265,7 @@ def build_run_artifacts(
             ),
             "operator_declared_retrieval_mode": retrieval_mode,
         },
-        metrics_requested=["answer_accuracy"],
+        metrics_requested=["recall_at_10", "recall_at_5", "answer_accuracy"],
     )
     return manifest, query_set
 
@@ -299,13 +318,14 @@ def run_benchmark(
 
     for entry in tqdm(remaining, desc="LongMemEval", unit="q"):
         qid = entry["question_id"]
+        extra: dict = {}
         try:
-            hypothesis = process_question(entry, config=config, chat_client=chat_client)
+            hypothesis, extra = process_question(entry, config=config, chat_client=chat_client)
         except Exception as exc:
             logger.error("Error on %s: %s", qid, exc)
             traceback.print_exc()
             hypothesis = f"Error: {exc}"
-        append_result(output_path, qid, hypothesis)
+        append_result(output_path, qid, hypothesis, extra=extra)
 
     total = len(load_completed_ids(output_path))
     print(f"\nDone. {total} answers written to {output_path}")

--- a/benchmarks/longmemeval/scripts/run_benchmark.py
+++ b/benchmarks/longmemeval/scripts/run_benchmark.py
@@ -9,6 +9,7 @@ import logging
 import sys
 import time
 import traceback
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -30,6 +31,7 @@ from metronix_client import MetronixMCPClient  # noqa: E402
 
 from benchmarks._shared import manifest as run_manifest  # noqa: E402
 from benchmarks._shared import oracle, retrieval_eval  # noqa: E402
+from benchmarks._shared import stack as stack_probe  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +226,9 @@ def process_question(
     )
     retrieval["retrieved_count"] = len(answer_hits)
     retrieval["question_type"] = entry.get("question_type", "unknown")
+    # This agent just stored its own haystack; retrieving nothing means the
+    # search path was degraded (a dropped Qdrant/graph leg), not "no evidence".
+    retrieval["search_suspect"] = not search_results and bool(sessions)
     retrieval["ingest_ms"] = outcome["ingest_ms"]
     retrieval["search_ms"] = outcome["search_ms"]
     retrieval["answer_ms"] = answer_ms
@@ -244,6 +249,8 @@ def build_run_artifacts(
     max_questions: int | None,
     retrieval_mode: str,
     run_id: str | None = None,
+    workspace_reset: str = "no",
+    stack_snapshot: dict | None = None,
 ) -> tuple[dict, dict]:
     """Return ``(manifest, query_set)`` for the exact question set to be run."""
     ids = [entry["question_id"] for entry in entries]
@@ -274,6 +281,8 @@ def build_run_artifacts(
                 config.metronix_mcp_url
             ),
             "operator_declared_retrieval_mode": retrieval_mode,
+            "workspace_reset": workspace_reset,
+            "probe": stack_snapshot or {},
         },
         metrics_requested=[
             "recall_at_10",
@@ -294,6 +303,8 @@ def run_benchmark(
     resume: bool = True,
     force: bool = False,
     retrieval_mode: str = "unspecified",
+    agent_id_prefix: str | None = None,
+    reset_workspace: bool = False,
 ) -> Path:
     dataset = load_dataset(variant)
     entries = lme_dataset.select_questions(dataset, max_questions=max_questions)
@@ -301,18 +312,39 @@ def run_benchmark(
     if force and output_path.exists():
         output_path.unlink()
 
+    # Only --force rotates the namespace. A plain resume (or --no-resume, which
+    # re-answers into the same file) keeps the run's existing memory namespace.
+    run_id, prefix = run_manifest.resolve_run_identity(
+        output_path,
+        benchmark="longmemeval",
+        retrieval_mode=retrieval_mode,
+        prefix_override=agent_id_prefix,
+        fresh=force,
+    )
+    config = replace(config, agent_id_prefix=prefix)
+
+    reset_status = "no"
+    if reset_workspace:
+        reset_status = stack_probe.reset_workspace(config.metronix_api_url, config.workspace_id)
+        print(f"  WORKSPACE RESET: {reset_status}")
+    snapshot = stack_probe.probe_stack(config.metronix_api_url)
+
     manifest, query_set = build_run_artifacts(
         variant=variant,
         entries=entries,
         config=config,
         max_questions=max_questions,
         retrieval_mode=retrieval_mode,
+        run_id=run_id,
+        workspace_reset=reset_status,
+        stack_snapshot=snapshot,
     )
     m_path, q_path = run_manifest.write_run_artifacts(
         output_path, manifest=manifest, query_set=query_set
     )
     print(f"  MANIFEST: {m_path}")
     print(f"  QUERY SET: {q_path} ({query_set['question_ids_sha256'][:12]}…)")
+    print(f"  AGENT-ID PREFIX: {prefix}")
 
     done_ids = load_completed_ids(output_path) if resume else set()
     remaining = [entry for entry in entries if entry["question_id"] not in done_ids]
@@ -373,6 +405,12 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("ERROR: LME_CHAT_API_KEY (or OPENAI_API_KEY) is required")
         return 1
 
+    # CLI flag wins; a non-default LME_AGENT_ID_PREFIX is honoured as an explicit
+    # pin; otherwise the runner derives a fresh run-scoped namespace.
+    pinned_prefix = args.agent_id_prefix or (
+        config.agent_id_prefix if config.agent_id_prefix != "lme" else None
+    )
+
     output_path = Path(args.output) if args.output else default_output_path(args.variant)
     run_benchmark(
         variant=args.variant,
@@ -382,6 +420,8 @@ def cmd_run(args: argparse.Namespace) -> int:
         resume=not args.no_resume,
         force=args.force,
         retrieval_mode=args.declare_retrieval_mode,
+        agent_id_prefix=pinned_prefix,
+        reset_workspace=args.reset_workspace,
     )
     return 0
 
@@ -420,6 +460,18 @@ def build_parser() -> argparse.ArgumentParser:
         default="unspecified",
         help="Operator-confirmed server retrieval mode, recorded in the run manifest "
         "(e.g. flag-off / flag-on for a PPR A/B)",
+    )
+    run_parser.add_argument(
+        "--agent-id-prefix",
+        default=None,
+        help="Pin the agent-id namespace instead of deriving a run-scoped one. "
+        "Use only to resume a run whose manifest was lost.",
+    )
+    run_parser.add_argument(
+        "--reset-workspace",
+        action="store_true",
+        help="DELETE all workspace data before the run (needs ALLOW_CLEANUP=true on "
+        "the server). The outcome is recorded in the manifest.",
     )
     run_parser.set_defaults(func=cmd_run)
 

--- a/benchmarks/longmemeval/scripts/run_benchmark.py
+++ b/benchmarks/longmemeval/scripts/run_benchmark.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import logging
 import sys
+import time
 import traceback
 from datetime import UTC, datetime
 from pathlib import Path
@@ -192,16 +193,19 @@ def process_question(
     question = entry["question"]
     current_date = entry.get("question_date", "")
 
+    started = time.perf_counter()
+
     # Search deep enough for recall@10 even when the answer prompt uses a
     # smaller top_k; only ``retrieve_top_k`` hits reach the LLM.
     search_k = max(config.retrieve_top_k, retrieval_eval.SEARCH_K_FLOOR)
-    search_results = mcp_client.ingest_and_search(
+    outcome = mcp_client.ingest_and_search(
         sessions=sessions,
         dates=dates,
         format_session_text=format_session_text,
         query=question,
         top_k=search_k,
     )
+    search_results = outcome["results"]
     answer_hits = search_results[: config.retrieve_top_k]
 
     user_message = ANSWER_PROMPT.format(
@@ -209,7 +213,9 @@ def process_question(
         current_date=current_date,
         question=question,
     )
+    answer_started = time.perf_counter()
     hypothesis = chat_complete(chat_client, model=config.chat_model, user_message=user_message)
+    answer_ms = (time.perf_counter() - answer_started) * 1000
 
     retrieval = retrieval_eval.recall_row(
         oracle.longmemeval_oracle_tags(entry),
@@ -218,6 +224,10 @@ def process_question(
     )
     retrieval["retrieved_count"] = len(answer_hits)
     retrieval["question_type"] = entry.get("question_type", "unknown")
+    retrieval["ingest_ms"] = outcome["ingest_ms"]
+    retrieval["search_ms"] = outcome["search_ms"]
+    retrieval["answer_ms"] = answer_ms
+    retrieval["total_ms"] = (time.perf_counter() - started) * 1000
     return hypothesis, retrieval
 
 
@@ -265,7 +275,12 @@ def build_run_artifacts(
             ),
             "operator_declared_retrieval_mode": retrieval_mode,
         },
-        metrics_requested=["recall_at_10", "recall_at_5", "answer_accuracy"],
+        metrics_requested=[
+            "recall_at_10",
+            "recall_at_5",
+            "answer_accuracy",
+            "search_latency_p50_p95",
+        ],
     )
     return manifest, query_set
 
@@ -318,6 +333,7 @@ def run_benchmark(
 
     for entry in tqdm(remaining, desc="LongMemEval", unit="q"):
         qid = entry["question_id"]
+        started = time.perf_counter()
         extra: dict = {}
         try:
             hypothesis, extra = process_question(entry, config=config, chat_client=chat_client)
@@ -325,6 +341,7 @@ def run_benchmark(
             logger.error("Error on %s: %s", qid, exc)
             traceback.print_exc()
             hypothesis = f"Error: {exc}"
+        extra.setdefault("total_ms", (time.perf_counter() - started) * 1000)
         append_result(output_path, qid, hypothesis, extra=extra)
 
     total = len(load_completed_ids(output_path))

--- a/docs/benchmarks/longmemeval.md
+++ b/docs/benchmarks/longmemeval.md
@@ -346,13 +346,30 @@ Select-String -Path ..\..\.env -Pattern METRONIX_MCP_API_KEY
 **Artifacts:**
 
 
-| File                                      | Content                   |
-| ----------------------------------------- | ------------------------- |
-| `results/<timestamp>_s.jsonl`             | Hypotheses                |
-| `results/<timestamp>_s.jsonl.eval-gpt-4o` | Per-question judge labels |
+| File                                          | Content                   |
+| --------------------------------------------- | ------------------------- |
+| `results/<timestamp>_s.jsonl`                 | Hypotheses                |
+| `results/<timestamp>_s.jsonl.manifest.json`   | Run identity — see below  |
+| `results/<timestamp>_s.jsonl.query_set.json`  | Ordered `question_id` list the run executed |
+| `results/<timestamp>_s.jsonl.eval-gpt-4o`     | Per-question judge labels |
 
 
 Runs **resume** automatically: existing `question_id` values in the output JSONL are skipped.
+
+### Run identity (`*.manifest.json`)
+
+Every run writes a manifest so two runs can be checked for comparability after
+the fact:
+
+- `dataset` — pinned Hugging Face revision + the SHA-256 the bytes were verified
+  against (the dataset is never fetched from `main`; see
+  `benchmarks/longmemeval/scripts/dataset.py`).
+- `query_set.question_ids_sha256` — an order-sensitive digest of the exact
+  question set. Two runs are only comparable when this matches.
+- `repository` — the harness commit and whether the working tree was dirty.
+- `config` / `stack` — workspace, `top_k`, agent-id prefix, chat/judge model and
+  base URL, the sanitized MCP endpoint identity, and the operator-declared
+  retrieval mode (`--declare-retrieval-mode`). No secrets.
 
 ## Troubleshooting
 
@@ -382,6 +399,7 @@ This harness targets **LongMemEval-S** only. Possible extensions (not implemente
 ## References
 
 - Paper: [LongMemEval (ICLR 2025)](https://github.com/xiaowu0162/LongMemEval)
-- Dataset: [xiaowu0162/longmemeval-cleaned](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned)
+- Dataset: [xiaowu0162/longmemeval-cleaned](https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned),
+  pinned to revision `98d7416c24c778c2fee6e6f3006e7a073259d48f`
 - Metronix MCP tools: [docs/MCP_API.md](../MCP_API.md)
 

--- a/docs/benchmarks/longmemeval.md
+++ b/docs/benchmarks/longmemeval.md
@@ -382,9 +382,17 @@ the fact:
 - `query_set.question_ids_sha256` — an order-sensitive digest of the exact
   question set. Two runs are only comparable when this matches.
 - `repository` — the harness commit and whether the working tree was dirty.
-- `config` / `stack` — workspace, `top_k`, agent-id prefix, chat/judge model and
-  base URL, the sanitized MCP endpoint identity, and the operator-declared
-  retrieval mode (`--declare-retrieval-mode`). No secrets.
+- `config` / `stack` — workspace, `top_k`, chat/judge model and base URL,
+  `chat_temperature` / `chat_max_tokens`, the run-scoped agent-id prefix, the
+  sanitized MCP endpoint identity, the operator-declared retrieval mode
+  (`--retrieval-mode` via `run.sh`, `--declare-retrieval-mode` directly),
+  `workspace_reset` (`--reset-workspace`), and a best-effort stack probe
+  (`stack.probe` — Qdrant/Neo4j status from `/api/v1/admin/status`). No secrets.
+
+The agent-id prefix is derived per run as
+`longmemeval-<mode>-<run_id[:8]>` and stored in the manifest — no two runs
+share a memory namespace, and resuming a results file reuses its prefix. Pass
+`--agent-id-prefix` only to resume a run whose manifest was lost.
 
 ## Troubleshooting
 

--- a/docs/benchmarks/longmemeval.md
+++ b/docs/benchmarks/longmemeval.md
@@ -346,12 +346,22 @@ Select-String -Path ..\..\.env -Pattern METRONIX_MCP_API_KEY
 **Artifacts:**
 
 
-| File                                          | Content                   |
-| --------------------------------------------- | ------------------------- |
-| `results/<timestamp>_s.jsonl`                 | Hypotheses                |
-| `results/<timestamp>_s.jsonl.manifest.json`   | Run identity — see below  |
-| `results/<timestamp>_s.jsonl.query_set.json`  | Ordered `question_id` list the run executed |
-| `results/<timestamp>_s.jsonl.eval-gpt-4o`     | Per-question judge labels |
+| File                                              | Content                   |
+| ------------------------------------------------- | ------------------------- |
+| `results/<timestamp>_s.jsonl`                     | Hypotheses + per-question `recall_at_5` / `recall_at_10` |
+| `results/<timestamp>_s.jsonl.manifest.json`       | Run identity — see below  |
+| `results/<timestamp>_s.jsonl.query_set.json`      | Ordered `question_id` list the run executed |
+| `results/<timestamp>_s.jsonl.retrieval.eval.json` | Aggregated recall@10 / recall@5 (the retrieval gate), overall + by `question_type` |
+| `results/<timestamp>_s.jsonl.eval-gpt-4o`         | Per-question judge labels (answer accuracy) |
+
+### Retrieval recall (`*.retrieval.eval.json`)
+
+The runner stores one memory record per haystack session (tagged
+`session_<i>`), searches at least top-10, and records whether the oracle session
+(`answer_session_ids`) was among the hits: `recall_at_10` is the retrieval gate,
+`recall_at_5` is reported alongside. Abstention questions (`*_abs`) have no
+retrieval target and are excluded from the aggregate. Computed by
+`evaluate_retrieval.py` — no LLM calls, always runs (even with `--run-only`).
 
 
 Runs **resume** automatically: existing `question_id` values in the output JSONL are skipped.

--- a/docs/benchmarks/longmemeval.md
+++ b/docs/benchmarks/longmemeval.md
@@ -354,14 +354,19 @@ Select-String -Path ..\..\.env -Pattern METRONIX_MCP_API_KEY
 | `results/<timestamp>_s.jsonl.retrieval.eval.json` | Aggregated recall@10 / recall@5 (the retrieval gate), overall + by `question_type` |
 | `results/<timestamp>_s.jsonl.eval-gpt-4o`         | Per-question judge labels (answer accuracy) |
 
-### Retrieval recall (`*.retrieval.eval.json`)
+### Retrieval recall + latency (`*.retrieval.eval.json`)
 
 The runner stores one memory record per haystack session (tagged
 `session_<i>`), searches at least top-10, and records whether the oracle session
 (`answer_session_ids`) was among the hits: `recall_at_10` is the retrieval gate,
 `recall_at_5` is reported alongside. Abstention questions (`*_abs`) have no
-retrieval target and are excluded from the aggregate. Computed by
-`evaluate_retrieval.py` — no LLM calls, always runs (even with `--run-only`).
+retrieval target and are excluded from the aggregate.
+
+Each question also records split latency — `ingest_ms`, `search_ms`, `answer_ms`,
+`total_ms` — and the report carries a `latency` block with p50/p95/max per phase.
+`search_ms` is wall-clock and includes the MCP round-trip, not just server
+compute. Computed by `evaluate_retrieval.py` — no LLM calls, always runs (even
+with `--run-only`).
 
 
 Runs **resume** automatically: existing `question_id` values in the output JSONL are skipped.

--- a/docs/benchmarks/ppr-evaluation-runbook.md
+++ b/docs/benchmarks/ppr-evaluation-runbook.md
@@ -290,7 +290,20 @@ For every pair confirm:
 5. Raw artifacts exist and are retained outside Git.
 6. No secrets or private memory content are present in the report.
 
-If any check fails, rerun the pair. Do not average incompatible legs.
+Checks 2–4 and the recall@10 comparison are done for you by:
+
+```bash
+python benchmarks/compare_runs.py \
+  results/ppr-off-full.jsonl results/ppr-on-full.jsonl \
+  --gate recall_at_10=<epic threshold> \
+  --max-regression recall_at_10=<noise band> \
+  --output results/ppr-recall-compare.json
+```
+
+It exits non-zero on any identity mismatch, a dirty-tree run, both legs
+declaring the same mode, or a gate / regression breach. Run it once per
+benchmark (LongMemEval and LoCoMo). If any check fails, rerun the pair. Do not
+average incompatible legs.
 
 **Primary retrieval signal:** `recall@10` from `*.retrieval.eval.json`
 (LongMemEval) / the `retrieval` block of `*.eval.json` (LoCoMo) — mean over the

--- a/docs/benchmarks/ppr-evaluation-runbook.md
+++ b/docs/benchmarks/ppr-evaluation-runbook.md
@@ -243,6 +243,11 @@ now records per-query latency plus mean, p50, p95, and maximum milliseconds.
 Do not use a changed or freshly reindexed workspace for only one leg. Inspect
 relationship-heavy queries separately as well as overall MRR/NDCG.
 
+The LongMemEval and LoCoMo runs also carry their own split latency now
+(`ingest_ms` / `search_ms` / `answer_ms` / `total_ms` per question; p50/p95/max
+per phase in the eval reports). `search_ms` is the agent-memory retrieval
+latency for a PPR A/B — compare it between legs alongside recall@10.
+
 ## 6. Footprint sampling
 
 ### Sample service footprint during each leg

--- a/docs/benchmarks/ppr-evaluation-runbook.md
+++ b/docs/benchmarks/ppr-evaluation-runbook.md
@@ -14,10 +14,20 @@ Hold these constant across both legs:
 - answer and judge models, base URLs, prompts, `top_k`, and credentials;
 - host, Docker resource limits, and competing workloads.
 
-Change only `METRONIX_RETRIEVAL_GRAPH_PPR_ENABLED`. Use distinct agent-ID
-prefixes for each leg so the second run cannot reuse memories written by the
-first. Do not publish `.env.benchmark`, API keys, raw private workspace content,
-or model-provider request logs.
+Change only `METRONIX_RETRIEVAL_GRAPH_PPR_ENABLED`. Both runners now mint a
+**run-scoped agent-ID prefix** automatically (`<benchmark>-<mode>-<run_id[:8]>`)
+and persist it in the manifest, so no two runs — even two flag-off repeats —
+can read each other's stored memories, and a resume of the same results file
+reuses its namespace. Pass `--agent-id-prefix` only to resume a run whose
+manifest was lost. Do not publish `.env.benchmark`, API keys, raw private
+workspace content, or model-provider request logs.
+
+Optionally pass `--reset-workspace` to each run to delete the workspace's data
+first (needs `ALLOW_CLEANUP=true` on the server); the outcome is recorded in the
+manifest and the comparator refuses to compare a reset leg against a
+non-reset one. Each runner also probes `/health` and `/api/v1/admin/status`
+before the run and records the Qdrant/Neo4j status in the manifest — a leg with
+a store down is visibly not comparable.
 
 Run the short smoke pair first. Run the full pair only after both smoke legs
 complete without errors. LongMemEval and LoCoMo can incur model charges and can
@@ -90,7 +100,8 @@ LME_JUDGE_BASE_URL=https://api.openai.com/v1
 LME_JUDGE_MODEL=gpt-4o
 
 LME_RETRIEVE_TOP_K=10
-LME_AGENT_ID_PREFIX=lme-ppr-off
+# LME_AGENT_ID_PREFIX is optional — leave it unset and the runner derives a
+# fresh run-scoped prefix per run. Set it only to pin a namespace for a resume.
 ```
 
 Setup and validate without printing secrets:
@@ -106,29 +117,36 @@ Use the same model identities and dataset hashes for both legs. The official
 paper protocol uses GPT-4o as judge; another OpenAI-compatible judge is useful
 for internal regression only and must be named in the report.
 
+Pass `--retrieval-mode flag-off` / `flag-on` to each `run.sh` so the manifest
+records the operator-confirmed server mode and the runner can derive a
+`longmemeval-flag-off-*` / `longmemeval-flag-on-*` namespace.
+
 ### LongMemEval smoke pair
 
-With PPR off and `LME_AGENT_ID_PREFIX=lme-ppr-off`:
+With PPR off:
 
 ```bash
-./run.sh --smoke --force --output results/ppr-off-smoke.jsonl
+./run.sh --smoke --force --retrieval-mode flag-off \
+  --output results/ppr-off-smoke.jsonl
 ```
 
-Enable PPR, recreate/verify `metronix-core`, change only the prefix to
-`lme-ppr-on`, then:
+Enable PPR, recreate/verify `metronix-core`, then:
 
 ```bash
-./run.sh --smoke --force --output results/ppr-on-smoke.jsonl
+./run.sh --smoke --force --retrieval-mode flag-on \
+  --output results/ppr-on-smoke.jsonl
 ```
 
 ### LongMemEval full pair
 
 ```bash
-# Flag off, prefix lme-ppr-off
-./run.sh --variant s --force --output results/ppr-off-full.jsonl
+# Flag off
+./run.sh --variant s --force --retrieval-mode flag-off \
+  --output results/ppr-off-full.jsonl
 
-# Flag on, prefix lme-ppr-on
-./run.sh --variant s --force --output results/ppr-on-full.jsonl
+# Flag on
+./run.sh --variant s --force --retrieval-mode flag-on \
+  --output results/ppr-on-full.jsonl
 ```
 
 Monitor a running leg from another terminal:
@@ -201,8 +219,8 @@ multi-answer F1 for category 1, and abstention phrase accuracy for category 5.
   --output results/ppr-on-smoke.jsonl --force
 ```
 
-The runner automatically uses distinct `locomo-flag-off-*` and
-`locomo-flag-on-*` agent IDs.
+The runner automatically uses a distinct run-scoped `locomo-flag-off-<run_id>` /
+`locomo-flag-on-<run_id>` agent-ID prefix per run.
 
 ### LoCoMo full pair
 
@@ -281,16 +299,19 @@ or images changed between legs.
 
 For every pair confirm:
 
-1. Both legs completed with zero benchmark errors.
+1. Both legs completed with zero benchmark errors and zero `suspect_count`
+   (questions that retrieved nothing from their own stored memory).
 2. Git revision, dataset hash, `question_ids_sha256` (from `*.query_set.json`),
-   categories, `top_k`, models, and base URLs match between the two
-   `*.manifest.json` files.
-3. Only `operator_declared_retrieval_mode` and the isolation prefix differ.
+   categories, `top_k`, models, base URLs, `chat_temperature` / `chat_max_tokens`,
+   workspace, `workspace_reset`, and the stack probe (`stack.probe`) match
+   between the two `*.manifest.json` files.
+3. Only `operator_declared_retrieval_mode` and the run-scoped `run_id` /
+   agent-ID prefix differ.
 4. Neither manifest reports `repository.dirty: true`.
 5. Raw artifacts exist and are retained outside Git.
 6. No secrets or private memory content are present in the report.
 
-Checks 2–4 and the recall@10 comparison are done for you by:
+Checks 1–4 and the recall@10 comparison are done for you by:
 
 ```bash
 python benchmarks/compare_runs.py \

--- a/docs/benchmarks/ppr-evaluation-runbook.md
+++ b/docs/benchmarks/ppr-evaluation-runbook.md
@@ -277,13 +277,20 @@ or images changed between legs.
 For every pair confirm:
 
 1. Both legs completed with zero benchmark errors.
-2. Git revision, dataset hash, categories, `top_k`, models, and base URLs match.
-3. Only retrieval mode and the isolation prefix differ.
-4. Question counts match the selected subset.
+2. Git revision, dataset hash, `question_ids_sha256` (from `*.query_set.json`),
+   categories, `top_k`, models, and base URLs match between the two
+   `*.manifest.json` files.
+3. Only `operator_declared_retrieval_mode` and the isolation prefix differ.
+4. Neither manifest reports `repository.dirty: true`.
 5. Raw artifacts exist and are retained outside Git.
 6. No secrets or private memory content are present in the report.
 
 If any check fails, rerun the pair. Do not average incompatible legs.
+
+**Primary retrieval signal:** `recall@10` from `*.retrieval.eval.json`
+(LongMemEval) / the `retrieval` block of `*.eval.json` (LoCoMo) — mean over the
+recall-eligible (non-abstention) questions. Answer accuracy (LLM judge) and
+token-F1 are secondary. `recall@5` is reported alongside.
 
 ## 8. Report template
 

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -63,10 +63,13 @@ _LONGMEMEVAL_DATASETS = {
 HIGHER_IS_BETTER = frozenset(
     {
         "search.precision_at_k",
+        "search.recall_at_k",
         "search.mrr",
         "search.ndcg_at_k",
         "search.negative_accuracy",
         "longmemeval.accuracy",
+        "longmemeval.recall_at_10",
+        "longmemeval.recall_at_5",
     }
 )
 
@@ -703,11 +706,48 @@ def _parse_longmemeval_summary(path: Path, stdout: str, stderr: str) -> dict[str
     accuracy = float(match.group(1)) if match else None
     if accuracy is not None and not math.isfinite(accuracy):
         accuracy = None
-    return {
+
+    summary: dict[str, SummaryValue] = {
         "answer_count": answer_count,
         "error_count": error_count,
         "accuracy": accuracy,
     }
+    summary.update(_longmemeval_retrieval_summary(path))
+    return summary
+
+
+def _longmemeval_retrieval_summary(answers_path: Path) -> dict[str, SummaryValue]:
+    """recall@k + search latency from the ``*.retrieval.eval.json`` the run wrote."""
+    report_path = answers_path.with_name(answers_path.name + ".retrieval.eval.json")
+    if not report_path.is_file():
+        return {}
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(report, dict):
+        return {}
+    recall = report.get("recall", {})
+    out: dict[str, SummaryValue] = {
+        "recall_eligible_count": _as_int(report.get("eligible_count")),
+        "recall_at_10": _as_finite_float(recall.get("10")) if isinstance(recall, dict) else None,
+        "recall_at_5": _as_finite_float(recall.get("5")) if isinstance(recall, dict) else None,
+    }
+    search = report.get("latency", {}).get("phases", {}).get("search_ms", {})
+    if isinstance(search, dict):
+        out["search_latency_p50_ms"] = _as_finite_float(search.get("p50_ms"))
+        out["search_latency_p95_ms"] = _as_finite_float(search.get("p95_ms"))
+    return {key: value for key, value in out.items() if value is not None}
+
+
+def _as_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _as_finite_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if math.isfinite(value) else None
 
 
 def _summary_failure_messages(

--- a/scripts/memory_eval_harness.py
+++ b/scripts/memory_eval_harness.py
@@ -38,20 +38,25 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _LONGMEMEVAL_ROOT = _REPO_ROOT / "benchmarks" / "longmemeval"
 _LONGMEMEVAL_ENV = _LONGMEMEVAL_ROOT / ".env.benchmark"
 _LONGMEMEVAL_LEGACY_ENV = _LONGMEMEVAL_ROOT / ".env"
+# Pinned to xiaowu0162/longmemeval-cleaned @ 98d7416c (see
+# benchmarks/longmemeval/scripts/dataset.py — the source of truth for the pin).
+_LONGMEMEVAL_HF_REVISION = "98d7416c24c778c2fee6e6f3006e7a073259d48f"
 _LONGMEMEVAL_DATASETS = {
     "oracle": {
         "filename": "longmemeval_oracle.json",
         "source": (
             "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
-            "resolve/main/longmemeval_oracle.json"
+            f"resolve/{_LONGMEMEVAL_HF_REVISION}/longmemeval_oracle.json"
         ),
+        "pinned_sha256": "821a2034d219ab45846873dd14c14f12cfe7776e73527a483f9dac095d38620c",
     },
     "s": {
         "filename": "longmemeval_s_cleaned.json",
         "source": (
             "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
-            "resolve/main/longmemeval_s_cleaned.json"
+            f"resolve/{_LONGMEMEVAL_HF_REVISION}/longmemeval_s_cleaned.json"
         ),
+        "pinned_sha256": "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442",
     },
 }
 

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -169,6 +169,7 @@ async def run_eval(
                 "category": q.category,
                 "is_negative": False,
                 "precision_at_k": result["precision_at_k"],
+                "recall_at_k": result["recall_at_k"],
                 "mrr": result["mrr"],
                 "ndcg_at_k": result["ndcg_at_k"],
                 "retrieved": retrieved,
@@ -179,6 +180,7 @@ async def run_eval(
         print(
             f"  [{q.id:<8}] "
             f"P@{k}={result['precision_at_k']:.2f}  "
+            f"R@{k}={result['recall_at_k']:.2f}  "
             f"MRR={result['mrr']:.2f}  "
             f"NDCG@{k}={result['ndcg_at_k']:.2f}"
         )
@@ -235,12 +237,18 @@ async def run_eval(
         print(
             f"POSITIVE:  "
             f"P@{k}={avgs['avg_precision_at_k']:.4f}  "
+            f"R@{k}={avgs['avg_recall_at_k']:.4f}  "
             f"MRR={avgs['avg_mrr']:.4f}  "
             f"NDCG@{k}={avgs['avg_ndcg_at_k']:.4f}  "
             f"({len(positive_queries)} queries)"
         )
     else:
-        avgs = {"avg_precision_at_k": 0.0, "avg_mrr": 0.0, "avg_ndcg_at_k": 0.0}
+        avgs = {
+            "avg_precision_at_k": 0.0,
+            "avg_recall_at_k": 0.0,
+            "avg_mrr": 0.0,
+            "avg_ndcg_at_k": 0.0,
+        }
 
     if negative_queries:
         neg_accuracy = neg_correct / len(negative_queries)
@@ -258,6 +266,7 @@ async def run_eval(
         "k": k,
         "averages": {
             "precision_at_k": avgs["avg_precision_at_k"],
+            "recall_at_k": avgs["avg_recall_at_k"],
             "mrr": avgs["avg_mrr"],
             "ndcg_at_k": avgs["avg_ndcg_at_k"],
             "negative_accuracy": neg_accuracy,
@@ -321,9 +330,10 @@ def compare_results(before: dict, after: dict) -> None:
     print()
 
     # Overall averages (positive metrics)
-    metrics = ["precision_at_k", "mrr", "ndcg_at_k"]
+    metrics = ["precision_at_k", "recall_at_k", "mrr", "ndcg_at_k"]
     labels = {
         "precision_at_k": "P@K",
+        "recall_at_k": "R@K",
         "mrr": "MRR",
         "ndcg_at_k": "NDCG@K",
         "negative_accuracy": "Neg Acc",
@@ -332,6 +342,8 @@ def compare_results(before: dict, after: dict) -> None:
     print(f"{'Metric':<12} {'BEFORE':>10} {'NOW':>10} {'DELTA':>16}")
     print("-" * 50)
     for m in metrics:
+        if m not in after["averages"] or m not in before["averages"]:
+            continue  # metric added after one of the results was saved
         b = before["averages"][m]
         a = after["averages"][m]
         delta = _delta_str(b, a)

--- a/src/metronix/benchmarker/services/metrics/retrieval.py
+++ b/src/metronix/benchmarker/services/metrics/retrieval.py
@@ -28,6 +28,20 @@ def precision_at_k(retrieved: Sequence[str], expected: set[str], k: int) -> floa
     return relevant / len(top_k)
 
 
+def recall_at_k(retrieved: Sequence[str], expected: set[str], k: int) -> float:
+    """Recall@K: fraction of relevant docs found in the top-K retrieved.
+
+    ``|top_k ∩ expected| / |expected|``. Returns 0.0 when ``expected`` is empty
+    (nothing to recall) or ``retrieved`` is empty. Unlike Precision@K the
+    denominator is the number of relevant docs, so this is the natural gate for
+    "did retrieval surface the evidence memory".
+    """
+    if not retrieved or not expected or k <= 0:
+        return 0.0
+    top_k = set(retrieved[:k])
+    return sum(1 for doc in expected if doc in top_k) / len(expected)
+
+
 def mean_reciprocal_rank(retrieved: Sequence[str], expected: set[str]) -> float:
     """MRR: 1/rank of first relevant doc. 0 if none found."""
     if not retrieved or not expected:
@@ -93,6 +107,7 @@ class RetrievalMetrics:
         deduped = _deduplicate(retrieved)
         return {
             "precision_at_k": precision_at_k(deduped, expected, k),
+            "recall_at_k": recall_at_k(deduped, expected, k),
             "mrr": mean_reciprocal_rank(deduped, expected),
             "ndcg_at_k": ndcg_at_k(deduped, expected, k),
             "k": float(k),
@@ -115,6 +130,7 @@ class RetrievalMetrics:
         if not pairs:
             return {
                 "avg_precision_at_k": 0.0,
+                "avg_recall_at_k": 0.0,
                 "avg_mrr": 0.0,
                 "avg_ndcg_at_k": 0.0,
             }
@@ -122,6 +138,7 @@ class RetrievalMetrics:
         n = len(results)
         return {
             "avg_precision_at_k": sum(r["precision_at_k"] for r in results) / n,
+            "avg_recall_at_k": sum(r["recall_at_k"] for r in results) / n,
             "avg_mrr": sum(r["mrr"] for r in results) / n,
             "avg_ndcg_at_k": sum(r["ndcg_at_k"] for r in results) / n,
         }

--- a/tests/unit/benchmarks/_shared/test_compare.py
+++ b/tests/unit/benchmarks/_shared/test_compare.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks._shared import compare
+
+
+def _write_lme_run(
+    directory: Path,
+    *,
+    name: str = "answers.jsonl",
+    mode: str = "flag-off",
+    dataset_sha: str = "d" * 64,
+    qids_sha: str = "q" * 64,
+    revision: str = "a" * 40,
+    dirty: bool = False,
+    recall10: float = 0.72,
+    recall5: float = 0.61,
+    eligible: int = 90,
+    search_p95: float = 380.0,
+    top_k: int = 10,
+    chat_model: str = "gpt-4o-mini",
+    endpoint: str = "http://localhost:8000/mcp",
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    results = directory / name
+    results.write_text('{"question_id": "q1", "hypothesis": "x"}\n', encoding="utf-8")
+    (directory / f"{name}.manifest.json").write_text(
+        json.dumps(
+            {
+                "benchmark": "longmemeval",
+                "run_id": f"run-{mode}",
+                "repository": {"revision": revision, "dirty": dirty},
+                "dataset": {"sha256": dataset_sha},
+                "config": {"top_k": top_k, "chat_model": chat_model, "judge_model": "gpt-4o"},
+                "stack": {
+                    "mcp_endpoint_identity": endpoint,
+                    "operator_declared_retrieval_mode": mode,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (directory / f"{name}.query_set.json").write_text(
+        json.dumps({"question_ids_sha256": qids_sha, "question_ids": ["q1"]}), encoding="utf-8"
+    )
+    (directory / f"{name}.retrieval.eval.json").write_text(
+        json.dumps(
+            {
+                "eligible_count": eligible,
+                "recall": {"5": recall5, "10": recall10},
+                "latency": {"phases": {"search_ms": {"p50_ms": 200.0, "p95_ms": search_p95}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return results
+
+
+def test_load_run_requires_sidecars(tmp_path: Path) -> None:
+    (tmp_path / "answers.jsonl").write_text("{}\n", encoding="utf-8")
+    with pytest.raises(FileNotFoundError, match="manifest"):
+        compare.load_run(tmp_path / "answers.jsonl")
+
+
+def test_metrics_longmemeval_from_retrieval_eval(tmp_path: Path) -> None:
+    run = compare.load_run(_write_lme_run(tmp_path, recall10=0.8, recall5=0.65))
+    m = compare.metrics(run)
+    assert m["benchmark"] == "longmemeval"
+    assert m["recall_at_10"] == 0.8
+    assert m["recall_at_5"] == 0.65
+    assert m["search_latency_p95_ms"] == 380.0
+    assert m["error_count"] == 0
+
+
+def test_metrics_locomo_from_eval_json(tmp_path: Path) -> None:
+    name = "answers.jsonl"
+    (tmp_path / name).write_text("{}\n", encoding="utf-8")
+    (tmp_path / f"{name}.manifest.json").write_text(
+        json.dumps({"benchmark": "locomo", "repository": {"dirty": False}}), encoding="utf-8"
+    )
+    (tmp_path / f"{name}.query_set.json").write_text(
+        json.dumps({"question_ids_sha256": "z" * 64}), encoding="utf-8"
+    )
+    (tmp_path / f"{name}.eval.json").write_text(
+        json.dumps(
+            {
+                "overall_score": 0.55,
+                "error_count": 0,
+                "retrieval": {"eligible_count": 1200, "recall": {"5": 0.5, "10": 0.7}},
+                "latency": {"phases": {"search_ms": {"p95_ms": 250.0}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    m = compare.metrics(compare.load_run(tmp_path / name))
+    assert m["recall_at_10"] == 0.7
+    assert m["answer_metric"] == 0.55
+    assert m["answer_metric_name"] == "token_f1"
+
+
+def test_comparable_pair_passes(tmp_path: Path) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off", recall10=0.70))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on", recall10=0.74))
+    report = compare.compare(base, cur)
+    assert report["comparable"] is True
+    assert report["verdict"] == "PASS"
+    assert report["metrics"]["recall_at_10"] == {
+        "baseline": 0.70,
+        "current": 0.74,
+        "delta": pytest.approx(0.04),
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwarg", "value"),
+    [
+        ("dataset_sha", "e" * 64),
+        ("qids_sha", "w" * 64),
+        ("revision", "b" * 40),
+        ("top_k", 20),
+        ("chat_model", "gpt-4o"),
+        ("endpoint", "https://other/mcp"),
+    ],
+)
+def test_identity_mismatch_blocks_comparison(tmp_path: Path, kwarg: str, value: object) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off"))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on", **{kwarg: value}))
+    report = compare.compare(base, cur)
+    assert report["comparable"] is False
+    assert report["verdict"] == "FAIL"
+    assert report["incompatibilities"]
+
+
+def test_dirty_run_blocks_unless_allowed(tmp_path: Path) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off"))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on", dirty=True))
+    assert compare.compare(base, cur)["comparable"] is False
+    assert compare.compare(base, cur, allow_dirty=True)["comparable"] is True
+
+
+def test_same_mode_blocks_unless_allowed(tmp_path: Path) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "a", mode="flag-off"))
+    cur = compare.load_run(_write_lme_run(tmp_path / "b", mode="flag-off"))
+    assert compare.compare(base, cur)["comparable"] is False
+    assert compare.compare(base, cur, allow_same_mode=True)["comparable"] is True
+
+
+def test_gate_floor_fails_when_current_below(tmp_path: Path) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off", recall10=0.7))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on", recall10=0.55))
+    report = compare.compare(base, cur, gates={"recall_at_10": 0.60})
+    assert report["verdict"] == "FAIL"
+    assert report["gate_failures"] and "0.5500" in report["gate_failures"][0]
+
+
+def test_max_regression_fails_on_decline(tmp_path: Path) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off", recall10=0.80))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on", recall10=0.74))
+    report = compare.compare(base, cur, max_regressions={"recall_at_10": 0.03})
+    assert report["verdict"] == "FAIL"
+    assert report["regressions"]
+
+
+def test_unknown_gate_metric_rejected(tmp_path: Path) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off"))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on"))
+    with pytest.raises(ValueError, match="unknown gate metric"):
+        compare.compare(base, cur, gates={"mrr": 0.5})
+
+
+def test_parse_metric_assignment() -> None:
+    assert compare.parse_metric_assignment("recall_at_10=0.62") == ("recall_at_10", 0.62)
+    with pytest.raises(ValueError, match="METRIC=NUMBER"):
+        compare.parse_metric_assignment("recall_at_10=high")

--- a/tests/unit/benchmarks/_shared/test_compare.py
+++ b/tests/unit/benchmarks/_shared/test_compare.py
@@ -20,10 +20,15 @@ def _write_lme_run(
     recall10: float = 0.72,
     recall5: float = 0.61,
     eligible: int = 90,
+    suspect_count: int = 0,
     search_p95: float = 380.0,
     top_k: int = 10,
     chat_model: str = "gpt-4o-mini",
+    chat_temperature: float = 0.0,
+    workspace: str = "MABENCH",
     endpoint: str = "http://localhost:8000/mcp",
+    workspace_reset: str = "no",
+    probe: dict | None = None,
 ) -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     results = directory / name
@@ -35,10 +40,18 @@ def _write_lme_run(
                 "run_id": f"run-{mode}",
                 "repository": {"revision": revision, "dirty": dirty},
                 "dataset": {"sha256": dataset_sha},
-                "config": {"top_k": top_k, "chat_model": chat_model, "judge_model": "gpt-4o"},
+                "config": {
+                    "top_k": top_k,
+                    "workspace": workspace,
+                    "chat_model": chat_model,
+                    "chat_temperature": chat_temperature,
+                    "judge_model": "gpt-4o",
+                },
                 "stack": {
                     "mcp_endpoint_identity": endpoint,
                     "operator_declared_retrieval_mode": mode,
+                    "workspace_reset": workspace_reset,
+                    "probe": probe if probe is not None else {},
                 },
             }
         ),
@@ -51,6 +64,7 @@ def _write_lme_run(
         json.dumps(
             {
                 "eligible_count": eligible,
+                "suspect_count": suspect_count,
                 "recall": {"5": recall5, "10": recall10},
                 "latency": {"phases": {"search_ms": {"p50_ms": 200.0, "p95_ms": search_p95}}},
             }
@@ -123,7 +137,10 @@ def test_comparable_pair_passes(tmp_path: Path) -> None:
         ("revision", "b" * 40),
         ("top_k", 20),
         ("chat_model", "gpt-4o"),
+        ("chat_temperature", 0.7),
+        ("workspace", "OTHER"),
         ("endpoint", "https://other/mcp"),
+        ("workspace_reset", "reset"),
     ],
 )
 def test_identity_mismatch_blocks_comparison(tmp_path: Path, kwarg: str, value: object) -> None:
@@ -133,6 +150,33 @@ def test_identity_mismatch_blocks_comparison(tmp_path: Path, kwarg: str, value: 
     assert report["comparable"] is False
     assert report["verdict"] == "FAIL"
     assert report["incompatibilities"]
+
+
+def test_stack_probe_mismatch_blocks_comparison(tmp_path: Path) -> None:
+    base = compare.load_run(
+        _write_lme_run(tmp_path / "off", mode="flag-off", probe={"qdrant": "connected"})
+    )
+    cur = compare.load_run(
+        _write_lme_run(tmp_path / "on", mode="flag-on", probe={"qdrant": "unavailable"})
+    )
+    report = compare.compare(base, cur)
+    assert report["comparable"] is False
+    assert any("stack probe qdrant" in reason for reason in report["incompatibilities"])
+
+
+def test_matching_stack_probe_is_comparable(tmp_path: Path) -> None:
+    probe = {"qdrant": "connected", "neo4j": "connected", "qdrant_collections": 4}
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off", probe=probe))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on", probe=probe))
+    assert compare.compare(base, cur)["comparable"] is True
+
+
+def test_suspect_search_rows_block_comparison(tmp_path: Path) -> None:
+    base = compare.load_run(_write_lme_run(tmp_path / "off", mode="flag-off"))
+    cur = compare.load_run(_write_lme_run(tmp_path / "on", mode="flag-on", suspect_count=3))
+    report = compare.compare(base, cur)
+    assert report["comparable"] is False
+    assert any("degraded retrieval leg" in reason for reason in report["incompatibilities"])
 
 
 def test_dirty_run_blocks_unless_allowed(tmp_path: Path) -> None:

--- a/tests/unit/benchmarks/_shared/test_latency.py
+++ b/tests/unit/benchmarks/_shared/test_latency.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from benchmarks._shared import latency
+from scripts.run_eval import latency_summary
+
+
+def test_summarize_basic() -> None:
+    out = latency.summarize([10, 20, 30, 40])
+    assert out["mean_ms"] == pytest.approx(25.0)
+    assert out["max_ms"] == 40.0
+    assert out["p50_ms"] == pytest.approx(25.0)  # linear interp between 20 and 30
+
+
+def test_summarize_single_value() -> None:
+    assert latency.summarize([7.5]) == {
+        "mean_ms": 7.5,
+        "p50_ms": 7.5,
+        "p95_ms": 7.5,
+        "max_ms": 7.5,
+    }
+
+
+def test_summarize_empty_raises() -> None:
+    with pytest.raises(ValueError, match="at least one measurement"):
+        latency.summarize([])
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_summarize_matches_run_eval_latency_summary(seed: int) -> None:
+    rng = random.Random(seed)
+    values = [rng.uniform(1, 5000) for _ in range(rng.randint(1, 200))]
+    assert latency.summarize(values) == latency_summary(values)
+
+
+def test_aggregate_latency_per_phase() -> None:
+    rows = [
+        {"ingest_ms": 100, "search_ms": 50, "answer_ms": 800, "total_ms": 960},
+        {"ingest_ms": 120, "search_ms": 70, "answer_ms": 900, "total_ms": 1100},
+        {"hypothesis": "Error: x"},  # no timing — skipped per phase
+    ]
+    report = latency.aggregate_latency(rows)
+    assert report["count"] == 3
+    assert report["phases"]["search_ms"]["n"] == 2
+    assert report["phases"]["search_ms"]["p50_ms"] == pytest.approx(60.0)
+    assert report["phases"]["answer_ms"]["n"] == 2
+    assert "total_ms" in report["phases"]
+
+
+def test_aggregate_latency_no_rows_with_timing() -> None:
+    report = latency.aggregate_latency([{"hypothesis": "Error"}])
+    assert report["phases"] == {}

--- a/tests/unit/benchmarks/_shared/test_manifest.py
+++ b/tests/unit/benchmarks/_shared/test_manifest.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks._shared import manifest
+
+
+def test_question_ids_digest_is_order_sensitive() -> None:
+    a = manifest.question_ids_digest(["q1", "q2", "q3"])
+    b = manifest.question_ids_digest(["q1", "q3", "q2"])
+    c = manifest.question_ids_digest(["q1", "q2"])
+    assert a != b != c
+    assert a == manifest.question_ids_digest(["q1", "q2", "q3"])
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://localhost:8000/mcp/", "http://localhost:8000/mcp"),
+        ("https://user:pass@Metronix.Example:443/mcp/?t=secret#x", "https://metronix.example/mcp"),
+        ("http://host:80/", "http://host"),
+        ("https://[::1]:8443/mcp", "https://[::1]:8443/mcp"),
+    ],
+)
+def test_sanitized_endpoint_identity_drops_credentials_and_defaults(
+    url: str, expected: str
+) -> None:
+    assert manifest.sanitized_endpoint_identity(url) == expected
+
+
+def test_sanitized_endpoint_identity_rejects_relative() -> None:
+    with pytest.raises(ValueError, match="absolute URL"):
+        manifest.sanitized_endpoint_identity("/mcp")
+
+
+def test_git_revision_reports_repo_state() -> None:
+    info = manifest.git_revision(Path(__file__).resolve().parents[4])
+    assert info["revision"] != "unknown"
+    assert len(info["revision"]) == 40
+    assert isinstance(info["dirty"], bool)
+
+
+def test_git_revision_tolerates_non_repo(tmp_path: Path) -> None:
+    info = manifest.git_revision(tmp_path)
+    assert info == {"revision": "unknown", "dirty": None}
+
+
+def test_build_query_set_and_summary_round_trip() -> None:
+    qs = manifest.build_query_set(
+        benchmark="locomo",
+        selector={"categories": [1, 2]},
+        question_ids=["a", "b", "c"],
+    )
+    assert qs["question_count"] == 3
+    assert qs["question_ids_sha256"] == manifest.question_ids_digest(["a", "b", "c"])
+    summary = manifest.query_set_summary(qs)
+    assert "question_ids" not in summary
+    assert summary["question_ids_sha256"] == qs["question_ids_sha256"]
+    assert summary["selector"] == {"categories": [1, 2]}
+
+
+def test_build_manifest_embeds_query_set_summary_not_ids(tmp_path: Path) -> None:
+    qs = manifest.build_query_set(
+        benchmark="longmemeval", selector={"variant": "s"}, question_ids=["q1", "q2"]
+    )
+    m = manifest.build_manifest(
+        benchmark="longmemeval",
+        repo_root=tmp_path,
+        dataset={"name": "x", "sha256": "deadbeef"},
+        query_set=qs,
+        config={"top_k": 10},
+        stack={"mcp_endpoint_identity": "http://localhost:8000/mcp"},
+        metrics_requested=["recall_at_10"],
+        run_id="fixed",
+    )
+    assert m["schema_version"] == manifest.MANIFEST_SCHEMA_VERSION
+    assert m["run_id"] == "fixed"
+    assert m["query_set"] == manifest.query_set_summary(qs)
+    assert "question_ids" not in m["query_set"]
+    assert m["repository"] == {"revision": "unknown", "dirty": None}
+
+
+def test_write_run_artifacts_writes_both_sidecars(tmp_path: Path) -> None:
+    out = tmp_path / "nested" / "answers.jsonl"
+    qs = manifest.build_query_set(benchmark="locomo", selector={}, question_ids=["a"])
+    m = manifest.build_manifest(
+        benchmark="locomo",
+        repo_root=tmp_path,
+        dataset={},
+        query_set=qs,
+        config={},
+        stack={},
+        metrics_requested=[],
+    )
+    m_path, q_path = manifest.write_run_artifacts(out, manifest=m, query_set=qs)
+
+    assert m_path == out.with_suffix(".jsonl.manifest.json")
+    assert q_path == out.with_suffix(".jsonl.query_set.json")
+    reloaded = manifest.load_query_set(q_path)
+    assert reloaded["question_ids"] == ["a"]
+    # sorted keys + trailing newline
+    text = m_path.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    assert json.loads(text)["benchmark"] == "locomo"
+
+
+def test_load_query_set_rejects_non_query_set(tmp_path: Path) -> None:
+    bad = tmp_path / "x.json"
+    bad.write_text('{"nope": 1}', encoding="utf-8")
+    with pytest.raises(ValueError, match="query_set"):
+        manifest.load_query_set(bad)

--- a/tests/unit/benchmarks/_shared/test_manifest.py
+++ b/tests/unit/benchmarks/_shared/test_manifest.py
@@ -112,3 +112,71 @@ def test_load_query_set_rejects_non_query_set(tmp_path: Path) -> None:
     bad.write_text('{"nope": 1}', encoding="utf-8")
     with pytest.raises(ValueError, match="query_set"):
         manifest.load_query_set(bad)
+
+
+def test_resolve_run_identity_fresh_run_is_scoped_to_run_id(tmp_path: Path) -> None:
+    out = tmp_path / "answers.jsonl"
+    run_id, prefix = manifest.resolve_run_identity(
+        out, benchmark="locomo", retrieval_mode="flag-off"
+    )
+    assert len(run_id) == 32
+    assert prefix == f"locomo-flag-off-{run_id[:8]}"
+
+
+def test_resolve_run_identity_two_fresh_runs_do_not_collide(tmp_path: Path) -> None:
+    first = manifest.resolve_run_identity(tmp_path / "a.jsonl", benchmark="lme")
+    second = manifest.resolve_run_identity(tmp_path / "b.jsonl", benchmark="lme")
+    assert first[0] != second[0]
+    assert first[1] != second[1]
+
+
+def test_resolve_run_identity_resume_reads_prior_identity_from_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "answers.jsonl"
+    run_id, prefix = manifest.resolve_run_identity(out, benchmark="locomo")
+    qs = manifest.build_query_set(benchmark="locomo", selector={}, question_ids=["a"])
+    m = manifest.build_manifest(
+        benchmark="locomo",
+        repo_root=tmp_path,
+        dataset={},
+        query_set=qs,
+        config={"agent_id_prefix": prefix},
+        stack={},
+        metrics_requested=[],
+        run_id=run_id,
+    )
+    manifest.write_manifest(out, m)
+
+    resumed_id, resumed_prefix = manifest.resolve_run_identity(out, benchmark="locomo")
+    assert (resumed_id, resumed_prefix) == (run_id, prefix)
+
+
+def test_resolve_run_identity_fresh_flag_ignores_existing_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "answers.jsonl"
+    run_id, prefix = manifest.resolve_run_identity(out, benchmark="locomo")
+    qs = manifest.build_query_set(benchmark="locomo", selector={}, question_ids=["a"])
+    manifest.write_manifest(
+        out,
+        manifest.build_manifest(
+            benchmark="locomo",
+            repo_root=tmp_path,
+            dataset={},
+            query_set=qs,
+            config={"agent_id_prefix": prefix},
+            stack={},
+            metrics_requested=[],
+            run_id=run_id,
+        ),
+    )
+    new_id, _ = manifest.resolve_run_identity(out, benchmark="locomo", fresh=True)
+    assert new_id != run_id
+
+
+def test_resolve_run_identity_prefix_override_wins(tmp_path: Path) -> None:
+    run_id, prefix = manifest.resolve_run_identity(
+        tmp_path / "answers.jsonl",
+        benchmark="locomo",
+        retrieval_mode="flag-off",
+        prefix_override="pinned-ns",
+    )
+    assert prefix == "pinned-ns"
+    assert len(run_id) == 32

--- a/tests/unit/benchmarks/_shared/test_oracle.py
+++ b/tests/unit/benchmarks/_shared/test_oracle.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from benchmarks._shared import oracle
+
+BENCH = Path(__file__).resolve().parents[4] / "benchmarks"
+sys.path.insert(0, str(BENCH / "longmemeval" / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+
+# ---------------------------------------------------------------------------
+# retrieved_session_tags
+# ---------------------------------------------------------------------------
+
+
+def test_retrieved_session_tags_one_per_hit_in_order() -> None:
+    hits = [
+        {"record": {"tags": ["date_x", "session_3"]}},
+        {"record": {"tags": ["session_0", "session_1"]}},  # first wins
+        {"record": {"tags": ["no-session-tag"]}},  # dropped
+        {"record": {}},
+    ]
+    assert oracle.retrieved_session_tags(hits) == ["session_3", "session_0"]
+
+
+# ---------------------------------------------------------------------------
+# LongMemEval
+# ---------------------------------------------------------------------------
+
+
+def test_longmemeval_oracle_maps_answer_ids_by_position() -> None:
+    entry = {
+        "question_id": "q1",
+        "haystack_session_ids": ["a", "b", "c", "d"],
+        "answer_session_ids": ["c", "a"],
+    }
+    assert oracle.longmemeval_oracle_tags(entry) == {"session_2", "session_0"}
+
+
+def test_longmemeval_oracle_skips_unknown_answer_id() -> None:
+    entry = {"haystack_session_ids": ["a"], "answer_session_ids": ["a", "zzz"]}
+    assert oracle.longmemeval_oracle_tags(entry) == {"session_0"}
+
+
+@pytest.mark.parametrize(
+    ("qid", "expected"),
+    [("gpt4_2655b836", False), ("gpt4_9c8f_abs", True)],
+)
+def test_longmemeval_abstention_detection(qid: str, expected: bool) -> None:
+    assert oracle.longmemeval_is_abstention({"question_id": qid}) is expected
+
+
+# ---------------------------------------------------------------------------
+# LoCoMo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("evidence", "expected"),
+    [
+        ("['D1:3']", ["D1:3"]),
+        ("['D2:8', 'D3:1']", ["D2:8", "D3:1"]),
+        ("D1:5", ["D1:5"]),
+        ("[]", []),
+        ("", []),
+        ("not a list", ["not a list"]),
+        (["D1:1"], ["D1:1"]),
+    ],
+)
+def test_parse_evidence_handles_repr_strings(evidence: object, expected: list[str]) -> None:
+    assert oracle._parse_evidence(evidence) == expected
+
+
+def test_locomo_oracle_maps_dia_number_to_ingest_position() -> None:
+    # sessions ingested in sorted order: [1, 3, 10] -> session_0, session_1, session_2
+    entry = {"session_numbers": [1, 3, 10], "evidence": "['D3:4', 'D10:1']", "category": 2}
+    assert oracle.locomo_oracle_tags(entry) == {"session_1", "session_2"}
+
+
+def test_locomo_oracle_empty_evidence_is_empty() -> None:
+    assert oracle.locomo_oracle_tags({"session_numbers": [1, 2], "evidence": "[]"}) == set()
+
+
+def test_locomo_abstention_is_category_5() -> None:
+    assert oracle.locomo_is_abstention({"category": 5}) is True
+    assert oracle.locomo_is_abstention({"category": "5"}) is True
+    assert oracle.locomo_is_abstention({"category": 2}) is False
+
+
+# ---------------------------------------------------------------------------
+# Real-data checks (skipped in a clean checkout)
+# ---------------------------------------------------------------------------
+
+
+def test_real_longmemeval_every_non_abstention_question_has_an_oracle() -> None:
+    import dataset as lme_dataset  # noqa: PLC0415
+
+    if not lme_dataset.dataset_path("oracle").exists():
+        pytest.skip("longmemeval oracle dataset not downloaded")
+    data = lme_dataset.load_dataset("oracle")
+    for entry in data:
+        tags = oracle.longmemeval_oracle_tags(entry)
+        if not oracle.longmemeval_is_abstention(entry):
+            assert tags, f"{entry['question_id']} has no oracle session"
+        assert all(t.startswith("session_") for t in tags)
+
+
+def test_real_locomo_oracle_coverage() -> None:
+    from benchmarks.locomo.scripts import dataset as locomo_dataset  # noqa: PLC0415
+
+    if not locomo_dataset.DATASET_PATH.exists():
+        pytest.skip("locomo dataset not downloaded")
+    data = locomo_dataset.load_dataset(locomo_dataset.DATASET_PATH)
+    missing = 0
+    for entry in locomo_dataset.iter_questions(data, categories={1, 2, 3, 4}):
+        tags = oracle.locomo_oracle_tags(entry)
+        assert all(t.startswith("session_") for t in tags)
+        if not tags:
+            missing += 1
+    # A handful of category-3 questions have empty evidence upstream; the rest resolve.
+    assert missing <= 10

--- a/tests/unit/benchmarks/_shared/test_retrieval_eval.py
+++ b/tests/unit/benchmarks/_shared/test_retrieval_eval.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import pytest
+
+from benchmarks._shared import retrieval_eval
+from metronix.benchmarker.services.metrics import retrieval as core_retrieval
+
+# ---------------------------------------------------------------------------
+# recall_at_k — and parity with the src/ implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("retrieved", "expected", "k"),
+    [
+        (["s0", "s1", "s2"], {"s0", "s2"}, 10),
+        (["s0", "s1", "s2"], {"s0", "s2"}, 2),
+        (["s3", "s4"], {"s0"}, 10),
+        ([], {"s0"}, 5),
+        (["s0"], set(), 5),
+        (["s0", "s0", "s1"], {"s0", "s1", "s2"}, 10),
+        (["s0"], {"s0"}, 0),
+    ],
+)
+def test_recall_matches_core_implementation(
+    retrieved: list[str], expected: set[str], k: int
+) -> None:
+    assert retrieval_eval.recall_at_k(retrieved, expected, k) == core_retrieval.recall_at_k(
+        retrieved, expected, k
+    )
+
+
+# ---------------------------------------------------------------------------
+# recall_row
+# ---------------------------------------------------------------------------
+
+
+def test_recall_row_computes_all_ks_and_eligibility() -> None:
+    row = retrieval_eval.recall_row({"session_1"}, ["session_2", "session_1"], eligible=True)
+    assert row["recall_at_10"] == 1.0
+    assert row["recall_at_5"] == 1.0
+    assert row["oracle_session_tags"] == ["session_1"]
+    assert row["retrieved_session_tags"] == ["session_2", "session_1"]
+    assert row["recall_gate_eligible"] is True
+
+
+def test_recall_row_not_eligible_when_abstention() -> None:
+    row = retrieval_eval.recall_row({"session_1"}, ["session_1"], eligible=False)
+    assert row["recall_gate_eligible"] is False
+
+
+def test_recall_row_not_eligible_when_no_oracle() -> None:
+    row = retrieval_eval.recall_row(set(), ["session_1"], eligible=True)
+    assert row["recall_gate_eligible"] is False
+
+
+def test_recall_row_recall_at_5_slices_first_five() -> None:
+    retrieved = [f"session_{i}" for i in range(9)]
+    row = retrieval_eval.recall_row({"session_7"}, retrieved, eligible=True)
+    assert row["recall_at_10"] == 1.0
+    assert row["recall_at_5"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# aggregate_recall / gate_value
+# ---------------------------------------------------------------------------
+
+
+def _row(rt: str, r10: float, r5: float, *, eligible: bool = True) -> dict:
+    return {
+        "question_type": rt,
+        "recall_at_10": r10,
+        "recall_at_5": r5,
+        "recall_gate_eligible": eligible,
+    }
+
+
+def test_aggregate_recall_overall_and_by_group() -> None:
+    rows = [
+        _row("temporal", 1.0, 1.0),
+        _row("temporal", 0.0, 0.0),
+        _row("multi-session", 1.0, 0.0),
+        _row("abs", 0.0, 0.0, eligible=False),  # excluded
+    ]
+    report = retrieval_eval.aggregate_recall(rows, group_key="question_type")
+    assert report["question_count"] == 4
+    assert report["eligible_count"] == 3
+    assert report["excluded_count"] == 1
+    assert report["recall"]["10"] == pytest.approx(2 / 3)
+    assert report["recall"]["5"] == pytest.approx(1 / 3)
+    assert report["by_group"]["temporal"] == {
+        "count": 2,
+        "recall": {"10": pytest.approx(0.5), "5": pytest.approx(0.5)},
+    }
+
+
+def test_gate_value_is_recall_at_10() -> None:
+    report = retrieval_eval.aggregate_recall([_row("x", 0.8, 0.5)], group_key="question_type")
+    assert retrieval_eval.gate_value(report, k=10) == pytest.approx(0.8)
+    assert retrieval_eval.gate_value(report, k=5) == pytest.approx(0.5)
+
+
+def test_gate_value_none_when_nothing_eligible() -> None:
+    report = retrieval_eval.aggregate_recall(
+        [_row("x", 0.0, 0.0, eligible=False)], group_key="question_type"
+    )
+    assert report["eligible_count"] == 0
+    assert retrieval_eval.gate_value(report, k=10) is None
+
+
+def test_aggregate_recall_empty() -> None:
+    report = retrieval_eval.aggregate_recall([], group_key="category")
+    assert report["question_count"] == 0
+    assert report["recall"] == {"5": 0.0, "10": 0.0}
+    assert retrieval_eval.gate_value(report) is None

--- a/tests/unit/benchmarks/_shared/test_retrieval_eval.py
+++ b/tests/unit/benchmarks/_shared/test_retrieval_eval.py
@@ -112,4 +112,17 @@ def test_aggregate_recall_empty() -> None:
     report = retrieval_eval.aggregate_recall([], group_key="category")
     assert report["question_count"] == 0
     assert report["recall"] == {"5": 0.0, "10": 0.0}
+    assert report["suspect_count"] == 0
     assert retrieval_eval.gate_value(report) is None
+
+
+def test_aggregate_recall_counts_suspect_rows() -> None:
+    rows = [
+        {**_row("x", 1.0, 1.0), "search_suspect": False},
+        {**_row("x", 0.0, 0.0), "search_suspect": True},
+        {**_row("x", 0.0, 0.0, eligible=False), "search_suspect": True},
+        _row("x", 1.0, 1.0),  # no search_suspect key at all
+    ]
+    report = retrieval_eval.aggregate_recall(rows, group_key="question_type")
+    # counted across every row, eligible or not
+    assert report["suspect_count"] == 2

--- a/tests/unit/benchmarks/_shared/test_stack.py
+++ b/tests/unit/benchmarks/_shared/test_stack.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import httpx
+import respx
+
+from benchmarks._shared import stack
+
+_API = "http://localhost:8000"
+
+
+@respx.mock
+def test_probe_stack_records_health_and_store_status() -> None:
+    respx.get(f"{_API}/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
+    respx.get(f"{_API}/api/v1/admin/status").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "cleanup_allowed": True,
+                "databases": {
+                    "qdrant": {"status": "connected", "collections_count": 3},
+                    "neo4j": {"status": "connected"},
+                },
+            },
+        )
+    )
+
+    snapshot = stack.probe_stack(_API + "/")
+
+    assert snapshot == {
+        "health": "ok",
+        "cleanup_allowed": True,
+        "qdrant": "connected",
+        "qdrant_collections": 3,
+        "neo4j": "connected",
+    }
+
+
+@respx.mock
+def test_probe_stack_tolerates_missing_admin_status() -> None:
+    respx.get(f"{_API}/health").mock(return_value=httpx.Response(200, text="pong"))
+    respx.get(f"{_API}/api/v1/admin/status").mock(return_value=httpx.Response(404))
+
+    snapshot = stack.probe_stack(_API)
+
+    assert snapshot["health"] == 200
+    assert snapshot["admin_status"] == 404
+
+
+@respx.mock
+def test_probe_stack_unavailable_on_transport_error() -> None:
+    respx.get(f"{_API}/health").mock(side_effect=httpx.ConnectError("refused"))
+
+    snapshot = stack.probe_stack(_API)
+
+    assert snapshot == {"probe": "unavailable", "reason": "ConnectError"}
+
+
+@respx.mock
+def test_reset_workspace_confirms_and_reports_reset() -> None:
+    route = respx.delete(f"{_API}/api/v1/admin/cleanup/workspace/LOCOMO").mock(
+        return_value=httpx.Response(200, json={"deleted": True})
+    )
+
+    assert stack.reset_workspace(_API, "LOCOMO") == "reset"
+    assert route.calls.last.request.headers["X-Confirm-Cleanup"] == "yes"
+
+
+@respx.mock
+def test_reset_workspace_reports_disabled_cleanup() -> None:
+    respx.delete(f"{_API}/api/v1/admin/cleanup/workspace/WS").mock(
+        return_value=httpx.Response(403, json={"detail": "cleanup disabled"})
+    )
+
+    assert stack.reset_workspace(_API, "WS") == (
+        "unavailable (ALLOW_CLEANUP not enabled on the server)"
+    )
+
+
+@respx.mock
+def test_reset_workspace_reports_unexpected_status() -> None:
+    respx.delete(f"{_API}/api/v1/admin/cleanup/workspace/WS").mock(
+        return_value=httpx.Response(500)
+    )
+
+    assert stack.reset_workspace(_API, "WS") == "unavailable (HTTP 500)"
+
+
+@respx.mock
+def test_reset_workspace_reports_transport_error() -> None:
+    respx.delete(f"{_API}/api/v1/admin/cleanup/workspace/WS").mock(
+        side_effect=httpx.ConnectTimeout("slow")
+    )
+
+    assert stack.reset_workspace(_API, "WS") == "unavailable (ConnectTimeout)"

--- a/tests/unit/benchmarks/locomo/test_dataset.py
+++ b/tests/unit/benchmarks/locomo/test_dataset.py
@@ -44,10 +44,11 @@ def test_load_dataset_validates_shape(tmp_path: Path) -> None:
 
 
 def test_sessions_ignore_date_only_placeholders() -> None:
-    sessions, dates = sessions_from_conversation(sample_dataset()[0]["conversation"])
+    sessions, dates, numbers = sessions_from_conversation(sample_dataset()[0]["conversation"])
 
     assert sessions == [[{"speaker": "A", "text": "Hello", "dia_id": "D1:1"}]]
     assert dates == ["1 Jan 2024"]
+    assert numbers == [1]
 
 
 def test_iter_questions_filters_categories_and_assigns_stable_ids() -> None:

--- a/tests/unit/benchmarks/locomo/test_evaluate.py
+++ b/tests/unit/benchmarks/locomo/test_evaluate.py
@@ -40,3 +40,40 @@ def test_evaluate_rows_reports_overall_category_and_errors() -> None:
     assert report["error_count"] == 1
     assert report["overall_score"] == pytest.approx(2 / 3)
     assert report["category_scores"] == {"2": 0.5, "5": 1.0}
+
+
+def test_evaluate_rows_includes_retrieval_recall_block() -> None:
+    report = evaluate_rows(
+        [
+            {
+                "category": 2,
+                "hypothesis": "Paris",
+                "answer": "Paris",
+                "recall_at_10": 1.0,
+                "recall_at_5": 1.0,
+                "recall_gate_eligible": True,
+            },
+            {
+                "category": 2,
+                "hypothesis": "Rome",
+                "answer": "Rome",
+                "recall_at_10": 0.0,
+                "recall_at_5": 0.0,
+                "recall_gate_eligible": True,
+            },
+            {
+                "category": 5,  # abstention — excluded from the recall gate
+                "hypothesis": "Not mentioned",
+                "answer": "",
+                "recall_at_10": 0.0,
+                "recall_at_5": 0.0,
+                "recall_gate_eligible": False,
+            },
+        ]
+    )
+
+    retrieval = report["retrieval"]
+    assert retrieval["group_key"] == "category"
+    assert retrieval["eligible_count"] == 2
+    assert retrieval["excluded_count"] == 1
+    assert retrieval["recall"]["10"] == pytest.approx(0.5)

--- a/tests/unit/benchmarks/locomo/test_locomo_runner.py
+++ b/tests/unit/benchmarks/locomo/test_locomo_runner.py
@@ -7,9 +7,15 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from benchmarks._shared import manifest as run_manifest
 from benchmarks.locomo.scripts import run_benchmark
 from benchmarks.locomo.scripts.env_config import BenchConfig
-from benchmarks.locomo.scripts.run_benchmark import chat_complete, parse_categories, write_manifest
+from benchmarks.locomo.scripts.run_benchmark import (
+    build_run_artifacts,
+    chat_complete,
+    parse_categories,
+    write_manifest,
+)
 
 
 def config() -> BenchConfig:
@@ -33,21 +39,58 @@ def test_parse_categories_is_explicit_and_bounded() -> None:
 
 def test_manifest_records_parity_fields_without_secrets(tmp_path: Path) -> None:
     output = tmp_path / "answers.jsonl"
-    manifest = write_manifest(
+    entries = [
+        {"question_id": "s1-q0001"},
+        {"question_id": "s1-q0002"},
+    ]
+    manifest_file = write_manifest(
         output,
         config=config(),
         categories={1, 2, 3, 4},
         retrieval_mode="flag-off",
         dataset_path=tmp_path / "locomo10.json",
+        entries=entries,
+    )
+    query_set_file = run_manifest.query_set_path(output)
+
+    data = json.loads(manifest_file.read_text(encoding="utf-8"))
+    query_set = json.loads(query_set_file.read_text(encoding="utf-8"))
+    serialized = json.dumps(data) + json.dumps(query_set)
+
+    assert data["schema_version"] == run_manifest.MANIFEST_SCHEMA_VERSION
+    assert data["benchmark"] == "locomo"
+    assert data["stack"]["operator_declared_retrieval_mode"] == "flag-off"
+    assert data["stack"]["mcp_endpoint_identity"] == "http://localhost:8000/mcp"
+    assert data["config"]["categories"] == [1, 2, 3, 4]
+    assert data["config"]["top_k"] == 10
+    assert data["config"]["agent_id_prefix"] == "locomo"
+    assert data["dataset"]["sha256"] == run_benchmark.DATASET_SHA256
+    assert data["dataset"]["upstream_ref"] == run_benchmark.UPSTREAM_COMMIT
+
+    # The query-set digest is the machine-checkable "same set of queries".
+    assert query_set["question_ids"] == ["s1-q0001", "s1-q0002"]
+    assert data["query_set"]["question_ids_sha256"] == query_set["question_ids_sha256"]
+    assert query_set["question_ids_sha256"] == run_manifest.question_ids_digest(
+        ["s1-q0001", "s1-q0002"]
     )
 
-    data = json.loads(manifest.read_text(encoding="utf-8"))
-    serialized = json.dumps(data)
-    assert data["operator_declared_retrieval_mode"] == "flag-off"
-    assert data["categories"] == [1, 2, 3, 4]
-    assert data["top_k"] == 10
     assert "secret-key" not in serialized
     assert "chat-secret" not in serialized
+
+
+def test_build_run_artifacts_manifest_and_query_set_agree(tmp_path: Path) -> None:
+    entries = [{"question_id": f"s-q{n:04d}"} for n in range(5)]
+    manifest, query_set = build_run_artifacts(
+        config=config(),
+        categories={2, 4},
+        retrieval_mode="flag-on",
+        entries=entries,
+        run_id="run-abc",
+    )
+    assert manifest["run_id"] == "run-abc"
+    assert manifest["dataset"]["question_count"] == 5
+    assert manifest["query_set"] == run_manifest.query_set_summary(query_set)
+    assert query_set["selector"] == {"categories": [2, 4]}
 
 
 def test_chat_complete_retries_an_empty_model_answer(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/benchmarks/locomo/test_locomo_runner.py
+++ b/tests/unit/benchmarks/locomo/test_locomo_runner.py
@@ -86,11 +86,81 @@ def test_build_run_artifacts_manifest_and_query_set_agree(tmp_path: Path) -> Non
         retrieval_mode="flag-on",
         entries=entries,
         run_id="run-abc",
+        workspace_reset="reset",
+        stack_snapshot={"qdrant": "connected"},
     )
     assert manifest["run_id"] == "run-abc"
     assert manifest["dataset"]["question_count"] == 5
     assert manifest["query_set"] == run_manifest.query_set_summary(query_set)
     assert query_set["selector"] == {"categories": [2, 4]}
+    assert manifest["stack"]["workspace_reset"] == "reset"
+    assert manifest["stack"]["probe"] == {"qdrant": "connected"}
+    assert manifest["config"]["chat_temperature"] == run_benchmark.CHAT_TEMPERATURE
+    assert manifest["config"]["chat_max_tokens"] == run_benchmark.CHAT_MAX_TOKENS
+
+
+def test_run_derives_a_run_scoped_agent_prefix_and_resumes_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    entry = {
+        "question_id": "sample-q0001",
+        "sample_id": "sample",
+        "category": 2,
+        "question": "When?",
+        "answer": "Tomorrow",
+        "evidence": [],
+    }
+    monkeypatch.setattr(run_benchmark, "load_dataset", lambda _: [{}])
+    monkeypatch.setattr(run_benchmark, "iter_questions", lambda *_a, **_k: iter([entry]))
+    monkeypatch.setattr(run_benchmark, "OpenAI", MagicMock())
+    monkeypatch.setattr(
+        run_benchmark.stack_probe, "probe_stack", lambda _url: {"probe": "skipped"}
+    )
+    reset_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        run_benchmark.stack_probe,
+        "reset_workspace",
+        lambda url, ws: reset_calls.append((url, ws)) or "reset",
+    )
+    monkeypatch.setattr(
+        run_benchmark,
+        "process_question",
+        MagicMock(return_value=("Tomorrow", {"retrieved_count": 0})),
+    )
+    output = tmp_path / "answers.jsonl"
+
+    run_benchmark.run(
+        config=config(),
+        dataset_path=tmp_path / "locomo10.json",
+        output_path=output,
+        categories={2},
+        max_questions=None,
+        force=False,
+        retrieval_mode="flag-off",
+        reset_workspace=True,
+    )
+
+    manifest_1 = json.loads(run_manifest.manifest_path(output).read_text(encoding="utf-8"))
+    prefix = manifest_1["config"]["agent_id_prefix"]
+    run_id = manifest_1["run_id"]
+    assert prefix == f"locomo-flag-off-{run_id[:8]}"
+    assert manifest_1["stack"]["workspace_reset"] == "reset"
+    assert manifest_1["stack"]["probe"] == {"probe": "skipped"}
+    assert reset_calls == [("http://localhost:8000", "LOCOMO")]
+
+    # A resume (no --force) must reuse the same namespace, not mint a new one.
+    run_benchmark.run(
+        config=config(),
+        dataset_path=tmp_path / "locomo10.json",
+        output_path=output,
+        categories={2},
+        max_questions=None,
+        force=False,
+        retrieval_mode="flag-off",
+    )
+    manifest_2 = json.loads(run_manifest.manifest_path(output).read_text(encoding="utf-8"))
+    assert manifest_2["run_id"] == run_id
+    assert manifest_2["config"]["agent_id_prefix"] == prefix
 
 
 def test_chat_complete_retries_an_empty_model_answer(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,6 +216,7 @@ def test_run_records_safe_empty_completion_diagnostics(
         MagicMock(side_effect=run_benchmark.EmptyChatCompletionError("length")),
     )
     monkeypatch.setattr(run_benchmark, "OpenAI", MagicMock())
+    monkeypatch.setattr(run_benchmark.stack_probe, "probe_stack", lambda _url: {})
     output = tmp_path / "answers.jsonl"
 
     run_benchmark.run(

--- a/tests/unit/benchmarks/longmemeval/test_lme_dataset.py
+++ b/tests/unit/benchmarks/longmemeval/test_lme_dataset.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+BENCH_SCRIPTS = Path(__file__).resolve().parents[4] / "benchmarks" / "longmemeval" / "scripts"
+sys.path.insert(0, str(BENCH_SCRIPTS))
+
+import dataset as lme_dataset  # noqa: E402
+
+
+def test_pin_is_a_commit_not_a_branch() -> None:
+    assert len(lme_dataset.HF_REVISION) == 40
+    for spec in lme_dataset.VARIANTS.values():
+        assert f"/resolve/{lme_dataset.HF_REVISION}/" in spec["url"]
+        assert "/resolve/main/" not in spec["url"]
+        assert len(spec["sha256"]) == 64
+
+
+def test_validate_dataset_rejects_non_array() -> None:
+    with pytest.raises(ValueError, match="JSON array"):
+        lme_dataset.validate_dataset({"question_id": "q1"})
+
+
+def test_validate_dataset_rejects_entry_without_question_id() -> None:
+    with pytest.raises(ValueError, match="no question_id"):
+        lme_dataset.validate_dataset([{"question": "?"}])
+
+
+def test_verify_dataset_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lme_dataset, "DATA_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError, match="download --variant oracle"):
+        lme_dataset.verify_dataset("oracle")
+
+
+def test_verify_dataset_hash_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(lme_dataset, "DATA_DIR", tmp_path)
+    (tmp_path / "longmemeval_oracle.json").write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError, match="does not match the pinned"):
+        lme_dataset.verify_dataset("oracle")
+
+
+def test_unknown_variant_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown LongMemEval variant"):
+        lme_dataset.dataset_path("tiny")
+
+
+def test_select_questions_is_dataset_order_prefix() -> None:
+    data = [{"question_id": f"q{n}"} for n in range(10)]
+    assert lme_dataset.question_ids(data, max_questions=3) == ["q0", "q1", "q2"]
+    assert lme_dataset.question_ids(data, max_questions=None) == [f"q{n}" for n in range(10)]
+
+
+def test_dataset_identity_shape() -> None:
+    identity = lme_dataset.dataset_identity("s", question_count=42)
+    assert identity["upstream_ref"] == lme_dataset.HF_REVISION
+    assert identity["sha256"] == lme_dataset.VARIANTS["s"]["sha256"]
+    assert identity["variant"] == "s"
+    assert identity["question_count"] == 42
+
+
+@pytest.mark.parametrize("variant", ["oracle", "s"])
+def test_pinned_dataset_matches_recorded_hash_when_present(variant: str) -> None:
+    """Real-data check: when the operator has downloaded the file, its bytes
+    match the SHA-256 recorded in ``dataset.py``. Skipped in a clean checkout."""
+    path = lme_dataset.dataset_path(variant)
+    if not path.exists():
+        pytest.skip(f"{path.name} not downloaded")
+    loaded = lme_dataset.load_dataset(variant)  # verifies sha + structure
+    assert isinstance(loaded, list) and loaded
+    ids = lme_dataset.question_ids(loaded)
+    assert len(ids) == len(set(ids))  # question ids are unique
+    assert all(isinstance(i, str) for i in ids)

--- a/tests/unit/benchmarks/longmemeval/test_run_benchmark.py
+++ b/tests/unit/benchmarks/longmemeval/test_run_benchmark.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
 from pathlib import Path
 
+import pytest
+
 BENCH_SCRIPTS = Path(__file__).resolve().parents[4] / "benchmarks" / "longmemeval" / "scripts"
 sys.path.insert(0, str(BENCH_SCRIPTS))
 
-from metronix_client import _parse_tool_payload  # noqa: E402
+import metronix_client  # noqa: E402
+from metronix_client import MetronixMCPClient, _parse_tool_payload  # noqa: E402
 from run_benchmark import (  # noqa: E402
     append_result,
     format_session_text,
@@ -61,3 +65,62 @@ def test_parse_tool_payload_from_json_text() -> None:
 def test_parse_tool_payload_from_dict() -> None:
     payload = _parse_tool_payload({"id": "abc", "deduped": False})
     assert payload["id"] == "abc"
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.stored: list[dict] = []
+
+    async def initialize(self) -> None:
+        return None
+
+    async def call_tool(self, name: str, args: dict):
+        if name == "metronix_memory_store":
+            self.stored.append(args)
+            return {"id": f"rec-{len(self.stored)}"}
+        return {"results": [{"record": {"tags": args["query"] and ["session_0"]}}]}
+
+
+def test_ingest_and_search_returns_results_and_phase_timings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _FakeSession()
+
+    @contextlib.asynccontextmanager
+    async def fake_client_session(_read, _write):
+        yield session
+
+    @contextlib.asynccontextmanager
+    async def fake_streamable(_url, http_client=None):
+        yield (None, None, None)
+
+    monkeypatch.setitem(sys.modules, "mcp", type("m", (), {"ClientSession": fake_client_session}))
+    monkeypatch.setitem(
+        sys.modules,
+        "mcp.client.streamable_http",
+        type("s", (), {"streamable_http_client": fake_streamable}),
+    )
+    monkeypatch.setattr(metronix_client.httpx, "AsyncClient", lambda **_kw: _NoopAsyncCM())
+
+    client = MetronixMCPClient(mcp_url="http://x/mcp", api_key="k", workspace_id="W", agent_id="a")
+    out = client.ingest_and_search(
+        sessions=[[{"role": "user", "content": "hi"}], [{"role": "user", "content": "yo"}]],
+        dates=["d1", "d2"],
+        format_session_text=lambda turns, date="": "text",
+        query="q",
+        top_k=10,
+    )
+
+    assert list(out) == ["results", "ingest_ms", "search_ms"]
+    assert isinstance(out["ingest_ms"], float) and out["ingest_ms"] >= 0.0
+    assert isinstance(out["search_ms"], float) and out["search_ms"] >= 0.0
+    assert out["results"] == [{"record": {"tags": ["session_0"]}}]
+    assert len(session.stored) == 2  # one store per haystack session
+
+
+class _NoopAsyncCM:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False

--- a/tests/unit/benchmarks/longmemeval/test_run_benchmark.py
+++ b/tests/unit/benchmarks/longmemeval/test_run_benchmark.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,12 +12,33 @@ BENCH_SCRIPTS = Path(__file__).resolve().parents[4] / "benchmarks" / "longmemeva
 sys.path.insert(0, str(BENCH_SCRIPTS))
 
 import metronix_client  # noqa: E402
+import run_benchmark as lme_run  # noqa: E402
+from env_config import BenchConfig  # noqa: E402
 from metronix_client import MetronixMCPClient, _parse_tool_payload  # noqa: E402
 from run_benchmark import (  # noqa: E402
     append_result,
+    build_run_artifacts,
     format_session_text,
     load_completed_ids,
 )
+
+from benchmarks._shared import manifest as run_manifest  # noqa: E402
+
+
+def _config() -> BenchConfig:
+    return BenchConfig(
+        metronix_mcp_api_key="secret-key",
+        metronix_mcp_url="http://localhost:8000/mcp",
+        metronix_api_url="http://localhost:8000",
+        workspace_id="MABENCH",
+        chat_api_key="chat-secret",
+        chat_base_url="https://api.openai.com/v1",
+        chat_model="gpt-4o-mini",
+        judge_api_key="judge-secret",
+        judge_base_url="https://api.openai.com/v1",
+        judge_model="gpt-4o",
+        retrieve_top_k=10,
+    )
 
 
 def test_format_session_text_includes_date() -> None:
@@ -124,3 +146,62 @@ class _NoopAsyncCM:
 
     async def __aexit__(self, *_exc):
         return False
+
+
+def test_build_run_artifacts_carries_stack_and_sampling_knobs() -> None:
+    entries = [{"question_id": f"q{n}"} for n in range(3)]
+    manifest, query_set = build_run_artifacts(
+        variant="s",
+        entries=entries,
+        config=_config(),
+        max_questions=None,
+        retrieval_mode="flag-on",
+        run_id="run-xyz",
+        workspace_reset="reset",
+        stack_snapshot={"neo4j": "connected"},
+    )
+    assert manifest["run_id"] == "run-xyz"
+    assert manifest["query_set"] == run_manifest.query_set_summary(query_set)
+    assert manifest["stack"]["workspace_reset"] == "reset"
+    assert manifest["stack"]["probe"] == {"neo4j": "connected"}
+    assert manifest["config"]["chat_temperature"] == lme_run.CHAT_TEMPERATURE
+    assert manifest["config"]["chat_max_tokens"] == lme_run.CHAT_MAX_TOKENS
+
+
+def test_run_benchmark_derives_run_scoped_prefix_and_resumes_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    entries = [{"question_id": "q1", "question": "Q1", "haystack_sessions": []}]
+    monkeypatch.setattr(lme_run, "load_dataset", lambda _variant: list(entries))
+    monkeypatch.setattr(lme_run, "OpenAI", MagicMock())
+    monkeypatch.setattr(lme_run.stack_probe, "probe_stack", lambda _url: {"probe": "skipped"})
+    reset_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        lme_run.stack_probe,
+        "reset_workspace",
+        lambda url, ws: reset_calls.append((url, ws)) or "reset",
+    )
+    monkeypatch.setattr(
+        lme_run, "process_question", MagicMock(return_value=("answer", {"retrieved_count": 0}))
+    )
+    output = tmp_path / "answers.jsonl"
+
+    lme_run.run_benchmark(
+        variant="s",
+        output_path=output,
+        config=_config(),
+        retrieval_mode="flag-off",
+        reset_workspace=True,
+    )
+
+    m1 = json.loads(run_manifest.manifest_path(output).read_text(encoding="utf-8"))
+    prefix, run_id = m1["config"]["agent_id_prefix"], m1["run_id"]
+    assert prefix == f"longmemeval-flag-off-{run_id[:8]}"
+    assert m1["stack"]["workspace_reset"] == "reset"
+    assert reset_calls == [("http://localhost:8000", "MABENCH")]
+
+    lme_run.run_benchmark(
+        variant="s", output_path=output, config=_config(), retrieval_mode="flag-off"
+    )
+    m2 = json.loads(run_manifest.manifest_path(output).read_text(encoding="utf-8"))
+    assert (m2["run_id"], m2["config"]["agent_id_prefix"]) == (run_id, prefix)

--- a/tests/unit/benchmarks/test_compare_runs_cli.py
+++ b/tests/unit/benchmarks/test_compare_runs_cli.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_CLI = Path(__file__).resolve().parents[3] / "benchmarks" / "compare_runs.py"
+
+
+def _run_dir(directory: Path, *, mode: str, recall10: float, dirty: bool = False) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    name = "answers.jsonl"
+    (directory / name).write_text('{"question_id":"q1","hypothesis":"x"}\n', encoding="utf-8")
+    (directory / f"{name}.manifest.json").write_text(
+        json.dumps(
+            {
+                "benchmark": "longmemeval",
+                "run_id": f"r-{mode}",
+                "repository": {"revision": "a" * 40, "dirty": dirty},
+                "dataset": {"sha256": "d" * 64},
+                "config": {"top_k": 10, "chat_model": "gpt-4o-mini"},
+                "stack": {
+                    "mcp_endpoint_identity": "http://localhost:8000/mcp",
+                    "operator_declared_retrieval_mode": mode,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (directory / f"{name}.query_set.json").write_text(
+        json.dumps({"question_ids_sha256": "q" * 64}), encoding="utf-8"
+    )
+    (directory / f"{name}.retrieval.eval.json").write_text(
+        json.dumps(
+            {
+                "eligible_count": 100,
+                "recall": {"5": recall10 - 0.1, "10": recall10},
+                "latency": {"phases": {"search_ms": {"p50_ms": 200.0, "p95_ms": 350.0}}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return directory / name
+
+
+def _cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_CLI), *args], capture_output=True, text=True, check=False
+    )
+
+
+def test_pass_when_comparable_and_gate_met(tmp_path: Path) -> None:
+    base = _run_dir(tmp_path / "off", mode="flag-off", recall10=0.70)
+    cur = _run_dir(tmp_path / "on", mode="flag-on", recall10=0.75)
+    out = tmp_path / "report.json"
+    res = _cli(str(base), str(cur), "--gate", "recall_at_10=0.60", "--output", str(out))
+    assert res.returncode == 0, res.stderr
+    assert "PASS" in res.stdout
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["verdict"] == "PASS"
+    assert report["metrics"]["recall_at_10"]["delta"] == pytest.approx(0.05)
+
+
+def test_fail_and_nonzero_exit_on_gate_breach(tmp_path: Path) -> None:
+    base = _run_dir(tmp_path / "off", mode="flag-off", recall10=0.70)
+    cur = _run_dir(tmp_path / "on", mode="flag-on", recall10=0.50)
+    res = _cli(str(base), str(cur), "--gate", "recall_at_10=0.60")
+    assert res.returncode == 1
+    assert "GATE FAIL" in res.stderr
+    assert "FAIL" in res.stdout
+
+
+def test_fail_on_incompatible_runs(tmp_path: Path) -> None:
+    base = _run_dir(tmp_path / "off", mode="flag-off", recall10=0.70)
+    cur = _run_dir(tmp_path / "on", mode="flag-on", recall10=0.70, dirty=True)
+    res = _cli(str(base), str(cur))
+    assert res.returncode == 1
+    assert "NOT COMPARABLE" in res.stderr
+
+
+def test_usage_error_on_unknown_metric(tmp_path: Path) -> None:
+    base = _run_dir(tmp_path / "off", mode="flag-off", recall10=0.70)
+    cur = _run_dir(tmp_path / "on", mode="flag-on", recall10=0.70)
+    res = _cli(str(base), str(cur), "--gate", "mrr=0.5")
+    assert res.returncode == 2
+    assert "unknown gate metric" in res.stderr

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -137,9 +137,10 @@ def suite_configuration(suite: str) -> dict[str, object]:
         "dataset": {
             "filename": "longmemeval_s_cleaned.json",
             "source": (
-                "https://huggingface.co/datasets/xiaowu0162/"
-                "longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json"
+                "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+                "resolve/98d7416c24c778c2fee6e6f3006e7a073259d48f/longmemeval_s_cleaned.json"
             ),
+            "pinned_sha256": "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442",
             "sha256": None,
         },
     }
@@ -406,6 +407,13 @@ def test_longmemeval_records_effective_non_secret_environment(
         "HTTPS://user:password@Metronix.Example:443/mcp/?token=secret#credentials",
     )
     monkeypatch.setenv("LME_CHAT_API_KEY", "must-not-be-reported")
+    # Point at a data-less benchmark root so the on-disk ``sha256`` is
+    # deterministically absent regardless of what the developer downloaded.
+    benchmark_root = tmp_path / "benchmarks" / "longmemeval"
+    benchmark_root.mkdir(parents=True)
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_ROOT", benchmark_root)
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_ENV", benchmark_root / ".env.benchmark")
+    monkeypatch.setattr(harness, "_LONGMEMEVAL_LEGACY_ENV", benchmark_root / ".env")
     request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
 
     report = run_suites(request, FakeRunner())
@@ -422,9 +430,10 @@ def test_longmemeval_records_effective_non_secret_environment(
     assert configuration["dataset"] == {
         "filename": "longmemeval_s_cleaned.json",
         "source": (
-            "https://huggingface.co/datasets/xiaowu0162/"
-            "longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json"
+            "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/"
+            "resolve/98d7416c24c778c2fee6e6f3006e7a073259d48f/longmemeval_s_cleaned.json"
         ),
+        "pinned_sha256": "d6f21ea9d60a0d56f34a05b609c79c88a451d2ae03597821ea3d5a9678c3a442",
         "sha256": None,
     }
     assert "must-not-be-reported" not in json.dumps(configuration)

--- a/tests/unit/test_memory_eval_harness.py
+++ b/tests/unit/test_memory_eval_harness.py
@@ -720,6 +720,45 @@ def test_longmemeval_error_hypothesis_fails_suite_even_when_runner_exits_zero(
     assert report.suites["longmemeval"].summary["error_count"] == 1
 
 
+def test_longmemeval_summary_picks_up_recall_from_retrieval_eval_sidecar(
+    tmp_path: Path,
+) -> None:
+    class WithRecallRunner(FakeRunner):
+        def run(
+            self,
+            command: Sequence[str],
+            *,
+            child_env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            output = Path(child_env["METRONIX_EVAL_ARTIFACT"])
+            output.write_text(
+                '{"question_id": "one", "hypothesis": "an answer"}\n', encoding="utf-8"
+            )
+            output.with_name(output.name + ".retrieval.eval.json").write_text(
+                json.dumps(
+                    {
+                        "eligible_count": 90,
+                        "recall": {"5": 0.61, "10": 0.78},
+                        "latency": {"phases": {"search_ms": {"p50_ms": 210.0, "p95_ms": 375.0}}},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return subprocess.CompletedProcess(
+                args=command, returncode=0, stdout="Accuracy: 0.8", stderr=""
+            )
+
+    request = replace(request_for_all_suites(tmp_path), suites=("longmemeval",))
+    report = run_suites(request, WithRecallRunner())
+
+    summary = report.suites["longmemeval"].summary
+    assert summary["recall_at_10"] == 0.78
+    assert summary["recall_at_5"] == 0.61
+    assert summary["recall_eligible_count"] == 90
+    assert summary["search_latency_p95_ms"] == 375.0
+    assert "longmemeval.recall_at_10" in harness.HIGHER_IS_BETTER
+
+
 @pytest.mark.parametrize("judge_output", ["Accuracy: not-a-number", "Accuracy: 1e309"])
 def test_judged_longmemeval_requires_finite_parsed_accuracy(
     tmp_path: Path, judge_output: str

--- a/tests/unit/test_retrieval_metrics.py
+++ b/tests/unit/test_retrieval_metrics.py
@@ -45,6 +45,7 @@ from metronix.benchmarker.services.metrics.retrieval import (
     mean_reciprocal_rank,
     ndcg_at_k,
     precision_at_k,
+    recall_at_k,
 )
 
 # ---------------------------------------------------------------------------
@@ -79,6 +80,55 @@ class TestPrecisionAtK:
     def test_k_one(self):
         assert precision_at_k(["d1", "d2"], {"d1"}, k=1) == 1.0
         assert precision_at_k(["d2", "d1"], {"d1"}, k=1) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# recall_at_k
+# ---------------------------------------------------------------------------
+
+
+class TestRecallAtK:
+    def test_all_relevant_found(self):
+        assert recall_at_k(["d1", "d2", "d3"], {"d1", "d2", "d3"}, k=3) == 1.0
+
+    def test_half_found(self):
+        assert recall_at_k(["d1", "d4"], {"d1", "d2"}, k=10) == pytest.approx(0.5)
+
+    def test_relevant_beyond_k_not_counted(self):
+        # d2 is relevant but at position 3, k=2
+        assert recall_at_k(["d1", "x", "d2"], {"d1", "d2"}, k=2) == pytest.approx(0.5)
+
+    def test_denominator_is_expected_not_retrieved(self):
+        # 1 of 3 relevant found, in a top-10 full of noise
+        retrieved = ["d1", *[f"n{i}" for i in range(9)]]
+        assert recall_at_k(retrieved, {"d1", "d2", "d3"}, k=10) == pytest.approx(1 / 3)
+
+    def test_empty_expected_is_zero(self):
+        assert recall_at_k(["d1"], set(), k=5) == 0.0
+
+    def test_empty_retrieved_is_zero(self):
+        assert recall_at_k([], {"d1"}, k=5) == 0.0
+
+    def test_k_zero_is_zero(self):
+        assert recall_at_k(["d1"], {"d1"}, k=0) == 0.0
+
+    def test_single_evidence_recall_is_binary(self):
+        assert recall_at_k(["x", "d1", "y"], {"d1"}, k=10) == 1.0
+        assert recall_at_k(["x", "y"], {"d1"}, k=10) == 0.0
+
+
+class TestRecallInRetrievalMetrics:
+    def test_compute_includes_recall(self):
+        result = RetrievalMetrics().compute(["d1", "d2"], {"d1", "d3"}, k=5)
+        assert result["recall_at_k"] == pytest.approx(0.5)
+
+    def test_averages_include_recall(self):
+        pairs = [(["d1"], {"d1", "d2"}), (["d3", "d4"], {"d3", "d4"})]
+        avgs = RetrievalMetrics().compute_averages(pairs, k=5)
+        assert avgs["avg_recall_at_k"] == pytest.approx((0.5 + 1.0) / 2)
+
+    def test_averages_empty_includes_recall_zero(self):
+        assert RetrievalMetrics().compute_averages([], k=5)["avg_recall_at_k"] == 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this harness does

A reproducible flag-off/flag-on evaluation harness for the PPR (graph retrieval) flag across both memory benchmarks (LongMemEval, LoCoMo), built for issue #156.

- **Run-identity manifest + query set** — every run writes `<results>.manifest.json` (git revision, dataset sha256, sampling knobs, run-scoped agent-id prefix, stack probe) and `<results>.query_set.json` (the exact ordered `question_id` list), so two runs can be checked for actual apples-to-apples comparability instead of assumed.
- **Run-scoped agent-id namespace** — each run mints `<benchmark>-<mode>-<run_id[:8]>`, so no two runs (even two flag-off repeats) can read each other's stored memories; a resume of the same results file reuses its namespace.
- **recall@k against the evidence session** — per-question `recall_at_5`/`recall_at_10` computed against the oracle session tags, aggregated overall and by question type/category, with a `suspect_count` for questions whose own stored sessions came back empty on search (a degraded-leg signal, not missing evidence).
- **Split per-phase latency** — `ingest_ms` / `search_ms` / `answer_ms` / `total_ms` per question, aggregated to p50/p95/max per phase.
- **`compare_runs.py`** — compares two runs and refuses unless dataset bytes, question set, repo revision (clean tree), sampling knobs, workspace, and workspace-reset state all match, and only the declared retrieval mode differs. Supports `--gate` (absolute floor) and `--max-regression` (vs. baseline) on any metric, non-zero exit on breach.

## Bugs found and fixed along the way

Dogfooding the harness on two full runs surfaced three real bugs, all filed and two fixed on this branch:

- **#484** — investigated a missing `query_set.json` sidecar on a LoCoMo run; turned out to be an artifact from the **pre-harness** LoCoMo runner (`schema_version: 1`, no `run_id`/`query_set`) predating the switch to this branch, not a bug in the current harness. Closed as not-a-bug; `compare.load_run` (#486, already merged) now names this case explicitly instead of a generic missing-sidecars error.
- **#489** (fixed on this branch) — `compare.py`'s LongMemEval branch never computed `error_count` (the LoCoMo branch does, via `hypothesis.startswith("Error:")`), so the comparator silently reported "0 errors" on a LongMemEval leg with 15-18% infra failures. Added `_longmemeval_error_count()` mirroring the LoCoMo idiom; verified against the actual #156 pair — `compare_runs.py` now correctly reports both legs NOT COMPARABLE instead of a silent PASS.
- **#490 / #491** — `chat_complete` dereferenced `completion.choices[0]` without checking `completion` for `None`, raising an unretryable `TypeError` that cost 15-18 minutes per occurrence (full ingest+search+answer re-run) and produced a bare `"Error: ..."` hypothesis the judge always grades wrong. Fixed in #491 (merged to `main`) with a guarded `EmptyChatCompletionError` added to the retryable set; merged into this branch so the next LongMemEval run doesn't hit it again.

## Result: PPR evaluation (issue #156)

Full-scale flag-off/flag-on pair on both benchmarks, same commit and stack:

| | LoCoMo (1540 q) | LongMemEval-S (500 q) |
|---|---|---|
| Primary metric | token-F1 | recall@10 / judge accuracy |
| flag-off → flag-on | 0.261 → 0.372 (**+11.1 п.п.**) | recall@10 0.9235 → 0.9227; accuracy (corrected for infra failures) 0.8694 → 0.8683 |
| Effect | Clear gain, concentrated on single-hop and open-domain; ~flat on temporal | Within noise on both recall and corrected accuracy |

LongMemEval's raw judge accuracy (0.732 → 0.712) is contaminated by ingest-side `context length exceeded` failures (79/500 flag-off, 90/500 flag-on) that the judge grades as wrong answers regardless of retrieval quality — recall@k is unaffected since those rows are correctly excluded from `eligible`. Corrected for that, the LongMemEval delta is effectively zero.

**Effect is non-uniform** — meaningful on LoCoMo, absent on LongMemEval-S — plausibly tied to dialogue length/structure or question-type mix rather than a universal retrieval-quality improvement. **Decision: keep PPR behind the flag** (`METRONIX_RETRIEVAL_GRAPH_PPR_ENABLED`), default off, rather than removing it or flipping the default — the corpora where it helps aren't uniformly represented by either benchmark alone.

Full memo with per-category/per-type breakdowns, latency, and raw manifests/eval files: **https://claude.ai/artifact/VzFRJdRhtS76xnqyNjfdnY**

## Test plan

- [x] `tests/unit/benchmarks/longmemeval/test_run_benchmark.py` — 12/12 passing (incl. 4 new from #491 merge)
- [x] `tests/unit/benchmarks/_shared/test_compare.py` — 24/24 passing (incl. 2 new for the #489 fix)
- [x] Full LongMemEval-S flag-off + flag-on runs (500/500 each), manifests + query_set sidecars verified present and matching
- [x] Full LoCoMo flag-off + flag-on runs (1540/1540 each), `error_count: 0` both legs
- [x] `compare_runs.py` run on both LongMemEval legs (`--allow-dirty`) — now correctly reports **NOT COMPARABLE** (79 and 90 benchmark errors) post-#489-fix, where it previously said PASS with a silent `error_count: 0`
- [ ] `compare_runs.py` run on both LoCoMo legs (not yet run — TODO before merge if wanted as part of this PR's record)
- [ ] Broader unit suite (`tests/unit`) — not re-run in full after the origin/main merge; only the touched file was verified

